### PR TITLE
Fix various issue regarding window size in music mode

### DIFF
--- a/iina/AppData.swift
+++ b/iina/AppData.swift
@@ -55,8 +55,8 @@ struct AppData {
   static let chromeExtensionLink = "https://chrome.google.com/webstore/detail/open-in-iina/pdnojahnhpgmdhjdhgphgdcecehkbhfo"
   static let firefoxExtensionLink = "https://addons.mozilla.org/addon/open-in-iina-x"
 
-  static let widthWhenNoVideo = 480
-  static let heightWhenNoVideo = 480
+  static let widthWhenNoVideo = 640
+  static let heightWhenNoVideo = 400
   static let sizeWhenNoVideo = NSSize(width: widthWhenNoVideo, height: heightWhenNoVideo)
 }
 

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -717,7 +717,9 @@ class MPVController: NSObject {
       // video size changed
       player.info.displayWidth = dwidth
       player.info.displayHeight = dheight
-      player.notifyMainWindowVideoSizeChanged()
+      DispatchQueue.main.sync {
+        player.notifyMainWindowVideoSizeChanged()
+      }
     }
   }
 

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -395,8 +395,8 @@ class MiniPlayerWindowController: NSWindowController, NSWindowDelegate, NSPopove
   func updateVideoSize() {
     guard let window = window else { return }
     let videoView = player.mainWindow.videoView
-    let (width, height) = player.videoSizeForDisplay
-    let aspect = CGFloat(width) / CGFloat(height)
+    let (width, height) = player.originalVideoSize
+    let aspect = width == 0 || height == 0 ? 1 : CGFloat(width) / CGFloat(height)
     let currentHeight = videoView.frame.height
     let newHeight = videoView.frame.width / aspect
     updateVideoViewAspectConstraint(withAspect: aspect)

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -396,7 +396,7 @@ class MiniPlayerWindowController: NSWindowController, NSWindowDelegate, NSPopove
     guard let window = window else { return }
     let videoView = player.mainWindow.videoView
     let (width, height) = player.originalVideoSize
-    let aspect = width == 0 || height == 0 ? 1 : CGFloat(width) / CGFloat(height)
+    let aspect = (width == 0 || height == 0) ? 1 : CGFloat(width) / CGFloat(height)
     let currentHeight = videoView.frame.height
     let newHeight = videoView.frame.width / aspect
     updateVideoViewAspectConstraint(withAspect: aspect)

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -365,11 +365,11 @@ class PlayerCore: NSObject {
     Utility.quickConstraints(["H:|[v]|", "V:|[v]|"], ["v": videoView])
 
     let (width, height) = originalVideoSize
-    let aspect = width == 0 || height == 0 ? 1 : CGFloat(width) / CGFloat(height)
+    let aspect = (width == 0 || height == 0) ? 1 : CGFloat(width) / CGFloat(height)
     miniPlayer.updateVideoViewAspectConstraint(withAspect: aspect)
 
     // if received video size before switching to music mode, hide default album art
-    if !info.videoTracks.isEmpty {
+    if info.vid != 0 {
       miniPlayer.defaultAlbumArt.isHidden = true
     }
     // in case of video size changed, reset mini player window size if playlist is folded
@@ -1061,8 +1061,12 @@ class PlayerCore: NSObject {
         mainWindow.volumeSlider.isEnabled = false
       }
 
+      if info.vid == 0 {
+        notifyMainWindowVideoSizeChanged()
+      }
+
       if self.isInMiniPlayer {
-        miniPlayer.defaultAlbumArt.isHidden = !self.info.videoTracks.isEmpty
+        miniPlayer.defaultAlbumArt.isHidden = self.info.vid != 0
       }
     }
     // set initial properties for the first file
@@ -1086,10 +1090,6 @@ class PlayerCore: NSObject {
   func playbackRestarted() {
     Logger.log("Playback restarted", subsystem: subsystem)
     reloadSavedIINAfilters()
-
-    if info.vid == 0 {
-      notifyMainWindowVideoSizeChanged()
-    }
 
     DispatchQueue.main.async {
       Timer.scheduledTimer(timeInterval: TimeInterval(0.2), target: self, selector: #selector(self.reEnableOSDAfterFileLoading), userInfo: nil, repeats: false)
@@ -1182,11 +1182,9 @@ class PlayerCore: NSObject {
   // MARK: - Sync with UI in MainWindow
 
   func notifyMainWindowVideoSizeChanged() {
-    DispatchQueue.main.sync {
-      self.mainWindow.adjustFrameByVideoSize()
-      if self.isInMiniPlayer {
-        self.miniPlayer.updateVideoSize()
-      }
+    mainWindow.adjustFrameByVideoSize()
+    if isInMiniPlayer {
+      miniPlayer.updateVideoSize()
     }
   }
 


### PR DESCRIPTION
**Description:**

Currently, if there's no video track, mpv won't send the `video reconfig` event and thus windows won't change their sizes accordingly. Info such as aspect ratio and video size will remain to be the last video track. I'm not sure whether it worked well before and it's an internal change in mpv. Now the player remains functional due to an awkward fallback mechanism, and here are some obvious glitches:

- Disable auto music mode switching and open an audio file without album art. The window aspect ratio will be the initial one (16:10) at first, but suddenly jump to 1:1 on resize. This also happens when switching back from music mode.
- Open a landscape or portrait video, switch to music mode, and open another audio without album art. The album art part of the mini player will have a wrong aspect ratio.

In this PR, `notifyMainWindowVideoSizeChanged` is also called on `playback restart` if there's no video track to make sure windows receive the resize event. `player.originalVideoSize` is used to check if there's no video in the mini player. The default window size has been changed to 640x400.

Before merging, extensive tests are required to ensure it didn't break anything.