### PR TITLE
add lrc to supportedFileExt[.sub]

### DIFF
--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -15,7 +15,7 @@ class Utility {
   static let supportedFileExt: [MPVTrack.TrackType: [String]] = [
     .video: ["mkv", "mp4", "avi", "m4v", "mov", "3gp", "ts", "mts", "m2ts", "wmv", "flv", "f4v", "asf", "webm", "rm", "rmvb", "qt", "dv", "mpg", "mpeg", "mxf", "vob", "gif"],
     .audio: ["mp3", "aac", "mka", "dts", "flac", "ogg", "oga", "mogg", "m4a", "ac3", "opus", "wav", "wv", "aiff", "aif", "ape", "tta", "tak"],
-    .sub: ["utf", "utf8", "utf-8", "idx", "sub", "srt", "smi", "rt", "ssa", "aqt", "jss", "js", "ass", "mks", "vtt", "sup", "scc"]
+    .sub: ["utf", "utf8", "utf-8", "idx", "sub", "srt", "smi", "rt", "ssa", "aqt", "jss", "js", "ass", "mks", "vtt", "sup", "scc", "lrc"]
   ]
   static let playableFileExt = supportedFileExt[.video]! + supportedFileExt[.audio]!
   static let singleFilePlaylistExt = ["cue"]


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #2658.

---

**Description:**

IINA currently can load `.lrc` lyrics from **Menu - Subtitles - Load External Subtitle...**, but does not allow loading by dragging the `.lrc` file into the player. I examined the source code and found that `.lrc` files, which can actually be loaded, was not in `supportedFileExt[.sub]`. This PR fixes this problem and allows drag-and-drop loading of `.lrc` files.
