### PR TITLE
Fixed shortcuts in HistoryWindowController.

### DIFF
--- a/iina/HistoryWindowController.swift
+++ b/iina/HistoryWindowController.swift
@@ -99,7 +99,7 @@ class HistoryWindowController: NSWindowController, NSOutlineViewDelegate, NSOutl
 
   override func keyDown(with event: NSEvent) {
     let commandKey = NSEvent.ModifierFlags.command
-    if [event.modifierFlags, NSEvent.ModifierFlags.deviceIndependentFlagsMask] == commandKey  {
+    if event.modifierFlags.intersection(.deviceIndependentFlagsMask) == commandKey  {
       switch event.charactersIgnoringModifiers! {
       case "f":
         window!.makeFirstResponder(historySearchField)


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #.

---

**Description:**

This small PR fixes shortcuts in the `Playback History` window.
Currently it is not possible to focus the `Search` text field via `⌘ + F`.