### PR TITLE
Fix subtitle border width option in quick settings

### DIFF
--- a/iina/QuickSettingViewController.swift
+++ b/iina/QuickSettingViewController.swift
@@ -707,10 +707,8 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
   }
 
   @IBAction func subTextSizeAction(_ sender: AnyObject) {
-    if let selectedItem = subTextSizePopUp.selectedItem {
-      if let value = Double(selectedItem.title) {
-        player.setSubTextSize(value)
-      }
+    if let selectedItem = subTextSizePopUp.selectedItem, let value = Double(selectedItem.title) {
+      player.setSubTextSize(value)
     }
   }
 
@@ -719,7 +717,7 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
   }
 
   @IBAction func subTextBorderWidthAction(_ sender: AnyObject) {
-    if let value = Double(subTextBorderWidthPopUp.stringValue) {
+    if let selectedItem = subTextBorderWidthPopUp.selectedItem, let value = Double(selectedItem.title) {
       player.setSubTextBorderSize(value)
     }
   }


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

Trying to set subtitle border width in the quick settings gets it stuck at 1, this hooks it up to use the correct selected value.