### PR TITLE
[WIP] Subtitles Toggles

### DIFF
--- a/iina/Base.lproj/FilterWindowController.xib
+++ b/iina/Base.lproj/FilterWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14313.13.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14313.13.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -35,7 +35,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="608" y="562" width="480" height="382"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1050"/>
             <view key="contentView" wantsLayer="YES" id="se5-gp-TjO">
                 <rect key="frame" x="0.0" y="0.0" width="480" height="382"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -74,7 +74,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="283" y="305" width="440" height="302"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1050"/>
             <view key="contentView" id="RNP-NG-UVn">
                 <rect key="frame" x="0.0" y="0.0" width="440" height="302"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -87,14 +87,13 @@
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnSelection="YES" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="n0t-vk-dME">
                                     <rect key="frame" x="0.0" y="0.0" width="138" height="244"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <size key="intercellSpacing" width="3" height="2"/>
                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                     <tableColumns>
                                         <tableColumn width="135" minWidth="40" maxWidth="1000" id="Wak-3T-72M">
                                             <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
-                                                <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
@@ -222,13 +221,13 @@ Gw
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="163" y="199" width="403" height="230"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
-            <view key="contentView" id="Af9-J4-L1C">
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1050"/>
+            <view key="contentView" misplaced="YES" id="Af9-J4-L1C">
                 <rect key="frame" x="0.0" y="0.0" width="403" height="230"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qz5-V0-iH0">
-                        <rect key="frame" x="12" y="115" width="379" height="22"/>
+                        <rect key="frame" x="12" y="115" width="379" height="21"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="tIJ-Qx-EGw">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -236,9 +235,9 @@ Gw
                         </textFieldCell>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VVZ-yu-5X9">
-                        <rect key="frame" x="10" y="141" width="38" height="14"/>
+                        <rect key="frame" x="10" y="140" width="38" height="14"/>
                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Name:" id="IYf-IE-5cL">
-                            <font key="font" metaFont="smallSystem"/>
+                            <font key="font" metaFont="menu" size="11"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
@@ -247,7 +246,7 @@ Gw
                         <rect key="frame" x="12" y="41" width="379" height="48"/>
                         <subviews>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oDS-CG-efd">
-                                <rect key="frame" x="107" y="16" width="165" height="17"/>
+                                <rect key="frame" x="107" y="16" width="165" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Press any button to record" id="jJk-0R-KQo">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -264,7 +263,7 @@ Gw
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IRi-nC-VIB">
                         <rect key="frame" x="12" y="93" width="75" height="14"/>
                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Shortcut key:" id="M9z-ss-1Ma">
-                            <font key="font" metaFont="smallSystem"/>
+                            <font key="font" metaFont="menu" size="11"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
@@ -296,7 +295,7 @@ Gw
                         </connections>
                     </button>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="THb-Ky-Cnh">
-                        <rect key="frame" x="10" y="201" width="72" height="17"/>
+                        <rect key="frame" x="10" y="198" width="72" height="16"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Save Filter" id="KGV-G1-A2l">
                             <font key="font" metaFont="systemBold"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -304,7 +303,7 @@ Gw
                         </textFieldCell>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="494-9n-dCn">
-                        <rect key="frame" x="10" y="163" width="383" height="34"/>
+                        <rect key="frame" x="10" y="162" width="383" height="32"/>
                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="By saving a filter, you can enable or disable it conveniently and even assign a shortcut key to it." id="8JN-kb-kGF">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -341,25 +340,24 @@ Gw
             </view>
             <point key="canvasLocation" x="393.5" y="658.5"/>
         </window>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="tI1-4J-bvZ">
-            <rect key="frame" x="0.0" y="0.0" width="480" height="194"/>
+        <customView misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tI1-4J-bvZ">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="169"/>
             <subviews>
                 <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="brl-j0-vbe">
-                    <rect key="frame" x="-1" y="19" width="482" height="176"/>
+                    <rect key="frame" x="-1" y="19" width="482" height="125"/>
                     <clipView key="contentView" id="Hbi-ga-FRu">
-                        <rect key="frame" x="1" y="0.0" width="480" height="175"/>
+                        <rect key="frame" x="1" y="0.0" width="480" height="124"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" headerView="ESY-lT-CzV" viewBased="YES" id="iTp-t4-bao">
-                                <rect key="frame" x="0.0" y="0.0" width="480" height="150"/>
-                                <autoresizingMask key="autoresizingMask"/>
+                                <rect key="frame" x="0.0" y="0.0" width="480" height="99"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <size key="intercellSpacing" width="3" height="2"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                 <tableColumns>
                                     <tableColumn identifier="Key" editable="NO" width="45" minWidth="40" maxWidth="1000" id="amK-Iz-lu8">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="#">
-                                            <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                         </tableHeaderCell>
@@ -375,7 +373,7 @@ Gw
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="cLl-pZ-KNW">
-                                                        <rect key="frame" x="0.0" y="0.0" width="45" height="17"/>
+                                                        <rect key="frame" x="0.0" y="1" width="45" height="16"/>
                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="WAS-rj-5Np">
                                                             <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -399,7 +397,6 @@ Gw
                                     </tableColumn>
                                     <tableColumn identifier="Value" width="320" minWidth="40" maxWidth="1000" id="4g6-LW-373">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Filter String">
-                                            <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                         </tableHeaderCell>
@@ -415,7 +412,7 @@ Gw
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="AfO-KW-cSw">
-                                                        <rect key="frame" x="0.0" y="0.0" width="320" height="17"/>
+                                                        <rect key="frame" x="0.0" y="1" width="320" height="16"/>
                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" title="Table View Cell" id="gtr-Iv-kcK">
                                                             <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -439,7 +436,6 @@ Gw
                                     </tableColumn>
                                     <tableColumn width="95" minWidth="10" maxWidth="3.4028234663852886e+38" id="lka-OZ-XXJ">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                            <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         </tableHeaderCell>
@@ -458,7 +454,7 @@ Gw
                                                         <rect key="frame" x="2" y="0.0" width="40" height="17"/>
                                                         <buttonCell key="cell" type="roundRect" title="Save" bezelStyle="roundedRect" alignment="center" controlSize="small" borderStyle="border" inset="2" id="tPs-K2-ZPz">
                                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <font key="font" metaFont="menu" size="11"/>
                                                         </buttonCell>
                                                         <connections>
                                                             <action selector="saveFilterAction:" target="-2" id="0VH-dl-F6K"/>
@@ -557,14 +553,13 @@ Gw
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnSelection="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="38" rowSizeStyle="automatic" viewBased="YES" id="cw6-pW-oMs">
                                 <rect key="frame" x="0.0" y="0.0" width="480" height="144"/>
-                                <autoresizingMask key="autoresizingMask"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <size key="intercellSpacing" width="3" height="2"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                 <tableColumns>
                                     <tableColumn width="477" minWidth="40" maxWidth="1000" id="TbO-kN-XQm">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
-                                            <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                         </tableHeaderCell>
@@ -580,7 +575,7 @@ Gw
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Lbk-r9-gQj">
-                                                        <rect key="frame" x="30" y="19" width="96" height="17"/>
+                                                        <rect key="frame" x="30" y="20" width="96" height="16"/>
                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="EXM-Xm-pvG">
                                                             <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -591,9 +586,9 @@ Gw
                                                         </connections>
                                                     </textField>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="748" translatesAutoresizingMaskIntoConstraints="NO" id="MIx-kF-Ju3">
-                                                        <rect key="frame" x="30" y="3" width="33" height="14"/>
+                                                        <rect key="frame" x="30" y="4" width="33" height="14"/>
                                                         <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" title="Label" id="09q-ZP-mpK">
-                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <font key="font" metaFont="message" size="11"/>
                                                             <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
@@ -645,7 +640,7 @@ Gw
                                                         </connections>
                                                     </button>
                                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="b2Y-ob-c1P">
-                                                        <rect key="frame" x="421" y="11" width="4" height="17"/>
+                                                        <rect key="frame" x="421" y="11" width="4" height="16"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="9xR-IJ-UkJ">
                                                             <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -702,7 +697,7 @@ Gw
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cIf-90-odO">
                     <rect key="frame" x="6" y="147" width="70" height="14"/>
                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Saved filters" id="m5X-Zl-aOj">
-                        <font key="font" metaFont="smallSystem"/>
+                        <font key="font" metaFont="message" size="11"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
@@ -723,13 +718,13 @@ Gw
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="163" y="199" width="393" height="240"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
-            <view key="contentView" id="knb-gb-GnG">
+            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1050"/>
+            <view key="contentView" misplaced="YES" id="knb-gb-GnG">
                 <rect key="frame" x="0.0" y="0.0" width="393" height="240"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="E7J-3Z-sWo">
-                        <rect key="frame" x="10" y="211" width="67" height="17"/>
+                        <rect key="frame" x="10" y="209" width="67" height="16"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Edit Filter" id="Dab-w9-6TY">
                             <font key="font" metaFont="systemBold"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -737,7 +732,7 @@ Gw
                         </textFieldCell>
                     </textField>
                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="O0s-TH-UaJ">
-                        <rect key="frame" x="12" y="163" width="369" height="22"/>
+                        <rect key="frame" x="12" y="162" width="369" height="21"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="cXe-Ng-Vqb">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -745,7 +740,7 @@ Gw
                         </textFieldCell>
                     </textField>
                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="L4P-KI-bQL">
-                        <rect key="frame" x="12" y="115" width="369" height="22"/>
+                        <rect key="frame" x="12" y="115" width="369" height="21"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="OdQ-xm-1k0">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -753,9 +748,9 @@ Gw
                         </textFieldCell>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KIF-JE-AL9">
-                        <rect key="frame" x="10" y="189" width="38" height="14"/>
+                        <rect key="frame" x="10" y="187" width="38" height="14"/>
                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Name:" id="9k2-lm-YGD">
-                            <font key="font" metaFont="smallSystem"/>
+                            <font key="font" metaFont="message" size="11"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
@@ -764,7 +759,7 @@ Gw
                         <rect key="frame" x="12" y="41" width="369" height="48"/>
                         <subviews>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="B5v-za-vBd">
-                                <rect key="frame" x="102" y="16" width="165" height="17"/>
+                                <rect key="frame" x="102" y="16" width="165" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Press any button to record" id="dL4-so-Qss">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -779,9 +774,9 @@ Gw
                         </constraints>
                     </customView>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3lk-uI-Pxk">
-                        <rect key="frame" x="10" y="141" width="68" height="14"/>
+                        <rect key="frame" x="10" y="140" width="68" height="14"/>
                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Filter string:" id="t9F-EU-fKj">
-                            <font key="font" metaFont="smallSystem"/>
+                            <font key="font" metaFont="message" size="11"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
@@ -815,7 +810,7 @@ Gw
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="An7-v8-Wy4">
                         <rect key="frame" x="10" y="93" width="75" height="14"/>
                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Shortcut key:" id="Nzk-zW-mIL">
-                            <font key="font" metaFont="smallSystem"/>
+                            <font key="font" metaFont="message" size="11"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -45,6 +45,8 @@
 "osd.subtitle_pos" = "Subtitle Position: %.1f";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
+"osd.disable_subtitles" = "Subtitles Disabled";
+"osd.enable_subtitles" = "Subtitles Enabled";
 "osd.screenshot" = "Screenshot Captured";
 "osd.abloop.a" = "AB-Loop: A";
 "osd.abloop.b" = "AB-Loop: B";

--- a/iina/Base.lproj/MainMenu.xib
+++ b/iina/Base.lproj/MainMenu.xib
@@ -511,6 +511,9 @@ CA
                                 <modifierMask key="keyEquivalentModifierMask"/>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="EvW-J9-wqJ"/>
+                            <menuItem title="Disable Subtitles" id="7kN-KF-Pba">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                            </menuItem>
                             <menuItem title="Cycle Subtitles" tag="2" id="sgu-dK-IGE">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                             </menuItem>
@@ -689,6 +692,7 @@ CA
                 <outlet property="deinterlace" destination="yHI-7D-OaI" id="Z8n-z4-52B"/>
                 <outlet property="deleteCurrentFile" destination="npH-8B-XA4" id="23t-fO-TbK"/>
                 <outlet property="delogo" destination="ArE-2s-JIV" id="zzg-gr-TsG"/>
+                <outlet property="disableSubtitles" destination="7kN-KF-Pba" id="RT2-kv-iV5"/>
                 <outlet property="doubleSize" destination="Hal-18-Tnf" id="vnl-Rb-Y3o"/>
                 <outlet property="encodingMenu" destination="Pf6-5i-B1E" id="Gat-gG-pkT"/>
                 <outlet property="fileLoop" destination="D1y-kv-85s" id="xSv-oo-UJa"/>

--- a/iina/Base.lproj/MainMenu.xib
+++ b/iina/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14460.30.1" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14460.30.1"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -660,6 +660,7 @@ CA
                     </menu>
                 </menuItem>
             </items>
+            <point key="canvasLocation" x="139" y="154"/>
         </menu>
         <customObject id="cyK-tE-xgA" customClass="MenuController" customModule="IINA" customModuleProvider="target">
             <connections>
@@ -692,7 +693,6 @@ CA
                 <outlet property="deinterlace" destination="yHI-7D-OaI" id="Z8n-z4-52B"/>
                 <outlet property="deleteCurrentFile" destination="npH-8B-XA4" id="23t-fO-TbK"/>
                 <outlet property="delogo" destination="ArE-2s-JIV" id="zzg-gr-TsG"/>
-                <outlet property="disableSubtitles" destination="7kN-KF-Pba" id="RT2-kv-iV5"/>
                 <outlet property="doubleSize" destination="Hal-18-Tnf" id="vnl-Rb-Y3o"/>
                 <outlet property="encodingMenu" destination="Pf6-5i-B1E" id="Gat-gG-pkT"/>
                 <outlet property="fileLoop" destination="D1y-kv-85s" id="xSv-oo-UJa"/>
@@ -765,6 +765,7 @@ CA
                 <outlet property="subFont" destination="rme-fr-5rr" id="fU3-xp-rD9"/>
                 <outlet property="subMenu" destination="EKp-Qx-4Mn" id="BeV-rZ-uYC"/>
                 <outlet property="subTrackMenu" destination="16p-PA-x34" id="yGc-SC-6rd"/>
+                <outlet property="toggleSubtitlesState" destination="7kN-KF-Pba" id="2ok-89-3qs"/>
                 <outlet property="videoFilters" destination="PyY-pR-jz7" id="QII-9H-SQV"/>
                 <outlet property="videoMenu" destination="HyV-fh-RgO" id="NtM-fw-Y8Q"/>
                 <outlet property="videoTrack" destination="j8P-Gb-HR7" id="hho-ys-R88"/>

--- a/iina/Base.lproj/QuickSettingViewController.xib
+++ b/iina/Base.lproj/QuickSettingViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -444,7 +444,7 @@
                                                                         <constraint firstAttribute="height" constant="14" id="ScZ-Cn-Mii"/>
                                                                     </constraints>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="1x" id="B0I-bX-HZS">
-                                                                        <font key="font" metaFont="label" size="9"/>
+                                                                        <font key="font" metaFont="toolTip" size="9"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
@@ -452,7 +452,7 @@
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Njq-za-TIf">
                                                                     <rect key="frame" x="167" y="323" width="19" height="11"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="4x" id="PLX-gY-e0h">
-                                                                        <font key="font" metaFont="label" size="9"/>
+                                                                        <font key="font" metaFont="toolTip" size="9"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
@@ -470,7 +470,7 @@
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3EN-WD-QNI" userLabel="Speed Slider Indicator">
                                                                     <rect key="frame" x="92" y="353" width="19" height="13"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="1x" usesSingleLineMode="YES" id="ldQ-YL-IEp">
-                                                                        <font key="font" metaFont="system" size="10"/>
+                                                                        <font key="font" metaFont="menu" size="10"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
@@ -481,7 +481,7 @@
                                                                         <constraint firstAttribute="height" constant="14" id="Duh-ya-4aq"/>
                                                                     </constraints>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="16x" id="p63-Nx-yJZ">
-                                                                        <font key="font" metaFont="label" size="9"/>
+                                                                        <font key="font" metaFont="toolTip" size="9"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
@@ -500,7 +500,7 @@
                                                                         <constraint firstAttribute="height" constant="14" id="JVv-2s-ysw"/>
                                                                     </constraints>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="0.25x" id="Ew1-N1-0Pi">
-                                                                        <font key="font" metaFont="label" size="9"/>
+                                                                        <font key="font" metaFont="toolTip" size="9"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
@@ -893,7 +893,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="360" height="823"/>
                                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="oVx-Sp-Lhl">
                                             <rect key="frame" x="0.0" y="0.0" width="360" height="823"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="NZU-RD-Dm3" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="315" width="360" height="508"/>
@@ -913,7 +913,7 @@
                                                                     <rect key="frame" x="0.0" y="388" width="360" height="76"/>
                                                                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="vgF-KN-yHf">
                                                                         <rect key="frame" x="0.0" y="0.0" width="360" height="76"/>
-                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                        <autoresizingMask key="autoresizingMask"/>
                                                                         <subviews>
                                                                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="FLg-2m-Zaq">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="360" height="76"/>
@@ -1078,7 +1078,7 @@
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="doa-7T-eeK">
                                                                     <rect key="frame" x="18" y="228" width="20" height="11"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="-5s" id="YCG-xK-eAs">
-                                                                        <font key="font" metaFont="label" size="9"/>
+                                                                        <font key="font" metaFont="toolTip" size="9"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
@@ -1086,7 +1086,7 @@
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kF3-Ee-Pha">
                                                                     <rect key="frame" x="247" y="228" width="15" height="11"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="5s" id="C0t-gm-Tim">
-                                                                        <font key="font" metaFont="label" size="9"/>
+                                                                        <font key="font" metaFont="toolTip" size="9"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
@@ -1094,7 +1094,7 @@
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="C39-jO-zwp">
                                                                     <rect key="frame" x="131" y="228" width="19" height="11"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="0s" id="wgA-op-JP4">
-                                                                        <font key="font" metaFont="label" size="9"/>
+                                                                        <font key="font" metaFont="toolTip" size="9"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
@@ -1125,7 +1125,7 @@
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gR7-cS-zmu" userLabel="Speed Slider Indicator">
                                                                     <rect key="frame" x="130" y="259" width="20" height="13"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="0s" usesSingleLineMode="YES" id="s3F-Tl-Siy">
-                                                                        <font key="font" metaFont="system" size="10"/>
+                                                                        <font key="font" metaFont="menu" size="10"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
@@ -1255,7 +1255,7 @@
                                                                             <rect key="frame" x="11" y="0.0" width="37" height="14"/>
                                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="31.25" id="HBF-J7-Tie">
-                                                                                <font key="font" metaFont="label" size="9"/>
+                                                                                <font key="font" metaFont="toolTip" size="9"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
@@ -1264,7 +1264,7 @@
                                                                             <rect key="frame" x="68" y="3" width="30" height="11"/>
                                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="125" id="1cq-dc-JfM">
-                                                                                <font key="font" metaFont="label" size="9"/>
+                                                                                <font key="font" metaFont="toolTip" size="9"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
@@ -1273,7 +1273,7 @@
                                                                             <rect key="frame" x="95" y="3" width="30" height="11"/>
                                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="250" id="ekh-gc-2qo">
-                                                                                <font key="font" metaFont="label" size="9"/>
+                                                                                <font key="font" metaFont="toolTip" size="9"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
@@ -1282,7 +1282,7 @@
                                                                             <rect key="frame" x="122" y="3" width="30" height="11"/>
                                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="500" id="tHa-vN-OlI">
-                                                                                <font key="font" metaFont="label" size="9"/>
+                                                                                <font key="font" metaFont="toolTip" size="9"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
@@ -1291,7 +1291,7 @@
                                                                             <rect key="frame" x="149" y="3" width="30" height="11"/>
                                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="1k" id="Rtc-Eg-J2u">
-                                                                                <font key="font" metaFont="label" size="9"/>
+                                                                                <font key="font" metaFont="toolTip" size="9"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
@@ -1300,7 +1300,7 @@
                                                                             <rect key="frame" x="176" y="3" width="30" height="11"/>
                                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="2k" id="j9w-YU-EcC">
-                                                                                <font key="font" metaFont="label" size="9"/>
+                                                                                <font key="font" metaFont="toolTip" size="9"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
@@ -1309,7 +1309,7 @@
                                                                             <rect key="frame" x="203" y="3" width="30" height="11"/>
                                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="4k" id="i0j-2a-vKD">
-                                                                                <font key="font" metaFont="label" size="9"/>
+                                                                                <font key="font" metaFont="toolTip" size="9"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
@@ -1318,7 +1318,7 @@
                                                                             <rect key="frame" x="228" y="3" width="30" height="11"/>
                                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="8k" id="e4X-H4-VxS">
-                                                                                <font key="font" metaFont="label" size="9"/>
+                                                                                <font key="font" metaFont="toolTip" size="9"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
@@ -1327,7 +1327,7 @@
                                                                             <rect key="frame" x="253" y="3" width="30" height="11"/>
                                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="16k" id="era-AG-bSl">
-                                                                                <font key="font" metaFont="label" size="9"/>
+                                                                                <font key="font" metaFont="toolTip" size="9"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
@@ -1336,7 +1336,7 @@
                                                                             <rect key="frame" x="41" y="3" width="30" height="11"/>
                                                                             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="62.5" id="4PG-5R-5G0">
-                                                                                <font key="font" metaFont="label" size="9"/>
+                                                                                <font key="font" metaFont="toolTip" size="9"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
@@ -1449,7 +1449,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="360" height="823"/>
                                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="epy-wp-Ja5">
                                             <rect key="frame" x="0.0" y="0.0" width="360" height="823"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="pm4-x9-WJ5" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="-2" width="360" height="825"/>
@@ -1461,7 +1461,7 @@
                                                                     <rect key="frame" x="0.0" y="301" width="360" height="72"/>
                                                                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="dJV-R0-O3M">
                                                                         <rect key="frame" x="0.0" y="0.0" width="360" height="72"/>
-                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                        <autoresizingMask key="autoresizingMask"/>
                                                                         <subviews>
                                                                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="2vU-hm-gGB">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="360" height="72"/>
@@ -1596,7 +1596,7 @@
                                                                     <rect key="frame" x="0.0" y="185" width="360" height="72"/>
                                                                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="EKn-MX-Fao">
                                                                         <rect key="frame" x="0.0" y="0.0" width="360" height="72"/>
-                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                        <autoresizingMask key="autoresizingMask"/>
                                                                         <subviews>
                                                                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="Jve-qX-Agy">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="360" height="72"/>
@@ -1764,7 +1764,7 @@
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VbE-TV-lb5">
                                                                     <rect key="frame" x="18" y="26" width="20" height="11"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="-5s" id="uCX-EC-jXM">
-                                                                        <font key="font" metaFont="label" size="9"/>
+                                                                        <font key="font" metaFont="toolTip" size="9"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
@@ -1772,7 +1772,7 @@
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="r77-VA-Z1b">
                                                                     <rect key="frame" x="241" y="26" width="21" height="11"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="+5s" id="xfX-wr-DTJ">
-                                                                        <font key="font" metaFont="label" size="9"/>
+                                                                        <font key="font" metaFont="toolTip" size="9"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
@@ -1780,7 +1780,7 @@
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VdJ-nq-zaM" userLabel="Speed Slider Indicator">
                                                                     <rect key="frame" x="130" y="57" width="20" height="13"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="0s" usesSingleLineMode="YES" id="upM-Lz-YwK">
-                                                                        <font key="font" metaFont="system" size="10"/>
+                                                                        <font key="font" metaFont="menu" size="10"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
@@ -1811,7 +1811,7 @@
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kzp-GR-Sy4">
                                                                     <rect key="frame" x="131" y="26" width="19" height="11"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="0s" id="LEZ-fv-buL">
-                                                                        <font key="font" metaFont="label" size="9"/>
+                                                                        <font key="font" metaFont="toolTip" size="9"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>

--- a/iina/IINACommand.swift
+++ b/iina/IINACommand.swift
@@ -35,5 +35,6 @@ enum IINACommand: String {
 
   case findOnlineSubs = "find-online-subs"
   case saveDownloadedSub = "save-downloaded-sub"
+  case disableSubtitles = "disable-subtitles"
 
 }

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -753,21 +753,11 @@ class MPVController: NSObject {
 
     case MPVOption.TrackSelection.sid:
       player.info.sid = Int(getInt(MPVOption.TrackSelection.sid))
-      if player.info.sid != 0 && player.info.subDisabled == true {
-        player.info.subDisabled = false
-      } else if player.info.sid == 0 && player.info.secondSid == 0 {
-        player.info.subDisabled = true
-      }
       player.postNotification(.iinaSIDChanged)
       player.sendOSD(.track(player.info.currentTrack(.sub) ?? .noneSubTrack))
 
     case MPVOption.Subtitles.secondarySid:
       player.info.secondSid = Int(getInt(MPVOption.Subtitles.secondarySid))
-      if player.info.secondSid != 0 && player.info.subDisabled == true {
-        player.info.subDisabled = false
-      } else if player.info.sid == 0 && player.info.secondSid == 0 {
-        player.info.subDisabled = true
-      }
       player.postNotification(.iinaSIDChanged)
 
     case MPVOption.PlaybackControl.pause:

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -753,11 +753,21 @@ class MPVController: NSObject {
 
     case MPVOption.TrackSelection.sid:
       player.info.sid = Int(getInt(MPVOption.TrackSelection.sid))
+      if player.info.sid != 0 && player.info.subDisabled == true {
+        player.info.subDisabled = false
+      } else if player.info.sid == 0 && player.info.secondSid == 0 {
+        player.info.subDisabled = true
+      }
       player.postNotification(.iinaSIDChanged)
       player.sendOSD(.track(player.info.currentTrack(.sub) ?? .noneSubTrack))
 
     case MPVOption.Subtitles.secondarySid:
       player.info.secondSid = Int(getInt(MPVOption.Subtitles.secondarySid))
+      if player.info.secondSid != 0 && player.info.subDisabled == true {
+        player.info.subDisabled = false
+      } else if player.info.sid == 0 && player.info.secondSid == 0 {
+        player.info.subDisabled = true
+      }
       player.postNotification(.iinaSIDChanged)
 
     case MPVOption.PlaybackControl.pause:

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -263,6 +263,10 @@ extension MainMenuActionHandler {
 // MARK: - Subtitles
 
 extension MainMenuActionHandler {
+  @objc func menuToggleSubtitle(_ sender: NSMenuItem) {
+    
+  }
+  
   @objc func menuLoadExternalSub(_ sender: NSMenuItem) {
     Utility.quickOpenPanel(title: "Load external subtitle file", chooseDir: false) { url in
       self.player.loadExternalSubFile(url, delay: true)

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -263,13 +263,15 @@ extension MainMenuActionHandler {
 // MARK: - Subtitles
 
 extension MainMenuActionHandler {
-
-  @objc func menuToggleDisableSubtitles(_ sender: NSMenuItem) {
-    if !player.info.subDisabled {
-      player.toggleDisableSubtitles(true)
-    } else {
-      player.toggleDisableSubtitles(false)
-    }
+  
+  /// Enables/disables subtitles by changing the active subtitle tracks.
+  ///
+  /// This method delegates al actuall functionalities to `player.toggleSubtitlesState()`.
+  ///
+  /// - Parameter sender: The menu item that calls this method.
+  @objc @inlinable
+  func menuToggleSubtitlesState(_ sender: NSMenuItem) {
+    player.toggleSubtitlesState()
   }
 
   @objc func menuLoadExternalSub(_ sender: NSMenuItem) {

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -260,7 +260,7 @@ extension MainMenuActionHandler {
   }
 }
 
-// MARK: - Sub
+// MARK: - Subtitles
 
 extension MainMenuActionHandler {
   @objc func menuLoadExternalSub(_ sender: NSMenuItem) {

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -263,10 +263,15 @@ extension MainMenuActionHandler {
 // MARK: - Subtitles
 
 extension MainMenuActionHandler {
-  @objc func menuToggleSubtitle(_ sender: NSMenuItem) {
-    
+
+  @objc func menuToggleDisableSubtitles(_ sender: NSMenuItem) {
+    if !player.info.subDisabled {
+      player.toggleDisableSubtitles(true)
+    } else {
+      player.toggleDisableSubtitles(false)
+    }
   }
-  
+
   @objc func menuLoadExternalSub(_ sender: NSMenuItem) {
     Utility.quickOpenPanel(title: "Load external subtitle file", chooseDir: false) { url in
       self.player.loadExternalSubFile(url, delay: true)

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -141,7 +141,6 @@ class MenuController: NSObject, NSMenuDelegate {
   // Subtitle
   @IBOutlet weak var subMenu: NSMenu!
   @IBOutlet weak var quickSettingsSub: NSMenuItem!
-  @IBOutlet weak var toggleSubtitles: NSMenuItem!
   @IBOutlet weak var cycleSubtitles: NSMenuItem!
   @IBOutlet weak var subTrackMenu: NSMenu!
   @IBOutlet weak var secondSubTrackMenu: NSMenu!
@@ -343,6 +342,7 @@ class MenuController: NSObject, NSMenuDelegate {
     loadExternalSub.action = #selector(MainMenuActionHandler.menuLoadExternalSub(_:))
     subTrackMenu.delegate = self
     secondSubTrackMenu.delegate = self
+    disableSubtitles.action = #selector(MainMenuActionHandler.menuToggleDisableSubtitles(_:))
 
     findOnlineSub.action = #selector(MainMenuActionHandler.menuFindOnlineSub(_:))
     saveDownloadedSub.action = #selector(MainMenuActionHandler.saveDownloadedSub(_:))
@@ -477,6 +477,7 @@ class MenuController: NSObject, NSMenuDelegate {
 
   private func updateSubMenu() {
     let player = PlayerCore.active
+    disableSubtitles.state = player.info.subDisabled ? .on : .off
     subDelayIndicator.title = String(format: NSLocalizedString("menu.sub_delay", comment: "Subtitle Delay:"), player.info.subDelay)
 
     let encodingCode = player.info.subEncoding ?? "auto"
@@ -680,6 +681,7 @@ class MenuController: NSObject, NSMenuDelegate {
       (resetSubDelay, false, ["set", "sub-delay", "0"], true, nil, nil),
       (increaseTextSize, false, ["multiply", "sub-scale", "1.1"], true, 1.01...1.49, nil),
       (decreaseTextSize, false, ["multiply", "sub-scale", "0.9"], true, 0.71...0.99, nil),
+      (disableSubtitles, true, ["disable-subtitles"], false, nil, nil),
       (resetTextSize, false, ["set", "sub-scale", "1"], true, nil, nil),
       (alwaysOnTop, false, ["cycle", "ontop"], false, nil, nil),
       (fullScreen, false, ["cycle", "fullscreen"], false, nil, nil)

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -141,6 +141,7 @@ class MenuController: NSObject, NSMenuDelegate {
   // Subtitle
   @IBOutlet weak var subMenu: NSMenu!
   @IBOutlet weak var quickSettingsSub: NSMenuItem!
+  @IBOutlet weak var toggleSubtitles: NSMenuItem!
   @IBOutlet weak var cycleSubtitles: NSMenuItem!
   @IBOutlet weak var subTrackMenu: NSMenu!
   @IBOutlet weak var secondSubTrackMenu: NSMenu!

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -478,7 +478,7 @@ class MenuController: NSObject, NSMenuDelegate {
 
   private func updateSubMenu() {
     let player = PlayerCore.active
-    toggleSubtitlesState.state = player.info.subDisabled ? .on : .off
+    toggleSubtitlesState.state = player.info.subtitlesAreDisabled ? .on : .off
     subDelayIndicator.title = String(format: NSLocalizedString("menu.sub_delay", comment: "Subtitle Delay:"), player.info.subDelay)
 
     let encodingCode = player.info.subEncoding ?? "auto"

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -140,6 +140,7 @@ class MenuController: NSObject, NSMenuDelegate {
   @IBOutlet weak var savedAudioFiltersMenu: NSMenu!
   // Subtitle
   @IBOutlet weak var subMenu: NSMenu!
+  @IBOutlet weak var toggleSubtitlesState: NSMenuItem!
   @IBOutlet weak var quickSettingsSub: NSMenuItem!
   @IBOutlet weak var cycleSubtitles: NSMenuItem!
   @IBOutlet weak var subTrackMenu: NSMenu!
@@ -342,7 +343,7 @@ class MenuController: NSObject, NSMenuDelegate {
     loadExternalSub.action = #selector(MainMenuActionHandler.menuLoadExternalSub(_:))
     subTrackMenu.delegate = self
     secondSubTrackMenu.delegate = self
-    disableSubtitles.action = #selector(MainMenuActionHandler.menuToggleDisableSubtitles(_:))
+    toggleSubtitlesState.action = #selector(MainMenuActionHandler.menuToggleSubtitlesState(_:))
 
     findOnlineSub.action = #selector(MainMenuActionHandler.menuFindOnlineSub(_:))
     saveDownloadedSub.action = #selector(MainMenuActionHandler.saveDownloadedSub(_:))
@@ -477,7 +478,7 @@ class MenuController: NSObject, NSMenuDelegate {
 
   private func updateSubMenu() {
     let player = PlayerCore.active
-    disableSubtitles.state = player.info.subDisabled ? .on : .off
+    toggleSubtitlesState.state = player.info.subDisabled ? .on : .off
     subDelayIndicator.title = String(format: NSLocalizedString("menu.sub_delay", comment: "Subtitle Delay:"), player.info.subDelay)
 
     let encodingCode = player.info.subEncoding ?? "auto"
@@ -681,7 +682,7 @@ class MenuController: NSObject, NSMenuDelegate {
       (resetSubDelay, false, ["set", "sub-delay", "0"], true, nil, nil),
       (increaseTextSize, false, ["multiply", "sub-scale", "1.1"], true, 1.01...1.49, nil),
       (decreaseTextSize, false, ["multiply", "sub-scale", "0.9"], true, 0.71...0.99, nil),
-      (disableSubtitles, true, ["disable-subtitles"], false, nil, nil),
+      (toggleSubtitlesState, true, ["disable-subtitles"], false, nil, nil),
       (resetTextSize, false, ["set", "sub-scale", "1"], true, nil, nil),
       (alwaysOnTop, false, ["cycle", "ontop"], false, nil, nil),
       (fullScreen, false, ["cycle", "fullscreen"], false, nil, nil)

--- a/iina/OSDMessage.swift
+++ b/iina/OSDMessage.swift
@@ -63,6 +63,8 @@ enum OSDMessage {
   case addFilter(String)
   case removeFilter
 
+  case disableSubtitles
+  case enableSubtitles
   case startFindingSub(String)  // sub source
   case foundSub(Int)
   case downloadedSub(String)  // filename
@@ -162,6 +164,12 @@ enum OSDMessage {
         String(format: NSLocalizedString("osd.subtitle_pos", comment: "Subtitle Position: %f"), value),
         .withProgress(value / 100)
       )
+
+    case .disableSubtitles:
+      return (NSLocalizedString("osd.subtitles_disabled", comment: "Subtitles Disabled"), .normal)
+
+    case .enableSubtitles:
+      return (NSLocalizedString("osd.subtitles_enabled", comment: "Subtitles Enabled"), .normal)
 
     case .mute:
       return (NSLocalizedString("osd.mute", comment: "Mute"), .normal)

--- a/iina/OSDMessage.swift
+++ b/iina/OSDMessage.swift
@@ -62,7 +62,8 @@ enum OSDMessage {
 
   case addFilter(String)
   case removeFilter
-
+  
+  //  FIXME: Use swifty case names for `disableSubtitles` and `enableSubtitles`.
   case disableSubtitles
   case enableSubtitles
   case startFindingSub(String)  // sub source

--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -135,6 +135,9 @@ class PlaybackInfo {
   var sid: Int?
   var vid: Int?
   var secondSid: Int?
+  var savedSid: Int?
+  var savedSecondSid: Int?
+  var subDisabled: Bool = false
 
   var subEncoding: String?
 

--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -132,12 +132,59 @@ class PlaybackInfo {
 
   /** Selected track IDs. Use these (instead of `isSelected` of a track) to check if selected */
   var aid: Int?
-  var sid: Int?
   var vid: Int?
-  var secondSid: Int?
-  var savedSid: Int?
-  var savedSecondSid: Int?
-  var subDisabled: Bool = false
+  //  FIXME: Use a tupple for the 2 subtitle track indices.
+  /// The first subtitle track index.
+  var sid: Int? = 0 {
+    didSet(previousFirstSubtitleTrackIndex) {
+      //  In order to prevent a didSet loop between the first subtitle track index's and the subtitles state's observers, we need to ensure that the subtitle track index did change before everything.
+      guard sid != previousFirstSubtitleTrackIndex else { return }
+      recoveredFirstSubtitleTrackIndex = previousFirstSubtitleTrackIndex
+      guard let firstSubtitleTrackIndex = sid, let secondSubtitleTrackIndex = secondSid else { return }
+      subtitlesAreEnabled = firstSubtitleTrackIndex > 0 || secondSubtitleTrackIndex > 0
+    }
+  }
+  
+  /// The second subtitle track index.
+  var secondSid: Int? = 0 {
+    didSet(previousSecondSubtitleTrackIndex) {
+      //  In order to prevent a didSet loop between the second subtitle track index's and the subtitles state's observers, we need to ensure that the subtitle track index did change before everything.
+      guard secondSid != previousSecondSubtitleTrackIndex else { return }
+      recoveredSecondSubtitleTrackIndex = previousSecondSubtitleTrackIndex
+      guard let firstSubtitleTrackIndex = sid, let secondSubtitleTrackIndex = secondSid else { return }
+      subtitlesAreEnabled = firstSubtitleTrackIndex > 0 || secondSubtitleTrackIndex > 0
+    }
+  }
+  
+  /// The first subtitle track index to revert to when subtitles are (re-)enabled.
+  ///
+  /// The default value is `1`. A video starts with no subtitles, with subtitles in the off state (disabled). When the user enables subtitles for the first time, the first subtitle switches to the 1st track.
+  var recoveredFirstSubtitleTrackIndex: Int? = 1
+  
+  /// The second subtitle track index to revert to when subtitles are (re-)enabled.
+  ///
+  /// The default value is `0`. A video starts with no subtitles, with subtitles in the off state (disabled). When the user enables subtitles for the first time, the second subtitle stays off.
+  var recoveredSecondSubtitleTrackIndex: Int? = 0
+  
+  //  FIXME: Remove `subtitlesAreDisabled`.
+  var subtitlesAreDisabled: Bool {
+    get { !subtitlesAreEnabled }
+    set(newSubtitleState) { subtitlesAreEnabled = !newSubtitleState }
+  }
+  
+  /// The Boolean value indicating whether the subtitles are on (enabled).
+  var subtitlesAreEnabled: Bool = false {
+    //  FIXME: Fix the property observer logic.
+    //  Everything before `sendOSD` should be in a `willSet` observer, but it will lead to `sendOSD` being called twise, so everything is in `didSet` for now.
+    didSet(previousSubtitlesState) {
+      //  In order to prevent a didSet loop between the subtitle tracks indices's and the subtitles state's observers, we need to ensure that the subtitles state did change before everything.
+      guard previousSubtitlesState != subtitlesAreEnabled else { return }
+      player.mpv.setInt(MPVOption.TrackSelection.sid, subtitlesAreEnabled ? recoveredFirstSubtitleTrackIndex! : 0)
+      player.mpv.setInt(MPVOption.Subtitles.secondarySid, subtitlesAreEnabled ? recoveredSecondSubtitleTrackIndex! : 0)
+      //  FIXME: sendOSD doesn't work here because as soon as a sub track changes, the property listeners in MPVController will fire their own OSD message effectively making the ones here unseen
+      player.sendOSD(subtitlesAreEnabled ? .enableSubtitles : .disableSubtitles)
+    }
+  }
 
   var subEncoding: String?
 

--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -129,7 +129,8 @@ class PlaybackInfo {
   var subTracks: [MPVTrack] = []
 
   var abLoopStatus: Int = 0 // 0: none, 1: A set, 2: B set (looping)
-
+  
+  //  FIXME: Make track indices concrete, non-optional.
   /** Selected track IDs. Use these (instead of `isSelected` of a track) to check if selected */
   var aid: Int?
   var vid: Int?

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -663,6 +663,28 @@ class PlayerCore: NSObject {
     mpv.setFlag(MPVOption.Video.deinterlace, enable)
   }
 
+// Add a "Disable Subtitles" toggle.
+  func toggleDisableSubtitles(_ enable: Bool) {
+    // FIXME sendOSD doesn't work here because as soon as a sub track changes,
+    // the property listeners in MPVController will fire their own OSD message
+    // effectively making the ones here unseen
+    if enable {
+      if !info.subDisabled {
+        info.savedSid = info.sid
+        info.savedSecondSid = info.secondSid
+        mpv.setInt(MPVOption.TrackSelection.sid, 0)
+        mpv.setInt(MPVOption.Subtitles.secondarySid, 0)
+        info.subDisabled = true
+        // sendOSD(.disableSubtitles)
+      }
+    } else {
+      mpv.setInt(MPVOption.TrackSelection.sid, info.savedSid ?? 1)
+      mpv.setInt(MPVOption.Subtitles.secondarySid, info.savedSecondSid ?? 0)
+      info.subDisabled = false
+      // sendOSD(.enableSubtitles)
+    }
+  }
+
   func toggleHardwareDecoding(_ enable: Bool) {
     let value = Preference.HardwareDecoderOption(rawValue: Preference.integer(for: .hardwareDecoder))?.mpvString ?? "auto"
     mpv.setString(MPVOption.Video.hwdec, enable ? value : "no")

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -663,26 +663,9 @@ class PlayerCore: NSObject {
     mpv.setFlag(MPVOption.Video.deinterlace, enable)
   }
 
-// Add a "Disable Subtitles" toggle.
-  func toggleDisableSubtitles(_ enable: Bool) {
-    // FIXME sendOSD doesn't work here because as soon as a sub track changes,
-    // the property listeners in MPVController will fire their own OSD message
-    // effectively making the ones here unseen
-    if enable {
-      if !info.subDisabled {
-        info.savedSid = info.sid
-        info.savedSecondSid = info.secondSid
-        mpv.setInt(MPVOption.TrackSelection.sid, 0)
-        mpv.setInt(MPVOption.Subtitles.secondarySid, 0)
-        info.subDisabled = true
-        // sendOSD(.disableSubtitles)
-      }
-    } else {
-      mpv.setInt(MPVOption.TrackSelection.sid, info.savedSid ?? 1)
-      mpv.setInt(MPVOption.Subtitles.secondarySid, info.savedSecondSid ?? 0)
-      info.subDisabled = false
-      // sendOSD(.enableSubtitles)
-    }
+  @inlinable
+  func toggleSubtitlesState() {
+    info.subtitlesAreEnabled.toggle()
   }
 
   func toggleHardwareDecoding(_ enable: Bool) {

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -498,7 +498,7 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
     case .saveDownloadedSub:
       menuActionHandler.saveDownloadedSub(.dummy)
     case .disableSubtitles:
-      menuActionHandler.menuToggleDisableSubtitles(.dummy)
+      menuActionHandler.menuToggleSubtitlesState(.dummy)
     default:
       break
     }

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -497,6 +497,8 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
       menuActionHandler.menuFindOnlineSub(.dummy)
     case .saveDownloadedSub:
       menuActionHandler.saveDownloadedSub(.dummy)
+    case .disableSubtitles:
+      menuActionHandler.menuToggleDisableSubtitles(.dummy)
     default:
       break
     }

--- a/iina/config/iina-default-input.conf
+++ b/iina/config/iina-default-input.conf
@@ -73,6 +73,7 @@ X add sub-delay 0.5
 Alt+Z add sub-delay -0.1
 Alt+X add sub-delay 0.1
 C set sub-delay 0
+#@iina Ctrl+v disable-subtitles
 
 ESC set fullscreen no
 ENTER set fullscreen yes

--- a/iina/config/iina-default-input.conf
+++ b/iina/config/iina-default-input.conf
@@ -73,7 +73,7 @@ X add sub-delay 0.5
 Alt+Z add sub-delay -0.1
 Alt+X add sub-delay 0.1
 C set sub-delay 0
-#@iina Ctrl+v disable-subtitles
+#@iina S disable-subtitles
 
 ESC set fullscreen no
 ENTER set fullscreen yes

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -45,6 +45,8 @@
 "osd.subtitle_pos" = "Subtitle Position: %.1f";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
+"osd.disable_subtitles" = "Subtitles Disabled";
+"osd.enable_subtitles" = "Subtitles Enabled";
 "osd.screenshot" = "Screenshot Captured";
 "osd.abloop.a" = "AB-Loop: A";
 "osd.abloop.b" = "AB-Loop: B";

--- a/iina/fr.lproj/Localizable.strings
+++ b/iina/fr.lproj/Localizable.strings
@@ -42,6 +42,8 @@
 "osd.subtitle_pos" = "Positon des sous-titres : %.1f";
 "osd.mute" = "Son coupé";
 "osd.unmute" = "Son rétabli";
+"osd.disable_subtitles" = "Sous-titres activés";
+"osd.enable_subtitles" = "Sous-titres désactivés";
 "osd.screenshot" = "Une capture d'écran a été prise";
 "osd.abloop.a" = "Boucle AB : A";
 "osd.abloop.b" = "Boucle AB : B";

--- a/iina/zh-Hans.lproj/Localizable.strings
+++ b/iina/zh-Hans.lproj/Localizable.strings
@@ -42,6 +42,8 @@
 "osd.subtitle_pos" = "字幕位置：%.1f";
 "osd.mute" = "静音";
 "osd.unmute" = "取消静音";
+"osd.disable_subtitles" = "已启用字幕";
+"osd.enable_subtitles" = "已停用字幕";
 "osd.screenshot" = "已保存截图";
 "osd.abloop.a" = "AB循环：A";
 "osd.abloop.b" = "AB循环：B";

--- a/iina/zh-Hant.lproj/Localizable.strings
+++ b/iina/zh-Hant.lproj/Localizable.strings
@@ -42,6 +42,8 @@
 "osd.subtitle_pos" = "字幕位置：%.1f";
 "osd.mute" = "靜音";
 "osd.unmute" = "解除靜音";
+"osd.disable_subtitles" = "已啟用字幕";
+"osd.enable_subtitles" = "已停用字幕";
 "osd.screenshot" = "螢幕快照已擷取";
 "osd.abloop.a" = "AB循環：A";
 "osd.abloop.b" = "AB循環：B";


### PR DESCRIPTION
- [x] This change has been discussed with the author.
- [x] It implements issue #2856.

---

This is a draft pull request, wherein not all features are fully implemented yet. In addition to taking advantage of the CI, it acts as a reference point for progress-tracking, and allows everyone an early glimpse of the code itself. The planned features are as follows:

- [ ] Add a subtitles state toggle that keeps subtitles visible but switches subtitles between user-selected tracks and the `None` tracks.
  - [x] Add the toggling logic. (The groundwork is done by @unique-username313)
  - [x] Bind its shortcut to the `S` key.
  - [ ] Provide the user with multiple ways/routes of toggling the subtitles state.
- [ ] Add subtitles visibility toggle that keeps the subtitles' track selection but hides/unhides the subtitles' rendering.
  - [ ] Add the toggling logic.
  - [ ] Bind its shortcut to the `V` key.
  - [ ] Provide the user with multiple ways/routes of toggling the subtitles visibility.
- [ ] Add preferences options for enabling/disabling either toggle features.
- [ ] Prevent OSD messages from hiding each other.

_slaps roof of pull request_ this bad boy can fit so much feature enhancement