### PR TITLE
Removed 'IINA v1.0 is coming!' from Beta Popup window

### DIFF
--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -123,7 +123,7 @@
 
 // Alerts
 "alert.beta_channel.title" = "Receive Updates for Beta Versions";
-"alert.beta_channel.message" = "IINA v1.0 is coming! Would you like to help us to test out beta versions? \n\nYou can change this behavior at anytime in Preferences - General.";
+"alert.beta_channel.message" = "Would you like to help us to test out beta versions? \n\nYou can change this behavior at anytime in Preferences - General.";
 
 "alert.title_error" = "Error";
 "alert.title_warning" = "Warning";


### PR DESCRIPTION

- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3047 

---

**Description:**
Fixed #3047 by removing entirely the 'IINA v1.0 is coming!' part. Now it is a simple question for the user if they want to test beta versions or not and removing any reference to the upcoming versions to avoid this issue in the future. I don't have much experience with localization so I just updated the Localizable.strings (Base). I hope that is the correct way of handling such issue.