### PR TITLE
Fixes videos opening over existing stream when launching from Safari

### DIFF
--- a/OpenInIINA/SafariExtensionHandler.swift
+++ b/OpenInIINA/SafariExtensionHandler.swift
@@ -53,7 +53,7 @@ class SafariExtensionHandler: SFSafariExtensionHandler {
 
   func launchIINA(withURL url: String) {
     guard let escapedURL = url.addingPercentEncoding(withAllowedCharacters: .alphanumerics),
-      let url = URL(string: "iina://weblink?url=\(escapedURL)") else {
+      let url = URL(string: "iina://weblink?url=\(escapedURL)&new_window=1") else {
         return
     }
     NSWorkspace.shared.open(url)


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #2472.

---

**Description:**
Opens videos in new window when launched from Safari, instead of opening them over existing stream.