### PR TITLE
Not show timepreview while dragging the controlbar

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -431,7 +431,9 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
     } else if obj == 1 {
       // slider
       isMouseInSlider = true
-      timePreviewWhenSeek.isHidden = false
+      if !controlBar.isDragging {
+        timePreviewWhenSeek.isHidden = false
+      }
       let mousePos = playSlider.convert(event.locationInWindow, from: nil)
       updateTimeLabel(mousePos.x)
     }


### PR DESCRIPTION
Sometimes it will show time preview when the control bar is being dragged. But it does not make any sense.