### PR TITLE
Fix saved subtitle filename, remove prefix like [1]

### DIFF
--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -366,7 +366,7 @@ extension MainMenuActionHandler {
       return
     }
     let subURL = URL(fileURLWithPath: path)
-    let subFileName = subURL.lastPathComponent
+    let subFileName = subURL.lastPathComponent.replacingOccurrences(of: #"^\[\d+\]"#, with: "", options: .regularExpression)
     let destURL = currURL.deletingLastPathComponent().appendingPathComponent(subFileName, isDirectory: false)
     do {
       try FileManager.default.copyItem(at: subURL, to: destURL)


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #2117.

---

**Description:** See issue #2117, currently saving downloaded subtitles will add a '[1]' prefix to the filename, which is inconvenient for video players to automatically load it (include IINA itself).

This PR removes the '[1]' prefix from the filename when saving the downloaded subtitle.