### PR TITLE
Fix nil unwrap in SubPopoverViewController.playerCore.getter

### DIFF
--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -728,9 +728,9 @@ class SubPopoverViewController: NSViewController, NSTableViewDelegate, NSTableVi
   @IBOutlet weak var playlistTableView: NSTableView!
   @IBOutlet weak var heightConstraint: NSLayoutConstraint!
 
-  lazy var playerCore: PlayerCore = {
-    let windowController = self.playlistTableView.window!.windowController
-    return (windowController as? MainWindowController)?.player ?? (windowController as! MiniPlayerWindowController).player
+  lazy var playerCore: PlayerCore? = {
+    let windowController = self.playlistTableView?.window?.windowController
+    return (windowController as? MainWindowController)?.player ?? (windowController as? MiniPlayerWindowController)?.player
   }()
 
   var filePath: String = ""
@@ -740,18 +740,18 @@ class SubPopoverViewController: NSViewController, NSTableViewDelegate, NSTableVi
   }
 
   func tableView(_ tableView: NSTableView, objectValueFor tableColumn: NSTableColumn?, row: Int) -> Any? {
-    guard let matchedSubs = playerCore.info.matchedSubs[filePath] else { return nil }
+    guard let matchedSubs = playerCore?.info.matchedSubs[filePath] else { return nil }
     return matchedSubs[row].lastPathComponent
   }
 
   func numberOfRows(in tableView: NSTableView) -> Int {
-    return playerCore.info.matchedSubs[filePath]?.count ?? 0
+    return playerCore?.info.matchedSubs[filePath]?.count ?? 0
   }
 
   @IBAction func wrongSubBtnAction(_ sender: AnyObject) {
-    playerCore.info.matchedSubs[filePath]?.removeAll()
+    playerCore?.info.matchedSubs[filePath]?.removeAll()
     tableView.reloadData()
-    if let row = playerCore.info.playlist.index(where: { $0.filename == filePath }) {
+    if let row = playerCore?.info.playlist.index(where: { $0.filename == filePath }) {
       playlistTableView.reloadData(forRowIndexes: IndexSet(integer: row), columnIndexes: IndexSet(integersIn: 0...1))
     }
   }


### PR DESCRIPTION
Threw a couple question marks at a crash report, since the code was already prepared for nil everywhere. Recreated this PR since apparently it's impossible to change source branch.

Exception Type:        EXC_BAD_INSTRUCTION (SIGILL)
Exception Codes:       0x0000000000000001, 0x0000000000000000
Exception Note:        EXC_CORPSE_NOTIFY

Termination Signal:    Illegal instruction: 4
Termination Reason:    Namespace SIGNAL, Code 0x4
Terminating Process:   exc handler [26767]

Thread 0 Crashed:: Dispatch queue: com.apple.main-thread
0   com.colliderli.iina           	0x000000010664ce50 closure #1 in SubPopoverViewController.playerCore.getter + 208
1   com.colliderli.iina           	0x0000000106655255 specialized SubPopoverViewController.numberOfRows(in:) + 53
2   com.colliderli.iina           	0x000000010664c376 @objc SubPopoverViewController.numberOfRows(in:) + 38