### PR TITLE
Resolve race issue with info not loaded errors

### DIFF
--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -153,7 +153,6 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
 
   override func windowDidLoad() {
     super.windowDidLoad()
-    loaded = true
     
     guard let window = window else { return }
     
@@ -190,6 +189,8 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
         self.player.pause()
       }
     })
+    
+    loaded = true
   }
 
   deinit {


### PR DESCRIPTION
Seems to fix issue #3013 but not sure why.
---
Original issue for me was when I moved a bunch of files I was working on from direct attached storage to a NAS, I began to get random fatal errors upon loading video files, usually about 1 in 6 to 1 in 8 times. This would be very irritating as I'd have to reload all the files already open, and re-opening would often cause the error to happen again.

After a bit of experimentation I moved the 'loaded = true' statement from the start to the end of windowDidLoad override function. This seems to have eliminated the problem with no discernible side effects. I'd like someone to check the change in case of unknown side effects, as frankly I'm not certain why this works other than some non-specific race condition. I have tested it plenty and cannot reproduce either the error nor any side effects though.
