### PR TITLE
README: update mpv install instructions (no flag)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,9 +58,8 @@ $ brew install cocoapods
 1. Install mpv:
 
 ```console
-$ brew install mpv --with-uchardet
+$ brew install mpv
 ```
-Feel free to include your own copies of the other libraries if you'd like.
 
 2. Copy latest [header files](https://github.com/mpv-player/mpv/tree/master/libmpv) into `libmpv/include/mpv/`.
 


### PR DESCRIPTION
- [x] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**

Homebrew maintainer here. [Options are no longer supported](https://brew.sh/2019/02/02/homebrew-2.0.0/) in the main [`homebrew-core`](https://github.com/Homebrew/homebrew-core) formulae repo.

Running the current command would give `Error: invalid option: --with-uchardet`. It is [already included in the formula](https://github.com/Homebrew/homebrew-core/blob/a506f8508e40d47040698349ba95d7df06f34d75/Formula/mpv.rb#L27).