### PR TITLE
Fix PlaylistLoop button state doesn't update with menu item

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -565,6 +565,9 @@ class PlayerCore: NSObject {
     let loopStatus = mpv.getString(MPVOption.PlaybackControl.loopPlaylist)
     let isLoop = (loopStatus == "inf" || loopStatus == "force")
     mpv.setString(MPVOption.PlaybackControl.loopPlaylist, isLoop ? "no" : "inf")
+    if self.mainWindow.playlistView.isViewLoaded {
+      self.mainWindow.playlistView.updateBtnStatus()
+    }
   }
 
   func toggleShuffle() {

--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -194,7 +194,12 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
       }
     }
   }
-
+    
+  func updateBtnStatus() {
+    let loopStatus = player.mpv.getString(MPVOption.PlaybackControl.loopPlaylist)
+    loopBtn.state = (loopStatus == "inf" || loopStatus == "force") ? .on : .off
+  }
+    
   // MARK: - Tab switching
 
   /** Switch tab (call from other objects) */


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**
Fixing the issue that clicking the PlaylistLoop menu item doesn't update the PlaylistLoop button state in PlaylistView when the PlaylistView already loaded.