### PR TITLE
Autoscroll the playlist to show the current item when opening new file/url

### DIFF
--- a/iina/AppData.swift
+++ b/iina/AppData.swift
@@ -95,6 +95,8 @@ struct Constants {
 extension Notification.Name {
   static let iinaMainWindowChanged = Notification.Name("IINAMainWindowChanged")
   static let iinaPlaylistChanged = Notification.Name("IINAPlaylistChanged")
+  /// Sent when *the user* has manually replaced the entire contents of the playlist
+  static let iinaPlaylistReplaced = Notification.Name("IINAPlaylistReplaced")
   static let iinaTracklistChanged = Notification.Name("IINATracklistChanged")
   static let iinaVIDChanged = Notification.Name("iinaVIDChanged")
   static let iinaAIDChanged = Notification.Name("iinaAIDChanged")

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -156,6 +156,10 @@ class PlayerCore: NSObject {
       return
     }
     Logger.log("Open URL: \(url.absoluteString)", subsystem: subsystem)
+    
+    // The user has at this point manually replaced the entire playlist
+    self.postNotification(.iinaPlaylistReplaced)
+
     let isNetwork = !url.isFileURL
     if shouldAutoLoad {
       info.shouldAutoLoadFiles = true
@@ -1285,7 +1289,7 @@ class PlayerCore: NSObject {
     case .playlist:
       DispatchQueue.main.async {
         if self.isInMiniPlayer ? self.miniPlayer.isPlaylistVisible : self.mainWindow.sideBarStatus == .playlist {
-          self.mainWindow.playlistView.playlistTableView.reloadData()
+          self.mainWindow.playlistView.reloadData(playlist: true, chapters: false)
         }
       }
 


### PR DESCRIPTION
If a new playlist has been loaded, the playlist will scroll to show the current item in case we resumed playback of an item that is not the first. This is convenient if you're on item 500 of a 1000 items long list.

Pros: No one wants to scroll twenty pages. 
Cons: None. 

Well, it's not the exact implementation I had hoped to write, but it's one that required me to read and figure out only half the codebase instead of all of it.

- [ ] This change has been discussed with the author.