### PR TITLE
Add checking when parsing keybinding files

### DIFF
--- a/iina/PrefKeyBindingViewController.swift
+++ b/iina/PrefKeyBindingViewController.swift
@@ -301,6 +301,17 @@ class PrefKeyBindingViewController: NSViewController, MASPreferencesViewControll
       }
       // split
       let splitted = line.characters.split(separator: " ", maxSplits: 1)
+      if splitted.count < 2 {
+        let alert = String(format: NSLocalizedString("alert.keybinding_config_error", comment: "Error setting keybinding configuration"), currentConfName)
+        Utility.showAlert(message: alert)
+        let title = "IINA Default"
+        currentConfName = title
+        currentConfFilePath = getFilePath(forConfig: title)!
+        configSelectPopUp.selectItem(withTitle: title)
+        loadConfigFile()
+        changeButtonEnabled()
+        return
+      }
       let key = String(splitted[0])
       let action = splitted[1].split(separator: " ").map { seq in return String(seq) }
 

--- a/iina/PrefKeyBindingViewController.swift
+++ b/iina/PrefKeyBindingViewController.swift
@@ -351,7 +351,7 @@ extension PrefKeyBindingViewController: NSTableViewDelegate, NSTableViewDataSour
   func tableView(_ tableView: NSTableView, objectValueFor tableColumn: NSTableColumn?, row: Int) -> Any? {
     guard let identifier = tableColumn?.identifier else { return nil }
 
-    let mapping = currentMapping[row]
+    guard let mapping = currentMapping.at(row) else { return nil }
     if identifier == Constants.Identifier.key {
       return mapping.key
     } else if identifier == Constants.Identifier.action {

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -84,3 +84,4 @@
 "track.none" = "<None>";
 
 "alert.extra_option_error" = "Error setting option --%@=%@ with return value %d. Please check your extra option settings in Preference > Advanced.";
+"alert.keybinding_config_error" = "Error parsing keybinding configuration file \"%@\"! Fallback to IINA Default keybinding setting. Please check your configuration.";

--- a/iina/zh-Hans.lproj/Localizable.strings
+++ b/iina/zh-Hans.lproj/Localizable.strings
@@ -84,3 +84,4 @@
 "track.none" = "<无>";
 
 "alert.extra_option_error" = "无法设置选项 --%@=%@ （返回值 %d）。 请在「设置>高级」中检查你的额外 mpv 选项。";
+"alert.keybinding_config_error" = "无法设置快捷键“%@”！退回到IINA默认配置。请检查你的快捷键文件是否正确。";


### PR DESCRIPTION
If iina get the wrong number of split, it will crash without a fallback.

This PR will add an alert and fallback to IINA Default. Maybe later we can store a cache to the last working config and fallback to that.  