### PR TITLE
Closes support Reduce motion preference, #3437

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		49542982216C34950058F680 /* ToolbarItemIcon.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 49542981216C34950058F680 /* ToolbarItemIcon.pdf */; };
 		49542986216C34950058F680 /* OpenInIINA.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 49542973216C34950058F680 /* OpenInIINA.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		496B19921E2968530035AF10 /* PIP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 496B19911E2968530035AF10 /* PIP.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		519872FF26879B9B00F84BCC /* AccessibilityPreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519872FE26879B9B00F84BCC /* AccessibilityPreference.swift */; };
 		6100FF2B1EDF9806002CF0FB /* dsa_pub.pem in Resources */ = {isa = PBXBuildFile; fileRef = 6100FF2A1EDF9806002CF0FB /* dsa_pub.pem */; };
 		8400D5C41E17C6D2006785F5 /* AboutWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8400D5C21E17C6D2006785F5 /* AboutWindowController.swift */; };
 		8400D5C61E1AB2F1006785F5 /* MainWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8400D5C81E1AB2F1006785F5 /* MainWindowController.xib */; };
@@ -534,6 +535,7 @@
 		49542981216C34950058F680 /* ToolbarItemIcon.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = ToolbarItemIcon.pdf; sourceTree = "<group>"; };
 		49542983216C34950058F680 /* OpenInIINA.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = OpenInIINA.entitlements; sourceTree = "<group>"; };
 		496B19911E2968530035AF10 /* PIP.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PIP.framework; path = ../../../../System/Library/PrivateFrameworks/PIP.framework; sourceTree = "<group>"; };
+		519872FE26879B9B00F84BCC /* AccessibilityPreference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPreference.swift; sourceTree = "<group>"; };
 		5879479521A87DD700757A6F /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/MiniPlayerWindowController.strings; sourceTree = "<group>"; };
 		5879479621A87E6100757A6F /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/PreferenceWindowController.strings; sourceTree = "<group>"; };
 		5EF9F7E521FB42E900748374 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/MainMenu.strings"; sourceTree = "<group>"; };
@@ -1649,6 +1651,7 @@
 				E3B3DD5920FDB8A600325184 /* PreferenceWindowController.xib */,
 				E3513AFA20F120F600F8C347 /* PreferenceViewController.swift */,
 				E374160B20F138A900B4F7F9 /* CollapseView.swift */,
+				519872FE26879B9B00F84BCC /* AccessibilityPreference.swift */,
 			);
 			name = Preference;
 			sourceTree = "<group>";
@@ -2502,6 +2505,7 @@
 				8476440A1D48CC3D004F6DF5 /* MPVCommand.swift in Sources */,
 				84C8D5911D796F9700D98A0E /* Aspect.swift in Sources */,
 				E3383689202651CF00ABC812 /* PrefOSCToolbarDraggingItemViewController.swift in Sources */,
+				519872FF26879B9B00F84BCC /* AccessibilityPreference.swift in Sources */,
 				842904E21F0EC01600478376 /* AutoFileMatcher.swift in Sources */,
 				8466BE181D5CDD0300039D03 /* QuickSettingViewController.swift in Sources */,
 				84A0BA9E1D2FAD4000BC8DA1 /* MainWindowController.swift in Sources */,

--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -14,7 +14,7 @@
 		49542982216C34950058F680 /* ToolbarItemIcon.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 49542981216C34950058F680 /* ToolbarItemIcon.pdf */; };
 		49542986216C34950058F680 /* OpenInIINA.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 49542973216C34950058F680 /* OpenInIINA.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		496B19921E2968530035AF10 /* PIP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 496B19911E2968530035AF10 /* PIP.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
-		519872FF26879B9B00F84BCC /* AccessibilityPreference.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519872FE26879B9B00F84BCC /* AccessibilityPreference.swift */; };
+		519872FF26879B9B00F84BCC /* AccessibilityPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519872FE26879B9B00F84BCC /* AccessibilityPreferences.swift */; };
 		6100FF2B1EDF9806002CF0FB /* dsa_pub.pem in Resources */ = {isa = PBXBuildFile; fileRef = 6100FF2A1EDF9806002CF0FB /* dsa_pub.pem */; };
 		8400D5C41E17C6D2006785F5 /* AboutWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8400D5C21E17C6D2006785F5 /* AboutWindowController.swift */; };
 		8400D5C61E1AB2F1006785F5 /* MainWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8400D5C81E1AB2F1006785F5 /* MainWindowController.xib */; };
@@ -535,7 +535,7 @@
 		49542981216C34950058F680 /* ToolbarItemIcon.pdf */ = {isa = PBXFileReference; lastKnownFileType = image.pdf; path = ToolbarItemIcon.pdf; sourceTree = "<group>"; };
 		49542983216C34950058F680 /* OpenInIINA.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = OpenInIINA.entitlements; sourceTree = "<group>"; };
 		496B19911E2968530035AF10 /* PIP.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PIP.framework; path = ../../../../System/Library/PrivateFrameworks/PIP.framework; sourceTree = "<group>"; };
-		519872FE26879B9B00F84BCC /* AccessibilityPreference.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPreference.swift; sourceTree = "<group>"; };
+		519872FE26879B9B00F84BCC /* AccessibilityPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPreferences.swift; sourceTree = "<group>"; };
 		5879479521A87DD700757A6F /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/MiniPlayerWindowController.strings; sourceTree = "<group>"; };
 		5879479621A87E6100757A6F /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/PreferenceWindowController.strings; sourceTree = "<group>"; };
 		5EF9F7E521FB42E900748374 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/MainMenu.strings"; sourceTree = "<group>"; };
@@ -1651,7 +1651,7 @@
 				E3B3DD5920FDB8A600325184 /* PreferenceWindowController.xib */,
 				E3513AFA20F120F600F8C347 /* PreferenceViewController.swift */,
 				E374160B20F138A900B4F7F9 /* CollapseView.swift */,
-				519872FE26879B9B00F84BCC /* AccessibilityPreference.swift */,
+				519872FE26879B9B00F84BCC /* AccessibilityPreferences.swift */,
 			);
 			name = Preference;
 			sourceTree = "<group>";
@@ -2505,7 +2505,7 @@
 				8476440A1D48CC3D004F6DF5 /* MPVCommand.swift in Sources */,
 				84C8D5911D796F9700D98A0E /* Aspect.swift in Sources */,
 				E3383689202651CF00ABC812 /* PrefOSCToolbarDraggingItemViewController.swift in Sources */,
-				519872FF26879B9B00F84BCC /* AccessibilityPreference.swift in Sources */,
+				519872FF26879B9B00F84BCC /* AccessibilityPreferences.swift in Sources */,
 				842904E21F0EC01600478376 /* AutoFileMatcher.swift in Sources */,
 				8466BE181D5CDD0300039D03 /* QuickSettingViewController.swift in Sources */,
 				84A0BA9E1D2FAD4000BC8DA1 /* MainWindowController.swift in Sources */,

--- a/iina/AccessibilityPreference.swift
+++ b/iina/AccessibilityPreference.swift
@@ -1,0 +1,39 @@
+//
+//  AccessibilityPreference.swift
+//  iina
+//
+//  Created by low-batt on 6/26/21.
+//  Copyright © 2021 lhc. All rights reserved.
+//
+
+import Foundation
+
+struct AccessibilityPreference {
+
+  /// Adjusts an animation to be instantaneous if the macOS System Preference Reduce motion is enabled.
+  /// - Parameter duration: Desired animation duration.
+  /// - Returns: `0` if reduce motion is enabled; otherwise the given duration.
+  static func adjustDuration(_ duration: TimeInterval) -> TimeInterval {
+    return reduceMotion() ? 0 : duration
+  }
+
+  /// Checks whether the macOS System Preference accessibility option to retuce motion is in an enabled state.
+  ///
+  /// This method provides a wrapper around the `NSWorkspace` property so that code that needs to check this preference setting
+  /// does not need to concern itself with this preference not being available until macOS Sierra.
+  ///
+  /// Proper handling of the Reduce motion preference setting is covered in the
+  /// [Apple Human Interface Guidelines under Appearance Effects and Motion](https://developer.apple.com/design/human-interface-guidelines/accessibility/overview/appearance-effects/).
+  ///
+  /// To change this preference, choose Apple menu > System Preferences, click Accessibility, click Display, then click Display and
+  /// check or uncheck Reduce motion.
+  ///
+  /// - Returns: `true` if reduce motion is enabled; otherwise `false`.
+  static func reduceMotion() -> Bool {
+    if #available(macOS 10.12, *) {
+      return NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+    } else {
+      return false
+    }
+  }
+}

--- a/iina/AccessibilityPreferences.swift
+++ b/iina/AccessibilityPreferences.swift
@@ -14,12 +14,12 @@ struct AccessibilityPreferences {
   /// - Parameter duration: Desired animation duration.
   /// - Returns: `0` if reduce motion is enabled; otherwise the given duration.
   static func adjustedDuration(_ duration: TimeInterval) -> TimeInterval {
-    return motionReductionEnabled() ? 0 : duration
+    return motionReductionEnabled ? 0 : duration
   }
 
-  /// Checks whether the macOS System Preference accessibility option to retuce motion is in an enabled state.
+  /// Reflects whether the macOS System Preference accessibility option to retuce motion is in an enabled state.
   ///
-  /// This method provides a wrapper around the `NSWorkspace` property so that code that needs to check this preference setting
+  /// This property provides a wrapper around the `NSWorkspace` property so that code that needs to check this preference setting
   /// does not need to concern itself with this preference not being available until macOS Sierra.
   ///
   /// Proper handling of the Reduce motion preference setting is covered in the
@@ -29,7 +29,7 @@ struct AccessibilityPreferences {
   /// check or uncheck Reduce motion.
   ///
   /// - Returns: `true` if reduce motion is enabled; otherwise `false`.
-  static func motionReductionEnabled() -> Bool {
+  static var motionReductionEnabled: Bool {
     if #available(macOS 10.12, *) {
       return NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
     } else {

--- a/iina/AccessibilityPreferences.swift
+++ b/iina/AccessibilityPreferences.swift
@@ -8,13 +8,13 @@
 
 import Foundation
 
-struct AccessibilityPreference {
+struct AccessibilityPreferences {
 
   /// Adjusts an animation to be instantaneous if the macOS System Preference Reduce motion is enabled.
   /// - Parameter duration: Desired animation duration.
   /// - Returns: `0` if reduce motion is enabled; otherwise the given duration.
-  static func adjustDuration(_ duration: TimeInterval) -> TimeInterval {
-    return reduceMotion() ? 0 : duration
+  static func adjustedDuration(_ duration: TimeInterval) -> TimeInterval {
+    return motionReductionEnabled() ? 0 : duration
   }
 
   /// Checks whether the macOS System Preference accessibility option to retuce motion is in an enabled state.
@@ -29,7 +29,7 @@ struct AccessibilityPreference {
   /// check or uncheck Reduce motion.
   ///
   /// - Returns: `true` if reduce motion is enabled; otherwise `false`.
-  static func reduceMotion() -> Bool {
+  static func motionReductionEnabled() -> Bool {
     if #available(macOS 10.12, *) {
       return NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
     } else {

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -995,9 +995,9 @@ class MainWindowController: PlayerWindowController {
     }
 
     if shouldApplyInitialWindowSize, let wfg = windowFrameFromGeometry(newSize: AppData.sizeWhenNoVideo, screen: screen) {
-      window!.setFrame(wfg, display: true)
+      window!.setFrame(wfg, display: true, animate: !AccessibilityPreference.reduceMotion())
     } else {
-      window!.setFrame(AppData.sizeWhenNoVideo.centeredRect(in: screen.visibleFrame), display: true)
+      window!.setFrame(AppData.sizeWhenNoVideo.centeredRect(in: screen.visibleFrame), display: true, animate: !AccessibilityPreference.reduceMotion())
     }
 
     videoView.videoLayer.draw(forced: true)
@@ -1074,7 +1074,7 @@ class MainWindowController: PlayerWindowController {
   func window(_ window: NSWindow, startCustomAnimationToEnterFullScreenOn screen: NSScreen, withDuration duration: TimeInterval) {
     NSAnimationContext.runAnimationGroup({ context in
       context.duration = duration
-      window.animator().setFrame(screen.frame, display: true)
+      window.animator().setFrame(screen.frame, display: true, animate: !AccessibilityPreference.reduceMotion())
     }, completionHandler: nil)
 
   }
@@ -1087,7 +1087,7 @@ class MainWindowController: PlayerWindowController {
 
     NSAnimationContext.runAnimationGroup({ context in
       context.duration = duration
-      window.animator().setFrame(priorWindowedFrame, display: true)
+      window.animator().setFrame(priorWindowedFrame, display: true, animate: !AccessibilityPreference.reduceMotion())
     }, completionHandler: nil)
 
     NSMenu.setMenuBarVisible(true)
@@ -1199,6 +1199,11 @@ class MainWindowController: PlayerWindowController {
   }
 
   func windowDidExitFullScreen(_ notification: Notification) {
+    if AccessibilityPreference.reduceMotion() {
+      // When animation is not used exiting full screen does not restore the previous size of the
+      // window. Restore it now.
+      window!.setFrame(fsState.priorWindowedFrame!, display: true, animate: false)
+    }
     if oscPosition != .top {
       addBackTitlebarViewToFadeableViews()
     }
@@ -1727,7 +1732,7 @@ class MainWindowController: PlayerWindowController {
     viewController.downShift = titleBarView.frame.height
     // show sidebar
     NSAnimationContext.runAnimationGroup({ (context) in
-      context.duration = SideBarAnimationDuration
+      context.duration = AccessibilityPreference.adjustDuration(SideBarAnimationDuration)
       context.timingFunction = CAMediaTimingFunction(name: .easeIn)
       sideBarRightConstraint.animator().constant = 0
     }) {
@@ -1740,7 +1745,7 @@ class MainWindowController: PlayerWindowController {
     sidebarAnimationState = .willHide
     let currWidth = sideBarWidthConstraint.constant
     NSAnimationContext.runAnimationGroup({ (context) in
-      context.duration = animate ? SideBarAnimationDuration : 0
+      context.duration = animate ? AccessibilityPreference.adjustDuration(SideBarAnimationDuration) : 0
       context.timingFunction = CAMediaTimingFunction(name: .easeIn)
       sideBarRightConstraint.animator().constant = -currWidth
     }) {

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -995,9 +995,9 @@ class MainWindowController: PlayerWindowController {
     }
 
     if shouldApplyInitialWindowSize, let wfg = windowFrameFromGeometry(newSize: AppData.sizeWhenNoVideo, screen: screen) {
-      window!.setFrame(wfg, display: true, animate: !AccessibilityPreferences.motionReductionEnabled())
+      window!.setFrame(wfg, display: true, animate: !AccessibilityPreferences.motionReductionEnabled)
     } else {
-      window!.setFrame(AppData.sizeWhenNoVideo.centeredRect(in: screen.visibleFrame), display: true, animate: !AccessibilityPreferences.motionReductionEnabled())
+      window!.setFrame(AppData.sizeWhenNoVideo.centeredRect(in: screen.visibleFrame), display: true, animate: !AccessibilityPreferences.motionReductionEnabled)
     }
 
     videoView.videoLayer.draw(forced: true)
@@ -1074,7 +1074,7 @@ class MainWindowController: PlayerWindowController {
   func window(_ window: NSWindow, startCustomAnimationToEnterFullScreenOn screen: NSScreen, withDuration duration: TimeInterval) {
     NSAnimationContext.runAnimationGroup({ context in
       context.duration = duration
-      window.animator().setFrame(screen.frame, display: true, animate: !AccessibilityPreferences.motionReductionEnabled())
+      window.animator().setFrame(screen.frame, display: true, animate: !AccessibilityPreferences.motionReductionEnabled)
     }, completionHandler: nil)
 
   }
@@ -1087,7 +1087,7 @@ class MainWindowController: PlayerWindowController {
 
     NSAnimationContext.runAnimationGroup({ context in
       context.duration = duration
-      window.animator().setFrame(priorWindowedFrame, display: true, animate: !AccessibilityPreferences.motionReductionEnabled())
+      window.animator().setFrame(priorWindowedFrame, display: true, animate: !AccessibilityPreferences.motionReductionEnabled)
     }, completionHandler: nil)
 
     NSMenu.setMenuBarVisible(true)
@@ -1199,7 +1199,7 @@ class MainWindowController: PlayerWindowController {
   }
 
   func windowDidExitFullScreen(_ notification: Notification) {
-    if AccessibilityPreferences.motionReductionEnabled() {
+    if AccessibilityPreferences.motionReductionEnabled {
       // When animation is not used exiting full screen does not restore the previous size of the
       // window. Restore it now.
       window!.setFrame(fsState.priorWindowedFrame!, display: true, animate: false)

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -995,9 +995,9 @@ class MainWindowController: PlayerWindowController {
     }
 
     if shouldApplyInitialWindowSize, let wfg = windowFrameFromGeometry(newSize: AppData.sizeWhenNoVideo, screen: screen) {
-      window!.setFrame(wfg, display: true, animate: !AccessibilityPreference.reduceMotion())
+      window!.setFrame(wfg, display: true, animate: !AccessibilityPreferences.motionReductionEnabled())
     } else {
-      window!.setFrame(AppData.sizeWhenNoVideo.centeredRect(in: screen.visibleFrame), display: true, animate: !AccessibilityPreference.reduceMotion())
+      window!.setFrame(AppData.sizeWhenNoVideo.centeredRect(in: screen.visibleFrame), display: true, animate: !AccessibilityPreferences.motionReductionEnabled())
     }
 
     videoView.videoLayer.draw(forced: true)
@@ -1074,7 +1074,7 @@ class MainWindowController: PlayerWindowController {
   func window(_ window: NSWindow, startCustomAnimationToEnterFullScreenOn screen: NSScreen, withDuration duration: TimeInterval) {
     NSAnimationContext.runAnimationGroup({ context in
       context.duration = duration
-      window.animator().setFrame(screen.frame, display: true, animate: !AccessibilityPreference.reduceMotion())
+      window.animator().setFrame(screen.frame, display: true, animate: !AccessibilityPreferences.motionReductionEnabled())
     }, completionHandler: nil)
 
   }
@@ -1087,7 +1087,7 @@ class MainWindowController: PlayerWindowController {
 
     NSAnimationContext.runAnimationGroup({ context in
       context.duration = duration
-      window.animator().setFrame(priorWindowedFrame, display: true, animate: !AccessibilityPreference.reduceMotion())
+      window.animator().setFrame(priorWindowedFrame, display: true, animate: !AccessibilityPreferences.motionReductionEnabled())
     }, completionHandler: nil)
 
     NSMenu.setMenuBarVisible(true)
@@ -1199,7 +1199,7 @@ class MainWindowController: PlayerWindowController {
   }
 
   func windowDidExitFullScreen(_ notification: Notification) {
-    if AccessibilityPreference.reduceMotion() {
+    if AccessibilityPreferences.motionReductionEnabled() {
       // When animation is not used exiting full screen does not restore the previous size of the
       // window. Restore it now.
       window!.setFrame(fsState.priorWindowedFrame!, display: true, animate: false)
@@ -1732,7 +1732,7 @@ class MainWindowController: PlayerWindowController {
     viewController.downShift = titleBarView.frame.height
     // show sidebar
     NSAnimationContext.runAnimationGroup({ (context) in
-      context.duration = AccessibilityPreference.adjustDuration(SideBarAnimationDuration)
+      context.duration = AccessibilityPreferences.adjustedDuration(SideBarAnimationDuration)
       context.timingFunction = CAMediaTimingFunction(name: .easeIn)
       sideBarRightConstraint.animator().constant = 0
     }) {
@@ -1745,7 +1745,7 @@ class MainWindowController: PlayerWindowController {
     sidebarAnimationState = .willHide
     let currWidth = sideBarWidthConstraint.constant
     NSAnimationContext.runAnimationGroup({ (context) in
-      context.duration = animate ? AccessibilityPreference.adjustDuration(SideBarAnimationDuration) : 0
+      context.duration = animate ? AccessibilityPreferences.adjustedDuration(SideBarAnimationDuration) : 0
       context.timingFunction = CAMediaTimingFunction(name: .easeIn)
       sideBarRightConstraint.animator().constant = -currWidth
     }) {


### PR DESCRIPTION
Added AccessiblityPreference struct containing methods that make it
easy for other code to handle the Reduce motion preference.

Modified methods in MainWindowController that support entering and
exiting full screen mode and showing and hiding the side bar to
suppress animations if Reduce motion has been enabled.

- [ ] This change has been discussed with the author.
- [x ] It implements / fixes issue #3437.

---

**Description:**
