### PR TITLE
reduce drag event sensitivity, requires minimum 1px movement to trigger

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -366,6 +366,16 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
 
   /** move window while dragging */
   override func mouseDragged(with event: NSEvent) {
+    /*current mechanism to differentiate between drag event and click event is via isDragging,
+     *it's necessary to filter out tiny movement to click rather than drag.
+     */
+    //reduce drag event sensitive, requires minimum 1px movement to trigger dragging event.
+    if (abs(mousePosRelatedToWindow!.x - NSEvent.mouseLocation().x + window!.frame.origin.x) +
+      abs(mousePosRelatedToWindow!.y - NSEvent.mouseLocation().y + window!.frame.origin.y)) < 1.0 {
+      //consider as click event rather drag event;
+      return
+    }
+    
     isDragging = true
     guard !controlBar.isDragging else { return }
     if mousePosRelatedToWindow != nil {

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -742,6 +742,16 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
       let newWidth = window!.frame.width - currentLocation.x - 2
       sideBarWidthConstraint.constant = newWidth.constrain(min: PlaylistMinWidth, max: PlaylistMaxWidth)
     } else {
+      /* Current mechanism to differentiate between dragging event and clicking event is via isDragging parameter,
+       * It's necessary to filter out tiny movement to clicking rather than dragging.
+       */
+      //Requires minimum 1px movement to trigger dragging event.
+      if (abs(mousePosRelatedToWindow!.x - NSEvent.mouseLocation().x + window!.frame.origin.x) +
+          abs(mousePosRelatedToWindow!.y - NSEvent.mouseLocation().y + window!.frame.origin.y)) < 1.0 {
+          //consider as clicking event;
+          return
+      }
+      
       isDragging = true
       guard !controlBarFloating.isDragging else { return }
       if mousePosRelatedToWindow != nil {


### PR DESCRIPTION
Fixes #96, this problem was caused by the click event fell to the drag event with a very tiny mouse move during clicking. 