### PR TITLE
improve FileSize.format() when size is unit size

### DIFF
--- a/iina/FileSize.swift
+++ b/iina/FileSize.swift
@@ -36,7 +36,7 @@ class FileSize {
     formatter.maximumFractionDigits = digits
 
     for (_, v) in unitValues.enumerated() {
-      if bytes > v.rawValue {
+      if bytes >= v.rawValue {
         let num = NSNumber(value: Double(bytes) / Double(v.rawValue))
         let str = formatter.string(from: num)
         return str == nil ? "Error" : "\(str!)\(v.string)"


### PR DESCRIPTION
for example, the output of 1024 will be 1KB, not 1024B

- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

1KB is better than 1000B.
