### PR TITLE
Added scroll controlling to mini player

### DIFF
--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -354,7 +354,12 @@ class MiniPlayerWindowController: NSWindowController, NSWindowDelegate, NSPopove
       scrollDirection = nil
     }
     
-    let scrollAction = scrollDirection == .horizontal ? horizontalScrollAction : verticalScrollAction
+    var scrollAction = scrollDirection == .horizontal ? horizontalScrollAction : verticalScrollAction
+    if isMouseEvent(event, inAnyOf: [playSlider]) {
+      scrollAction = .seek
+    } else if isMouseEvent(event, inAnyOf: [volumeSlider]) {
+      scrollAction = .volume
+    }
     
     // pause video when seek begins.
     
@@ -376,7 +381,7 @@ class MiniPlayerWindowController: NSWindowController, NSWindowDelegate, NSPopove
     
     // show volume popover when volume seek begins and hide on end
     
-    if scrollAction == .volume {
+    if scrollAction == .volume && !isMouseEvent(event, inAnyOf: [volumeSlider]) {
       if isTrackpadBegan {
         // enabling animation here causes user not seeing their volume changes during popover transition
         volumePopover.animates = false
@@ -688,6 +693,12 @@ class MiniPlayerWindowController: NSWindowController, NSWindowDelegate, NSPopove
     default:
       break
     }
+  }
+  
+  func isMouseEvent(_ event: NSEvent, inAnyOf views: [NSView?]) -> Bool {
+    return views.filter { $0 != nil }.reduce(false, { (result, view) in
+      return result || view!.isMousePoint(view!.convert(event.locationInWindow, from: nil), in: view!.bounds)
+    })
   }
 
 }

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -387,7 +387,8 @@ class MiniPlayerWindowController: NSWindowController, NSWindowDelegate, NSPopove
         volumePopover.animates = false
         volumePopover.show(relativeTo: volumeButton.bounds, of: volumeButton, preferredEdge: .minY)
       } else if isTrackpadEnd {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3, execute: hideVolumePopover!)
+        let timeout = Preference.double(for: .osdAutoHideTimeout)
+        DispatchQueue.main.asyncAfter(deadline: .now() + timeout, execute: hideVolumePopover!)
       } else if isMouse {
         // if its a mouse, simply show popover then hide after a while when user stops scrolling
         if !volumePopover.isShown {
@@ -399,7 +400,8 @@ class MiniPlayerWindowController: NSWindowController, NSWindowDelegate, NSPopove
           self.volumePopover.animates = true
           self.volumePopover.performClose(self)
         }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5, execute: hideVolumePopover!)
+        let timeout = Preference.double(for: .osdAutoHideTimeout)
+        DispatchQueue.main.asyncAfter(deadline: .now() + timeout, execute: hideVolumePopover!)
       }
     }
     

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -377,6 +377,11 @@ class MiniPlayerWindowController: NSWindowController, NSWindowDelegate, NSPopove
     // show volume popover when volume seek begins and hide on end
     
     if scrollAction == .volume {
+      hideVolumePopover?.cancel()
+      hideVolumePopover = DispatchWorkItem {
+        self.volumePopover.animates = true
+        self.volumePopover.performClose(self)
+      }
       if isTrackpadBegan {
         // enabling animation here causes user not seeing their volume changes during popover transition
         volumePopover.animates = false
@@ -389,11 +394,6 @@ class MiniPlayerWindowController: NSWindowController, NSWindowDelegate, NSPopove
         if !volumePopover.isShown {
           volumePopover.animates = false
           volumePopover.show(relativeTo: volumeButton.bounds, of: volumeButton, preferredEdge: .minY)
-        }
-        hideVolumePopover?.cancel()
-        hideVolumePopover = DispatchWorkItem {
-          self.volumePopover.animates = true
-          self.volumePopover.performClose(self)
         }
         let timeout = Preference.double(for: .osdAutoHideTimeout)
         DispatchQueue.main.asyncAfter(deadline: .now() + timeout, execute: hideVolumePopover!)

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -354,12 +354,7 @@ class MiniPlayerWindowController: NSWindowController, NSWindowDelegate, NSPopove
       scrollDirection = nil
     }
     
-    var scrollAction = scrollDirection == .horizontal ? horizontalScrollAction : verticalScrollAction
-    if isMouseEvent(event, inAnyOf: [playSlider]) {
-      scrollAction = .seek
-    } else if isMouseEvent(event, inAnyOf: [volumeSlider]) {
-      scrollAction = .volume
-    }
+    let scrollAction = scrollDirection == .horizontal ? horizontalScrollAction : verticalScrollAction
     
     // pause video when seek begins.
     
@@ -381,7 +376,7 @@ class MiniPlayerWindowController: NSWindowController, NSWindowDelegate, NSPopove
     
     // show volume popover when volume seek begins and hide on end
     
-    if scrollAction == .volume && !isMouseEvent(event, inAnyOf: [volumeSlider]) {
+    if scrollAction == .volume {
       if isTrackpadBegan {
         // enabling animation here causes user not seeing their volume changes during popover transition
         volumePopover.animates = false
@@ -696,13 +691,6 @@ class MiniPlayerWindowController: NSWindowController, NSWindowDelegate, NSPopove
       break
     }
   }
-  
-  func isMouseEvent(_ event: NSEvent, inAnyOf views: [NSView?]) -> Bool {
-    return views.filter { $0 != nil }.reduce(false, { (result, view) in
-      return result || view!.isMousePoint(view!.convert(event.locationInWindow, from: nil), in: view!.bounds)
-    })
-  }
-
 }
 
 fileprivate extension NSRect {

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -369,20 +369,22 @@ class MiniPlayerWindowController: NSWindowController, NSWindowDelegate, NSPopove
     
     // show volume popover when volume seek begins and hide on end
     
-    if scrollAction == .volume && isTrackpadBegan {
-      // enabling animation here causes user not seeing their volume changes during popover transition
-      volumePopover.animates = false
-      volumePopover.show(relativeTo: volumeButton.bounds, of: volumeButton, preferredEdge: .minY)
-    } else if scrollAction == .volume && isTrackpadEnd {
-      volumePopover.animates = true
-      volumePopover.performClose(self)
-    } else if isMouse && !volumePopover.isShown {
-      // if its a mouse, simply show then hide after a while
-      volumePopover.animates = false
-      volumePopover.show(relativeTo: volumeButton.bounds, of: volumeButton, preferredEdge: .minY)
-      DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
-        self.volumePopover.animates = true
-        self.volumePopover.performClose(self)
+    if scrollAction == .volume {
+      if isTrackpadBegan {
+        // enabling animation here causes user not seeing their volume changes during popover transition
+        volumePopover.animates = false
+        volumePopover.show(relativeTo: volumeButton.bounds, of: volumeButton, preferredEdge: .minY)
+      } else if isTrackpadEnd {
+        volumePopover.animates = true
+        volumePopover.performClose(self)
+      } else if isMouse && !volumePopover.isShown {
+        // if its a mouse, simply show popover then hide after a while
+        volumePopover.animates = false
+        volumePopover.show(relativeTo: volumeButton.bounds, of: volumeButton, preferredEdge: .minY)
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+          self.volumePopover.animates = true
+          self.volumePopover.performClose(self)
+        }
       }
     }
     


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #2157.

---

**Description:**

I did it because I personally just wanted that.
Implementation is somewhat lazy and its nearly just a copy-paste from MainWindowController.
However instead of having the dedicated OSD, this scroll controlling on mini player indicates the volume change by showing volume popover while moving trackpad/mouse.