### PR TITLE
Fix memory leaks in FFmpegController, #1720

### DIFF
--- a/iina/FFmpegController.h
+++ b/iina/FFmpegController.h
@@ -40,6 +40,6 @@
 
 - (void)generateThumbnailForFile:(nonnull NSString *)file;
 
-+ (NSDictionary *)probeVideoInfoForFile:(nonnull NSString *)file;
++ (nullable NSDictionary *)probeVideoInfoForFile:(nonnull NSString *)file;
 
 @end


### PR DESCRIPTION
The method `getPeeksForFile` in `FFmpegController` is leaking memory
when generating thumbnails. This commit will:

- Add a `@try-@finally` block in the while loop to free the packet

- Replace `av_free` by `av_frame_free`, when freeing an `AVFrame`

- Add a call to `sws_freeContext` to free the `SwsContext`

- Replace deprecated method `avcodec_close` with `avcodec_free_context`

- Add `nullable` annotation to declaration of `probeVideoInfoForFile`

This is a stopgap fix and does not address all of the potential leaks
in the method. This commit focuses on the leaks that occur during the
normal flow when generating thumbnails. Error flows will still leak
memory. At some point this method should be refactored to always
properly free memory.

- [ ] This change has been discussed with the author.
- [ x] It implements / fixes issue #1720.

---

**Description:**
