### PR TITLE
Fix toggling saved audio filters (#2729)

### DIFF
--- a/iina/FilterWindowController.swift
+++ b/iina/FilterWindowController.swift
@@ -164,19 +164,34 @@ class FilterWindowController: NSWindowController, NSWindowDelegate {
     saveFilter(filters[row])
   }
 
+  /// User activates or deactivates previously saved audio or video filter
+  /// - Parameter sender: A checkbox in lower portion of filter window
   @IBAction func toggleSavedFilterAction(_ sender: NSButton) {
     let row = savedFiltersTableView.row(for: sender)
-    let filter = savedFilters[row]
+    let savedFilter = savedFilters[row]
     let pc = PlayerCore.active
-    if sender.state == .on {
-      if pc.addVideoFilter(MPVFilter(rawString: filter.filterString)!) {
-        pc.sendOSD(.addFilter(filter.name))
-      }
+
+    // choose approriate add/remove functions for .af/.vf
+    var addFilterFunction: (MPVFilter) -> Bool
+    var removeFilterFunction: (MPVFilter) -> Bool
+    if filterType == MPVProperty.vf {
+      addFilterFunction = pc.addVideoFilter
+      removeFilterFunction = pc.removeVideoFilter
     } else {
-      if pc.removeVideoFilter(MPVFilter(rawString: filter.filterString)!) {
+      addFilterFunction = pc.addAudioFilter(_:)
+      removeFilterFunction = pc.removeAudioFilter
+    }
+
+    if sender.state == .on {  // user activated filter
+      if addFilterFunction(MPVFilter(rawString: savedFilter.filterString)!) {
+        pc.sendOSD(.addFilter(savedFilter.name))
+      }
+    } else {  // user deactivated filter
+      if removeFilterFunction(MPVFilter(rawString: savedFilter.filterString)!) {
         pc.sendOSD(.removeFilter)
       }
     }
+
     reloadTable()
   }
 


### PR DESCRIPTION
Rewrote "toggleSavedFilterAction" IBAction in FilterWindowController.swift.
* It was calling playercore.addVideoFilter or removeVideoFilter for
audio filters as well as video filters.

- [ ] This change has been discussed with the author.
- [ x] It implements / fixes issue #2729 .

---

**Description:**
