### PR TITLE
WIP: Refactor MainWindowController & MiniPlayerWindowController

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -124,6 +124,7 @@
 		84C6D3671EB2A427009BF721 /* HistoryWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C6D3651EB2A427009BF721 /* HistoryWindowController.swift */; };
 		84C8D58F1D794CE600D98A0E /* MPVFilter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C8D58E1D794CE600D98A0E /* MPVFilter.swift */; };
 		84C8D5911D796F9700D98A0E /* Aspect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84C8D5901D796F9700D98A0E /* Aspect.swift */; };
+		84CFC92623F8DDE000381E5B /* PlayerWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84CFC92523F8DDE000381E5B /* PlayerWindowController.swift */; };
 		84D0FB7E1F5E519300C6A6A7 /* FreeSelectingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D0FB7C1F5E519300C6A6A7 /* FreeSelectingViewController.swift */; };
 		84D0FB811F5E5A4000C6A6A7 /* CropBoxViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84D0FB801F5E5A4000C6A6A7 /* CropBoxViewController.swift */; };
 		84D0FB821F5E6A3800C6A6A7 /* FreeSelectingViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 84D0FB841F5E6A3800C6A6A7 /* FreeSelectingViewController.xib */; };
@@ -1060,6 +1061,7 @@
 		84CE10BA22E6EAA1008ED3AC /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.rtf; name = pl; path = pl.lproj/Contribution.rtf; sourceTree = "<group>"; };
 		84CE10BB22E6EAA1008ED3AC /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/FilterPresets.strings; sourceTree = "<group>"; };
 		84CE10BC22E6EAA1008ED3AC /* pl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = pl; path = pl.lproj/KeyBinding.strings; sourceTree = "<group>"; };
+		84CFC92523F8DDE000381E5B /* PlayerWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerWindowController.swift; sourceTree = "<group>"; };
 		84D0FB7C1F5E519300C6A6A7 /* FreeSelectingViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FreeSelectingViewController.swift; sourceTree = "<group>"; };
 		84D0FB801F5E5A4000C6A6A7 /* CropBoxViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CropBoxViewController.swift; sourceTree = "<group>"; };
 		84D0FB831F5E6A3800C6A6A7 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/FreeSelectingViewController.xib; sourceTree = "<group>"; };
@@ -1681,6 +1683,7 @@
 			children = (
 				84A0BA931D2F9E9600BC8DA1 /* MainMenu.xib */,
 				E38BD4AE20054BD9007635FC /* MainWindow.swift */,
+				84CFC92523F8DDE000381E5B /* PlayerWindowController.swift */,
 				84A0BA9C1D2FAD4000BC8DA1 /* MainWindowController.swift */,
 				84D123B31ECAA405004E0D53 /* TouchBarSupport.swift */,
 				8400D5C81E1AB2F1006785F5 /* MainWindowController.xib */,
@@ -2471,6 +2474,7 @@
 				845ABEAC1D4D19C000BFB15B /* MPVTrack.swift in Sources */,
 				84AABE981DBFB62F00D138FD /* FixedFontManager.m in Sources */,
 				84EB1EDA1D2F51D3004FA5A1 /* AppDelegate.swift in Sources */,
+				84CFC92623F8DDE000381E5B /* PlayerWindowController.swift in Sources */,
 				840820111ECF6C1800361416 /* FileGroup.swift in Sources */,
 				E374160C20F138A900B4F7F9 /* CollapseView.swift in Sources */,
 				84A0BA901D2F8D4100BC8DA1 /* IINAError.swift in Sources */,

--- a/iina/Base.lproj/MiniPlayerWindowController.xib
+++ b/iina/Base.lproj/MiniPlayerWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15702" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15705" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15702"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15705"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -45,7 +45,7 @@
             <windowCollectionBehavior key="collectionBehavior" fullScreenNone="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="300" height="72"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="3840" height="1057"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1057"/>
             <value key="minSize" type="size" width="300" height="72"/>
             <view key="contentView" id="se5-gp-TjO">
                 <rect key="frame" x="0.0" y="0.0" width="300" height="72"/>
@@ -112,7 +112,7 @@
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="h25-bp-EvL" customClass="ScrollingTextField" customModule="IINA" customModuleProvider="target">
                                         <rect key="frame" x="133" y="26" width="35" height="16"/>
                                         <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" alignment="center" title="Title" id="Rs9-6l-6vp">
-                                            <font key="font" metaFont="system"/>
+                                            <font key="font" metaFont="label" size="13"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
@@ -149,7 +149,7 @@
                                         </constraints>
                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="play" imagePosition="only" alignment="center" alternateImage="pause" refusesFirstResponder="YES" state="on" imageScaling="proportionallyUpOrDown" inset="2" id="F9X-N7-Uv0">
                                             <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
-                                            <font key="font" metaFont="system"/>
+                                            <font key="font" metaFont="label" size="13"/>
                                         </buttonCell>
                                         <connections>
                                             <action selector="playBtnAction:" target="-2" id="7Hb-fd-gCC"/>
@@ -163,7 +163,7 @@
                                         </constraints>
                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="nextr" imagePosition="only" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="DPp-zB-KXR">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                            <font key="font" metaFont="system"/>
+                                            <font key="font" metaFont="label" size="13"/>
                                         </buttonCell>
                                         <connections>
                                             <action selector="nextBtnAction:" target="-2" id="ivD-3f-1va"/>
@@ -177,7 +177,7 @@
                                         </constraints>
                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="nextl" imagePosition="only" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="bti-JU-2h9">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                            <font key="font" metaFont="system"/>
+                                            <font key="font" metaFont="label" size="13"/>
                                         </buttonCell>
                                         <connections>
                                             <action selector="prevBtnAction:" target="-2" id="BDa-Ku-caU"/>
@@ -191,7 +191,7 @@
                                         </constraints>
                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="playlist" imagePosition="only" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="9be-Tw-9hy">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                            <font key="font" metaFont="system"/>
+                                            <font key="font" metaFont="label" size="13"/>
                                         </buttonCell>
                                         <connections>
                                             <action selector="togglePlaylist:" target="-2" id="0da-p5-HBI"/>
@@ -205,7 +205,7 @@
                                         </constraints>
                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="volume" imagePosition="only" alignment="center" alternateImage="mute" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="9bz-eY-31X">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                            <font key="font" metaFont="system"/>
+                                            <font key="font" metaFont="label" size="13"/>
                                         </buttonCell>
                                         <connections>
                                             <action selector="volumeBtnAction:" target="-2" id="ynf-E4-jte"/>
@@ -219,7 +219,7 @@
                                         </constraints>
                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="toggle-album-art" imagePosition="only" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="VB3-JD-dpR">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                            <font key="font" metaFont="system"/>
+                                            <font key="font" metaFont="label" size="13"/>
                                         </buttonCell>
                                         <connections>
                                             <action selector="toggleVideoView:" target="-2" id="Q4b-pa-4UM"/>
@@ -290,7 +290,7 @@
                                         </constraints>
                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSStopProgressFreestandingTemplate" imagePosition="only" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="A3f-Go-Xss">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                            <font key="font" metaFont="system"/>
+                                            <font key="font" metaFont="label" size="13"/>
                                         </buttonCell>
                                     </button>
                                     <button toolTip="Back to video mode" translatesAutoresizingMaskIntoConstraints="NO" id="WS6-ix-uBJ">
@@ -301,7 +301,7 @@
                                         </constraints>
                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="back" imagePosition="overlaps" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="FaS-tJ-QNE">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                            <font key="font" metaFont="system"/>
+                                            <font key="font" metaFont="label" size="13"/>
                                         </buttonCell>
                                         <connections>
                                             <action selector="backBtnAction:" target="-2" id="wwC-Mg-w9P"/>
@@ -332,7 +332,7 @@
                                             </constraints>
                                             <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSStopProgressFreestandingTemplate" imagePosition="only" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="T9Y-J8-Nj6">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" metaFont="system"/>
+                                                <font key="font" metaFont="label" size="13"/>
                                             </buttonCell>
                                         </button>
                                         <button toolTip="Back to video mode" translatesAutoresizingMaskIntoConstraints="NO" id="K7j-vB-FlK">
@@ -343,7 +343,7 @@
                                             </constraints>
                                             <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="back" imagePosition="overlaps" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="wd8-60-NJn">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" metaFont="system"/>
+                                                <font key="font" metaFont="label" size="13"/>
                                             </buttonCell>
                                             <connections>
                                                 <action selector="backBtnAction:" target="-2" id="At6-dB-7qN"/>
@@ -434,10 +434,10 @@
                     </constraints>
                     <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="volume" imagePosition="only" alignment="center" alternateImage="mute" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="6jy-7B-dv6">
                         <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="label" size="13"/>
                     </buttonCell>
                     <connections>
-                        <action selector="muteBtnAction:" target="-2" id="MJ5-9y-y2w"/>
+                        <action selector="muteButtonAction:" target="-2" id="u5U-Dm-QKi"/>
                     </connections>
                 </button>
             </subviews>

--- a/iina/Base.lproj/MiniPlayerWindowController.xib
+++ b/iina/Base.lproj/MiniPlayerWindowController.xib
@@ -121,7 +121,7 @@
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kcj-EY-i9R" customClass="ScrollingTextField" customModule="IINA" customModuleProvider="target">
                                         <rect key="frame" x="109" y="8" width="82" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Artist - Album" id="Nle-gv-CWY">
-                                            <font key="font" metaFont="controlContent" size="11"/>
+                                            <font key="font" metaFont="message" size="11"/>
                                             <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
@@ -153,7 +153,7 @@
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
                                         <connections>
-                                            <action selector="playBtnAction:" target="-2" id="7Hb-fd-gCC"/>
+                                            <action selector="playButtonAction:" target="-2" id="tSb-as-bee"/>
                                         </connections>
                                     </button>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="998-mn-oHJ">

--- a/iina/Base.lproj/MiniPlayerWindowController.xib
+++ b/iina/Base.lproj/MiniPlayerWindowController.xib
@@ -35,6 +35,7 @@
                 <outlet property="volumeLabel" destination="MP6-sS-T7f" id="Ztm-8c-Zay"/>
                 <outlet property="volumePopover" destination="yea-QL-Hlq" id="ByH-tP-YzC"/>
                 <outlet property="volumeSlider" destination="Ene-VG-UYY" id="0cq-9R-Yk9"/>
+                <outlet property="volumeSliderView" destination="JoU-Y0-cxJ" id="aKh-R6-I13"/>
                 <outlet property="window" destination="F0z-JX-Cv5" id="gIp-Ho-8D9"/>
             </connections>
         </customObject>
@@ -77,7 +78,7 @@
                                     <constraint firstAttribute="width" constant="32" id="Dnz-rF-ikZ"/>
                                 </constraints>
                                 <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="-:--:--" id="V74-PQ-Yfr">
-                                    <font key="font" metaFont="miniSystem"/>
+                                    <font key="font" metaFont="label" size="9"/>
                                     <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
@@ -91,7 +92,7 @@
                                     <constraint firstAttribute="width" constant="32" id="1iE-QR-s8H"/>
                                 </constraints>
                                 <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="-:--:--" id="WnA-NE-3bG">
-                                    <font key="font" metaFont="miniSystem"/>
+                                    <font key="font" metaFont="label" size="9"/>
                                     <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
@@ -112,7 +113,7 @@
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="h25-bp-EvL" customClass="ScrollingTextField" customModule="IINA" customModuleProvider="target">
                                         <rect key="frame" x="133" y="26" width="35" height="16"/>
                                         <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" alignment="center" title="Title" id="Rs9-6l-6vp">
-                                            <font key="font" metaFont="label" size="13"/>
+                                            <font key="font" metaFont="system"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
@@ -120,7 +121,7 @@
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kcj-EY-i9R" customClass="ScrollingTextField" customModule="IINA" customModuleProvider="target">
                                         <rect key="frame" x="109" y="8" width="82" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Artist - Album" id="Nle-gv-CWY">
-                                            <font key="font" metaFont="message" size="11"/>
+                                            <font key="font" metaFont="controlContent" size="11"/>
                                             <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
@@ -149,7 +150,7 @@
                                         </constraints>
                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="play" imagePosition="only" alignment="center" alternateImage="pause" refusesFirstResponder="YES" state="on" imageScaling="proportionallyUpOrDown" inset="2" id="F9X-N7-Uv0">
                                             <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
-                                            <font key="font" metaFont="label" size="13"/>
+                                            <font key="font" metaFont="system"/>
                                         </buttonCell>
                                         <connections>
                                             <action selector="playBtnAction:" target="-2" id="7Hb-fd-gCC"/>
@@ -163,7 +164,7 @@
                                         </constraints>
                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="nextr" imagePosition="only" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="DPp-zB-KXR">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                            <font key="font" metaFont="label" size="13"/>
+                                            <font key="font" metaFont="system"/>
                                         </buttonCell>
                                         <connections>
                                             <action selector="nextBtnAction:" target="-2" id="ivD-3f-1va"/>
@@ -177,7 +178,7 @@
                                         </constraints>
                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="nextl" imagePosition="only" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="bti-JU-2h9">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                            <font key="font" metaFont="label" size="13"/>
+                                            <font key="font" metaFont="system"/>
                                         </buttonCell>
                                         <connections>
                                             <action selector="prevBtnAction:" target="-2" id="BDa-Ku-caU"/>
@@ -191,7 +192,7 @@
                                         </constraints>
                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="playlist" imagePosition="only" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="9be-Tw-9hy">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                            <font key="font" metaFont="label" size="13"/>
+                                            <font key="font" metaFont="system"/>
                                         </buttonCell>
                                         <connections>
                                             <action selector="togglePlaylist:" target="-2" id="0da-p5-HBI"/>
@@ -205,7 +206,7 @@
                                         </constraints>
                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="volume" imagePosition="only" alignment="center" alternateImage="mute" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="9bz-eY-31X">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                            <font key="font" metaFont="label" size="13"/>
+                                            <font key="font" metaFont="system"/>
                                         </buttonCell>
                                         <connections>
                                             <action selector="volumeBtnAction:" target="-2" id="ynf-E4-jte"/>
@@ -219,7 +220,7 @@
                                         </constraints>
                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="toggle-album-art" imagePosition="only" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="VB3-JD-dpR">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                            <font key="font" metaFont="label" size="13"/>
+                                            <font key="font" metaFont="system"/>
                                         </buttonCell>
                                         <connections>
                                             <action selector="toggleVideoView:" target="-2" id="Q4b-pa-4UM"/>
@@ -290,7 +291,7 @@
                                         </constraints>
                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSStopProgressFreestandingTemplate" imagePosition="only" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="A3f-Go-Xss">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                            <font key="font" metaFont="label" size="13"/>
+                                            <font key="font" metaFont="system"/>
                                         </buttonCell>
                                     </button>
                                     <button toolTip="Back to video mode" translatesAutoresizingMaskIntoConstraints="NO" id="WS6-ix-uBJ">
@@ -301,7 +302,7 @@
                                         </constraints>
                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="back" imagePosition="overlaps" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="FaS-tJ-QNE">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                            <font key="font" metaFont="label" size="13"/>
+                                            <font key="font" metaFont="system"/>
                                         </buttonCell>
                                         <connections>
                                             <action selector="backBtnAction:" target="-2" id="wwC-Mg-w9P"/>
@@ -332,7 +333,7 @@
                                             </constraints>
                                             <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSStopProgressFreestandingTemplate" imagePosition="only" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="T9Y-J8-Nj6">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" metaFont="label" size="13"/>
+                                                <font key="font" metaFont="system"/>
                                             </buttonCell>
                                         </button>
                                         <button toolTip="Back to video mode" translatesAutoresizingMaskIntoConstraints="NO" id="K7j-vB-FlK">
@@ -343,7 +344,7 @@
                                             </constraints>
                                             <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="back" imagePosition="overlaps" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="wd8-60-NJn">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" metaFont="label" size="13"/>
+                                                <font key="font" metaFont="system"/>
                                             </buttonCell>
                                             <connections>
                                                 <action selector="backBtnAction:" target="-2" id="At6-dB-7qN"/>
@@ -434,7 +435,7 @@
                     </constraints>
                     <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="volume" imagePosition="only" alignment="center" alternateImage="mute" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="6jy-7B-dv6">
                         <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
-                        <font key="font" metaFont="label" size="13"/>
+                        <font key="font" metaFont="system"/>
                     </buttonCell>
                     <connections>
                         <action selector="muteButtonAction:" target="-2" id="u5U-Dm-QKi"/>

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -9,8 +9,6 @@
 import Cocoa
 import Foundation
 
-fileprivate typealias PK = Preference.Key
-
 fileprivate let yes_str = "yes"
 fileprivate let no_str = "no"
 

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -70,13 +70,6 @@ class MainWindowController: PlayerWindowController, NSWindowDelegate {
     return quickSettingView
   }()
 
-  /** The playlist and chapter sidebar. */
-  lazy var playlistView: PlaylistViewController = {
-    let playlistView = PlaylistViewController()
-    playlistView.mainWindow = self
-    return playlistView
-  }()
-
   /** The control view for interactive mode. */
   var cropSettingsView: CropBoxViewController?
 

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -539,11 +539,11 @@ class MainWindowController: PlayerWindowController {
 
     // add notification observers
 
-    notificationCenter(.default, addObserverForName: .iinaFileLoaded, object: player) { [unowned self] _ in
+    addObserver(to: .default, forName: .iinaFileLoaded, object: player) { [unowned self] _ in
       self.quickSettingView.reload()
     }
 
-    notificationCenter(.default, addObserverForName: NSApplication.didChangeScreenParametersNotification) { [unowned self] _ in
+    addObserver(to: .default, forName: NSApplication.didChangeScreenParametersNotification) { [unowned self] _ in
       // This observer handles a situation that the user connected a new screen or removed a screen
       let screenCount = NSScreen.screens.count
       if self.fsState.isFullscreen && Preference.bool(for: .blackOutMonitor) && self.cachedScreenCount != screenCount {
@@ -739,7 +739,7 @@ class MainWindowController: PlayerWindowController {
   @discardableResult
   override func handleKeyBinding(_ keyBinding: KeyMapping) -> Bool {
     let success = super.handleKeyBinding(keyBinding)
-    if (success && keyBinding.action[0] == MPVCommand.screenshot.rawValue) {
+    if (success && keyBinding.action.first! == MPVCommand.screenshot.rawValue) {
       player.sendOSD(.screenshot)
     }
     return success

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2655,34 +2655,34 @@ class MainWindowController: PlayerWindowController, NSWindowDelegate {
     switch cmd {
     case .togglePIP:
       if #available(macOS 10.12, *) {
-        self.menuTogglePIP(.dummy)
+        menuTogglePIP(.dummy)
       }
     case .videoPanel:
-      self.menuShowVideoQuickSettings(.dummy)
+      menuShowVideoQuickSettings(.dummy)
     case .audioPanel:
-      self.menuShowAudioQuickSettings(.dummy)
+      menuShowAudioQuickSettings(.dummy)
     case .subPanel:
-      self.menuShowSubQuickSettings(.dummy)
+      menuShowSubQuickSettings(.dummy)
     case .playlistPanel:
-      self.menuShowPlaylistPanel(.dummy)
+      menuShowPlaylistPanel(.dummy)
     case .chapterPanel:
-      self.menuShowChaptersPanel(.dummy)
+      menuShowChaptersPanel(.dummy)
     case .toggleMusicMode:
-      self.menuSwitchToMiniPlayer(.dummy)
+      menuSwitchToMiniPlayer(.dummy)
     case .deleteCurrentFileHard:
-      self.menuActionHandler.menuDeleteCurrentFileHard(.dummy)
+      menuActionHandler.menuDeleteCurrentFileHard(.dummy)
     case .biggerWindow:
       let item = NSMenuItem()
       item.tag = 11
-      self.menuChangeWindowSize(item)
+      menuChangeWindowSize(item)
     case .smallerWindow:
       let item = NSMenuItem()
       item.tag = 10
-      self.menuChangeWindowSize(item)
+      menuChangeWindowSize(item)
     case .fitToScreen:
       let item = NSMenuItem()
       item.tag = 3
-      self.menuChangeWindowSize(item)
+      menuChangeWindowSize(item)
     default:
       break
     }

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1879,8 +1879,8 @@ class MainWindowController: PlayerWindowController, NSWindowDelegate {
   }
 
   /** Set material for OSC and title bar */
-  override internal func setMaterial(_ theme: Preference.Theme?) {
-    guard let window = window, let theme = theme else { return }
+  override internal func setMaterial(_ theme: Preference.Theme) {
+    guard let window = window else { return }
 
     if #available(macOS 10.14, *) {} else {
       let (appearance, material) = Utility.getAppearanceAndMaterial(from: theme)

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -281,7 +281,7 @@ class MainWindowController: PlayerWindowController {
   private lazy var pinchAction: Preference.PinchAction = Preference.enum(for: .pinchAction)
   lazy var displayTimeAndBatteryInFullScreen: Bool = Preference.bool(for: .displayTimeAndBatteryInFullScreen)
 
-  private let localObservedPrefKeys: [PK] = [
+  private let localObservedPrefKeys: [Preference.Key] = [
     .oscPosition,
     .showChapterPos,
     .arrowButtonAction,
@@ -301,43 +301,35 @@ class MainWindowController: PlayerWindowController {
       if let newValue = change[.newKey] as? Int {
         setupOnScreenController(withPosition: Preference.OSCPosition(rawValue: newValue) ?? .floating)
       }
-
     case PK.showChapterPos.rawValue:
       if let newValue = change[.newKey] as? Bool {
         (playSlider.cell as! PlaySliderCell).drawChapters = newValue
       }
-
     case PK.verticalScrollAction.rawValue:
       if let newValue = change[.newKey] as? Int {
         verticalScrollAction = Preference.ScrollAction(rawValue: newValue)!
       }
-
     case PK.horizontalScrollAction.rawValue:
       if let newValue = change[.newKey] as? Int {
         horizontalScrollAction = Preference.ScrollAction(rawValue: newValue)!
       }
-
     case PK.arrowButtonAction.rawValue:
       if let newValue = change[.newKey] as? Int {
         arrowBtnFunction = Preference.ArrowButtonAction(rawValue: newValue)!
         updateArrowButtonImage()
       }
-
     case PK.pinchAction.rawValue:
       if let newValue = change[.newKey] as? Int {
         pinchAction = Preference.PinchAction(rawValue: newValue)!
       }
-
     case PK.blackOutMonitor.rawValue:
       if let newValue = change[.newKey] as? Bool {
         if fsState.isFullscreen {
           newValue ? blackOutOtherMonitors() : removeBlackWindow()
         }
       }
-
     case PK.useLegacyFullScreen.rawValue:
       resetCollectionBehavior()
-
     case PK.displayTimeAndBatteryInFullScreen.rawValue:
       if let newValue = change[.newKey] as? Bool {
         displayTimeAndBatteryInFullScreen = newValue
@@ -345,12 +337,10 @@ class MainWindowController: PlayerWindowController {
           additionalInfoView.isHidden = true
         }
       }
-
     case PK.controlBarToolbarButtons.rawValue:
       if let newValue = change[.newKey] as? [Int] {
         setupOSCToolbarButtons(newValue.compactMap(Preference.ToolBarButton.init(rawValue:)))
       }
-
     default:
       return
     }
@@ -452,7 +442,7 @@ class MainWindowController: PlayerWindowController {
   override func windowDidLoad() {
     super.windowDidLoad()
 
-    guard let window = self.window else { return }
+    guard let window = window else { return }
 
     window.styleMask.insert(.fullSizeContentView)
 
@@ -739,7 +729,7 @@ class MainWindowController: PlayerWindowController {
   @discardableResult
   override func handleKeyBinding(_ keyBinding: KeyMapping) -> Bool {
     let success = super.handleKeyBinding(keyBinding)
-    if (success && keyBinding.action.first! == MPVCommand.screenshot.rawValue) {
+    if success && keyBinding.action.first! == MPVCommand.screenshot.rawValue {
       player.sendOSD(.screenshot)
     }
     return success

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -370,7 +370,7 @@ class MiniPlayerWindowController: PlayerWindowController, NSWindowDelegate, NSPo
     } else {
       // show
       isPlaylistVisible = true
-      player.mainWindow.playlistView.reloadData(playlist: true, chapters: true)
+      playlistView.reloadData(playlist: true, chapters: true)
 
       var newFrame = window.frame
       newFrame.origin.y -= DefaultPlaylistHeight

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -209,8 +209,8 @@ class MiniPlayerWindowController: PlayerWindowController, NSWindowDelegate, NSPo
     artistAlbumLabel.scroll()
   }
 
-  override internal func setMaterial(_ theme: Preference.Theme?) {
-    guard let window = window, let theme = theme else { return }
+  override internal func setMaterial(_ theme: Preference.Theme) {
+    guard let window = window else { return }
 
     if #available(macOS 10.14, *) {} else {
       let (appearance, material) = Utility.getAppearanceAndMaterial(from: theme)

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -27,17 +27,6 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     return player.mainWindow.videoView
   }
 
-  // MARK: - Observed user defaults
-
-  override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
-    super.observeValue(forKeyPath: keyPath, of: object, change: change, context: context)
-    guard let _ = keyPath, let _ = change else { return }
-    switch keyPath {
-    default:
-      return
-    }
-  }
-
   @IBOutlet weak var volumeButton: NSButton!
   @IBOutlet var volumePopover: NSPopover!
   @IBOutlet weak var volumeSliderView: NSView!

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -112,9 +112,6 @@ class MiniPlayerWindowController: PlayerWindowController, NSWindowDelegate, NSPo
     // switching UI
     controlView.alphaValue = 0
 
-    updatePlayButtonState(player.info.isPaused ? .off : .on)
-    rightLabel.mode = Preference.bool(for: .showRemainingTime) ? .remaining : .duration
-
     if Preference.bool(for: .alwaysFloatOnTop) {
       setWindowFloatingOnTop(true)
     }
@@ -132,41 +129,25 @@ class MiniPlayerWindowController: PlayerWindowController, NSWindowDelegate, NSPo
   func windowWillStartLiveResize(_ notification: Notification) {
     originalWindowFrame = window!.frame
   }
-
-  override func keyDown(with event: NSEvent) {
-    let keyCode = KeyCodeHelper.mpvKeyCode(from: event)
-    if let kb = PlayerCore.keyBindings[keyCode] {
-      if kb.isIINACommand {
-        // - IINA command
-        if let iinaCommand = IINACommand(rawValue: kb.rawAction) {
-          handleIINACommand(iinaCommand)
-        } else {
-          Logger.log("Unknown iina command \(kb.rawAction)", level: .error)
-        }
-      } else {
-        // - mpv command
-        let returnValue: Int32
-        // execute the command
-        switch kb.action[0] {
-        case MPVCommand.abLoop.rawValue:
-          player.abLoop()
-          returnValue = 0
-        default:
-          returnValue = player.mpv.command(rawString: kb.rawAction)
-        }
-        // handle return value
-        if returnValue != 0 {
-          Logger.log("Return value \(returnValue) when executing key command \(kb.rawAction)", level: .warning)
-        }
-      }
-    } else {
-      super.keyDown(with: event)
-    }
-  }
-
+  
   override func mouseDown(with event: NSEvent) {
     window?.makeFirstResponder(window)
     super.mouseDown(with: event)
+  }
+  
+  override func mouseUp(with event: NSEvent) {
+    guard !isMouseEvent(event, inAnyOf: [backgroundView]) else { return }
+    super.mouseUp(with: event)
+  }
+  
+  override func rightMouseUp(with event: NSEvent) {
+    guard !isMouseEvent(event, inAnyOf: [backgroundView]) else { return }
+    super.rightMouseUp(with: event)
+  }
+  
+  override func otherMouseUp(with event: NSEvent) {
+    guard !isMouseEvent(event, inAnyOf: [backgroundView]) else { return }
+    super.otherMouseUp(with: event)
   }
 
   private func showControl() {

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -163,7 +163,7 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     if isMouseEvent(event, inAnyOf: [playSlider]) && playSlider.isEnabled {
       seekOverride = true
     } else if isMouseEvent(event, inAnyOf: [volumeSliderView]) && volumeSlider.isEnabled {
-    volumeOverride = true
+      volumeOverride = true
     } else {
       guard !isMouseEvent(event, inAnyOf: [backgroundView]) else { return }
     }

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -303,23 +303,23 @@ class MiniPlayerWindowController: PlayerWindowController, NSWindowDelegate, NSPo
   // MARK: - Sync UI with playback
   @objc
   override func updateTitle() {
-    let (mediaTitle, mediaAlbum, mediaArtist) = self.player.getMusicMetadata()
-    self.titleLabel.stringValue = mediaTitle
-    self.window?.title = mediaTitle
+    let (mediaTitle, mediaAlbum, mediaArtist) = player.getMusicMetadata()
+    titleLabel.stringValue = mediaTitle
+    window?.title = mediaTitle
     // hide artist & album label when info not available
     if mediaArtist.isEmpty && mediaAlbum.isEmpty {
-      self.titleLabelTopConstraint.constant = 6 + 10
-      self.artistAlbumLabel.stringValue = ""
+      titleLabelTopConstraint.constant = 6 + 10
+      artistAlbumLabel.stringValue = ""
     } else {
-      self.titleLabelTopConstraint.constant = 6
+      titleLabelTopConstraint.constant = 6
       if mediaArtist.isEmpty || mediaAlbum.isEmpty {
-        self.artistAlbumLabel.stringValue = "\(mediaArtist)\(mediaAlbum)"
+        artistAlbumLabel.stringValue = "\(mediaArtist)\(mediaAlbum)"
       } else {
-        self.artistAlbumLabel.stringValue = "\(mediaArtist) - \(mediaAlbum)"
+        artistAlbumLabel.stringValue = "\(mediaArtist) - \(mediaAlbum)"
       }
     }
-    self.titleLabel.scroll()
-    self.artistAlbumLabel.scroll()
+    titleLabel.scroll()
+    artistAlbumLabel.scroll()
   }
 
   override func updateVolume() {
@@ -430,7 +430,7 @@ class MiniPlayerWindowController: PlayerWindowController, NSWindowDelegate, NSPo
     super.handleIINACommand(cmd)
     switch cmd {
     case .toggleMusicMode:
-      self.menuSwitchToMiniPlayer(.dummy)
+      menuSwitchToMiniPlayer(.dummy)
     default:
       break
     }

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -12,7 +12,7 @@ fileprivate let DefaultPlaylistHeight: CGFloat = 300
 fileprivate let AutoHidePlaylistThreshold: CGFloat = 200
 fileprivate let AnimationDurationShowControl: TimeInterval = 0.2
 
-class MiniPlayerWindowController: PlayerWindowController, NSWindowDelegate, NSPopoverDelegate {
+class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
 
   override var windowNibName: NSNib.Name {
     return NSNib.Name("MiniPlayerWindowController")
@@ -22,6 +22,10 @@ class MiniPlayerWindowController: PlayerWindowController, NSWindowDelegate, NSPo
     let fontSize = NSFont.systemFontSize(for: .mini)
     return NSFont.monospacedDigitSystemFont(ofSize: fontSize, weight: .regular)
   }()
+
+  override var videoView: VideoView {
+    return player.mainWindow.videoView
+  }
 
   // MARK: - Observed user defaults
 
@@ -36,6 +40,7 @@ class MiniPlayerWindowController: PlayerWindowController, NSWindowDelegate, NSPo
 
   @IBOutlet weak var volumeButton: NSButton!
   @IBOutlet var volumePopover: NSPopover!
+  @IBOutlet weak var volumeSliderView: NSView!
   @IBOutlet weak var backgroundView: NSVisualEffectView!
   @IBOutlet weak var closeButtonView: NSView!
   @IBOutlet weak var closeButtonBackgroundViewVE: NSVisualEffectView!
@@ -119,6 +124,21 @@ class MiniPlayerWindowController: PlayerWindowController, NSWindowDelegate, NSPo
     volumePopover.delegate = self
   }
 
+  override internal func setMaterial(_ theme: Preference.Theme) {
+    guard let window = window else { return }
+
+    if #available(macOS 10.14, *) {} else {
+      let (appearance, material) = Utility.getAppearanceAndMaterial(from: theme)
+
+      [backgroundView, closeButtonBackgroundViewVE, playlistWrapperView].forEach {
+        $0?.appearance = appearance
+        $0?.material = material
+      }
+
+      window.appearance = appearance
+    }
+  }
+
   func windowWillClose(_ notification: Notification) {
     player.switchedToMiniPlayerManually = false
     player.switchedBackFromMiniPlayerManually = false
@@ -129,25 +149,40 @@ class MiniPlayerWindowController: PlayerWindowController, NSWindowDelegate, NSPo
   func windowWillStartLiveResize(_ notification: Notification) {
     originalWindowFrame = window!.frame
   }
-  
+
   override func mouseDown(with event: NSEvent) {
     window?.makeFirstResponder(window)
     super.mouseDown(with: event)
   }
-  
+
   override func mouseUp(with event: NSEvent) {
     guard !isMouseEvent(event, inAnyOf: [backgroundView]) else { return }
     super.mouseUp(with: event)
   }
-  
+
   override func rightMouseUp(with event: NSEvent) {
     guard !isMouseEvent(event, inAnyOf: [backgroundView]) else { return }
     super.rightMouseUp(with: event)
   }
-  
+
   override func otherMouseUp(with event: NSEvent) {
     guard !isMouseEvent(event, inAnyOf: [backgroundView]) else { return }
     super.otherMouseUp(with: event)
+  }
+
+  override func scrollWheel(with event: NSEvent) {
+    if isMouseEvent(event, inAnyOf: [playSlider]) && playSlider.isEnabled {
+      seekOverride = true
+    } else if isMouseEvent(event, inAnyOf: [volumeSliderView]) && volumeSlider.isEnabled {
+    volumeOverride = true
+    } else {
+      guard !isMouseEvent(event, inAnyOf: [backgroundView]) else { return }
+    }
+
+    super.scrollWheel(with: event)
+
+    seekOverride = false
+    volumeOverride = false
   }
 
   private func showControl() {
@@ -199,29 +234,20 @@ class MiniPlayerWindowController: PlayerWindowController, NSWindowDelegate, NSPo
     }
   }
 
+  // MARK: - Window delegate: Size
+
   func windowDidResize(_ notification: Notification) {
     guard let window = window, !window.inLiveResize else { return }
-    self.player.mainWindow.videoView.videoLayer.draw()
+    videoView.videoLayer.draw()
   }
 
-  func windowDidBecomeMain(_ notification: Notification) {
+  // MARK: - Window delegate: Activeness status
+
+  override func windowDidBecomeMain(_ notification: Notification) {
+    super.windowDidBecomeMain(notification)
+
     titleLabel.scroll()
     artistAlbumLabel.scroll()
-  }
-
-  override internal func setMaterial(_ theme: Preference.Theme) {
-    guard let window = window else { return }
-
-    if #available(macOS 10.14, *) {} else {
-      let (appearance, material) = Utility.getAppearanceAndMaterial(from: theme)
-
-      [backgroundView, closeButtonBackgroundViewVE, playlistWrapperView].forEach {
-        $0?.appearance = appearance
-        $0?.material = material
-      }
-
-      window.appearance = appearance
-    }
   }
 
   // MARK: - NSPopoverDelegate
@@ -263,7 +289,6 @@ class MiniPlayerWindowController: PlayerWindowController, NSWindowDelegate, NSPo
 
   func updateVideoSize() {
     guard let window = window else { return }
-    let videoView = player.mainWindow.videoView
     let (width, height) = player.originalVideoSize
     let aspect = (width == 0 || height == 0) ? 1 : CGFloat(width) / CGFloat(height)
     let currentHeight = videoView.frame.height
@@ -280,7 +305,6 @@ class MiniPlayerWindowController: PlayerWindowController, NSWindowDelegate, NSPo
     if let constraint = videoViewAspectConstraint {
       constraint.isActive = false
     }
-    let videoView = player.mainWindow.videoView
     videoViewAspectConstraint = NSLayoutConstraint(item: videoView, attribute: .width, relatedBy: .equal,
                                                    toItem: videoView, attribute: .height, multiplier: aspect, constant: 0)
     videoViewAspectConstraint?.isActive = true
@@ -319,7 +343,7 @@ class MiniPlayerWindowController: PlayerWindowController, NSWindowDelegate, NSPo
     controlViewTopConstraint.isActive = !isVideoVisible
     closeButtonBackgroundViewVE.isHidden = !isVideoVisible
     closeButtonBackgroundViewBox.isHidden = isVideoVisible
-    let videoViewHeight = round(player.mainWindow.videoView.frame.height)
+    let videoViewHeight = round(videoView.frame.height)
     if isVideoVisible {
       var frame = window.frame
       frame.size.height += videoViewHeight

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -141,8 +141,8 @@ class PlayerCore: NSObject {
     super.init()
     self.mpv = MPVController(playerCore: self)
     self.mainWindow = MainWindowController(playerCore: self)
+    self.miniPlayer = MiniPlayerWindowController(playerCore: self)
     self.initialWindow = InitialWindowController(playerCore: self)
-    self.miniPlayer = MiniPlayerWindowController(player: self)
     if #available(macOS 10.12.2, *) {
       self._touchBarSupport = TouchBarSupport(playerCore: self)
     }
@@ -345,7 +345,7 @@ class PlayerCore: NSObject {
     let needRestoreLayout = !miniPlayer.loaded
     miniPlayer.showWindow(self)
 
-    miniPlayer.updateTrack()
+    miniPlayer.updateTitle()
     let playlistView = mainWindow.playlistView.view
     let videoView = mainWindow.videoView
     // reset down shift for playlistView

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -37,8 +37,10 @@ class PlayerWindowController: NSWindowController {
   internal lazy var useExtractSeek: Preference.SeekOption = Preference.enum(for: .useExactSeek)
   internal lazy var relativeSeekAmount: Int = Preference.integer(for: .relativeSeekAmount)
   internal lazy var volumeScrollAmount: Int = Preference.integer(for: .volumeScrollAmount)
+  internal lazy var singleClickAction: Preference.MouseClickAction = Preference.enum(for: .singleClickAction)
+  internal lazy var doubleClickAction: Preference.MouseClickAction = Preference.enum(for: .doubleClickAction)
   
-  private let observedPrefKeys: [PK] = [
+  internal var observedPrefKeys: [PK] = [
     .themeMaterial,
     .showRemainingTime,
     .alwaysFloatOnTop,
@@ -46,6 +48,8 @@ class PlayerWindowController: NSWindowController {
     .useExactSeek,
     .relativeSeekAmount,
     .volumeScrollAmount,
+    .singleClickAction,
+    .doubleClickAction,
   ]
   
   override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
@@ -93,6 +97,16 @@ class PlayerWindowController: NSWindowController {
         volumeScrollAmount = newValue.clamped(to: 1...4)
       }
 
+    case PK.singleClickAction.rawValue:
+      if let newValue = change[.newKey] as? Int {
+        singleClickAction = Preference.MouseClickAction(rawValue: newValue)!
+      }
+
+    case PK.doubleClickAction.rawValue:
+      if let newValue = change[.newKey] as? Int {
+        doubleClickAction = Preference.MouseClickAction(rawValue: newValue)!
+      }
+
     default:
       return
     }
@@ -108,6 +122,10 @@ class PlayerWindowController: NSWindowController {
   @IBOutlet weak var rightLabel: DurationDisplayTextField!
   @IBOutlet weak var leftLabel: NSTextField!
   
+  /** Differentiate between single clicks and double clicks. */
+  internal var singleClickTimer: Timer?
+  internal var mouseExitEnterCount = 0
+
   override func windowDidLoad() {
     super.windowDidLoad()
     loaded = true
@@ -129,22 +147,146 @@ class PlayerWindowController: NSWindowController {
         self.updateTitle()
     }
     
+    rightLabel.mode = Preference.bool(for: .showRemainingTime) ? .remaining : .duration
+    
     updateVolume()
+    
+    observedPrefKeys.forEach { key in
+      UserDefaults.standard.addObserver(self, forKeyPath: key.rawValue, options: .new, context: nil)
+    }
+    
+    notificationCenter(.default, addObserverForName: .iinaFileLoaded, object: player) { [unowned self] _ in
+      self.updateTitle()
+    }
+    
+    NSWorkspace.shared.notificationCenter.addObserver(forName: NSWorkspace.willSleepNotification, object: nil, queue: nil, using: { [unowned self] _ in
+      if Preference.bool(for: .pauseWhenGoesToSleep) {
+        self.player.pause()
+      }
+    })
+  }
+  
+  deinit {
+    ObjcUtils.silenced {
+      for key in self.observedPrefKeys {
+        UserDefaults.standard.removeObserver(self, forKeyPath: key.rawValue)
+      }
+      for (center, observers) in self.notificationObservers {
+        for observer in observers {
+          center.removeObserver(observer)
+        }
+      }
+    }
   }
   
   internal func notificationCenter(_ center: NotificationCenter, addObserverForName name: Notification.Name, object: Any? = nil, using block: @escaping (Notification) -> Void) {
     let observer = center.addObserver(forName: name, object: object, queue: .main, using: block)
     notificationObservers[center, default: []].append(observer)
   }
-
   
+  // MARK: - Mouse / Trackpad event
+  
+  override func keyDown(with event: NSEvent) {
+    let keyCode = KeyCodeHelper.mpvKeyCode(from: event)
+    if let kb = PlayerCore.keyBindings[keyCode] {
+      handleKeyBinding(kb)
+    } else {
+      super.keyDown(with: event)
+    }
+  }
+
+  @discardableResult
+  func handleKeyBinding(_ keyBinding: KeyMapping) -> Bool {
+    if keyBinding.isIINACommand {
+      // - IINA command
+      if let iinaCommand = IINACommand(rawValue: keyBinding.rawAction) {
+        handleIINACommand(iinaCommand)
+        return true
+      } else {
+        Logger.log("Unknown iina command \(keyBinding.rawAction)", level: .error)
+        return false
+      }
+    } else {
+      // - mpv command
+      let returnValue: Int32
+      // execute the command
+      switch keyBinding.action[0] {
+      case MPVCommand.abLoop.rawValue:
+        player.abLoop()
+        returnValue = 0
+      default:
+        returnValue = player.mpv.command(rawString: keyBinding.rawAction)
+      }
+      if returnValue == 0 {
+        return true
+      } else {
+        Logger.log("Return value \(returnValue) when executing key command \(keyBinding.rawAction)", level: .error)
+        return false
+      }
+    }
+  }
+  
+  override func mouseUp(with event: NSEvent) {
+    if event.clickCount == 1 {
+      if doubleClickAction == .none {
+        performMouseAction(singleClickAction)
+      } else {
+        singleClickTimer = Timer.scheduledTimer(timeInterval: NSEvent.doubleClickInterval, target: self, selector: #selector(self.performMouseActionLater(_:)), userInfo: singleClickAction, repeats: false)
+        mouseExitEnterCount = 0
+      }
+    } else if event.clickCount == 2 {
+      if let timer = singleClickTimer {
+        timer.invalidate()
+        singleClickTimer = nil
+      }
+      performMouseAction(doubleClickAction)
+    }
+  }
+  
+  override func rightMouseUp(with event: NSEvent) {
+    performMouseAction(Preference.enum(for: .rightClickAction))
+  }
+  
+  override func otherMouseUp(with event: NSEvent) {
+    if event.buttonNumber == 2 {
+      performMouseAction(Preference.enum(for: .middleClickAction))
+    } else {
+      super.otherMouseUp(with: event)
+    }
+  }
+  
+  internal func performMouseAction(_ action: Preference.MouseClickAction) {
+    switch action {
+    case .pause:
+      player.togglePause()
+    default:
+      break
+    }
+  }
+
+  /**
+   Being called to perform single click action after timeout.
+
+   - SeeAlso:
+   mouseUp(with:)
+   */
+  @objc internal func performMouseActionLater(_ timer: Timer) {
+    guard let action = timer.userInfo as? Preference.MouseClickAction else { return }
+    if mouseExitEnterCount >= 2 && action == .hideOSC {
+      // the counter being greater than or equal to 2 means that the mouse re-entered the window
+      // `showUI()` must be called due to the movement in the window, thus `hideOSC` action should be cancelled
+      return
+    }
+    performMouseAction(action)
+  }
+
   internal func setMaterial(_ theme: Preference.Theme?) {
     guard let window = window, let theme = theme else { return }
 
     if #available(macOS 10.14, *) {
       window.appearance = NSAppearance(iinaTheme: theme)
     }
-    // See override functions for 10.14-
+    // See overridden functions for 10.14-
   }
   
   @objc
@@ -201,7 +343,6 @@ class PlayerWindowController: NSWindowController {
     player.seek(percent: percentage, forceExact: !followGlobalSeekTypeWhenAdjustSlider)
   }
   
-  
   /** This method will not set `isOntop`! */
   func setWindowFloatingOnTop(_ onTop: Bool) {
     guard let window = window else { return }
@@ -230,6 +371,12 @@ class PlayerWindowController: NSWindowController {
     default:
       break
     }
+  }
+  
+  internal func isMouseEvent(_ event: NSEvent, inAnyOf views: [NSView?]) -> Bool {
+    return views.filter { $0 != nil }.reduce(false, { (result, view) in
+      return result || view!.isMousePoint(view!.convert(event.locationInWindow, from: nil), in: view!.bounds)
+    })
   }
 
 }

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -61,19 +61,16 @@ class PlayerWindowController: NSWindowController {
     
     setMaterial(Preference.enum(for: .themeMaterial))
     
-    notificationCenter(.default, addObserverfor: .iinaMediaTitleChanged, object: player) { [unowned self] _ in
+    notificationCenter(.default, addObserverForName: .iinaMediaTitleChanged, object: player) { [unowned self] _ in
         self.updateTitle()
     }
     
     updateVolume()
   }
   
-  internal func notificationCenter(_ center: NotificationCenter, addObserverfor name: NSNotification.Name, object: Any? = nil, using block: @escaping (Notification) -> Void) {
+  internal func notificationCenter(_ center: NotificationCenter, addObserverForName name: Notification.Name, object: Any? = nil, using block: @escaping (Notification) -> Void) {
     let observer = center.addObserver(forName: name, object: object, queue: .main, using: block)
-    if notificationObservers[center] == nil {
-      notificationObservers[center] = []
-    }
-    notificationObservers[center]!.append(observer)
+    notificationObservers[center, default: []].append(observer)
   }
 
   
@@ -144,32 +141,28 @@ class PlayerWindowController: NSWindowController {
   /** This method will not set `isOntop`! */
   func setWindowFloatingOnTop(_ onTop: Bool) {
     guard let window = window else { return }
-    if onTop {
-      window.level = .iinaFloating
-    } else {
-      window.level = .normal
-    }
+    window.level = onTop ? .iinaFloating : .normal
   }
   
   internal func handleIINACommand(_ cmd: IINACommand) {
-    let appDeletate = (NSApp.delegate! as! AppDelegate)
+    let appDelegate = (NSApp.delegate! as! AppDelegate)
     switch cmd {
     case .openFile:
-      appDeletate.openFile(self)
+      appDelegate.openFile(self)
     case .openURL:
-      appDeletate.openURL(self)
+      appDelegate.openURL(self)
     case .flip:
-      self.menuActionHandler.menuToggleFlip(.dummy)
+      menuActionHandler.menuToggleFlip(.dummy)
     case .mirror:
-      self.menuActionHandler.menuToggleMirror(.dummy)
+      menuActionHandler.menuToggleMirror(.dummy)
     case .saveCurrentPlaylist:
-      self.menuActionHandler.menuSavePlaylist(.dummy)
+      menuActionHandler.menuSavePlaylist(.dummy)
     case .deleteCurrentFile:
-      self.menuActionHandler.menuDeleteCurrentFile(.dummy)
+      menuActionHandler.menuDeleteCurrentFile(.dummy)
     case .findOnlineSubs:
-      self.menuActionHandler.menuFindOnlineSub(.dummy)
+      menuActionHandler.menuFindOnlineSub(.dummy)
     case .saveDownloadedSub:
-      self.menuActionHandler.saveDownloadedSub(.dummy)
+      menuActionHandler.saveDownloadedSub(.dummy)
     default:
       break
     }

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -1,0 +1,170 @@
+//
+//  PlayerWindowController.swift
+//  iina
+//
+//  Created by Yuze Jiang on 2/15/20.
+//  Copyright © 2020 lhc. All rights reserved.
+//
+
+import Foundation
+
+class PlayerWindowController: NSWindowController {
+  unowned var player: PlayerCore
+  
+  var menuActionHandler: MainMenuActionHandler!
+  
+  var loaded = false
+  
+  init(playerCore: PlayerCore) {
+    self.player = playerCore
+    super.init(window: nil)
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+  
+  internal lazy var followGlobalSeekTypeWhenAdjustSlider: Bool = Preference.bool(for: .followGlobalSeekTypeWhenAdjustSlider)
+  
+  /** Observers added to `UserDefauts.standard`. */
+  internal var notificationObservers: [NotificationCenter: [NSObjectProtocol]] = [:]
+  
+  @IBOutlet weak var volumeSlider: NSSlider!
+  @IBOutlet weak var muteButton: NSButton!
+  @IBOutlet weak var playButton: NSButton!
+  @IBOutlet weak var playSlider: NSSlider!
+  @IBOutlet weak var rightLabel: DurationDisplayTextField!
+  @IBOutlet weak var leftLabel: NSTextField!
+  
+  override func windowDidLoad() {
+    super.windowDidLoad()
+    loaded = true
+    
+    guard let window = window else { return }
+    
+    // Insert `menuActionHandler` into the responder chain
+    menuActionHandler = MainMenuActionHandler(playerCore: player)
+    let responder = window.nextResponder
+    window.nextResponder = menuActionHandler
+    menuActionHandler.nextResponder = responder
+    
+    window.initialFirstResponder = nil
+    window.titlebarAppearsTransparent = true
+    
+    setMaterial(Preference.enum(for: .themeMaterial))
+    
+    notificationCenter(.default, addObserverfor: .iinaMediaTitleChanged, object: player) { [unowned self] _ in
+        self.updateTitle()
+    }
+    
+    updateVolume()
+  }
+  
+  internal func notificationCenter(_ center: NotificationCenter, addObserverfor name: NSNotification.Name, object: Any? = nil, using block: @escaping (Notification) -> Void) {
+    let observer = center.addObserver(forName: name, object: object, queue: .main, using: block)
+    if notificationObservers[center] == nil {
+      notificationObservers[center] = []
+    }
+    notificationObservers[center]!.append(observer)
+  }
+
+  
+  internal func setMaterial(_ theme: Preference.Theme?) {
+    guard let window = window, let theme = theme else { return }
+
+    if #available(macOS 10.14, *) {
+      window.appearance = NSAppearance(iinaTheme: theme)
+    }
+    // See override functions for 10.14-
+  }
+  
+  @objc
+  func updateTitle() {
+    fatalError("Must implement in the subclass")
+  }
+  
+  func updateVolume() {
+    volumeSlider.doubleValue = player.info.volume
+    muteButton.state = player.info.isMuted ? .on : .off
+  }
+  
+  func updatePlayTime(withDuration: Bool, andProgressBar: Bool) {
+    guard loaded else { return }
+    guard let duration = player.info.videoDuration, let pos = player.info.videoPosition else {
+      Logger.fatal("video info not available")
+    }
+    let percentage = (pos.second / duration.second) * 100
+    leftLabel.stringValue = pos.stringRepresentation
+    rightLabel.updateText(with: duration, given: pos)
+    if andProgressBar {
+      playSlider.doubleValue = percentage
+      if #available(macOS 10.12.2, *) {
+        player.touchBarSupport.touchBarPlaySlider?.setDoubleValueSafely(percentage)
+        player.touchBarSupport.touchBarPosLabels.forEach { $0.updateText(with: duration, given: pos) }
+      }
+    }
+  }
+  
+  func updatePlayButtonState(_ state: NSControl.StateValue) {
+    guard loaded else { return }
+    playButton.state = state
+  }
+  
+  @IBAction func volumeSliderChanges(_ sender: NSSlider) {
+    let value = sender.doubleValue
+    if Preference.double(for: .maxVolume) > 100, value > 100 && value < 101 {
+      NSHapticFeedbackManager.defaultPerformer.perform(.generic, performanceTime: .default)
+    }
+    player.setVolume(value)
+  }
+  
+  @IBAction func playButtonAction(_ sender: NSButton) {
+    player.info.isPaused ? player.resume() : player.pause()
+  }
+  
+  @IBAction func muteButtonAction(_ sender: NSButton) {
+    player.toggleMute()
+  }
+  
+  @IBAction func playSliderChanges(_ sender: NSSlider) {
+    guard !player.info.fileLoading else { return }
+    let percentage = 100 * sender.doubleValue / sender.maxValue
+    player.seek(percent: percentage, forceExact: !followGlobalSeekTypeWhenAdjustSlider)
+  }
+  
+  
+  /** This method will not set `isOntop`! */
+  func setWindowFloatingOnTop(_ onTop: Bool) {
+    guard let window = window else { return }
+    if onTop {
+      window.level = .iinaFloating
+    } else {
+      window.level = .normal
+    }
+  }
+  
+  internal func handleIINACommand(_ cmd: IINACommand) {
+    let appDeletate = (NSApp.delegate! as! AppDelegate)
+    switch cmd {
+    case .openFile:
+      appDeletate.openFile(self)
+    case .openURL:
+      appDeletate.openURL(self)
+    case .flip:
+      self.menuActionHandler.menuToggleFlip(.dummy)
+    case .mirror:
+      self.menuActionHandler.menuToggleMirror(.dummy)
+    case .saveCurrentPlaylist:
+      self.menuActionHandler.menuSavePlaylist(.dummy)
+    case .deleteCurrentFile:
+      self.menuActionHandler.menuDeleteCurrentFile(.dummy)
+    case .findOnlineSubs:
+      self.menuActionHandler.menuFindOnlineSub(.dummy)
+    case .saveDownloadedSub:
+      self.menuActionHandler.saveDownloadedSub(.dummy)
+    default:
+      break
+    }
+  }
+
+}

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -280,8 +280,8 @@ class PlayerWindowController: NSWindowController {
     performMouseAction(action)
   }
 
-  internal func setMaterial(_ theme: Preference.Theme?) {
-    guard let window = window, let theme = theme else { return }
+  internal func setMaterial(_ theme: Preference.Theme) {
+    guard let window = window else { return }
 
     if #available(macOS 10.14, *) {
       window.appearance = NSAppearance(iinaTheme: theme)

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -6,11 +6,19 @@
 //  Copyright © 2020 lhc. All rights reserved.
 //
 
-import Foundation
+import Cocoa
 
 class PlayerWindowController: NSWindowController {
+
   unowned var player: PlayerCore
-  
+
+  /** The playlist and chapter sidebar. */
+  lazy var playlistView: PlaylistViewController = {
+    let playlistView = PlaylistViewController()
+    playlistView.mainWindow = self
+    return playlistView
+  }()
+
   var menuActionHandler: MainMenuActionHandler!
   
   var loaded = false

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -9,8 +9,6 @@
 import Cocoa
 
 class PlayerWindowController: NSWindowController, NSWindowDelegate {
-  
-  internal typealias PK = Preference.Key
 
   unowned var player: PlayerCore
   
@@ -46,7 +44,7 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
   internal lazy var horizontalScrollAction: Preference.ScrollAction = Preference.enum(for: .horizontalScrollAction)
   internal lazy var verticalScrollAction: Preference.ScrollAction = Preference.enum(for: .verticalScrollAction)
   
-  internal var observedPrefKeys: [PK] = [
+  internal var observedPrefKeys: [Preference.Key] = [
     .themeMaterial,
     .showRemainingTime,
     .alwaysFloatOnTop,
@@ -68,12 +66,10 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
       if let newValue = change[.newKey] as? Int {
         setMaterial(Preference.Theme(rawValue: newValue) ?? .system)
       }
-
     case PK.showRemainingTime.rawValue:
       if let newValue = change[.newKey] as? Bool {
         rightLabel.mode = newValue ? .remaining : .duration
       }
-
     case PK.alwaysFloatOnTop.rawValue:
       if let newValue = change[.newKey] as? Bool {
         if player.info.isPlaying {
@@ -81,7 +77,6 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
           setWindowFloatingOnTop(newValue)
         }
       }
-
     case PK.maxVolume.rawValue:
       if let newValue = change[.newKey] as? Int {
         volumeSlider.maxValue = Double(newValue)
@@ -89,32 +84,26 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
           player.mpv.setDouble(MPVOption.Audio.volume, Double(newValue))
         }
       }
-
     case PK.useExactSeek.rawValue:
       if let newValue = change[.newKey] as? Int {
         useExtractSeek = Preference.SeekOption(rawValue: newValue)!
       }
-
     case PK.relativeSeekAmount.rawValue:
       if let newValue = change[.newKey] as? Int {
         relativeSeekAmount = newValue.clamped(to: 1...5)
       }
-
     case PK.volumeScrollAmount.rawValue:
       if let newValue = change[.newKey] as? Int {
         volumeScrollAmount = newValue.clamped(to: 1...4)
       }
-
     case PK.singleClickAction.rawValue:
       if let newValue = change[.newKey] as? Int {
         singleClickAction = Preference.MouseClickAction(rawValue: newValue)!
       }
-
     case PK.doubleClickAction.rawValue:
       if let newValue = change[.newKey] as? Int {
         doubleClickAction = Preference.MouseClickAction(rawValue: newValue)!
       }
-
     default:
       return
     }
@@ -261,7 +250,7 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
       if doubleClickAction == .none {
         performMouseAction(singleClickAction)
       } else {
-        singleClickTimer = Timer.scheduledTimer(timeInterval: NSEvent.doubleClickInterval, target: self, selector: #selector(self.performMouseActionLater(_:)), userInfo: singleClickAction, repeats: false)
+        singleClickTimer = Timer.scheduledTimer(timeInterval: NSEvent.doubleClickInterval, target: self, selector: #selector(performMouseActionLater), userInfo: singleClickAction, repeats: false)
         mouseExitEnterCount = 0
       }
     } else if event.clickCount == 2 {

--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -22,7 +22,7 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
     return NSNib.Name("PlaylistViewController")
   }
 
-  weak var mainWindow: PlayerWindowController! {
+  weak var mainWindow: MainWindowController! {
     didSet {
       self.player = mainWindow.player
     }

--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -22,7 +22,7 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
     return NSNib.Name("PlaylistViewController")
   }
 
-  weak var mainWindow: MainWindowController! {
+  weak var mainWindow: PlayerWindowController! {
     didSet {
       self.player = mainWindow.player
     }

--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -8,6 +8,8 @@
 
 import Cocoa
 
+typealias PK = Preference.Key
+
 class Utility {
 
   static let supportedFileExt: [MPVTrack.TrackType: [String]] = [

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -51,7 +51,6 @@ class VideoView: NSView {
   // MARK: - Init
 
   override init(frame: CGRect) {
-
     super.init(frame: frame)
 
     // set up layer
@@ -65,6 +64,11 @@ class VideoView: NSView {
 
     // dragging init
     registerForDraggedTypes([.nsFilenames, .nsURL, .string])
+  }
+  
+  convenience init(frame: CGRect, player: PlayerCore) {
+    self.init(frame: frame)
+    self.player = player
   }
 
   required init?(coder: NSCoder) {


### PR DESCRIPTION
Make `MainWindowController` and `MiniPlayerWindowController` inherent from `PlayerWindowController`.

`PlayerWindowController` consists same or similar code from `MainWindowController`
and `MiniPlayerWindowController`. There are some functions in `MiniPlayerWindowControler`
directly copy-pasted from `MainWindowController`.

Besides, we can implement more features in the main window but not in the miniplayer without copy-pasting code (e.g. https://github.com/iina/iina/pull/2191.)

Ref: #2157