### PR TITLE
Fix toggle menus to adhere to HIG, #3116

### DIFF
--- a/iina/AppData.swift
+++ b/iina/AppData.swift
@@ -81,6 +81,13 @@ struct Constants {
     static let subDelay = "Subtitle Delay"
     static let pip = NSLocalizedString("menu.pip", comment: "Enter Picture-in-Picture")
     static let exitPIP = NSLocalizedString("menu.exit_pip", comment: "Exit Picture-in-Picture")
+    static let chaptersPanel = NSLocalizedString("menu.chapters", comment: "Show Chapters Panel")
+    static let hideChaptersPanel = NSLocalizedString("menu.hide_chapters", comment: "Hide Chapters Panel")
+    static let playlistPanel = NSLocalizedString("menu.playlist", comment: "Show Playlist Panel")
+    static let hidePlaylistPanel = NSLocalizedString("menu.hide_playlist", comment: "Hide Playlist Panel")
+    static let quickSettingsPanel = NSLocalizedString("menu.quicksettings", comment: "Show Quick Settings Panel")
+    static let hideQuickSettingsPanel = NSLocalizedString("menu.hide_quicksettings", comment: "Hide Quick Settings Panel")
+
     static let custom = NSLocalizedString("menu.crop_custom", comment: "Custom crop size")
   }
   struct Time {

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -112,6 +112,12 @@
 "menu.pause" = "Pause";
 "menu.resume" = "Resume";
 "menu.speed" = "Speed: %.2fx";
+"menu.chapters" = "Show Chapters Panel";
+"menu.hide_chapters" = "Hide Chapters Panel";
+"menu.playlist" = "Show Playlist Panel";
+"menu.hide_playlist" = "Hide Playlist Panel";
+"menu.quicksettings" = "Show Quick Settings Panel";
+"menu.hide_quicksettings" = "Hide Quick Settings Panel";
 
 "menu.seek_forward" = "Step Forward %.0fs";
 "menu.seek_backward" = "Step Backward %.0fs";

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -442,6 +442,10 @@ class MenuController: NSObject, NSMenuDelegate {
     let isPlaylistLoop = player.mpv.getString(MPVOption.PlaybackControl.loopPlaylist)
     playlistLoop.state = (isPlaylistLoop == "inf" || isPlaylistLoop == "force") ? .on : .off
     speedIndicator.title = String(format: NSLocalizedString("menu.speed", comment: "Speed:"), player.info.playSpeed)
+    let isDisplayingPlaylist = player.mainWindow.sideBarStatus == .playlist && player.mainWindow.playlistView.currentTab == .playlist
+    playlistPanel?.title = isDisplayingPlaylist ? Constants.String.hidePlaylistPanel : Constants.String.playlistPanel
+    let isDisplayingChapters = player.mainWindow.sideBarStatus == .playlist && player.mainWindow.playlistView.currentTab == .chapters
+    chapterPanel?.title = isDisplayingChapters ? Constants.String.hideChaptersPanel : Constants.String.chaptersPanel
   }
 
   private func updateVideoMenu() {
@@ -454,12 +458,16 @@ class MenuController: NSObject, NSMenuDelegate {
     fullScreen.title = isInFullScreen ? Constants.String.exitFullScreen : Constants.String.fullScreen
     pictureInPicture?.title = isInPIP ? Constants.String.exitPIP : Constants.String.pip
     delogo.state = isDelogo ? .on : .off
+    let isDisplayingSettings = PlayerCore.active.mainWindow.sideBarStatus == .settings && PlayerCore.active.mainWindow.quickSettingView.currentTab == .video
+    quickSettingsVideo?.title = isDisplayingSettings ? Constants.String.hideQuickSettingsPanel : Constants.String.quickSettingsPanel
   }
 
   private func updateAudioMenu() {
     let player = PlayerCore.active
     volumeIndicator.title = String(format: NSLocalizedString("menu.volume", comment: "Volume:"), Int(player.info.volume))
     audioDelayIndicator.title = String(format: NSLocalizedString("menu.audio_delay", comment: "Audio Delay:"), player.info.audioDelay)
+    let isDisplayingSettings = player.mainWindow.sideBarStatus == .settings && player.mainWindow.quickSettingView.currentTab == .audio
+    quickSettingsAudio?.title = isDisplayingSettings ? Constants.String.hideQuickSettingsPanel : Constants.String.quickSettingsPanel
   }
 
   private func updateAudioDevice() {
@@ -489,6 +497,8 @@ class MenuController: NSObject, NSMenuDelegate {
         encodingMenu.item(withTitle: encoding.title)?.state = .on
       }
     }
+    let isDisplayingSettings = player.mainWindow.sideBarStatus == .settings && player.mainWindow.quickSettingView.currentTab == .sub
+    quickSettingsSub?.title = isDisplayingSettings ? Constants.String.hideQuickSettingsPanel : Constants.String.quickSettingsPanel
   }
 
   func updateSavedFiltersMenu(type: String) {

--- a/iina/ca.lproj/Localizable.strings
+++ b/iina/ca.lproj/Localizable.strings
@@ -112,6 +112,9 @@
 "menu.pause" = "Pausa";
 "menu.resume" = "Reprèn";
 "menu.speed" = "Velocitat: %.2fx";
+"menu.chapters" = "Mostra panell de capítols";
+"menu.playlist" = "Mostra panell de la llista de reproducció";
+"menu.quicksettings" = "Mostra panell de configuració ràpida";
 
 "menu.seek_forward" = "Avança %.0fs";
 "menu.seek_backward" = "Retrocedeix %.0fs";

--- a/iina/cs.lproj/Localizable.strings
+++ b/iina/cs.lproj/Localizable.strings
@@ -112,6 +112,9 @@
 "menu.pause" = "Pozastavit";
 "menu.resume" = "Pokračovat";
 "menu.speed" = "Rychlost: %.2fx";
+"menu.chapters" = "Zobrazit panel kapitol";
+"menu.playlist" = "Zobrazit playlist";
+"menu.quicksettings" = "Zobrazit panel rychlých nastavení";
 
 "menu.seek_forward" = "Posunout vpřed o %.0f s";
 "menu.seek_backward" = "Posunout vzad o %.0f s";

--- a/iina/de.lproj/Localizable.strings
+++ b/iina/de.lproj/Localizable.strings
@@ -112,6 +112,12 @@
 "menu.pause" = "Pause";
 "menu.resume" = "Wiedergabe";
 "menu.speed" = "Geschwindigkeit: %.2fx";
+"menu.chapters" = "Kapitel anzeigen";
+"menu.hide_chapters" = "Kapitel ausblenden";
+"menu.playlist" = "Wiedergabeliste anzeigen";
+"menu.hide_playlist" = "Wiedergabeliste ausblenden";
+"menu.quicksettings" = "Schnelleinstellungen anzeigen";
+"menu.hide_quicksettings" = "Schnelleinstellungen ausblenden";
 
 "menu.seek_forward" = "%.0f s vorspulen";
 "menu.seek_backward" = "%.0f s zurückspulen";

--- a/iina/de.lproj/MainMenu.strings
+++ b/iina/de.lproj/MainMenu.strings
@@ -2,7 +2,7 @@
 "0Cz-OE-85L.title" = "Verzögerung + 0,1 s";
 
 /* Class = "NSMenuItem"; title = "Show Playlist Panel"; ObjectID = "0T7-Nu-SL7"; */
-"0T7-Nu-SL7.title" = "Wiedergabeliste ein-/ausblenden";
+"0T7-Nu-SL7.title" = "Wiedergabeliste anzeigen";
 
 /* Class = "NSMenuItem"; title = "Open URL…"; ObjectID = "0m7-3r-twH"; */
 "0m7-3r-twH.title" = "Adresse öffnen …";
@@ -26,13 +26,13 @@
 "2id-wn-xsC.title" = "Springe zu …";
 
 /* Class = "NSMenuItem"; title = "Show Quick Settings Panel"; ObjectID = "2t8-Ot-yoO"; */
-"2t8-Ot-yoO.title" = "Videoeinstellungen";
+"2t8-Ot-yoO.title" = "Schnelleinstellungen anzeigen";
 
 /* Class = "NSMenuItem"; title = "Select All"; ObjectID = "3Ax-P3-QQu"; */
 "3Ax-P3-QQu.title" = "Alles auswählen";
 
 /* Class = "NSMenuItem"; title = "Show Quick Settings Panel"; ObjectID = "43n-Ed-5kT"; */
-"43n-Ed-5kT.title" = "Audioeinstellungen";
+"43n-Ed-5kT.title" = "Schnelleinstellungen anzeigen";
 
 /* Class = "NSMenuItem"; title = "Audio Delay + 0.5s"; ObjectID = "4ae-MT-2L1"; */
 "4ae-MT-2L1.title" = "Verzögerung + 0,5 s";
@@ -71,7 +71,7 @@
 "8pV-XQ-AvB.title" = "Geschwindigkeit:";
 
 /* Class = "NSMenuItem"; title = "Show Quick Settings Panel"; ObjectID = "8y7-Cy-lKT"; */
-"8y7-Cy-lKT.title" = "Untertiteleinstellungen";
+"8y7-Cy-lKT.title" = "Schnelleinstellungen anzeigen";
 
 /* Class = "NSMenuItem"; title = "Speed Up to 1.1x"; ObjectID = "91n-xW-L37"; */
 "91n-xW-L37.title" = "Beschleunigen auf 1,1x";
@@ -119,7 +119,7 @@
 "DVo-aG-piG.title" = "Schließen";
 
 /* Class = "NSMenuItem"; title = "Show Chapters Panel"; ObjectID = "DwM-3d-Eb9"; */
-"DwM-3d-Eb9.title" = "Kapitel ein-/ausblenden";
+"DwM-3d-Eb9.title" = "Kapitel anzeigen";
 
 /* Class = "NSMenu"; title = "Subtitles"; ObjectID = "EKp-Qx-4Mn"; */
 "EKp-Qx-4Mn.title" = "Untertitel";

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -112,6 +112,12 @@
 "menu.pause" = "Pause";
 "menu.resume" = "Resume";
 "menu.speed" = "Speed: %.2fx";
+"menu.chapters" = "Show Chapters Panel";
+"menu.hide_chapters" = "Hide Chapters Panel";
+"menu.playlist" = "Show Playlist Panel";
+"menu.hide_playlist" = "Hide Playlist Panel";
+"menu.quicksettings" = "Show Quick Settings Panel";
+"menu.hide_quicksettings" = "Hide Quick Settings Panel";
 
 "menu.seek_forward" = "Step Forward %.0fs";
 "menu.seek_backward" = "Step Backward %.0fs";

--- a/iina/es.lproj/Localizable.strings
+++ b/iina/es.lproj/Localizable.strings
@@ -112,6 +112,9 @@
 "menu.pause" = "Pausar";
 "menu.resume" = "Reanudar";
 "menu.speed" = "Velocidad: %.2fx";
+"menu.chapters" = "Mostrar panel de capítulos";
+"menu.playlist" = "Mostrar panel de lista de reproducción";
+"menu.quicksettings" = "Mostrar panel de configuración rápida";
 
 "menu.seek_forward" = "Adelantar %.0fs";
 "menu.seek_backward" = "Retroceder %.0fs";

--- a/iina/fr.lproj/Localizable.strings
+++ b/iina/fr.lproj/Localizable.strings
@@ -112,6 +112,9 @@
 "menu.pause" = "Pause";
 "menu.resume" = "Lire";
 "menu.speed" = "Vitesse : %.2fx";
+"menu.chapters" = "Afficher les chapitres";
+"menu.playlist" = "Afficher la playlist";
+"menu.quicksettings" = "Afficher les réglages rapides";
 
 "menu.seek_forward" = "Reculer de %.0fs";
 "menu.seek_backward" = "Avancer de %.0fs";

--- a/iina/hi.lproj/Localizable.strings
+++ b/iina/hi.lproj/Localizable.strings
@@ -112,6 +112,9 @@
 "menu.pause" = "रोकें";
 "menu.resume" = "पुनः आरंभ";
 "menu.speed" = "गति: %.2fx";
+"menu.chapters" = "अध्याय पैनल दिखाएं";
+"menu.playlist" = "प्लेलिस्ट पैनल दिखाएं";
+"menu.quicksettings" = "त्वरित सेटिंग पैनल दिखाएं";
 
 "menu.seek_forward" = "आगे कदम %.0fs";
 "menu.seek_backward" = "पीछे जाओ %.0fs";

--- a/iina/it.lproj/Localizable.strings
+++ b/iina/it.lproj/Localizable.strings
@@ -112,6 +112,9 @@
 "menu.pause" = "Pausa";
 "menu.resume" = "Riprendi";
 "menu.speed" = "Velocità: %.2fx";
+"menu.chapters" = "Pannello capitoli";
+"menu.playlist" = "Pannello playlist";
+"menu.quicksettings" = "Pannello impostazioni veloci";
 
 "menu.seek_forward" = "Avanti %.0fs";
 "menu.seek_backward" = "Indietro %.0fs";

--- a/iina/ja.lproj/Localizable.strings
+++ b/iina/ja.lproj/Localizable.strings
@@ -112,6 +112,9 @@
 "menu.pause" = "一時停止";
 "menu.resume" = "再生";
 "menu.speed" = "再生速度: %.2f倍";
+"menu.chapters" = "チャプタパネルを表示";
+"menu.playlist" = "プレイリストパネルを開く";
+"menu.quicksettings" = "クイック設定パネルを表示";
 
 "menu.seek_forward" = "%.0f秒進む";
 "menu.seek_backward" = "%.0f秒戻る";

--- a/iina/ja.lproj/MainMenu.strings
+++ b/iina/ja.lproj/MainMenu.strings
@@ -71,7 +71,7 @@
 "8pV-XQ-AvB.title" = "再生速度:";
 
 /* Class = "NSMenuItem"; title = "Show Quick Settings Panel"; ObjectID = "8y7-Cy-lKT"; */
-"8y7-Cy-lKT.title" = "クイック設定 パネル";
+"8y7-Cy-lKT.title" = "クイック設定パネルを表示";
 
 /* Class = "NSMenuItem"; title = "Speed Up to 1.1x"; ObjectID = "91n-xW-L37"; */
 "91n-xW-L37.title" = "再生速度を1.1倍";

--- a/iina/ko.lproj/Localizable.strings
+++ b/iina/ko.lproj/Localizable.strings
@@ -112,6 +112,9 @@
 "menu.pause" = "일시 정지";
 "menu.resume" = "재생";
 "menu.speed" = "재생속도: %.2fx";
+"menu.chapters" = "챕터 목록 보기";
+"menu.playlist" = "재생목록 보기";
+"menu.quicksettings" = "빠른 설정";
 
 "menu.seek_forward" = "앞으로 탐색 %.0f초";
 "menu.seek_backward" = "뒤로 탐색 %.0f초";

--- a/iina/nl.lproj/Localizable.strings
+++ b/iina/nl.lproj/Localizable.strings
@@ -112,6 +112,9 @@
 "menu.pause" = "Pauzeer";
 "menu.resume" = "Hervat";
 "menu.speed" = "Snelheid: %.2fx";
+"menu.chapters" = "Toon hoofdstukken";
+"menu.playlist" = "Toon afspeellijst";
+"menu.quicksettings" = "Toon snelle instellingen";
 
 "menu.seek_forward" = "Ga %.0fs vooruit";
 "menu.seek_backward" = "Ga %.0fs terug";

--- a/iina/pl.lproj/Localizable.strings
+++ b/iina/pl.lproj/Localizable.strings
@@ -112,6 +112,9 @@
 "menu.pause" = "Pauza";
 "menu.resume" = "Wznów";
 "menu.speed" = "Prędkość: %.2fx";
+"menu.chapters" = "Panel rozdziałów";
+"menu.playlist" = "Panel playlisty";
+"menu.quicksettings" = "Panel opcji";
 
 "menu.seek_forward" = "Przewiń w przód o %.0fs";
 "menu.seek_backward" = "Przewiń w tył o %.0fs";

--- a/iina/pt-BR.lproj/Localizable.strings
+++ b/iina/pt-BR.lproj/Localizable.strings
@@ -112,6 +112,9 @@
 "menu.pause" = "Pausar";
 "menu.resume" = "Reproduzir";
 "menu.speed" = "Velocidade: %.2fx";
+"menu.chapters" = "Mostrar Capitulos";
+"menu.playlist" = "Mostrar painel de playlist";
+"menu.quicksettings" = "Mostrar painel de ajustes";
 
 "menu.seek_forward" = "Ir adiante %.0fs";
 "menu.seek_backward" = "Ir pra trás %.0fs";

--- a/iina/ro.lproj/Localizable.strings
+++ b/iina/ro.lproj/Localizable.strings
@@ -112,6 +112,9 @@
 "menu.pause" = "Pauză";
 "menu.resume" = "Reia";
 "menu.speed" = "Viteză: %.2fx";
+"menu.chapters" = "Afilșează panoul Capitole";
+"menu.playlist" = "Arată panoul Listă de redare";
+"menu.quicksettings" = "Arată panoul Setări rapide";
 
 "menu.seek_forward" = "Sari înainte %.0fs";
 "menu.seek_backward" = "Sari înapoi %.0fs";

--- a/iina/ru.lproj/Localizable.strings
+++ b/iina/ru.lproj/Localizable.strings
@@ -112,6 +112,9 @@
 "menu.pause" = "Пауза";
 "menu.resume" = "Возобновить";
 "menu.speed" = "Скорость: %.2fx";
+"menu.chapters" = "Панель глав";
+"menu.playlist" = "Панель плейлистов";
+"menu.quicksettings" = "Панель быстрых настроек";
 
 "menu.seek_forward" = "Шаг вперед %.0f с";
 "menu.seek_backward" = "Шаг назад %.0f с";

--- a/iina/sk.lproj/Localizable.strings
+++ b/iina/sk.lproj/Localizable.strings
@@ -112,6 +112,9 @@
 "menu.pause" = "Pozastaviť";
 "menu.resume" = "Pokračovať";
 "menu.speed" = "Rýchlosť: %.2fx";
+"menu.chapters" = "Zobraziť panel s kapitolami";
+"menu.playlist" = "Zobraziť panel playlistu";
+"menu.quicksettings" = "Zobraziť panel rýchlych nastavení";
 
 "menu.seek_forward" = "Posunúť dopredu %.0f s";
 "menu.seek_backward" = "Posunúť dozadu %.0f s";

--- a/iina/sv.lproj/Localizable.strings
+++ b/iina/sv.lproj/Localizable.strings
@@ -112,6 +112,9 @@
 "menu.pause" = "Pausa";
 "menu.resume" = "Fortsätt";
 "menu.speed" = "Hastighet: %.2fx";
+"menu.chapters" = "Visa snabbinställningar";
+"menu.playlist" = "Visa spellistepanel";
+"menu.quicksettings" = "Visa snabbinställningar";
 
 "menu.seek_forward" = "Gå framåt %.0f s";
 "menu.seek_backward" = "Gå bakåt %.0f s";

--- a/iina/tr.lproj/Localizable.strings
+++ b/iina/tr.lproj/Localizable.strings
@@ -112,6 +112,9 @@
 "menu.pause" = "Duraklat";
 "menu.resume" = "Sürdür";
 "menu.speed" = "Hız: %.2fx";
+"menu.chapters" = "Bölümler Panelini Göster";
+"menu.playlist" = "Oynatma Listesi Paneli";
+"menu.quicksettings" = "Hızlı Ayarlar Panelini Göster";
 
 "menu.seek_forward" = "%.0f sn İleriye Sar";
 "menu.seek_backward" = "%.0f sn Geriye Sar";

--- a/iina/uk.lproj/Localizable.strings
+++ b/iina/uk.lproj/Localizable.strings
@@ -112,6 +112,9 @@
 "menu.pause" = "Пауза";
 "menu.resume" = "Відновити";
 "menu.speed" = "Швидкість: %.2fx";
+"menu.chapters" = "Панель розділів";
+"menu.playlist" = "Панель підбірки";
+"menu.quicksettings" = "Панель швидкого налаштування";
 
 "menu.seek_forward" = "Крок уперед на %.0f с";
 "menu.seek_backward" = "Крок назад на %.0f с";

--- a/iina/zh-Hans.lproj/Localizable.strings
+++ b/iina/zh-Hans.lproj/Localizable.strings
@@ -112,6 +112,9 @@
 "menu.pause" = "暂停";
 "menu.resume" = "继续";
 "menu.speed" = "速度: %.2fx";
+"menu.chapters" = "显示章节面板";
+"menu.playlist" = "显示播放列表面板";
+"menu.quicksettings" = "显示快速设置面板";
 
 "menu.seek_forward" = "渐进 %.0f秒";
 "menu.seek_backward" = "渐退 %.0f秒";

--- a/iina/zh-Hant.lproj/Localizable.strings
+++ b/iina/zh-Hant.lproj/Localizable.strings
@@ -112,6 +112,9 @@
 "menu.pause" = "暫停";
 "menu.resume" = "繼續";
 "menu.speed" = "速度：%.2fx";
+"menu.chapters" = "顯示章節面板";
+"menu.playlist" = "顯示播放列表面板";
+"menu.quicksettings" = "顯示快速設定面板";
 
 "menu.seek_forward" = "快轉 %.0fs";
 "menu.seek_backward" = "倒轉 %.0fs";


### PR DESCRIPTION
If applied this commit will change these toggle menus to use "Hide" in their
title instead of "Show" when selecting the menu item hides the panel:
- Show Chapters Panel
- Show Playlist Panel
- Show Quick Settings Panel

This commit adds text that will require localization.

This fix only corrects one part of the reported issue. The behavior of buttons
still needs to be updated to adhere to the HIG.

There are some issues with the localization. See the discussions in the issue.

- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

It is part of the changes required to fix #3116

---

**Description:**

There are issues with localization, such as files missing from the Xcode project.
See the discussion in issue #3116.