### PR TITLE
Added Tool tip to OSC ToolBar buttons

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -619,6 +619,7 @@ class MainWindowController: PlayerWindowController {
       button.tag = buttonType.rawValue
       button.translatesAutoresizingMaskIntoConstraints = false
       button.refusesFirstResponder = true
+      button.toolTip = buttonType.description()
       let buttonWidth = buttons.count == 5 ? "20" : "24"
       Utility.quickConstraints(["H:[btn(\(buttonWidth))]", "V:[btn(24)]"], ["btn": button])
       fragToolbarView.addView(button, in: .trailing)


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue   #2871.

---

**Description:**

This pull request simply adds Tool tip description to the buttons in the OSCToolBar (eg, "Toggle Picture-in-Picture", "Playlist and chapters", "Quick Settings", etc.).
It only implements one of the requested features in #2871 (the second one to be specific).