### PR TITLE
Pause resume refactor

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -554,15 +554,15 @@ class RemoteCommandController {
 
   static func setup() {
     remoteCommand.playCommand.addTarget { _ in
-      PlayerCore.lastActive.togglePause(false)
+      PlayerCore.lastActive.resume()
       return .success
     }
     remoteCommand.pauseCommand.addTarget { _ in
-      PlayerCore.lastActive.togglePause(true)
+      PlayerCore.lastActive.pause()
       return .success
     }
     remoteCommand.togglePlayPauseCommand.addTarget { _ in
-      PlayerCore.lastActive.togglePause(nil)
+      PlayerCore.lastActive.togglePause()
       return .success
     }
     remoteCommand.stopCommand.addTarget { _ in

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -75,7 +75,7 @@ class MainMenuActionHandler: NSResponder {
 
 extension MainMenuActionHandler {
   @objc func menuTogglePause(_ sender: NSMenuItem) {
-    player.togglePause(!player.info.isPaused)
+    player.togglePause()
   }
 
   @objc func menuStop(_ sender: NSMenuItem) {
@@ -94,7 +94,7 @@ extension MainMenuActionHandler {
 
   @objc func menuStepFrame(_ sender: NSMenuItem) {
     if !player.info.isPaused {
-      player.togglePause(true)
+      player.pause()
     }
     if sender.tag == 0 { // -> 1f
       player.frameStep(backwards: false)

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -93,7 +93,7 @@ extension MainMenuActionHandler {
   }
 
   @objc func menuStepFrame(_ sender: NSMenuItem) {
-    if !player.info.isPaused {
+    if player.info.isPlaying {
       player.pause()
     }
     if sender.tag == 0 { // -> 1f

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -700,7 +700,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
 
     NSWorkspace.shared.notificationCenter.addObserver(forName: NSWorkspace.willSleepNotification, object: nil, queue: nil, using: { [unowned self] _ in
       if Preference.bool(for: .pauseWhenGoesToSleep) {
-        self.player.togglePause(true)
+        self.player.pause()
       }
     })
   }
@@ -1058,7 +1058,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
     case .fullscreen:
       toggleWindowFullScreen()
     case .pause:
-      player.togglePause(nil)
+      player.togglePause()
     case .hideOSC:
       hideUI()
     }
@@ -1158,14 +1158,14 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
       // record pause status
       wasPlayingWhenSeekBegan = !player.info.isPaused
       if wasPlayingWhenSeekBegan! {
-        player.togglePause(true)
+        player.pause()
       }
     }
 
     if isTrackpadEnd && wasPlayingWhenSeekBegan != nil {
       // only resume playback when it was playing when began
       if wasPlayingWhenSeekBegan! {
-        player.togglePause(false)
+        player.resume()
       }
       wasPlayingWhenSeekBegan = nil
     }
@@ -1397,7 +1397,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
     }
 
     if Preference.bool(for: .playWhenEnteringFullScreen) && player.info.isPaused {
-      player.togglePause(false)
+      player.resume()
     }
 
     if #available(macOS 10.12.2, *) {
@@ -1459,7 +1459,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
     }
 
     if Preference.bool(for: .pauseWhenLeavingFullScreen) && !player.info.isPaused {
-      player.togglePause(true)
+      player.pause()
     }
 
     if #available(macOS 10.12.2, *) {
@@ -1579,7 +1579,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
   func windowDidBecomeKey(_ notification: Notification) {
     window!.makeFirstResponder(window!)
     if Preference.bool(for: .pauseWhenInactive) && isPausedDueToInactive {
-      player.togglePause(false)
+      player.resume()
       isPausedDueToInactive = false
     }
   }
@@ -1591,7 +1591,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
       (NSApp.keyWindow?.windowController is MainWindowController ||
         (NSApp.keyWindow?.windowController is MiniPlayerWindowController && NSApp.keyWindow?.windowController != player.miniPlayer)) {
       if Preference.bool(for: .pauseWhenInactive), !player.info.isPaused {
-        player.togglePause(true)
+        player.pause()
         isPausedDueToInactive = true
       }
     }
@@ -1618,7 +1618,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
   func windowWillMiniaturize(_ notification: Notification) {
     if Preference.bool(for: .pauseWhenMinimized), !player.info.isPaused {
       isPausedDueToMiniaturization = true
-      player.togglePause(true)
+      player.pause()
     }
   }
   
@@ -1632,7 +1632,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
 
   func windowDidDeminiaturize(_ notification: Notification) {
     if Preference.bool(for: .pauseWhenMinimized) && isPausedDueToMiniaturization {
-      player.togglePause(false)
+      player.resume()
       isPausedDueToMiniaturization = false
     }
     if Preference.bool(for: .togglePipByMinimizingWindow) && !isWindowMiniaturizedDueToPip {
@@ -1952,7 +1952,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
       return
     }
 
-    player.togglePause(true)
+    player.pause()
     isInInteractiveMode = true
     hideUI()
 
@@ -2032,7 +2032,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
   func exitInteractiveMode(immediately: Bool = false, then: @escaping () -> Void = {}) {
     window?.backgroundColor = .black
 
-    player.togglePause(false)
+    player.resume()
     isInInteractiveMode = false
     cropSettingsView?.cropBoxView.isHidden = true
 
@@ -2523,10 +2523,10 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
   /** Play button: pause & resume */
   @IBAction func playButtonAction(_ sender: NSButton) {
     if sender.state == .on {
-      player.togglePause(false)
+      player.resume()
     }
     if sender.state == .off {
-      player.togglePause(true)
+      player.pause()
       // speed is already reset by playerCore
       speedValueIndex = AppData.availableSpeedValues.count / 2
       leftArrowLabel.isHidden = true
@@ -2644,7 +2644,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
       // if is paused
       if playButton.state == .off {
         updatePlayButtonState(.on)
-        player.togglePause(false)
+        player.resume()
       }
 
     case .playlist:
@@ -2852,7 +2852,7 @@ extension MainWindowController: PIPViewControllerDelegate {
         break
       }
       if Preference.bool(for: .pauseWhenPip) {
-        player.togglePause(true)
+        player.pause()
       }
     }
   }
@@ -2921,16 +2921,16 @@ extension MainWindowController: PIPViewControllerDelegate {
   }
 
   func pipActionPlay(_ pip: PIPViewController) {
-    player.togglePause(false)
+    player.resume()
   }
 
   func pipActionPause(_ pip: PIPViewController) {
-    player.togglePause(true)
+    player.pause()
   }
 
   func pipActionStop(_ pip: PIPViewController) {
     // Stopping PIP pauses playback
-    player.togglePause(true)
+    player.pause()
   }
 }
 

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -428,7 +428,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
 
     case PK.alwaysFloatOnTop.rawValue:
       if let newValue = change[.newKey] as? Bool {
-        if !player.info.isPaused {
+        if player.info.isPlaying {
           self.isOntop = newValue
           setWindowFloatingOnTop(newValue)
         }
@@ -1156,7 +1156,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
 
     if scrollAction == .seek && isTrackpadBegan {
       // record pause status
-      wasPlayingWhenSeekBegan = !player.info.isPaused
+      wasPlayingWhenSeekBegan = player.info.isPlaying
       if wasPlayingWhenSeekBegan! {
         player.pause()
       }
@@ -1458,7 +1458,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
       removeBlackWindow()
     }
 
-    if Preference.bool(for: .pauseWhenLeavingFullScreen) && !player.info.isPaused {
+    if Preference.bool(for: .pauseWhenLeavingFullScreen) && player.info.isPlaying {
       player.pause()
     }
 
@@ -1467,7 +1467,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
     }
 
     // restore ontop status
-    if !player.info.isPaused {
+    if player.info.isPlaying {
       setWindowFloatingOnTop(isOntop)
     }
 
@@ -1590,7 +1590,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
     if NSApp.keyWindow == nil ||
       (NSApp.keyWindow?.windowController is MainWindowController ||
         (NSApp.keyWindow?.windowController is MiniPlayerWindowController && NSApp.keyWindow?.windowController != player.miniPlayer)) {
-      if Preference.bool(for: .pauseWhenInactive), !player.info.isPaused {
+      if Preference.bool(for: .pauseWhenInactive), player.info.isPlaying {
         player.pause()
         isPausedDueToInactive = true
       }
@@ -1616,7 +1616,7 @@ class MainWindowController: NSWindowController, NSWindowDelegate {
   }
 
   func windowWillMiniaturize(_ notification: Notification) {
-    if Preference.bool(for: .pauseWhenMinimized), !player.info.isPaused {
+    if Preference.bool(for: .pauseWhenMinimized), player.info.isPlaying {
       isPausedDueToMiniaturization = true
       player.pause()
     }
@@ -2824,7 +2824,7 @@ extension MainWindowController: PIPViewControllerDelegate {
 
     pipVideo = NSViewController()
     pipVideo.view = videoView
-    pip.playing = !player.info.isPaused
+    pip.playing = player.info.isPlaying
     pip.title = window?.title
 
     pip.presentAsPicture(inPicture: pipVideo)

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -472,11 +472,7 @@ class MiniPlayerWindowController: NSWindowController, NSWindowDelegate, NSPopove
   }
 
   @IBAction func playBtnAction(_ sender: NSButton) {
-    if player.info.isPaused {
-      player.togglePause(false)
-    } else {
-      player.togglePause(true)
-    }
+    player.info.isPaused ? player.resume() : player.pause()
   }
 
   @IBAction func nextBtnAction(_ sender: NSButton) {

--- a/iina/PlaySliderCell.swift
+++ b/iina/PlaySliderCell.swift
@@ -214,7 +214,7 @@ class PlaySliderCell: NSSliderCell {
     isPausedBeforeSeeking = playerCore.info.isPaused
     let result = super.startTracking(at: startPoint, in: controlView)
     if result {
-      playerCore.togglePause(true)
+      playerCore.pause()
       playerCore.mainWindow.thumbnailPeekView.isHidden = true
     }
     return result
@@ -222,7 +222,7 @@ class PlaySliderCell: NSSliderCell {
 
   override func stopTracking(last lastPoint: NSPoint, current stopPoint: NSPoint, in controlView: NSView, mouseIsUp flag: Bool) {
     if !isPausedBeforeSeeking {
-      playerCore.togglePause(false)
+      playerCore.resume()
     }
     super.stopTracking(last: lastPoint, current: stopPoint, in: controlView, mouseIsUp: flag)
   }

--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -56,6 +56,7 @@ class PlaybackInfo {
   }
 
   var isSeeking: Bool = false
+
   var isPaused: Bool = false {
     didSet {
       PlayerCore.checkStatusForSleep()
@@ -64,9 +65,17 @@ class PlaybackInfo {
           NowPlayingInfoManager.updateState(isPaused ? .paused : .playing)
         }
         if #available(macOS 10.12, *), player.mainWindow.pipStatus == .inPIP {
-          player.mainWindow.pip.playing = !isPaused
+          player.mainWindow.pip.playing = isPlaying
         }
       }
+    }
+  }
+  var isPlaying: Bool {
+    get {
+      return !isPaused
+    }
+    set {
+      isPaused = !newValue
     }
   }
 

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1603,7 +1603,7 @@ class PlayerCore: NSObject {
 
   static func checkStatusForSleep() {
     for player in playing {
-      if !player.info.isPaused {
+      if player.info.isPlaying {
         SleepPreventer.preventSleep()
         return
       }

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -436,26 +436,20 @@ class PlayerCore: NSObject {
 
   // MARK: - MPV commands
 
-  /** Pause / resume. Reset speed to 0 when pause. */
-  func togglePause(_ set: Bool?) {
-    if let setPause = set {
-      // if paused by EOF, replay the video.
-      if !setPause {
-        if mpv.getFlag(MPVProperty.eofReached) {
-          seek(absoluteSecond: 0)
-        }
-      }
-      mpv.setFlag(MPVOption.PlaybackControl.pause, setPause)
-    } else {
-      if (info.isPaused) {
-        if mpv.getFlag(MPVProperty.eofReached) {
-          seek(absoluteSecond: 0)
-        }
-        mpv.setFlag(MPVOption.PlaybackControl.pause, false)
-      } else {
-        mpv.setFlag(MPVOption.PlaybackControl.pause, true)
-      }
+  func togglePause(_ set: Bool? = nil) {
+    info.isPaused ? resume() : pause()
+  }
+  
+  func pause() {
+    mpv.setFlag(MPVOption.PlaybackControl.pause, true)
+  }
+  
+  func resume() {
+    // Restart playback when reached EOF
+    if mpv.getFlag(MPVProperty.eofReached) {
+      seek(absoluteSecond: 0)
     }
+    mpv.setFlag(MPVOption.PlaybackControl.pause, false)
   }
 
   func stop() {
@@ -801,7 +795,7 @@ class PlayerCore: NSObject {
   func playChapter(_ pos: Int) {
     let chapter = info.chapters[pos]
     mpv.command(.seek, args: ["\(chapter.time.second)", "absolute"])
-    togglePause(false)
+    resume()
     // need to update time pos
     syncUITime()
   }

--- a/iina/TouchBarSupport.swift
+++ b/iina/TouchBarSupport.swift
@@ -173,7 +173,7 @@ class TouchBarSupport: NSObject, NSTouchBarDelegate {
   }
 
   @objc func touchBarPlayBtnAction(_ sender: NSButton) {
-    player.togglePause(nil)
+    player.togglePause()
   }
 
   @objc func touchBarVolumeAction(_ sender: NSButton) {
@@ -273,13 +273,13 @@ class TouchBarPlaySlider: NSSlider {
 
   override func touchesBegan(with event: NSEvent) {
     isTouching = true
-    playerCore.togglePause(true)
+    playerCore.pause()
     super.touchesBegan(with: event)
   }
 
   override func touchesEnded(with event: NSEvent) {
     isTouching = false
-    playerCore.togglePause(false)
+    playerCore.resume()
     super.touchesEnded(with: event)
   }
 


### PR DESCRIPTION
- Split `togglePause(_)` into `togglePause()`, `pause()` and `resume()`
- Provide `PlayerCore.info.isPlaying`, which is calcuated from isPaused