### PR TITLE
Fix unlabeled trailing closure build warnings, #3466

### DIFF
--- a/iina/AboutWindowContributorAvatarItem.swift
+++ b/iina/AboutWindowContributorAvatarItem.swift
@@ -32,14 +32,14 @@ class AboutWindowContributorAvatarItem: NSCollectionViewItem {
       if let data = AboutWindowContributorAvatarItem.imageCache.object(forKey: url as NSString) {
         self.imageView!.image = data
       } else {
-        Just.get(url) { respond in
+        Just.get(url, asyncCompletionHandler: { respond in
           guard let data = respond.content, var image = NSImage(data: data) else { return }
           image = image.rounded()
           DispatchQueue.main.async {
             self.imageView!.image = image
           }
           AboutWindowContributorAvatarItem.imageCache.setObject(image, forKey: url as NSString)
-        }
+        })
       }
     }
   }

--- a/iina/AboutWindowController.swift
+++ b/iina/AboutWindowController.swift
@@ -140,7 +140,7 @@ extension AboutWindowController: NSCollectionViewDataSource {
   }
 
   private func loadContributors(from url: String) {
-    Just.get(url) { response in
+    Just.get(url, asyncCompletionHandler: { response in
       let prevCount = self.contributors.count
       guard let data = response.content,
         let contributors = try? JSONDecoder().decode([Contributor].self, from: data) else {
@@ -161,7 +161,7 @@ extension AboutWindowController: NSCollectionViewDataSource {
       if let nextURL = response.links["next"]?["url"] {
         self.loadContributors(from: nextURL)
       }
-    }
+    })
   }
 }
 

--- a/iina/AssrtSubtitle.swift
+++ b/iina/AssrtSubtitle.swift
@@ -52,7 +52,7 @@ final class AssrtSubtitle: OnlineSubtitle {
       // download from file list
       when(fulfilled: fileList.map { file -> Promise<URL> in
         Promise { resolver in
-          Just.get(file.url) { response in
+          Just.get(file.url, asyncCompletionHandler: { response in
             guard response.ok, let data = response.content else {
               resolver.reject(AssrtSupport.AssrtError.networkError)
               return
@@ -61,7 +61,7 @@ final class AssrtSubtitle: OnlineSubtitle {
             if let url = data.saveToFolder(Utility.tempDirURL, filename: subFilename) {
               resolver.fulfill(url)
             }
-          }
+          })
         }
       }).map { urls in
         callback(.ok(urls))
@@ -70,7 +70,7 @@ final class AssrtSubtitle: OnlineSubtitle {
       }
     } else if let url = url, let filename = filename {
       // download from url
-      Just.get(url) { response in
+      Just.get(url, asyncCompletionHandler: { response in
         guard response.ok, let data = response.content else {
           callback(.failed)
           return
@@ -79,7 +79,7 @@ final class AssrtSubtitle: OnlineSubtitle {
         if let url = data.saveToFolder(Utility.tempDirURL, filename: subFilename) {
           callback(.ok([url]))
         }
-      }
+      })
     } else {
       callback(.failed)
       return
@@ -164,7 +164,7 @@ class AssrtSupport {
 
   func search(_ query: String) -> Promise<[AssrtSubtitle]> {
     return Promise { resolver in
-      Just.post(searchApi, params: ["q": query], headers: header) { result in
+      Just.post(searchApi, params: ["q": query], headers: header, asyncCompletionHandler: { result in
         guard let json = result.json as? [String: Any] else {
           resolver.reject(AssrtError.networkError)
           return
@@ -207,7 +207,7 @@ class AssrtSupport {
           index += 1
         }
         resolver.fulfill(subtitles)
-      }
+      })
     }
   }
 
@@ -233,7 +233,7 @@ class AssrtSupport {
 
   func loadDetails(forSub sub: AssrtSubtitle) -> Promise<AssrtSubtitle> {
     return Promise { resolver in
-      Just.post(detailApi, params: ["id": sub.id], headers: header) { result in
+      Just.post(detailApi, params: ["id": sub.id], headers: header, asyncCompletionHandler:  { result in
         guard let json = result.jsonIgnoringError as? [String: Any] else {
           resolver.reject(AssrtError.networkError)
           return
@@ -266,7 +266,7 @@ class AssrtSupport {
         }
 
         resolver.fulfill(sub)
-      }
+      })
     }
   }
 

--- a/iina/JustXMLRPC.swift
+++ b/iina/JustXMLRPC.swift
@@ -60,7 +60,7 @@ class JustXMLRPC {
     methodCall.addChild(params)
     let reqXML = XMLDocument(rootElement: methodCall)
     // Request
-    Just.post(location, requestBody: reqXML.xmlData) { response in
+    Just.post(location, requestBody: reqXML.xmlData, asyncCompletionHandler: { response in
       if response.ok, let content = response.content, let responseDoc = try? XMLDocument(data: content) {
         let rootElement = responseDoc.rootElement()
         if let _ = rootElement?.child("fault") {
@@ -76,7 +76,7 @@ class JustXMLRPC {
         // http error
         callback(.error(XMLRPCError(method: method, httpCode: response.statusCode ?? 0, reason: response.reason)))
       }
-    }
+    })
   }
 
   private static func toValueElement(_ value: Any) -> XMLElement {

--- a/iina/OpenSubSubtitle.swift
+++ b/iina/OpenSubSubtitle.swift
@@ -39,7 +39,7 @@ final class OpenSubSubtitle: OnlineSubtitle {
   }
 
   override func download(callback: @escaping DownloadCallback) {
-    Just.get(subDlLink) { response in
+    Just.get(subDlLink, asyncCompletionHandler: { response in
       guard response.ok, let data = response.content, let unzipped = try? data.gunzipped() else {
         callback(.failed)
         return
@@ -48,7 +48,7 @@ final class OpenSubSubtitle: OnlineSubtitle {
       if let url = unzipped.saveToFolder(Utility.tempDirURL, filename: subFilename) {
         callback(.ok([url]))
       }
-    }
+    })
   }
 
 }

--- a/iina/ShooterSubtitle.swift
+++ b/iina/ShooterSubtitle.swift
@@ -29,7 +29,7 @@ final class ShooterSubtitle: OnlineSubtitle {
   }
 
   override func download(callback: @escaping DownloadCallback) {
-    Just.get(files[0].path) { response in
+    Just.get(files[0].path, asyncCompletionHandler: { response in
       guard response.ok, let data = response.content else {
         callback(.failed)
         return
@@ -38,7 +38,7 @@ final class ShooterSubtitle: OnlineSubtitle {
       if let url = data.saveToFolder(Utility.tempDirURL, filename: fileName) {
         callback(.ok([url]))
       }
-    }
+    })
   }
 
 }
@@ -115,7 +115,7 @@ class ShooterSupport {
 
   func request(_ info: FileInfo) -> Promise<[ShooterSubtitle]> {
     return Promise { resolver in
-      Just.post(apiPath, params: info.dictionary, timeout: 10) { response in
+      Just.post(apiPath, params: info.dictionary, timeout: 10, asyncCompletionHandler: { response in
         guard response.ok else {
           resolver.reject(ShooterError.networkError)
           return
@@ -140,7 +140,7 @@ class ShooterSupport {
           index += 1
         }
         resolver.fulfill(subtitles)
-      }
+      })
     }
   }
 


### PR DESCRIPTION
This commit will eliminate Swift compiler build warnings due to backward
matching of unabled trailing closure being deprecated as of Swift 5.3.

The changes merely involve adding parameter labels to trailing closures in
calls to `Just.get` and `Just.post`.

- [ ] This change has been discussed with the author.
- [x ] It implements / fixes issue #3466.

---

**Description:**
