### PR TITLE
Fix warning "display-fps" deprecated, #3464

### DIFF
--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -220,7 +220,7 @@ class VideoView: NSView {
       Logger.log("Falling back to standard display refresh rate: 60 from \(actualFps)")
       actualFps = 60;
     }
-    player.mpv.setDouble(MPVOption.Video.displayFps, actualFps)
+    player.mpv.setDouble(MPVOption.Video.overrideDisplayFps, actualFps)
     
     setICCProfile(displayId)
     currentDisplay = displayId


### PR DESCRIPTION
This commit will change the method `VideoView.updateDisplayLink` to
set the mpv property `override-display-fps` instead of the deprecated
property `display-fps`, eliminating a warning message logged by mpv.
