### PR TITLE
Fix logger date format

### DIFF
--- a/iina/Logger.swift
+++ b/iina/Logger.swift
@@ -46,7 +46,7 @@ struct Logger {
 
   static let logDirectory: URL = {
     let formatter = DateFormatter()
-    formatter.dateFormat = "YYYY-MM-dd-HH-mm-ss"
+    formatter.dateFormat = "yyyy-MM-dd-HH-mm-ss"
     let timeString  = formatter.string(from: Date())
     let token = Utility.ShortCodeGenerator.getCode(length: 6)
     let sessionDirName = "\(timeString)_\(token)"


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**

Currently, a log directory for 2020-12-29 is created for the current date (December 29, 2019), which is incorrect. Use yyyy instead of YYYY to get the actual calendar year (instead of the week-based year). 