### PR TITLE
Improve the appearance of KeyRecordView on 10.15

### DIFF
--- a/iina/Base.lproj/KeyRecordViewController.xib
+++ b/iina/Base.lproj/KeyRecordViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14313.13.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14868" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14313.13.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14868"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -18,11 +18,11 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="480" height="156"/>
+            <rect key="frame" x="0.0" y="0.0" width="480" height="155"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="LZ8-DJ-i0e" customClass="KeyRecordView" customModule="IINA" customModuleProvider="target">
-                    <rect key="frame" x="0.0" y="110" width="480" height="46"/>
+                    <rect key="frame" x="0.0" y="109" width="480" height="46"/>
                     <subviews>
                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Jqj-WM-ez4">
                             <rect key="frame" x="-2" y="7" width="484" height="31"/>
@@ -53,31 +53,30 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Q4h-ui-SRm">
-                    <rect key="frame" x="-2" y="84" width="76" height="14"/>
+                    <rect key="frame" x="-2" y="83" width="76" height="14"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="14" id="bEJ-bs-24N"/>
                     </constraints>
                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Select action:" id="gSW-bE-4yF">
-                        <font key="font" metaFont="smallSystem"/>
+                        <font key="font" metaFont="message" size="11"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
                 <scrollView wantsLayer="YES" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="y9W-a9-7sk">
-                    <rect key="frame" x="0.0" y="55" width="480" height="25"/>
-                    <clipView key="contentView" copiesOnScroll="NO" id="it8-db-s5l">
-                        <rect key="frame" x="1" y="1" width="478" height="23"/>
+                    <rect key="frame" x="0.0" y="55" width="480" height="24"/>
+                    <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="it8-db-s5l">
+                        <rect key="frame" x="1" y="1" width="478" height="22"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <ruleEditor nestingMode="simple" rowHeight="24" id="aaj-fS-PWS">
-                                <rect key="frame" x="0.0" y="0.0" width="478" height="23"/>
+                                <rect key="frame" x="0.0" y="0.0" width="478" height="22"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             </ruleEditor>
                         </subviews>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </clipView>
                     <constraints>
-                        <constraint firstAttribute="height" constant="25" id="oKe-g6-ngE"/>
+                        <constraint firstAttribute="height" constant="24" id="oKe-g6-ngE"/>
                     </constraints>
                     <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="wdt-7b-vYv">
                         <rect key="frame" x="-100" y="-100" width="223" height="15"/>
@@ -94,7 +93,7 @@
                         <constraint firstAttribute="height" constant="14" id="HlN-0J-WTS"/>
                     </constraints>
                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Or enter mpv command:" id="xhd-tg-xTO">
-                        <font key="font" metaFont="smallSystem"/>
+                        <font key="font" metaFont="message" size="11"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>

--- a/iina/Base.lproj/KeyRecordViewController.xib
+++ b/iina/Base.lproj/KeyRecordViewController.xib
@@ -31,6 +31,9 @@
                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                             </textFieldCell>
+                            <connections>
+                                <outlet property="delegate" destination="-2" id="Owg-ud-gCI"/>
+                            </connections>
                         </textField>
                     </subviews>
                     <constraints>
@@ -51,6 +54,9 @@
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
+                    <connections>
+                        <outlet property="delegate" destination="-2" id="KCO-hs-Ur3"/>
+                    </connections>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Q4h-ui-SRm">
                     <rect key="frame" x="-2" y="83" width="76" height="14"/>
@@ -58,7 +64,7 @@
                         <constraint firstAttribute="height" constant="14" id="bEJ-bs-24N"/>
                     </constraints>
                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Select action:" id="gSW-bE-4yF">
-                        <font key="font" metaFont="message" size="11"/>
+                        <font key="font" metaFont="controlContent" size="11"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
@@ -93,7 +99,7 @@
                         <constraint firstAttribute="height" constant="14" id="HlN-0J-WTS"/>
                     </constraints>
                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Or enter mpv command:" id="xhd-tg-xTO">
-                        <font key="font" metaFont="message" size="11"/>
+                        <font key="font" metaFont="controlContent" size="11"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>

--- a/iina/KeyRecordView.swift
+++ b/iina/KeyRecordView.swift
@@ -64,12 +64,18 @@ class KeyRecordView: NSView {
   }
 
   override func resignFirstResponder() -> Bool {
+    let saved = NSAppearance.current
+    NSAppearance.current = self.effectiveAppearance
     layer?.backgroundColor = NSColor.keyRecordViewBackground.cgColor
+    NSAppearance.current = saved
     return true
   }
 
   override func becomeFirstResponder() -> Bool {
+    let saved = NSAppearance.current
+    NSAppearance.current = self.effectiveAppearance
     layer?.backgroundColor = NSColor.keyRecordViewBackgroundActive.cgColor
+    NSAppearance.current = saved
     return true
   }
 

--- a/iina/KeyRecordViewController.swift
+++ b/iina/KeyRecordViewController.swift
@@ -8,7 +8,7 @@
 
 import Cocoa
 
-class KeyRecordViewController: NSViewController, KeyRecordViewDelegate, NSRuleEditorDelegate {
+class KeyRecordViewController: NSViewController, KeyRecordViewDelegate, NSRuleEditorDelegate, NSTextFieldDelegate {
 
   @IBOutlet weak var keyRecordView: KeyRecordView!
   @IBOutlet weak var keyLabel: NSTextField!
@@ -19,6 +19,8 @@ class KeyRecordViewController: NSViewController, KeyRecordViewDelegate, NSRuleEd
 
   private var pendingKey: String?
   private var pendingAction: String?
+
+  @objc dynamic var ready = false
 
   var keyCode: String {
     get {
@@ -55,6 +57,9 @@ class KeyRecordViewController: NSViewController, KeyRecordViewDelegate, NSRuleEd
     ruleEditor.delegate = self
     ruleEditor.addRow(self)
 
+    keyLabel.delegate = self
+    actionTextField.delegate = self
+
     if let pk = pendingKey {
       keyLabel.stringValue = pk
       pendingKey = nil
@@ -71,6 +76,7 @@ class KeyRecordViewController: NSViewController, KeyRecordViewDelegate, NSRuleEd
 
   func keyRecordView(_ view: KeyRecordView, recordedKeyDownWith event: NSEvent) {
     keyLabel.stringValue = KeyCodeHelper.mpvKeyCode(from: event)
+    NotificationCenter.default.post(.init(name: NSControl.textDidChangeNotification, object: keyLabel))
   }
 
   // MARK: - NSRuleEditorDelegate
@@ -112,6 +118,7 @@ class KeyRecordViewController: NSViewController, KeyRecordViewDelegate, NSRuleEd
     default:
       break
     }
+    NotificationCenter.default.post(.init(name: NSControl.textDidChangeNotification, object: keyLabel))
   }
 
   // MARK: - Other
@@ -119,7 +126,11 @@ class KeyRecordViewController: NSViewController, KeyRecordViewDelegate, NSRuleEd
   private func updateCommandField() {
     guard let criterions = ruleEditor.criteria(forRow: 0) as? [Criterion] else { return }
     actionTextField.stringValue = KeyBindingTranslator.string(fromCriteria: criterions)
+    NotificationCenter.default.post(.init(name: NSControl.textDidChangeNotification, object: actionTextField))
   }
 
+  func controlTextDidChange(_ obj: Notification) {
+    ready = !keyCode.isEmpty && !action.isEmpty
+  }
 }
 

--- a/iina/PrefKeyBindingViewController.swift
+++ b/iina/PrefKeyBindingViewController.swift
@@ -124,7 +124,8 @@ class PrefKeyBindingViewController: NSViewController, PreferenceWindowEmbeddable
     panel.informativeText = NSLocalizedString("keymapping.message", comment: "Press any key to record.")
     panel.accessoryView = keyRecordViewController.view
     panel.window.initialFirstResponder = keyRecordViewController.keyRecordView
-    panel.addButton(withTitle: NSLocalizedString("general.ok", comment: "OK"))
+    let okButton = panel.addButton(withTitle: NSLocalizedString("general.ok", comment: "OK"))
+    okButton.cell!.bind(.enabled, to: keyRecordViewController, withKeyPath: "ready", options: nil)
     panel.addButton(withTitle: NSLocalizedString("general.cancel", comment: "Cancel"))
     panel.beginSheetModal(for: view.window!) { respond in
       if respond == .alertFirstButtonReturn {


### PR DESCRIPTION
- The rule editor does not draw background anymore
- Reduced the height of the rule editor by 1, otherwise, the upper padding and the lower padding would be different
- Make the OK button disabled when there is no action or keycode
- Fix the key record view isn't colored correctly when changing the system appearance

**Visual Changes**
Before:
<img width="588" alt="Before" src="https://user-images.githubusercontent.com/20237141/66413839-ceda1400-e9bd-11e9-9397-0992a00a63b2.png">

After:
<img width="585" alt="After" src="https://user-images.githubusercontent.com/20237141/66413843-d1d50480-e9bd-11e9-86d7-980719612ce9.png">
