### PR TITLE
[doc] remove CocoaPods steps in the "Building" section in README.md and replace "iina.xcworkspace" with "iina.xcodeproj" in both README.md and CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ IINA follows the standard fork/commit/pull request process for integrating chang
 
 1. Fork and clone the repository
 2. Follow [the guide to build with pre-compiled dylibs in README.md](README.md#using-the-pre-compiled-libraries), unless you're modifying those.
-3. Open `iina.xcworkspace` in Xcode. Again, make sure you are using the [latest public version of Xcode](https://itunes.apple.com/us/app/xcode/id497799835); IINA may build with another version but this is not guaranteed. Generally, around June, a new branch will pop up with support for the new version of macOS and associated developer tools; however, main development will still occur on `develop`.
+3. Open `iina.xcodeproj` in Xcode. Again, make sure you are using the [latest public version of Xcode](https://itunes.apple.com/us/app/xcode/id497799835); IINA may build with another version but this is not guaranteed. Generally, around June, a new branch will pop up with support for the new version of macOS and associated developer tools; however, main development will still occur on `develop`.
 4. Commit your changes, test them, push to your repository, and submit a pull request against iina/iina's `develop` branch.
 
 Some tips for your pull request:

--- a/README.md
+++ b/README.md
@@ -33,23 +33,7 @@
 
 ## Building
 
-1. IINA uses [CocoaPods](https://cocoapods.org) for managing the installation of third-party libraries. If you don't already have it installed, here's how you can do so:
-
-	#### Using RubyGems
-	```console
-	$ sudo gem install cocoapods
-	```
-
-	#### Using Homebrew
-	```console
-	$ brew install cocoapods
-	```
-
-2. Run `pod install` in project's root directory.
-
-3. Obtain the mpv libraries.
-
-	IINA uses mpv for media playback. To build IINA, you can either fetch copies of these libraries we have already built (using the instructions below) or build them yourself by skipping to [these instructions](#building-mpv-manually).
+IINA uses mpv for media playback. To build IINA, you can either fetch copies of these libraries we have already built (using the instructions below) or build them yourself by skipping to [these instructions](#building-mpv-manually).
 
 	### Using the pre-compiled libraries
 
@@ -58,7 +42,7 @@
 	./other/download_libs.sh
 	```
 
-	2. Open iina.xcworkspace in the [latest public version of Xcode](https://itunes.apple.com/us/app/xcode/id497799835). *IINA may not build if you use any other version.*
+	2. Open iina.xcodeproj in the [latest public version of Xcode](https://itunes.apple.com/us/app/xcode/id497799835). *IINA may not build if you use any other version.*
 
 	3. Build the project.
 
@@ -101,7 +85,7 @@
 	    $ port contents mpv | grep '\.dylib$' | xargs other/change_lib_dependencies.rb /opt/local
 	    ```
 
-	5. Open iina.xcworkspace in the [latest public version of Xcode](https://itunes.apple.com/us/app/xcode/id497799835). *IINA may not build if you use any other version.*
+	5. Open iina.xcodeproj in the [latest public version of Xcode](https://itunes.apple.com/us/app/xcode/id497799835). *IINA may not build if you use any other version.*
 
 	6. Remove all of references to .dylib files from the Frameworks group in the sidebar and drag all the .dylib files in `deps/lib` to that group.
 


### PR DESCRIPTION
This change follows from #2877.