### PR TITLE
Don't exit fullscreen on entering PiP

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2800,11 +2800,6 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
 extension MainWindowController: PIPViewControllerDelegate {
 
   func enterPIP() {
-    // Exit fullscreen if necessary
-    if fsState.isFullscreen {
-      toggleWindowFullScreen()
-    }
-
     pipStatus = .inPIP
     showUI()
 


### PR DESCRIPTION
Entering PiP and exiting fullscreen are orthogonal concepts; PiP manages its own window, so the two aren't mutually exclusive. Requesting one of them should not imply requesting the other. 

Whatever fullscreen / split-screen setup the user has should be preserved whenever possible — not torn down. For example, I might be watching something in fullscreen but need to do something else real quick. The natural way to do this is to activate PiP, move to another space and do the task, then use the Exit PiP button in the PiP window to _restore the setup to its previous state_.

Even worse is if I've put IINA in split-screen with another app to be able to watch a video without having a PiP window obscuring any part of the other app. If I want to complete a short task on another space, then I'm currently confronted with the choice of A) pausing the video, or B) destroying my carefully laid out split-screen setup.



- [ ] This change has been discussed with the author.

---

**Description:**
