### PR TITLE
Properly escape whitespace in change_lib_dependencies.rb

### DIFF
--- a/other/change_lib_dependencies.rb
+++ b/other/change_lib_dependencies.rb
@@ -22,7 +22,7 @@ class DylibFile
   end
 
   def parse_otool_L_output!
-    stdout, stderr, status = Open3.capture3("otool -L #{path}")
+    stdout, stderr, status = Open3.capture3("otool -L \"#{path}\"")
     abort(stderr) unless status.success?
     libs = stdout.split("\n")
     libs.shift # first line is the filename


### PR DESCRIPTION
Handle whitespace in path by surrounding it with double quotes

- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**
It's possible there's more than one place that need double quotes, I didn't check the whole document