### PR TITLE
Accept seconds-only format string in VideoTime

### DIFF
--- a/iina/VideoTime.swift
+++ b/iina/VideoTime.swift
@@ -49,19 +49,18 @@ class VideoTime {
   }
 
   convenience init?(_ format: String) {
-    let split = format.split(separator: ":").map { (seq) -> Int? in
-      return Int(String(seq))
+    let split = format.split(separator: ":").map { Int($0) }
+    if split.contains(nil) {
+      return nil
     }
-    if !(split.contains {$0 == nil}) {
-      // if no nil in array
-      if split.count == 2 {
-        self.init(0, split[0]!, split[1]!)
-      } else if split.count == 3 {
-        self.init(split[0]!, split[1]!, split[2]!)
-      } else {
-        return nil
-      }
-    } else {
+    switch split.count {
+    case 1:
+      self.init(0, 0, split[0]!)
+    case 2:
+      self.init(0, split[0]!, split[1]!)
+    case 3:
+      self.init(split[0]!, split[1]!, split[2]!)
+    default:
       return nil
     }
   }


### PR DESCRIPTION
VideoTime convenience initializer now accepts a bare `second` format
string, in addition to previously accepted `minute:second` and
`hour:minute:second`.

This is consistent with the `init(_ second: Double)` designated
initializer, and allows users to just input bare second values in the
_Jump to..._ dialog, so instead of `0:40` and `1:20` one could enter
`40` and `80`.

- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**
