### PR TITLE
Refactor termination logic

### DIFF
--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - GRMustache.swift (2.0.0)
-  - GzipSwift (4.0.4)
+  - GzipSwift (4.1.0)
   - Just (0.7.1)
   - PromiseKit (6.8.3):
     - PromiseKit/CorePromise (= 6.8.3)
@@ -40,7 +40,7 @@ CHECKOUT OPTIONS:
 
 SPEC CHECKSUMS:
   GRMustache.swift: 53405b02c374520f9193cf41bfa677f03a6d70aa
-  GzipSwift: 1a5bc5f7827e09846b0635b5079f1224bc3b1c3a
+  GzipSwift: df1636fa095bd8f21d98db14e7393ecc9e230fed
   Just: 60c0995e04718eb621a07abef45ce6883c562f2b
   PromiseKit: 94c6e781838c5bf4717677d0d882b0e7250c80fc
   Sparkle: 1678d4707e7665960c7d1b43aca125e6392d11c4

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -263,7 +263,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
   func applicationWillTerminate(_ notification: Notification) {
     Logger.log("App will terminate")
-    PlayerCore.playerCores.forEach { $0.terminateMPV() }
+    PlayerCore.playerCores.forEach { $0.mpv.mpvQuit() }
     Logger.closeLogFile()
   }
 

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -251,9 +251,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
   func applicationShouldTerminate(_ sender: NSApplication) -> NSApplication.TerminateReply {
     guard !PlayerCore.active.mainWindow.isWindowHidden else { return .terminateCancel }
     Logger.log("App should terminate")
-    for pc in PlayerCore.playerCores {
-     pc.terminateMPV()
-    }
     return .terminateNow
   }
 
@@ -266,6 +263,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
   func applicationWillTerminate(_ notification: Notification) {
     Logger.log("App will terminate")
+    PlayerCore.playerCores.forEach { $0.terminateMPV() }
     Logger.closeLogFile()
   }
 

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -562,12 +562,16 @@ class MPVController: NSObject {
 
     switch eventId {
     case MPV_EVENT_SHUTDOWN:
-      if !player.isMpvTerminated {
-        PlayerCore.recycle(player)
-      } else {
-        mpv_destroy(mpv)
-        mpv = nil
+      guard !player.isMpvTerminated else { return }
+      player.savePlaybackPosition()
+      if player.mainWindow.isWindowLoaded {
+        DispatchQueue.main.sync {
+          self.player.mainWindow.close()
+        }
+        player.isMpvTerminated = true
       }
+      mpv_destroy(mpv)
+      mpv = nil
 
     case MPV_EVENT_LOG_MESSAGE:
       let dataOpaquePtr = OpaquePointer(event.pointee.data)

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -408,36 +408,43 @@ class MPVController: NSObject {
 
   // Set property
   func setFlag(_ name: String, _ flag: Bool) {
+    guard let _ = mpv else { return }
     var data: Int = flag ? 1 : 0
     mpv_set_property(mpv, name, MPV_FORMAT_FLAG, &data)
   }
 
   func setInt(_ name: String, _ value: Int) {
+    guard let _ = mpv else { return }
     var data = Int64(value)
     mpv_set_property(mpv, name, MPV_FORMAT_INT64, &data)
   }
 
   func setDouble(_ name: String, _ value: Double) {
+    guard let _ = mpv else { return }
     var data = value
     mpv_set_property(mpv, name, MPV_FORMAT_DOUBLE, &data)
   }
 
   func setFlagAsync(_ name: String, _ flag: Bool) {
+    guard let _ = mpv else { return }
     var data: Int = flag ? 1 : 0
     mpv_set_property_async(mpv, 0, name, MPV_FORMAT_FLAG, &data)
   }
 
   func setIntAsync(_ name: String, _ value: Int) {
+    guard let _ = mpv else { return }
     var data = Int64(value)
     mpv_set_property_async(mpv, 0, name, MPV_FORMAT_INT64, &data)
   }
 
   func setDoubleAsync(_ name: String, _ value: Double) {
+    guard let _ = mpv else { return }
     var data = value
     mpv_set_property_async(mpv, 0, name, MPV_FORMAT_DOUBLE, &data)
   }
 
   func setString(_ name: String, _ value: String) {
+    guard let _ = mpv else { return }
     mpv_set_property_string(mpv, name, value)
   }
 

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -359,6 +359,12 @@ class MPVController: NSObject {
     mpv_render_context_set_update_callback(mpvRenderContext!, mpvUpdateCallback, mutableRawPointerOf(obj: player.mainWindow.videoView.videoLayer))
   }
 
+  func mpvUninitRendering() {
+    guard let mpvRenderContext = mpvRenderContext else { return }
+    mpv_render_context_set_update_callback(mpvRenderContext, nil, nil)
+    mpv_render_context_free(mpvRenderContext)
+  }
+
   func mpvReportSwap() {
     guard let mpvRenderContext = mpvRenderContext else { return }
     mpv_render_context_report_swap(mpvRenderContext)

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -359,12 +359,6 @@ class MPVController: NSObject {
     mpv_render_context_set_update_callback(mpvRenderContext!, mpvUpdateCallback, mutableRawPointerOf(obj: player.mainWindow.videoView.videoLayer))
   }
 
-  func mpvUninitRendering() {
-    guard let mpvRenderContext = mpvRenderContext else { return }
-    mpv_render_context_set_update_callback(mpvRenderContext, nil, nil)
-    mpv_render_context_free(mpvRenderContext)
-  }
-
   func mpvReportSwap() {
     guard let mpvRenderContext = mpvRenderContext else { return }
     mpv_render_context_report_swap(mpvRenderContext)
@@ -562,9 +556,8 @@ class MPVController: NSObject {
 
     switch eventId {
     case MPV_EVENT_SHUTDOWN:
-      let quitByMPV = !player.isMpvTerminated
-      if quitByMPV {
-        NSApp.terminate(nil)
+      if !player.isMpvTerminated {
+        PlayerCore.recycle(player)
       } else {
         mpv_destroy(mpv)
         mpv = nil

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1283,6 +1283,9 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
     }
     // stop playing
     if !player.isMpvTerminated {
+      if case .fullscreen(legacy: true, priorWindowedFrame: let frame) = fsState {
+        legacyAnimateToWindowed(framePriorToBeingInFullscreen: frame)
+      }
       player.savePlaybackPosition()
       player.stop()
       videoView.stopDisplayLink()
@@ -1293,9 +1296,6 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
     guard let w = self.window, let cv = w.contentView else { return }
     cv.trackingAreas.forEach(cv.removeTrackingArea)
     playSlider.trackingAreas.forEach(playSlider.removeTrackingArea)
-    if case .fullscreen(legacy: true, priorWindowedFrame: let frame) = fsState {
-      legacyAnimateToWindowed(framePriorToBeingInFullscreen: frame)
-    }
   }
 
   // MARK: - Window delegate: Full screen

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -74,14 +74,6 @@ class PlayerCore: NSObject {
     return useNew ? newPlayerCore : active
   }
 
-  static func recycle(_ player: PlayerCore) {
-    player.terminateMPV(sendQuit: false)
-    DispatchQueue.main.async {
-      player.mainWindow.close()
-    }
-    playerCores.removeAll { $0 === player }
-  }
-
   // MARK: - Fields
 
   lazy var subsystem = Logger.Subsystem(rawValue: "player\(label!)")
@@ -316,23 +308,6 @@ class PlayerCore: NSObject {
     mainWindow.videoView.videoLayer.display()
     mpv.mpvInitRendering()
     mainWindow.videoView.startDisplayLink()
-  }
-
-  // Terminate mpv
-  func terminateMPV(sendQuit: Bool = true) {
-    guard !isMpvTerminated else { return }
-    savePlaybackPosition()
-    invalidateTimer()
-
-    if mainWindow.isWindowLoaded {
-      mainWindow.videoView.stopDisplayLink()
-      mainWindow.videoView.uninit()
-    }
-
-    if sendQuit {
-      mpv.mpvQuit()
-    }
-    isMpvTerminated = true
   }
 
   // invalidate timer

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -71,6 +71,17 @@ class VideoView: NSView {
     fatalError("init(coder:) has not been implemented")
   }
 
+  func uninit() {
+    uninitLock.lock()
+    guard !isUninited else {
+      uninitLock.unlock()
+      return
+    }
+    player.mpv.mpvUninitRendering()
+    isUninited = true
+    uninitLock.unlock()
+  }
+
   override func draw(_ dirtyRect: NSRect) {
     // do nothing
   }

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -71,23 +71,6 @@ class VideoView: NSView {
     fatalError("init(coder:) has not been implemented")
   }
 
-  func uninit() {
-    uninitLock.lock()
-
-    guard !isUninited else {
-      uninitLock.unlock()
-      return
-    }
-
-    player.mpv.mpvUninitRendering()
-    isUninited = true
-    uninitLock.unlock()
-  }
-
-  deinit {
-    uninit()
-  }
-
   override func draw(_ dirtyRect: NSRect) {
     // do nothing
   }

--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -118,7 +118,7 @@ class ViewLayer: CAOpenGLLayer {
     needsMPVRender = false
 
     videoView.uninitLock.lock()
-    
+
     guard !videoView.isUninited else {
       videoView.uninitLock.unlock()
       return

--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -118,7 +118,7 @@ class ViewLayer: CAOpenGLLayer {
     needsMPVRender = false
 
     videoView.uninitLock.lock()
-
+    
     guard !videoView.isUninited else {
       videoView.uninitLock.unlock()
       return


### PR DESCRIPTION
- [x] This change has been discussed with the author.
- [x] It implements / fixes issue #2396.

---

**Description:**
I revisited the the logic of termination, and refactor it a bit. Feel free to correct me if I have understood anything wrong.

In this PR:
-  An instance of mpv terminating will not cause the whole app exits. (e.g. press <kbd>Q</kbd>)
Previously when we get `MPV_EVENT_SHUTDOWN` and confirm that this is caused by mpv, we just terminate the app. Now we terminate the corresponding mpv instance, and remove the player from our reference list.
- Terminate all players during `applicationWillTerminate` instead of `applicationShouldTerminate`.
- Fixes #2396.
- Refactoring
**Original Logic:**
![Original](https://user-images.githubusercontent.com/20237141/55515732-e90ef000-5630-11e9-9c02-8a5f82c825d4.jpg)
**Revised Logic:** (Edited)
![Revised](https://user-images.githubusercontent.com/20237141/55575910-9cc9bb80-56d5-11e9-8679-93d90a7fd8c6.png)

- Remove `deinit` of `VideoView`.
I'm not sure about this one. I don't know when this `deinit` could be called. But I'm OK to revert this change back if anyone can explain it to me.