### PR TITLE
Corrected language

### DIFF
--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -100,8 +100,8 @@
 
 "menu.seek_forward" = "Step Forward %.0fs";
 "menu.seek_backward" = "Step Backward %.0fs";
-"menu.speed_up" = "Speed Up to %.1fx";
-"menu.speed_down" = "Speed Down to %.1fx";
+"menu.speed_up" = "Speed Up by %.1fx";
+"menu.speed_down" = "Speed Down by %.1fx";
 "menu.volume_up" = "Volume + %.0f%%";
 "menu.volume_down" = "Volume - %.0f%%";
 "menu.audio_delay_up" = "Audio Delay + %.1fs";


### PR DESCRIPTION
Replaced "to" with "by" in "Speed up/down to", since that is the correct term. 

If the menu item in question (Speed up to 1.5x) is clicked the two times, the term "to" incorrectly tells the users that the speed will still just be 1.5x. If however the term is "by" (Speed up by 1.5x), the user is correctly made aware that the current speed will by sped up 1.5x.