### PR TITLE
Minor adjustment of Swedish translation

### DIFF
--- a/iina/sv.lproj/PrefUIViewController.strings
+++ b/iina/sv.lproj/PrefUIViewController.strings
@@ -16,7 +16,7 @@
 "2YJ-bg-OdR.title" = "% av skärm";
 
 /* Class = "NSTextFieldCell"; title = "Use left/right button for:"; ObjectID = "3CY-YS-rG6"; */
-"3CY-YS-rG6.title" = "Använd höger-/vänstertangenten till:";
+"3CY-YS-rG6.title" = "Använd vänster-/högertangenten till:";
 
 /* Class = "NSTextFieldCell"; title = "MB"; ObjectID = "3jK-z5-NDH"; */
 "3jK-z5-NDH.title" = "MB";


### PR DESCRIPTION
Correct the mention of keys to map correctly to the mention of their respective functions

---

**Description:**

left / right was incorrectly translated to the equivalent of right / left