### PR TITLE
Fix many FileInfo objects leaked, #3445

### DIFF
--- a/iina/FileGroup.swift
+++ b/iina/FileGroup.swift
@@ -157,8 +157,7 @@ class FileGroup {
 
   func flatten() -> [String: [FileInfo]] {
     var result: [String: [FileInfo]] = [:]
-    var search: ((FileGroup) -> Void)!
-    search = { group in
+    func search(_ group: FileGroup) {
       if group.groups.count > 0 {
         for g in group.groups {
           search(g)


### PR DESCRIPTION
Fixes a retain cycle in the FileGroup.flatten method by replacing a recursive
closure with a nested function. This eliminates a memory leak consisting of a
collection of FileInfo objects representing the files contained in the directory
of the video being played.

- [ ] This change has been discussed with the author.
- [x ] It implements / fixes issue #3445.

---

**Description:**
