### PR TITLE
Closes log the versions of dependencies, #3490

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -92,7 +92,14 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     // Start the log file by logging the version of IINA producing the log file.
     let (version, build) = Utility.iinaVersion()
-    Logger.log("IINA \(version) Build \(build) Copyright © 2017-2021 Collider LI, et al.")
+    Logger.log("IINA \(version) Build \(build)")
+
+    // The copyright is used in the Finder "Get Info" window which is a narrow window so the
+    // copyright consists of multiple lines.
+    let copyright = Utility.iinaCopyright()
+    copyright.enumerateLines { line, _ in
+      Logger.log(line)
+    }
 
     // Useful to know the versions of significant dependencies that are being used so log that
     // information as well when it can be obtained.

--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -295,6 +295,11 @@ class Utility {
 
   // MARK: - App functions
 
+  static func iinaCopyright() -> String {
+    let infoDic = Bundle.main.infoDictionary!
+    return infoDic["NSHumanReadableCopyright"] as! String
+  }
+
   static func iinaVersion() -> (String, String) {
     let infoDic = Bundle.main.infoDictionary!
     let version = infoDic["CFBundleShortVersionString"] as! String

--- a/iina/iina-Bridging-Header.h
+++ b/iina/iina-Bridging-Header.h
@@ -4,6 +4,11 @@
 #import <mpv/render.h>
 #import <mpv/render_gl.h>
 
+#import <libavcodec/avcodec.h>
+#import <libavformat/avformat.h>
+#import <libavutil/avutil.h>
+#import <libswscale/swscale.h>
+
 #import <stdio.h>
 #import <stdlib.h>
 #import "FixedFontManager.h"


### PR DESCRIPTION
This commit will:
- Change AppDelegage.applicationWillFinishLaunching to log the IINA version,
  FFmpeg version and the versions of FFmpeg libraries
- Change AppDelegage.applicationDidFinishLaunching to log the mpv version

The version of mpv is not logged in  applicationWillFinishLaunching because
mpv does not provide a static method that returns the version. To obtain
version related information you must construct a mpv object, which has side
effects. So the mpv version is logged in applicationDidFinishLaunching to
preserve the existing order of initialization.

- [ ] This change has been discussed with the author.
- [x ] It implements / fixes issue #3490.

---

**Description:**
