### PR TITLE
Double-click online subtitle to download it

### DIFF
--- a/iina/SubChooseViewController.swift
+++ b/iina/SubChooseViewController.swift
@@ -45,6 +45,10 @@ class SubChooseViewController: NSViewController {
 
     tableView.delegate = self
     tableView.dataSource = self
+
+    // Download subtitle when table view row is double clicked
+    tableView.target = self
+    tableView.doubleAction = #selector(downloadBtnAction(_:))
   }
 
   @IBAction func downloadBtnAction(_ sender: Any) {


### PR DESCRIPTION
Allows user to double-click on an online subtitle to download it immediately rather than having to select it then move the mouse to click the download button.