### PR TITLE
Fixed build instructions in README.md, updated script help text

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,10 +33,6 @@
 
 ## Building
 
-IINA ships with pre-compiled dynamic libraries for convenience reasons. If you aren't planning on modifying these libraries, you can follow the instructions below to build IINA; otherwise, skip down to [Building mpv manually](#building-mpv-manually) and then run the steps here:
-
-### Using the pre-compiled libraries
-
 1. IINA uses [CocoaPods](https://cocoapods.org) for managing the installation of third-party libraries. If you don't already have it installed, here's how you can do so:
 
 #### Using RubyGems
@@ -51,7 +47,13 @@ $ brew install cocoapods
 
 2. Run `pod install` in project's root directory.
 
-3. Open iina.xcworkspace in the [latest public version of Xcode](https://itunes.apple.com/us/app/xcode/id497799835). *IINA may not build if you use any other version.*
+IINA ships with pre-compiled dynamic libraries for convenience reasons. If you aren't planning on modifying these libraries, you can follow the instructions below to build IINA; otherwise, skip down to [Building mpv manually](#building-mpv-manually):
+
+### Using the pre-compiled libraries
+
+1. Open iina.xcworkspace in the [latest public version of Xcode](https://itunes.apple.com/us/app/xcode/id497799835). *IINA may not build if you use any other version.*
+
+2. Build the project.
 
 ### Building mpv manually
 
@@ -59,7 +61,7 @@ $ brew install cocoapods
 
 #### Homebrew
 
-Use our tap, since passes the correct flags during configuration:
+Use our tap as it passes in the correct flags to mpv's configure script:
 
 ```console
 $ brew tap iina/homebrew-mpv-iina
@@ -68,19 +70,37 @@ $ brew install mpv-iina
 
 #### MacPorts
 
-Pass in the flags when installing:
+Pass in these flags when installing:
 
 ```console
 # port install mpv +uchardet -bundle -rubberband configure.args="--enable-libmpv-shared --enable-lua --enable-libarchive --enable-libbluray --disable-swift --disable-rubberband" 
 ```
 
-2. Copy latest [header files](https://github.com/mpv-player/mpv/tree/master/libmpv) into `libmpv/include/mpv/`.
+2. Copy the latest [header files from mpv](https://github.com/mpv-player/mpv/tree/master/libmpv) (\*.h) into `deps/include/mpv/`.
 
 3. Run `other/parse_doc.rb`. This script will fetch the latest mpv documentation and generate `MPVOption.swift`, `MPVCommand.swift` and `MPVProperty.swift`. This is only needed when updating libmpv. Note that if the API changes, the player source code may also need to be changed.
 
-4. Run `other/change_lib_dependencies.rb`. This script will deploy the depended libraries into `libmpv/libs`. Once this is finished, go to Xcode and delete all of the dylibs from the Frameworks group in the sidebar and drag in your own from `libmpv/libs`; do the same in the "Embedded Binaries" section of the iina target.
+4. Run `other/change_lib_dependencies.rb`. This script will deploy the dependent libraries into `deps/libs`. If you're using a package manager to manage dependencies, invoke it like so:
 
-5. Run a fresh build in Xcode.
+#### Homebrew
+
+```console
+$ other/change_lib_dependencies.rb "$(brew --prefix)" "$(brew --prefix mpv-iina)/lib/libmpv.dylib"
+```
+
+#### MacPorts
+
+```console
+$ port contents mpv | grep '\.dylib$' | xargs other/change_lib_dependencies.rb /opt/local
+```
+
+5. Open iina.xcworkspace in the [latest public version of Xcode](https://itunes.apple.com/us/app/xcode/id497799835). *IINA may not build if you use any other version.* 
+
+6. Remove all of references to .dylib files from the Frameworks group in the sidebar and drag all the .dylib files in `deps/libs` to that group.
+
+7. Drag all the .dylib files in `deps/libs` into the "Embedded Binaries" section of the iina target.
+
+8. Build the project.
 
 ## Contributing
 

--- a/other/change_lib_dependencies.rb
+++ b/other/change_lib_dependencies.rb
@@ -58,10 +58,10 @@ if ARGV.length <= 1
   abort <<~END
     Usage: change_lib_dependencies.rb prefix libraries...
 
-    If you're using Homebrew, your invokation might look like this:
-      $ ./change_lib_dependencies.rb "$(brew --prefix)" "$(brew --prefix mpv)/lib/*.dylib"
+    If you're using Homebrew, your invocation might look like this:
+      $ ./change_lib_dependencies.rb "$(brew --prefix)" "$(brew --prefix mpv-iina)/lib/libmpv.dylib"
 
-    If you're using MacPorts, your invokcation might look like this:
+    If you're using MacPorts, your invocation might look like this:
       $ port contents mpv | grep '\.dylib$' | xargs ./change_lib_dependencies.rb /opt/local
   END
 end


### PR DESCRIPTION
Fixes:
- `README.md` references `libmpv/include/mpv/` when in reality it’s `deps/include/mpv/`
- `README.md` doesn’t mention running pod install when you’re manually adding libraries
- `README.md` has some misc typos
- `other/change_lib_dependencies.rb` references the wrong Homebrew package in its help text

Workarounds:
- Homebrew’s mpv-iina package produces libmpv.1.*.0.dylib without +w which breaks the script `other/change_lib_dependencies.rb` (Homebrew’s mpv package does have +w on that .dylib file), added a step in `README.md` to fix that

- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**
I've tried building IINA using the instructions in README.md and ran into several issues. This PR updates the instructions to better reflect the actual steps needed to build the project from scratch. I also fixed a few miscellaneous typos in `README.md` and `other/change_lib_dependencies.rb` and tweaked the instruction's flow a bit to make it more linear. 