### PR TITLE
Make the remaining time label in Touch Bar show total duration when touching on it 

### DIFF
--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -275,5 +275,5 @@
 "touchbar.play_pause" = "Play / Pause";
 "touchbar.seek" = "Seek";
 "touchbar.time" = "Time Position";
-"touchbar.remainingTime" = "Remaining Time";
+"touchbar.remainingOrTotalTime" = "Remaining Time / Total Time";
 "touchbar.toggle_pip" = "Toggle Picture-in-Picture";

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -275,5 +275,5 @@
 "touchbar.play_pause" = "Play / Pause";
 "touchbar.seek" = "Seek";
 "touchbar.time" = "Time Position";
-"touchbar.remainingOrTotalTime" = "Remaining Time / Total Time";
+"touchbar.remainingTimeOrTotalDuration" = "Remaining Time / Total Duration";
 "touchbar.toggle_pip" = "Toggle Picture-in-Picture";

--- a/iina/Base.lproj/MainWindowController.xib
+++ b/iina/Base.lproj/MainWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16096" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16096"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -29,7 +29,7 @@
                 <outlet property="fragVolumeView" destination="N3B-DL-XOA" id="4VW-Wa-AD7"/>
                 <outlet property="leftArrowButton" destination="10x-bg-xlj" id="HOT-Yl-7aO"/>
                 <outlet property="leftArrowLabel" destination="Yg9-Sd-sWy" id="fps-VD-ZgC"/>
-                <outlet property="leftLabel" destination="NBD-MV-OuG" id="cCh-WT-abz"/>
+                <outlet property="leftLabel" destination="NBD-MV-OuG" id="0tU-eK-sbp"/>
                 <outlet property="muteButton" destination="2py-h1-0km" id="baB-6t-gO7"/>
                 <outlet property="oscBottomMainView" destination="Qmi-hb-0aM" id="PM5-Ic-nvt"/>
                 <outlet property="oscFloatingBottomView" destination="hb6-oe-rHm" id="ZKe-zm-evE"/>
@@ -67,7 +67,7 @@
         <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" tabbingMode="disallowed" id="F0z-JX-Cv5" customClass="MainWindow" customModule="IINA" customModuleProvider="target">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
             <rect key="contentRect" x="196" y="240" width="640" height="400"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="3440" height="1417"/>
             <view key="contentView" id="se5-gp-TjO">
                 <rect key="frame" x="0.0" y="0.0" width="640" height="400"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -384,7 +384,7 @@
                         <action selector="playSliderChanges:" target="-2" id="UBG-Ky-3rr"/>
                     </connections>
                 </slider>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" alphaValue="0.5" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NBD-MV-OuG" userLabel="Left Label">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" alphaValue="0.5" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NBD-MV-OuG" userLabel="Left Label" customClass="DurationDisplayTextField" customModule="IINA" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="5" width="50" height="14"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="46" id="CMl-dC-PCr"/>
@@ -595,8 +595,8 @@
     </objects>
     <resources>
         <image name="mute" width="17" height="14"/>
-        <image name="ontop" width="16" height="16"/>
-        <image name="ontop_off" width="16" height="16"/>
+        <image name="ontop" width="16" height="14"/>
+        <image name="ontop_off" width="16" height="14"/>
         <image name="pause" width="24" height="24"/>
         <image name="play" width="24" height="24"/>
         <image name="speed" width="24" height="24"/>

--- a/iina/Base.lproj/MiniPlayerWindowController.xib
+++ b/iina/Base.lproj/MiniPlayerWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15705" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15705"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -20,7 +20,7 @@
                 <outlet property="controlView" destination="cDR-8J-QI7" id="B1L-ru-Mnc"/>
                 <outlet property="controlViewTopConstraint" destination="sJO-Qa-tUh" id="iXu-0b-vwV"/>
                 <outlet property="defaultAlbumArt" destination="Psi-wJ-2SC" id="oeb-1Z-2ho"/>
-                <outlet property="leftLabel" destination="9EY-2T-Ebf" id="ICj-Tc-hjF"/>
+                <outlet property="leftLabel" destination="9EY-2T-Ebf" id="L1e-2I-Mbu"/>
                 <outlet property="mediaInfoView" destination="Zv7-H8-iOq" id="LrZ-za-HpC"/>
                 <outlet property="muteButton" destination="5Og-lg-qvH" id="9dA-7h-PGA"/>
                 <outlet property="playButton" destination="aC9-OK-a4x" id="3Ej-3P-qnY"/>
@@ -46,7 +46,7 @@
             <windowCollectionBehavior key="collectionBehavior" fullScreenNone="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="300" height="72"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1057"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="3440" height="1417"/>
             <value key="minSize" type="size" width="300" height="72"/>
             <view key="contentView" id="se5-gp-TjO">
                 <rect key="frame" x="0.0" y="0.0" width="300" height="72"/>
@@ -86,7 +86,7 @@
                                     <binding destination="-2" name="font" keyPath="monospacedFont" id="TM3-Ri-L7h"/>
                                 </connections>
                             </textField>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9EY-2T-Ebf">
+                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9EY-2T-Ebf" customClass="DurationDisplayTextField" customModule="IINA" customModuleProvider="target">
                                 <rect key="frame" x="4" y="9" width="36" height="11"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="32" id="1iE-QR-s8H"/>

--- a/iina/DurationDisplayTextField.swift
+++ b/iina/DurationDisplayTextField.swift
@@ -18,8 +18,9 @@ class DurationDisplayTextField: NSTextField {
 
   var mode: DisplayMode = .duration
 
-  /** Switches the display mode for the right label */
+  /** Switches the display mode between duration and remaining time */
   func switchMode() {
+    guard mode != .current else { return }
     switch mode {
     case .duration:
       mode = .remaining
@@ -30,7 +31,6 @@ class DurationDisplayTextField: NSTextField {
 
 
   func updateText(with duration: VideoTime, given current: VideoTime) {
-
     let stringValue: String
     switch mode {
     case .current:

--- a/iina/DurationDisplayTextField.swift
+++ b/iina/DurationDisplayTextField.swift
@@ -54,4 +54,12 @@ class DurationDisplayTextField: NSTextField {
     Preference.set(mode == .remaining, for: .showRemainingTime)
   }
 
+  override func touchesBegan(with event: NSEvent) {
+    // handles the remaining time text field in the touch bar
+    super.touchesBegan(with: event)
+
+    self.switchMode()
+    Preference.set(mode == .remaining, for: .touchbarShowRemainingTime)
+  }
+
 }

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -113,7 +113,7 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
   @IBOutlet weak var playButton: NSButton!
   @IBOutlet weak var playSlider: NSSlider!
   @IBOutlet weak var rightLabel: DurationDisplayTextField!
-  @IBOutlet weak var leftLabel: NSTextField!
+  @IBOutlet weak var leftLabel: DurationDisplayTextField!
 
   /** Differentiate between single clicks and double clicks. */
   internal var singleClickTimer: Timer?
@@ -165,7 +165,8 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
     addObserver(to: .default, forName: .iinaMediaTitleChanged, object: player) { [unowned self] _ in
         self.updateTitle()
     }
-    
+
+    leftLabel.mode = .current
     rightLabel.mode = Preference.bool(for: .showRemainingTime) ? .remaining : .duration
     
     updateVolume()
@@ -426,14 +427,15 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
     guard let duration = player.info.videoDuration, let pos = player.info.videoPosition else {
       Logger.fatal("video info not available")
     }
-    let percentage = (pos.second / duration.second) * 100
-    leftLabel.stringValue = pos.stringRepresentation
-    rightLabel.updateText(with: duration, given: pos)
+    [leftLabel, rightLabel].forEach { $0.updateText(with: duration, given: pos) }
+    if #available(macOS 10.12.2, *) {
+      player.touchBarSupport.touchBarPosLabels.forEach { $0.updateText(with: duration, given: pos) }
+    }
     if andProgressBar {
+      let percentage = (pos.second / duration.second) * 100
       playSlider.doubleValue = percentage
       if #available(macOS 10.12.2, *) {
         player.touchBarSupport.touchBarPlaySlider?.setDoubleValueSafely(percentage)
-        player.touchBarSupport.touchBarPosLabels.forEach { $0.updateText(with: duration, given: pos) }
       }
     }
   }

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -229,6 +229,7 @@ struct Preference {
     static let forceTouchAction = Key("forceTouchAction")
 
     static let showRemainingTime = Key("showRemainingTime")
+    static let touchbarShowRemainingTime = Key("touchbarShowRemainingTime")
 
     static let followGlobalSeekTypeWhenAdjustSlider = Key("followGlobalSeekTypeWhenAdjustSlider")
 
@@ -695,6 +696,7 @@ struct Preference {
     .resizeWindowTiming: ResizeWindowTiming.onlyWhenOpen.rawValue,
     .resizeWindowOption: ResizeWindowOption.videoSize10.rawValue,
     .showRemainingTime: false,
+    .touchbarShowRemainingTime: true,
     .enableThumbnailPreview: true,
     .maxThumbnailPreviewCacheSize: 500,
     .enableThumbnailForRemoteFiles: false,

--- a/iina/TouchBarSupport.swift
+++ b/iina/TouchBarSupport.swift
@@ -129,7 +129,7 @@ class TouchBarSupport: NSObject, NSTouchBarDelegate {
       let label = DurationDisplayTextField(labelWithString: "00:00")
       label.alignment = .center
       label.font = .monospacedDigitSystemFont(ofSize: 0, weight: .regular)
-      label.mode = .remaining
+      label.mode = Preference.bool(for: .touchbarShowRemainingTime) ? .remaining : .duration
       self.touchBarPosLabels.append(label)
       item.view = label
       item.customizationLabel = NSLocalizedString("touchbar.remainingTime", comment: "Remaining Time Position")

--- a/iina/TouchBarSupport.swift
+++ b/iina/TouchBarSupport.swift
@@ -27,7 +27,7 @@ fileprivate extension NSTouchBarItem.Identifier {
   static let rewind = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.rewind")
   static let fastForward = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.forward")
   static let time = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.time")
-  static let remainingOrTotalTime = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.remainingOrTotalTime")
+  static let remainingTimeOrTotalDuration = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.remainingTimeOrTotalDuration")
   static let ahead15Sec = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.ahead15Sec")
   static let back15Sec = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.back15Sec")
   static let ahead30Sec = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.ahead30Sec")
@@ -62,8 +62,8 @@ class TouchBarSupport: NSObject, NSTouchBarDelegate {
     let touchBar = NSTouchBar()
     touchBar.delegate = self
     touchBar.customizationIdentifier = .windowBar
-    touchBar.defaultItemIdentifiers = [.playPause, .time, .slider, .remainingOrTotalTime]
-    touchBar.customizationAllowedItemIdentifiers = [.playPause, .slider, .volumeUp, .volumeDown, .rewind, .fastForward, .time, .remainingOrTotalTime, .ahead15Sec, .ahead30Sec, .back15Sec, .back30Sec, .next, .prev, .togglePIP, .fixedSpaceLarge]
+    touchBar.defaultItemIdentifiers = [.playPause, .time, .slider, .remainingTimeOrTotalDuration]
+    touchBar.customizationAllowedItemIdentifiers = [.playPause, .slider, .volumeUp, .volumeDown, .rewind, .fastForward, .time, .remainingTimeOrTotalDuration, .ahead15Sec, .ahead30Sec, .back15Sec, .back30Sec, .next, .prev, .togglePIP, .fixedSpaceLarge]
     return touchBar
   }()
 
@@ -124,7 +124,7 @@ class TouchBarSupport: NSObject, NSTouchBarDelegate {
       item.customizationLabel = NSLocalizedString("touchbar.time", comment: "Time Position")
       return item
 
-    case .remainingOrTotalTime:
+    case .remainingTimeOrTotalDuration:
       let item = NSCustomTouchBarItem(identifier: identifier)
       let label = DurationDisplayTextField(labelWithString: "00:00")
       label.alignment = .center
@@ -132,7 +132,7 @@ class TouchBarSupport: NSObject, NSTouchBarDelegate {
       label.mode = Preference.bool(for: .touchbarShowRemainingTime) ? .remaining : .duration
       self.touchBarPosLabels.append(label)
       item.view = label
-      item.customizationLabel = NSLocalizedString("touchbar.remainingOrTotalTime", comment: "Show Remaining Time or Total Time")
+      item.customizationLabel = NSLocalizedString("touchbar.remainingTimeOrTotalDuration", comment: "Show Remaining Time or Total Duration")
       return item
 
     case .ahead15Sec,

--- a/iina/TouchBarSupport.swift
+++ b/iina/TouchBarSupport.swift
@@ -27,7 +27,7 @@ fileprivate extension NSTouchBarItem.Identifier {
   static let rewind = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.rewind")
   static let fastForward = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.forward")
   static let time = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.time")
-  static let remainingTime = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.remainingTime")
+  static let remainingOrTotalTime = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.remainingOrTotalTime")
   static let ahead15Sec = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.ahead15Sec")
   static let back15Sec = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.back15Sec")
   static let ahead30Sec = NSTouchBarItem.Identifier("\(Bundle.main.bundleIdentifier!).TouchBarItem.ahead30Sec")
@@ -62,8 +62,8 @@ class TouchBarSupport: NSObject, NSTouchBarDelegate {
     let touchBar = NSTouchBar()
     touchBar.delegate = self
     touchBar.customizationIdentifier = .windowBar
-    touchBar.defaultItemIdentifiers = [.playPause, .time, .slider, .remainingTime]
-    touchBar.customizationAllowedItemIdentifiers = [.playPause, .slider, .volumeUp, .volumeDown, .rewind, .fastForward, .time, .remainingTime, .ahead15Sec, .ahead30Sec, .back15Sec, .back30Sec, .next, .prev, .togglePIP, .fixedSpaceLarge]
+    touchBar.defaultItemIdentifiers = [.playPause, .time, .slider, .remainingOrTotalTime]
+    touchBar.customizationAllowedItemIdentifiers = [.playPause, .slider, .volumeUp, .volumeDown, .rewind, .fastForward, .time, .remainingOrTotalTime, .ahead15Sec, .ahead30Sec, .back15Sec, .back30Sec, .next, .prev, .togglePIP, .fixedSpaceLarge]
     return touchBar
   }()
 
@@ -71,7 +71,7 @@ class TouchBarSupport: NSObject, NSTouchBarDelegate {
   weak var touchBarPlayPauseBtn: NSButton?
   var touchBarPosLabels: [DurationDisplayTextField] = []
   var touchBarPosLabelWidthLayout: NSLayoutConstraint?
-  /** The current/remaining time label in Touch Bar. */
+  /** The current / remaining time/totol time label in Touch Bar. */
   lazy var sizingTouchBarTextField: NSTextField = {
     return NSTextField()
   }()
@@ -124,7 +124,7 @@ class TouchBarSupport: NSObject, NSTouchBarDelegate {
       item.customizationLabel = NSLocalizedString("touchbar.time", comment: "Time Position")
       return item
 
-    case .remainingTime:
+    case .remainingOrTotalTime:
       let item = NSCustomTouchBarItem(identifier: identifier)
       let label = DurationDisplayTextField(labelWithString: "00:00")
       label.alignment = .center
@@ -132,7 +132,7 @@ class TouchBarSupport: NSObject, NSTouchBarDelegate {
       label.mode = Preference.bool(for: .touchbarShowRemainingTime) ? .remaining : .duration
       self.touchBarPosLabels.append(label)
       item.view = label
-      item.customizationLabel = NSLocalizedString("touchbar.remainingTime", comment: "Remaining Time Position")
+      item.customizationLabel = NSLocalizedString("touchbar.remainingOrTotalTime", comment: "Show Remaining Time or Total Time")
       return item
 
     case .ahead15Sec,

--- a/iina/TouchBarSupport.swift
+++ b/iina/TouchBarSupport.swift
@@ -71,7 +71,7 @@ class TouchBarSupport: NSObject, NSTouchBarDelegate {
   weak var touchBarPlayPauseBtn: NSButton?
   var touchBarPosLabels: [DurationDisplayTextField] = []
   var touchBarPosLabelWidthLayout: NSLayoutConstraint?
-  /** The current / remaining time/totol time label in Touch Bar. */
+  /** The current / remaining time/total time label in Touch Bar. */
   lazy var sizingTouchBarTextField: NSTextField = {
     return NSTextField()
   }()

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -275,5 +275,5 @@
 "touchbar.play_pause" = "Play / Pause";
 "touchbar.seek" = "Seek";
 "touchbar.time" = "Time Position";
-"touchbar.remainingTime" = "Remaining Time";
+"touchbar.remainingOrTotalTime" = "Remaining Time / Total Time";
 "touchbar.toggle_pip" = "Toggle Picture-in-Picture";

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -275,5 +275,5 @@
 "touchbar.play_pause" = "Play / Pause";
 "touchbar.seek" = "Seek";
 "touchbar.time" = "Time Position";
-"touchbar.remainingOrTotalTime" = "Remaining Time / Total Time";
+"touchbar.remainingTimeOrTotalDuration" = "Remaining Time / Total Duration";
 "touchbar.toggle_pip" = "Toggle Picture-in-Picture";


### PR DESCRIPTION
- [x] It implements / fixes issue #1312.
---
**Description:**
- Make the remaining time label in Touch Bar show total duration when touching on it (and vice versa.)
- Update its name and description in English
- `leftLabel` in the main window (and the mini player window) is now `DurationDisplayTextField` instead of `NSTextField`.