### PR TITLE
Fix crash on files within specific folders, #3413

### DIFF
--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -381,8 +381,13 @@ extension Data {
 }
 
 extension FileHandle {
-  func read<T>(type: T.Type /* To prevent unintended specializations */) -> T {
-    return readData(ofLength: MemoryLayout<T>.size).withUnsafeBytes {
+  func read<T>(type: T.Type /* To prevent unintended specializations */) -> T? {
+    let size = MemoryLayout<T>.size
+    let data = readData(ofLength: size)
+    guard data.count == size else {
+      return nil
+    }
+    return data.withUnsafeBytes {
       $0.bindMemory(to: T.self).first!
     }
   }


### PR DESCRIPTION
The code in Extensions.read was triggering a crash when readData failed
to return all the bytes requested due to trying to read past EOF. This
happened when IINA tried to read a thumbnail cache entry that was
truncated due to there being no space left on the storage device when
the cache entry was being written.

If applied this commit will:

- Add code to read to check that readData returned the bytes requested

- Change the return type of read to be optional

- Update some callers in ThumbnailCache to handle read failures

- [ ] This change has been discussed with the author.
- [ x] It implements / fixes issue #3413.

---

**Description:**
