### PR TITLE
Fix bitrate display in Inspector window

### DIFF
--- a/iina/InspectorWindowController.swift
+++ b/iina/InspectorWindowController.swift
@@ -119,7 +119,6 @@ class InspectorWindowController: NSWindowController, NSTableViewDelegate, NSTabl
           MPVProperty.currentAo: self.aoField,
           MPVProperty.audioParamsFormat: self.aformatField,
           MPVProperty.audioParamsChannels: self.achannelsField,
-          MPVProperty.audioBitrate: self.abitrateField,
           MPVProperty.audioParamsSamplerate: self.asamplerateField
         ]
 


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**
- ~~The bitrate is expressed in bits per second, so the value must be divided by 1000, instead of 1024.~~
- ~~The bitrate is now always displayed in kbps, which is the most common format.~~
- Fixed the audio bitrate label being greyed out when switching to the next track.