### PR TITLE
[FEATURE] Preserve the Title of saved Playlist Items

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 <p align=center>
 <a href="https://iina.io">Website</a> ·
 <a href="https://github.com/iina/iina/releases">Releases</a> ·
-<a href="https://t.me/IINAUsers">Telegram Group</a>
+<a href="https://t.me/joinchat/IINAUsers">Telegram Group</a>
 </p>
 
 ---

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -33,12 +33,12 @@ class MainMenuActionHandler: NSResponder {
       // Writes Extended M3U Playlist
       if url.isFileURL {
         // File Header
-        var playlist = "#EXTM3U\n"
+        var playlist = "#EXTM3U\n\n"
         for item in self.player.info.playlist {
           // Track Info
           playlist.append("#EXTINF:-1," + item.filenameForDisplay + "\n")
           // Track Path / URL
-          playlist.append((item.filename + "\n"))
+          playlist.append((item.filename + "\n\n"))
         }
 
         do {

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -31,8 +31,9 @@ class MainMenuActionHandler: NSResponder {
   @objc func menuSavePlaylist(_ sender: NSMenuItem) {
     Utility.quickSavePanel(title: "Save to playlist", types: ["m3u8"]) { (url) in
       if url.isFileURL {
-        var playlist = ""
+        var playlist = "#EXTM3U\n"
         for item in self.player.info.playlist {
+          playlist.append("#EXTINF:-1," + item.filenameForDisplay + "\n")
           playlist.append((item.filename + "\n"))
         }
 

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -36,9 +36,9 @@ class MainMenuActionHandler: NSResponder {
         var playlist = "#EXTM3U\n\n"
         for item in self.player.info.playlist {
           // Track Info
-          playlist.append("#EXTINF:-1," + item.filenameForDisplay + "\n")
+          playlist.append("#EXTINF:-1,\(item.filenameForDisplay)\n")
           // Track Path / URL
-          playlist.append((item.filename + "\n\n"))
+          playlist.append("\(item.filename)\n\n")
         }
 
         do {

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -30,10 +30,14 @@ class MainMenuActionHandler: NSResponder {
 
   @objc func menuSavePlaylist(_ sender: NSMenuItem) {
     Utility.quickSavePanel(title: "Save to playlist", types: ["m3u8"]) { (url) in
+      // Writes Extended M3U Playlist
       if url.isFileURL {
+        // File Header
         var playlist = "#EXTM3U\n"
         for item in self.player.info.playlist {
+          // Track Info
           playlist.append("#EXTINF:-1," + item.filenameForDisplay + "\n")
+          // Track Path / URL
           playlist.append((item.filename + "\n"))
         }
 


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #1944 .

---

### 🛃 Description
 - Currently, opening a saved playlist (e.g., `playlist.m3u8`) not restore the titles of any contained YouTube video. This results in a playlist with `youtube-dl` ids instead of the videos' names.
 - The playlist file entry for YouTube videos does only contain the `youtube-dl` id (e.g., `ytdl://PHov9j`) and not the video title.

 
### 🚀 Solution
 - This PR augments the playlist disk writing logic.
 - By writing playlist files in the [Extended M3U](https://en.wikipedia.org/wiki/M3U#Extended_M3U) format instead of the [Standard M3U](https://en.wikipedia.org/wiki/M3U#File_format) format, the title of each playlist item is preserved and will be restored upon opening the playlist file.
 - The change results in the restoration of the title of each YouTube playlist item, whilst maintaining the familiar behavior for filepath-based playlist entries. 


### 🖼 Example

#### Before (Standard M3U)

```
ytdl://hPBlH7eAkcs
~/file.mp4
ytdl://9sXx0iDIJnM
```


#### After (Extended M3U)

```
#EXTM3U

#EXTINF:-1,YouTube Video Title
ytdl://hPBlH7eAkcs

#EXTINF:-1,File Title
~/file.mp4

#EXTINF:-1,YouTube Video Title
ytdl://9sXx0iDIJnM
```

   
## 🗂 Type
Feature    
   
   
## 🔥 Severity
Non-Breaking   
   
   
## 🛃 Tests
Changes have been tested manually on macOS 10.13 and 10.14 (Developer Beta 9)