### PR TITLE
Trim URL string whitespace and newlines

### DIFF
--- a/iina/OpenURLWindowController.swift
+++ b/iina/OpenURLWindowController.swift
@@ -74,7 +74,8 @@ class OpenURLWindowController: NSWindowController, NSTextFieldDelegate, NSContro
     guard !urlField.stringValue.isEmpty else { return (nil, false) }
     let username = usernameField.stringValue
     let password = passwordField.stringValue
-    guard var urlValue = urlField.stringValue.addingPercentEncoding(withAllowedCharacters: .urlAllowed) else {
+    let trimmedUrlString = urlField.stringValue.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard var urlValue = trimmedUrlString.addingPercentEncoding(withAllowedCharacters: .urlAllowed) else {
       return (nil, false)
     }
     var hasScheme = true


### PR DESCRIPTION
If the URL input in the Open URL window contains a trailing newline the open operation fails. This is a common scenario e.g. when selecting (triple clicking) and copying an entire line that only consists of an URL.

For some reason the Open URL window does not funnel its open URL operation through `PlayerCore.openURLString` which would have been my first guess as to where URL strings centrally get converted into `URL`s. Anyway, this fixes the problem with trailing newlines at least in that window. 

I am not aware if there are any other ways to open a URL. If there's e.g. dragging and dropping which isn't in turn funneled through the Open URL window routines (unlikely) then there would most likely still be a problem. That's out of scope for this PR.

- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.
