### PR TITLE
Add more options to browser addon context menu

### DIFF
--- a/browser/Chrome_Open_In_IINA/background.js
+++ b/browser/Chrome_Open_In_IINA/background.js
@@ -11,4 +11,40 @@ updateBrowserAction();
             openInIINA(tab.id, info[linkType]);
         },
     });
+
+    chrome.contextMenus.create({
+        title: `Open this ${item} in fullscreen`,
+        id: `open${item}infullscreen`,
+        contexts: [item],
+        onclick: (info, tab) => {
+            openInIINA(tab.id, info[linkType], { mode: "fullScreen" });
+        },
+    });
+
+    chrome.contextMenus.create({
+        title: `Add this ${item} and enter picture-in-picture`,
+        id: `open${item}inpip`,
+        contexts: [item],
+        onclick: (info, tab) => {
+            openInIINA(tab.id, info[linkType], { mode: "pip" });
+        },
+    });
+
+    chrome.contextMenus.create({
+        title: `Open this ${item} in new IINA window`,
+        id: `open${item}innewwindow`,
+        contexts: [item],
+        onclick: (info, tab) => {
+            openInIINA(tab.id, info[linkType], { newWindow: true });
+        },
+    });
+
+    chrome.contextMenus.create({
+        title: `Add this ${item} to playlist`,
+        id: `add${item}toiinaplaylist`,
+        contexts: [item],
+        onclick: (info, tab) => {
+            openInIINA(tab.id, info[linkType], { mode: "enqueue" });
+        },
+    });
 });


### PR DESCRIPTION
Mimicks the toolbar button menu. No need to open a tab for each link just to enqueue a bunch of URLs.

Future improvement could include a setting to only show a single item in the context menu in order to avoid the submenu.

- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #2558

---