### PR TITLE
Fix constant CPU usage by Playlist Panel, #3162

### DIFF
--- a/iina/FFmpegController.m
+++ b/iina/FFmpegController.m
@@ -333,14 +333,18 @@ return -1;\
   AVFormatContext *pFormatCtx = NULL;
   ret = avformat_open_input(&pFormatCtx, cFilename, NULL, NULL);
   free(cFilename);
-  if (ret < 0) return NULL;
+  if (ret < 0) {
+    NSLog(@"Error when opening file %@ to obtain info: %s (%d)", file, av_err2str(ret), ret);
+    return NULL;
+  }
 
   duration = pFormatCtx->duration;
   if (duration <= 0) {
     ret = avformat_find_stream_info(pFormatCtx, NULL);
-    if (ret < 0)
+    if (ret < 0) {
+      NSLog(@"Error when probing %@ to obtain info: %s (%d)", file, av_err2str(ret), ret);
       duration = -1;
-    else
+    } else
       duration = pFormatCtx->duration;
   }
 

--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -532,9 +532,16 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
             // get related data and schedule a reload
             if Preference.bool(for: .prefetchPlaylistVideoDuration) {
               self.player.refreshCachedVideoInfo(forVideoPath: item.filename)
-              self.refreshTotalLength()
-              DispatchQueue.main.async {
-                self.playlistTableView.reloadData(forRowIndexes: IndexSet(integer: row), columnIndexes: IndexSet(integersIn: 0...1))
+              // Only schedule a reload if data was obtained and cached to avoid looping
+              if let cached = self.player.info.cachedVideoDurationAndProgress[item.filename],
+                 let duration = cached.duration {
+                if duration > 0 {
+                  // if FFmpeg got the duration succcessfully
+                  self.refreshTotalLength()
+                  DispatchQueue.main.async {
+                    self.playlistTableView.reloadData(forRowIndexes: IndexSet(integer: row), columnIndexes: IndexSet(integersIn: 0...1))
+                  }
+                }
               }
             }
           }

--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -534,13 +534,11 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
               self.player.refreshCachedVideoInfo(forVideoPath: item.filename)
               // Only schedule a reload if data was obtained and cached to avoid looping
               if let cached = self.player.info.cachedVideoDurationAndProgress[item.filename],
-                 let duration = cached.duration {
-                if duration > 0 {
-                  // if FFmpeg got the duration succcessfully
-                  self.refreshTotalLength()
-                  DispatchQueue.main.async {
-                    self.playlistTableView.reloadData(forRowIndexes: IndexSet(integer: row), columnIndexes: IndexSet(integersIn: 0...1))
-                  }
+                  let duration = cached.duration, duration > 0 {
+                // if FFmpeg got the duration succcessfully
+                self.refreshTotalLength()
+                DispatchQueue.main.async {
+                  self.playlistTableView.reloadData(forRowIndexes: IndexSet(integer: row), columnIndexes: IndexSet(integersIn: 0...1))
                 }
               }
             }


### PR DESCRIPTION
This commit will change the method PlaylistViewController.tableView to
check if PlayerCore.refreshCachedVideoInfo was able to populate
PlaybackInfo.cachedVideoDurationAndProgress and not submit a reload of
the view if the cache is missing data.

This commit also updates FFmpegController.probeVideoInfoForFile to log
errors when libavformat methods return an error code.

This fixes an infinite table view reload loop that currently occurs when
refreshCachedVideoInfo is unable to populate the cache.

The infinite reload loop may be the cause of this issue:
Excessive CPU consumption when opening the Playlist Panel, #3162

- [ ] This change has been discussed with the author.
- [x ] It implements / fixes issue #3162.

---

**Description:**

This commit fixes a serious Playlist Panel issue.
Not certain it is the same problem reported in #3162.
See the replies to the issue for details.