### PR TITLE
Prevent subtitles from being matched twice. fix #2687

### DIFF
--- a/iina/AutoFileMatcher.swift
+++ b/iina/AutoFileMatcher.swift
@@ -227,7 +227,7 @@ class AutoFileMatcher {
       if subAutoLoadOption.shouldLoadSubsContainingVideoName() {
         Logger.log("Matching subtitles containing video name...", level: .verbose, subsystem: subsystem)
         try subtitles.filter {
-          return $0.filename.contains(video.filename)
+          $0.filename.contains(video.filename) && !$0.isMatched
         }.forEach { sub in
           try checkTicket()
           Logger.log("Matched \(sub.filename) and \(video.filename)", level: .verbose, subsystem: subsystem)


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #2687.

---

**Description:**
One subtitle will be used in`subAutoLoadOption.shouldLoadSubsMatchedByIINA()` and `subAutoLoadOption.shouldLoadSubsContainingVideoName()` at the same time.