### PR TITLE
Fix script parse_doc.rb, MPVProperty fails to compile, #3494

### DIFF
--- a/other/parse_doc.rb
+++ b/other/parse_doc.rb
@@ -26,7 +26,12 @@ def write_prop(file, node)
   end
   $prop_set[camel_name] += 1
 
-  if name.include? '/'
+  if name.include? 'current-tracks'
+    # According to the mpv documentation this property is not supposed to be
+    # used programmatically. We still output a comment for the property so
+    # people can figure out why the Swift constant is missing.
+    file.write "  /** #{name}  As per mpv doc, scripts etc. should not use this. */\n"
+  elsif name.include? '/'
     if name.include? 'N'
       func_name = name.to_camel
       return_str = name.gsub('N', '\(n)')

--- a/other/parse_doc.rb
+++ b/other/parse_doc.rb
@@ -30,7 +30,7 @@ def write_prop(file, node)
     # According to the mpv documentation this property is not supposed to be
     # used programmatically. We still output a comment for the property so
     # people can figure out why the Swift constant is missing.
-    file.write "  /** #{name}  As per mpv doc, scripts etc. should not use this. */\n"
+    file.write "  /** #{name}  As per mpv docs, scripts etc. should not use this. */\n"
   elsif name.include? '/'
     if name.include? 'N'
       func_name = name.to_camel


### PR DESCRIPTION
This commit will change the script parse_doc.rb to treat the property
"current-tracks" as a special case and only add a comment to
MPVProperty that indicates why a constant wasn't generated for it.

- [ ] This change has been discussed with the author.
- [ x] It implements / fixes issue #3494.

---

**Description:**
