### PR TITLE
Fix NSApplication.terminate(_:) must be used from main thread only.

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -564,7 +564,9 @@ class MPVController: NSObject {
     case MPV_EVENT_SHUTDOWN:
       let quitByMPV = !player.isMpvTerminated
       if quitByMPV {
-        NSApp.terminate(nil)
+        DispatchQueue.main.async {
+          NSApp.terminate(nil)
+        }
       } else {
         mpv_destroy(mpv)
         mpv = nil


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**
```
=================================================================
Main Thread Checker: UI API called on a background thread: -[NSApplication terminate:]
PID: 15306, TID: 3660579, Thread name: (none), Queue name: com.colliderli.iina.controller, QoS: 25
Backtrace:
4   IINA                                0x000000010042855a $s4IINA13MPVControllerC11handleEvent33_AA8C985EFDB89116DD68AB87EEE66A73LLyySPySo9mpv_eventVGSgF + 1642
5   IINA                                0x0000000100427ed0 $s4IINA13MPVControllerC10readEvents33_AA8C985EFDB89116DD68AB87EEE66A73LLyyFyycfU_ + 400
6   IINA                                0x000000010002ce6d $sIeg_IeyB_TR + 45
7   libdispatch.dylib                   0x00000001045dd7b3 _dispatch_call_block_and_release + 12
8   libdispatch.dylib                   0x00000001045de78f _dispatch_client_callout + 8
9   libdispatch.dylib                   0x00000001045e5d31 _dispatch_lane_serial_drain + 777
10  libdispatch.dylib                   0x00000001045e6ae8 _dispatch_lane_invoke + 438
11  libdispatch.dylib                   0x00000001045f3f2e _dispatch_workloop_worker_thread + 681
12  libsystem_pthread.dylib             0x000000010466a02c _pthread_wqthread + 290
13  libsystem_pthread.dylib             0x0000000104669157 start_wqthread + 15
2019-12-19 15:44:06.712766+0800 IINA[15306:3660579] [reports] Main Thread Checker: UI API called on a background thread: -[NSApplication terminate:]
PID: 15306, TID: 3660579, Thread name: (none), Queue name: com.colliderli.iina.controller, QoS: 25
Backtrace:
4   IINA                                0x000000010042855a $s4IINA13MPVControllerC11handleEvent33_AA8C985EFDB89116DD68AB87EEE66A73LLyySPySo9mpv_eventVGSgF + 1642
5   IINA                                0x0000000100427ed0 $s4IINA13MPVControllerC10readEvents33_AA8C985EFDB89116DD68AB87EEE66A73LLyyFyycfU_ + 400
6   IINA                                0x000000010002ce6d $sIeg_IeyB_TR + 45
7   libdispatch.dylib                   0x00000001045dd7b3 _dispatch_call_block_and_release + 12
8   libdispatch.dylib                   0x00000001045de78f _dispatch_client_callout + 8
9   libdispatch.dylib                   0x00000001045e5d31 _dispatch_lane_serial_drain + 777
10  libdispatch.dylib                   0x00000001045e6ae8 _dispatch_lane_invoke + 438
11  libdispatch.dylib                   0x00000001045f3f2e _dispatch_workloop_worker_thread + 681
12  libsystem_pthread.dylib             0x000000010466a02c _pthread_wqthread + 290
13  libsystem_pthread.dylib             0x0000000104669157 start_wqthread + 15

```