### PR TITLE
Fix IINA 1.2.0 crashes instantly (Big Sur), #3478

### DIFF
--- a/iina/SleepPreventer.swift
+++ b/iina/SleepPreventer.swift
@@ -17,6 +17,14 @@ class SleepPreventer: NSObject {
 
   static private var preventedSleep = false
 
+  private static func errorToString(_ code: IOReturn) -> String {
+    if let error = mach_error_string(code) {
+      return String(cString: error)
+    } else {
+      return ""
+    }
+  }
+
   static func preventSleep() {
     if preventedSleep {
       return
@@ -29,7 +37,10 @@ class SleepPreventer: NSObject {
     if success == kIOReturnSuccess {
       preventedSleep = true
     } else {
-      Utility.showAlert("sleep")
+      Logger.log("Cannot prevent display sleep: \(errorToString(success)) (\(success))", level: .error)
+      DispatchQueue.main.async {
+        Utility.showAlert("sleep")
+      }
     }
   }
 

--- a/iina/SleepPreventer.swift
+++ b/iina/SleepPreventer.swift
@@ -17,14 +17,6 @@ class SleepPreventer: NSObject {
 
   static private var preventedSleep = false
 
-  private static func errorToString(_ code: IOReturn) -> String {
-    if let error = mach_error_string(code) {
-      return String(cString: error)
-    } else {
-      return ""
-    }
-  }
-
   static func preventSleep() {
     if preventedSleep {
       return
@@ -37,7 +29,7 @@ class SleepPreventer: NSObject {
     if success == kIOReturnSuccess {
       preventedSleep = true
     } else {
-      Logger.log("Cannot prevent display sleep: \(errorToString(success)) (\(success))", level: .error)
+      Logger.log("Cannot prevent display sleep: \(String(cString: mach_error_string(success))) (\(success))", level: .error)
       DispatchQueue.main.async {
         Utility.showAlert("sleep")
       }


### PR DESCRIPTION
This commit will change the method `SleepPreventer.preventSleep`
to submit a task to the main DispatchQueue to display an alert if macOS
returns an error when IINA asks it to not put the display to sleep.

This fixes a crash due to trying to display an alert using a thread other than
the main thread.

Logging has been added to log the failure macOS is returning.

- [ ] This change has been discussed with the author.
- [x ] It implements / fixes issue #3478.

---

**Description:**

This also fixes issue #3361.
