### PR TITLE
Fixes MiniPlayer slider knob getting out of bounds at the end of track

### DIFF
--- a/iina/Base.lproj/MiniPlayerWindowController.xib
+++ b/iina/Base.lproj/MiniPlayerWindowController.xib
@@ -101,7 +101,7 @@
                             </textField>
                             <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="e3M-Ma-JJM">
                                 <rect key="frame" x="44" y="8" width="212" height="15"/>
-                                <sliderCell key="cell" controlSize="small" continuous="YES" refusesFirstResponder="YES" state="on" alignment="left" maxValue="100" doubleValue="50" tickMarkPosition="above" sliderType="linear" id="Y51-2C-Qcg" customClass="PlaySliderCell" customModule="IINA" customModuleProvider="target"/>
+                                <sliderCell key="cell" continuous="YES" refusesFirstResponder="YES" state="on" alignment="left" maxValue="100" doubleValue="50" tickMarkPosition="above" sliderType="linear" id="Y51-2C-Qcg" customClass="PlaySliderCell" customModule="IINA" customModuleProvider="target"/>
                                 <connections>
                                     <action selector="playSliderChanges:" target="-2" id="qdw-Jb-iyq"/>
                                 </connections>


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**
7975166 makes slider knob clip through at the end of track. PlaySliderCell control size should be changed from small to regular to mitigate this.
Before:
![Screenshot 2019-06-02 at 01 19 10](https://user-images.githubusercontent.com/16036254/58754593-6abdb580-84dc-11e9-81f6-4587c8548352.png)
After:
![Screenshot 2019-06-02 at 01 20 36](https://user-images.githubusercontent.com/16036254/58754594-6e513c80-84dc-11e9-95e7-f2a288fdcf01.png)

