### PR TITLE
Prevent crash when adding mpv filter with no name

### DIFF
--- a/iina/Base.lproj/FilterWindowController.xib
+++ b/iina/Base.lproj/FilterWindowController.xib
@@ -211,6 +211,7 @@ Gw
         </window>
         <viewController id="bda-X5-kCJ" customClass="NewFilterSheetViewController" customModule="IINA" customModuleProvider="target">
             <connections>
+                <outlet property="addButton" destination="THV-Yh-VnK" id="GeO-qk-FbF"/>
                 <outlet property="filterWindow" destination="-2" id="Pjr-CT-nJA"/>
                 <outlet property="scrollContentView" destination="ZHP-RK-Ly4" id="NhJ-gL-sPY"/>
                 <outlet property="tableView" destination="n0t-vk-dME" id="IBk-xT-LkA"/>

--- a/iina/FilterWindowController.swift
+++ b/iina/FilterWindowController.swift
@@ -299,7 +299,8 @@ class NewFilterSheetViewController: NSViewController, NSTableViewDelegate, NSTab
   @IBOutlet weak var filterWindow: FilterWindowController!
   @IBOutlet weak var tableView: NSTableView!
   @IBOutlet weak var scrollContentView: NSView!
-
+  @IBOutlet weak var addButton: NSButton!
+  
   private var currentPreset: FilterPreset?
   private var currentBindings: [String: NSControl] = [:]
   private var presets: [FilterPreset] = []
@@ -333,6 +334,11 @@ class NewFilterSheetViewController: NSViewController, NSTableViewDelegate, NSTab
       self.scrollContentView.addSubview(self.quickLabel(yPos: maxY, title: preset.localizedParamName(name)))
       maxY += 21
       let input = self.quickInput(yPos: &maxY, param: param)
+      // For preventing crash due to adding a filter with no name:
+      if name == "name", preset.name.starts(with: "custom_"), let textField = input as? NSTextField {
+        textField.delegate = self
+        self.addButton.isEnabled = !textField.stringValue.isEmpty
+      }
       self.scrollContentView.addSubview(input)
       self.currentBindings[name] = input
     }
@@ -441,4 +447,13 @@ class NewFilterSheetViewController: NSViewController, NSTableViewDelegate, NSTab
     filterWindow.window!.endSheet(filterWindow.newFilterSheet, returnCode: .cancel)
   }
 
+}
+
+/* For preventing crash due to to adding filter with no name */
+extension NewFilterSheetViewController: NSTextFieldDelegate {
+  func controlTextDidChange(_ obj: Notification) {
+    if let textField = obj.object as? NSTextField {
+      self.addButton.isEnabled = !textField.stringValue.isEmpty
+    }
+  }
 }


### PR DESCRIPTION
- [x] This change has been discussed with the author.
- [x] It implements / fixes issue #2348.

---

**Description:**

Prevents crash when adding new custom MPV filter.  NewFilterSheet's add button is now disabled until the filter is given a name.

Changes to `NewFilterSheetViewController` (in `FilterWindowController.swift`):
1. new outlet "`addButton`"  in `NewFilterSheetViewController` that connects to `NewFilterSheet`'s add button
2. in `NewFilterSheetViewController.showSettings()`, check if quickInput is text field for name of custom filter and disable `addButton` if text field is empty
3. assign this `NSTextField's` delegate property to self
4. new extension to `NewFilterSheetViewController` in `FilterWindowController.swift` that implements `NSTexFieldDelegate: controlTextDidChange()` -- enables/disables add button if text/no-text
5. discarded all unintentional changes to` FilterWindowController.xib`, e.g., tools version, rect dimensions.  Leaving only:
 `<outlet property="addButton" destination="THV-Yh-VnK" id="GeO-qk-FbF"/>`