### PR TITLE
Add translation in MPVFilter's init

### DIFF
--- a/iina/MPVFilter.swift
+++ b/iina/MPVFilter.swift
@@ -109,7 +109,19 @@ class MPVFilter: NSObject {
     self.type = FilterType(rawValue: name)
     self.name = name
     self.label = label
-    self.params = params
+    if let params = params, let type = type, let format = MPVFilter.formats[type]?.components(separatedBy: ":") {
+      var translated: [String: String] = [:]
+      for (key, value) in params {
+        if let number = Int(key.dropFirst()) {
+          translated[format[number]] = value
+        } else {
+          translated[key] = value
+        }
+      }
+      self.params = translated
+    } else {
+      self.params = params
+    }
   }
 
   init?(rawString: String) {


### PR DESCRIPTION
- [x] This change has been discussed with the author.
- [x] It implements / fixes issue #2155.

---

**Description:**
The filters we get from mpv have no explicit keys, they are "@0", "@1"
instead of "w", "h". So that when we get update of filters via
`getFilters`, our local copy of filters will become massy.
