### PR TITLE
Specify larger/arbitrary thumbnail size from UI

### DIFF
--- a/iina/Base.lproj/PrefUIViewController.xib
+++ b/iina/Base.lproj/PrefUIViewController.xib
@@ -998,6 +998,46 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HuG-oX-DYq">
+                    <rect key="frame" x="365" y="9" width="44" height="16"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Width:" id="oRr-Pl-6jA">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField identifier="AccessoryLabelTextSize" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ub2-7Q-IEp">
+                    <rect key="frame" x="479" y="9" width="19" height="16"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="px" id="xzu-gE-gAq">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="f1z-eR-2dl">
+                    <rect key="frame" x="415" y="5" width="58" height="21"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="58" id="QQs-WH-J0x"/>
+                    </constraints>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" drawsBackground="YES" id="TeR-oh-jFk">
+                        <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="C4U-YV-QWW">
+                            <real key="minimum" value="0.0"/>
+                        </numberFormatter>
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                    <connections>
+                        <binding destination="lH7-Vv-0M1" name="enabled" keyPath="values.enableThumbnailPreview" id="OGg-fd-Bxo"/>
+                        <binding destination="lH7-Vv-0M1" name="value" keyPath="values.thumbnailWidth" id="4pi-Ru-apY">
+                            <dictionary key="options">
+                                <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                            </dictionary>
+                        </binding>
+                    </connections>
+                </textField>
             </subviews>
             <constraints>
                 <constraint firstItem="Oba-nc-n1C" firstAttribute="baseline" secondItem="bWp-lc-kLe" secondAttribute="baseline" id="2fJ-Tc-1Da"/>

--- a/iina/FFmpegController.h
+++ b/iina/FFmpegController.h
@@ -38,7 +38,8 @@
 
 @property(nonatomic) NSInteger thumbnailCount;
 
-- (void)generateThumbnailForFile:(nonnull NSString *)file;
+- (void)generateThumbnailForFile:(nonnull NSString *)file
+                      thumbWidth:(int)thumbWidth;
 
 + (NSDictionary *)probeVideoInfoForFile:(nonnull NSString *)file;
 

--- a/iina/FFmpegController.m
+++ b/iina/FFmpegController.m
@@ -45,7 +45,7 @@ return -1;\
   double _timestamp;
 }
 
-- (int)getPeeksForFile:(NSString *)file;
+- (int)getPeeksForFile:(NSString *)file thumbnailsWidth:(int)thumbnailsWidth;
 - (void)saveThumbnail:(AVFrame *)pFrame width:(int)width height:(int)height index:(int)index realTime:(int)second forFile:(NSString *)file;
 
 @end
@@ -69,6 +69,7 @@ return -1;\
 
 
 - (void)generateThumbnailForFile:(NSString *)file
+                      thumbWidth:(int)thumbWidth
 {
   [_queue cancelAllOperations];
   NSBlockOperation *op = [[NSBlockOperation alloc] init];
@@ -78,7 +79,7 @@ return -1;\
       return;
     }
     self->_timestamp = CACurrentMediaTime();
-    int success = [self getPeeksForFile:file];
+    int success = [self getPeeksForFile:file thumbnailsWidth:thumbWidth];
     if (self.delegate) {
       [self.delegate didGenerateThumbnails:[NSArray arrayWithArray:self->_thumbnails]
                                    forFile: file
@@ -90,6 +91,7 @@ return -1;\
 
 
 - (int)getPeeksForFile:(NSString *)file
+      thumbnailsWidth:(int)thumbnailsWidth
 {
   int i, ret;
 
@@ -159,8 +161,9 @@ return -1;\
 
   // Allocate the output frame
   // We need to convert the video frame to RGBA to satisfy CGImage's data format
-  int thumbWidth = THUMB_WIDTH;
-  int thumbHeight = THUMB_WIDTH / ((float)pCodecCtx->width / pCodecCtx->height);
+
+  int thumbWidth = thumbnailsWidth;
+  int thumbHeight = thumbWidth / ((float)pCodecCtx->width / pCodecCtx->height);
 
   AVFrame *pFrameRGB = av_frame_alloc();
   CHECK_NOTNULL(pFrameRGB, @"Cannot alloc RGBA frame")

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1951,10 +1951,12 @@ class MainWindowController: PlayerWindowController {
       if player.info.thumbnailsReady, let image = player.info.getThumbnail(forSecond: previewTime.second)?.image {
         thumbnailPeekView.imageView.image = image.rotate(rotation)
         thumbnailPeekView.isHidden = false
-        let height = round(120 / thumbnailPeekView.imageView.image!.size.aspect)
+        let thumbWidth = CGFloat(Preference.integer(for: .thumbnailWidth))
+        let height = round(thumbWidth / thumbnailPeekView.imageView.image!.size.aspect)
         let yPos = (oscPosition == .top || (oscPosition == .floating && sliderFrameInWindow.y + 52 + height >= window!.frame.height)) ?
           sliderFrameInWindow.y - height : sliderFrameInWindow.y + 32
-        thumbnailPeekView.frame.size = NSSize(width: 120, height: height)
+        thumbnailPeekView.frame.size = NSSize(width: thumbWidth, height: height)
+        thumbnailPeekView.imageView.image?.size = NSSize(width: thumbWidth, height: height)
         thumbnailPeekView.frame.origin = NSPoint(x: round(originalPos.x - thumbnailPeekView.frame.width / 2), y: yPos)
       } else {
         thumbnailPeekView.isHidden = true

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1425,7 +1425,7 @@ class PlayerCore: NSObject {
         }
       } else {
         Logger.log("Request new thumbnails", subsystem: subsystem)
-        ffmpegController.generateThumbnail(forFile: url.path)
+        ffmpegController.generateThumbnail(forFile: url.path, thumbWidth:Int32(Preference.integer(for: .thumbnailWidth)))
       }
     }
   }

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -132,6 +132,7 @@ struct Preference {
     static let enableThumbnailPreview = Key("enableThumbnailPreview")
     static let maxThumbnailPreviewCacheSize = Key("maxThumbnailPreviewCacheSize")
     static let enableThumbnailForRemoteFiles = Key("enableThumbnailForRemoteFiles")
+    static let thumbnailWidth = Key("thumbnailWidth")
 
     static let autoSwitchToMusicMode = Key("autoSwitchToMusicMode")
     static let musicModeShowPlaylist = Key("musicModeShowPlaylist")
@@ -670,6 +671,7 @@ struct Preference {
     .controlBarToolbarButtons: [ToolBarButton.pip.rawValue, ToolBarButton.playlist.rawValue, ToolBarButton.settings.rawValue],
     .oscPosition: OSCPosition.floating.rawValue,
     .playlistWidth: 270,
+    .thumbnailWidth: 120,
     .prefetchPlaylistVideoDuration: true,
     .themeMaterial: Theme.dark.rawValue,
     .enableOSD: true,


### PR DESCRIPTION
- [X] This change has been discussed with the author - yes, in the form of this pull request.
- [X] It implements / fixes issue #885.

**Description**

Main description of the problem is here: https://github.com/iina/iina/issues/885

Thumbnails can appear too small on larger screens. This improvement allows to specify arbitrary thumbnail size from the UI. Added the "Width" UI element to preferences in IINA.

<img width="568" alt="Screen Shot 2021-01-15 at 7 08 39 PM" src="https://user-images.githubusercontent.com/1848380/104795681-1de82a80-5765-11eb-8e48-02061821ab51.png">
<img width="590" alt="Screen Shot 2021-01-15 at 7 09 35 PM" src="https://user-images.githubusercontent.com/1848380/104795695-3a846280-5765-11eb-815e-aa04c6072fe2.png">
