### PR TITLE
Fix crash when pix_fmt is invalid value

### DIFF
--- a/iina/FFmpegController.m
+++ b/iina/FFmpegController.m
@@ -138,6 +138,12 @@ return -1;\
   avcodec_parameters_to_context(pCodecCtx, pVideoStream->codecpar);
   pCodecCtx->time_base = pVideoStream->time_base;
 
+  if (pCodecCtx->pix_fmt < 0 || pCodecCtx->pix_fmt >= AV_PIX_FMT_NB) {
+    avcodec_free_context(&pCodecCtx);
+    avformat_close_input(&pFormatCtx);
+    return -1;
+  }
+  
   ret = avcodec_open2(pCodecCtx, pCodec, &optionsDict);
   CHECK_SUCCESS(ret, @"Cannot open codec")
 


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.
---

**Description:**
Fix issue #2027 