### PR TITLE
Fix screenshot crash with long video title, #3334

### DIFF
--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -194,6 +194,8 @@
 
 "alert.playlist.error_deleting" = "Error deleting: %@";
 
+"alert.screenshot.error_taking" = "Cannot take a screenshot!";
+
 "alert.sub.no_selected" = "Please select a downloaded subtitle first.";
 "alert.sub_lang_not_set" = "Please set preferred subtitle languages in preferences before using OpenSubtitles. English(eng) will be used this time.";
 "alert.sub.cannot_save_passwd" = "Cannot save your password to Keychain: %@";

--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -457,6 +457,10 @@ extension NSMenuItem {
 
 
 extension URL {
+  var creationDate: Date? {
+    (try? resourceValues(forKeys: [.creationDateKey]))?.creationDate
+  }
+
   var isExistingDirectory: Bool {
     return (try? self.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
   }

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -909,6 +909,18 @@ class MPVController: NSObject {
     case MPV_EVENT_COMMAND_REPLY:
       let reply = event.pointee.reply_userdata
       if reply == MPVController.UserData.screenshot {
+        let code = event.pointee.error
+        guard 0 <= code else {
+          let error = String.init(cString: mpv_error_string(code))
+          Logger.log("Cannot take a screenshot, mpv API error: \(error), Return value: \(code)", level: .error)
+          // Unfortunately the mpv API does not provide any details on the failure. The error
+          // code returned maps to "error running command", so all the alert can report is
+          // that we cannot take a screenshot.
+          DispatchQueue.main.async {
+            Utility.showAlert("screenshot.error_taking")
+          }
+          return
+        }
         player.screenshotCallback()
       }
 

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -910,8 +910,8 @@ class MPVController: NSObject {
       let reply = event.pointee.reply_userdata
       if reply == MPVController.UserData.screenshot {
         let code = event.pointee.error
-        guard 0 <= code else {
-          let error = String.init(cString: mpv_error_string(code))
+        guard code >= 0 else {
+          let error = String(cString: mpv_error_string(code))
           Logger.log("Cannot take a screenshot, mpv API error: \(error), Return value: \(code)", level: .error)
           // Unfortunately the mpv API does not provide any details on the failure. The error
           // code returned maps to "error running command", so all the alert can report is

--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -503,17 +503,8 @@ class Utility {
       at: folder,
       includingPropertiesForKeys: [.creationDateKey],
       options: .skipsSubdirectoryDescendants),
-      var latestFile = contents.first else { return nil }
-
-    var latestDate = Date.distantPast
-
-    for file in contents {
-      if let date = try? file.resourceValues(forKeys: [.creationDateKey]).creationDate, date > latestDate {
-        latestDate = date
-        latestFile = file
-      }
-    }
-    return latestFile
+          !contents.isEmpty else { return nil }
+    return contents.max { a, b in a.creationDate! < b.creationDate! }
   }
 
   /// Make sure the block is executed on the main thread. Be careful since it uses `sync`. Keep the block mininal.

--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -502,10 +502,10 @@ class Utility {
     guard let contents = try? FileManager.default.contentsOfDirectory(
       at: folder,
       includingPropertiesForKeys: [.creationDateKey],
-      options: .skipsSubdirectoryDescendants), !contents.isEmpty else { return nil }
+      options: .skipsSubdirectoryDescendants),
+      var latestFile = contents.first else { return nil }
 
     var latestDate = Date.distantPast
-    var latestFile: URL = contents[0]
 
     for file in contents {
       if let date = try? file.resourceValues(forKeys: [.creationDateKey]).creationDate, date > latestDate {

--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -504,7 +504,7 @@ class Utility {
       includingPropertiesForKeys: [.creationDateKey],
       options: .skipsSubdirectoryDescendants),
           !contents.isEmpty else { return nil }
-    return contents.max { a, b in a.creationDate! < b.creationDate! }
+    return contents.filter { $0.creationDate != nil }.max { $0.creationDate! < $1.creationDate! }
   }
 
   /// Make sure the block is executed on the main thread. Be careful since it uses `sync`. Keep the block mininal.

--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -502,7 +502,7 @@ class Utility {
     guard let contents = try? FileManager.default.contentsOfDirectory(
       at: folder,
       includingPropertiesForKeys: [.creationDateKey],
-      options: .skipsSubdirectoryDescendants) else { return nil }
+      options: .skipsSubdirectoryDescendants), !contents.isEmpty else { return nil }
 
     var latestDate = Date.distantPast
     var latestFile: URL = contents[0]

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -192,6 +192,8 @@
 
 "alert.playlist.error_deleting" = "Error deleting: %@";
 
+"alert.screenshot.error_taking" = "Cannot take a screenshot!";
+
 "alert.sub.no_selected" = "Please select a downloaded subtitle first.";
 "alert.sub_lang_not_set" = "Please set preferred subtitle languages in preferences before using OpenSubtitles. English(eng) will be used this time.";
 "alert.sub.cannot_save_passwd" = "Cannot save your password to Keychain: %@";


### PR DESCRIPTION
This commit will:

- Change the method  MPVController.handleEvent to raise an alert if
    screenshot generation failed
- Change the method  Utility.getLatestScreenshot to guard against an empty
    screenshot directory

This commit adds new text for the alert that will require localization.

- [ ] This change has been discussed with the author.
- [ x] It implements / fixes issue #3334.

---

**Description:**

NOTE the need for localization of the added alert message text.