### PR TITLE
Fix Video QuickSettings view

### DIFF
--- a/iina/Base.lproj/QuickSettingViewController.xib
+++ b/iina/Base.lproj/QuickSettingViewController.xib
@@ -795,7 +795,7 @@
                                                                 <constraint firstItem="ItN-JT-puN" firstAttribute="centerY" secondItem="dsX-c1-BZP" secondAttribute="centerY" id="SAV-G5-5wL"/>
                                                                 <constraint firstItem="g3A-4u-nNt" firstAttribute="top" secondItem="8ZJ-PD-t0R" secondAttribute="bottom" constant="7" id="SKe-RW-aSJ"/>
                                                                 <constraint firstItem="Cec-wN-J62" firstAttribute="centerY" secondItem="SL7-DZ-5ff" secondAttribute="centerY" id="SbN-O3-hQF"/>
-                                                                <constraint firstItem="8ZJ-PD-t0R" firstAttribute="top" secondItem="rsV-qL-l7b" secondAttribute="bottom" constant="20" id="SsM-RU-d20"/>
+                                                                <constraint firstItem="8ZJ-PD-t0R" firstAttribute="top" secondItem="ykw-rb-M9D" secondAttribute="bottom" constant="20" id="SsM-RU-d20"/>
                                                                 <constraint firstItem="8Uj-eX-hSm" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="20" id="T08-gr-bMl"/>
                                                                 <constraint firstItem="mjX-Jf-925" firstAttribute="trailing" secondItem="UWh-M9-5Nw" secondAttribute="trailing" id="Tfz-E0-gcH"/>
                                                                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="7vv-En-VYY" secondAttribute="trailing" constant="35" id="UG0-YC-mdd"/>


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**

Constraints in the Video Quicksettings view were misconfigured. The "Aspect Ratio" section (and everything below it) had their vertical positioning constrained to the "Table View" instead of the table's respective "Scroll View". This means that if a video has more than 3 video tracks or so, Aspect ratio and everything below it are pushed down to be aligned with the bottom of the video track list, no matter how long that list is and even if everything after the third track is hidden by the limit of the scroll view.

This issue is understandably hard to come by since most media files only have 1 video track (if any, in case of audio only tracks). I happen to configure youtube-dl to show all tracks available giving me the ability to choose between them at runtime, switching resolutions, codecs, and bitrates around without having to restart the video with different ytdl format settings. This is how I encountered this issue. This commit fixes it. See screenshot below.

Here is two screenshots combined in one picture. Taken while playing a video that has 20 video tracks. Left is current behavior, right is with the proposed fix.

![quicksettings-fix](https://user-images.githubusercontent.com/32626712/85955614-718d5500-b988-11ea-8a1b-8cf6406f59e1.png)

Notice on the left sided screen how the Y position of the Aspect Ration section is positioned right where the entire list of video tracks is supposed to end (i.e after 20 entries). Although the latter are hidden by the limits of the scroll view. One the right however, everything is lined up how it's supposed to be.
