### PR TITLE
Close add A-B Loop indicator on progress bar, #548

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -17,6 +17,8 @@
 		49542986216C34950058F680 /* OpenInIINA.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 49542973216C34950058F680 /* OpenInIINA.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		496B19921E2968530035AF10 /* PIP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 496B19911E2968530035AF10 /* PIP.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		513A4FFA29B53F8100A8EA7D /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513A4FF929B53F8100A8EA7D /* Atomic.swift */; };
+		516B7E00283337F8001A14D8 /* PlaySlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516B7DFF283337F8001A14D8 /* PlaySlider.swift */; };
+		516B7E0228333813001A14D8 /* PlaySliderLoopKnob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516B7E0128333813001A14D8 /* PlaySliderLoopKnob.swift */; };
 		519872FF26879B9B00F84BCC /* AccessibilityPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519872FE26879B9B00F84BCC /* AccessibilityPreferences.swift */; };
 		51C1BA3A291CA76700C1208A /* InfoDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C1BA39291CA76700C1208A /* InfoDictionary.swift */; };
 		51CACB9529D500290034CEE5 /* VideoPIPViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51CACB9429D500290034CEE5 /* VideoPIPViewController.swift */; };
@@ -809,6 +811,8 @@
 		496B19911E2968530035AF10 /* PIP.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PIP.framework; path = ../../../../System/Library/PrivateFrameworks/PIP.framework; sourceTree = "<group>"; };
 		49F7E3BF2920D65C002DA28E /* Availability.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Availability.xcconfig; sourceTree = "<group>"; };
 		513A4FF929B53F8100A8EA7D /* Atomic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
+		516B7DFF283337F8001A14D8 /* PlaySlider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaySlider.swift; sourceTree = "<group>"; };
+		516B7E0128333813001A14D8 /* PlaySliderLoopKnob.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaySliderLoopKnob.swift; sourceTree = "<group>"; };
 		519872FE26879B9B00F84BCC /* AccessibilityPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPreferences.swift; sourceTree = "<group>"; };
 		51C1BA39291CA76700C1208A /* InfoDictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InfoDictionary.swift; sourceTree = "<group>"; };
 		51CACB9429D500290034CEE5 /* VideoPIPViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPIPViewController.swift; sourceTree = "<group>"; };
@@ -2114,6 +2118,7 @@
 		84A0BAA61D2FAF8400BC8DA1 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				8407D13F1E3A684C0043895D /* ViewLayer.swift */,
 				84A886E21E24F2D3008755BB /* Sub */,
 				8497A4831D2FF573005F504F /* iina-Bridging-Header.h */,
 				513A4FF929B53F8100A8EA7D /* Atomic.swift */,
@@ -2398,7 +2403,9 @@
 				E3DBD23D218EF4F100B3AFBF /* AboutWindowContributorAvatarItem.xib */,
 				9E47DABF1E3CFA6D00457420 /* DurationDisplayTextField.swift */,
 				843FFD4C1D5DAA01001F3A44 /* RoundedTextFieldCell.swift */,
+				516B7DFF283337F8001A14D8 /* PlaySlider.swift */,
 				8461C52D1D45FFF6006E91FF /* PlaySliderCell.swift */,
+				516B7E0128333813001A14D8 /* PlaySliderLoopKnob.swift */,
 				84F725551D4783EE000DEF1B /* VolumeSliderCell.swift */,
 				8434BAAC1D5E4546003BECF2 /* SlideUpButton.swift */,
 				8487BEC01D744FA800FD17B0 /* FlippedView.swift */,
@@ -2425,7 +2432,6 @@
 			isa = PBXGroup;
 			children = (
 				84A0BAA01D2FAE7600BC8DA1 /* VideoView.swift */,
-				8407D13F1E3A684C0043895D /* ViewLayer.swift */,
 			);
 			name = Video;
 			sourceTree = "<group>";
@@ -2886,6 +2892,7 @@
 				8492C2881E7721A600CE5825 /* ISO639Helper.swift in Sources */,
 				84F5D4991E44E8AC0060A838 /* KeyBindingDataLoader.swift in Sources */,
 				E34C0C3124934D7B0065A0C6 /* Switch.swift in Sources */,
+				516B7E0228333813001A14D8 /* PlaySliderLoopKnob.swift in Sources */,
 				84EC12831F4F939000137C1E /* FilterPresets.swift in Sources */,
 				E374160F20F3AF7E00B4F7F9 /* PrefUtilsViewController.swift in Sources */,
 				E3FC31461FE1501E00B9B86F /* PowerSource.swift in Sources */,
@@ -2965,6 +2972,7 @@
 				51F7974728C7E00200812D0D /* Lock.swift in Sources */,
 				84C8D58F1D794CE600D98A0E /* MPVFilter.swift in Sources */,
 				845404AA1E4396F500B02B12 /* ScriptLoader.swift in Sources */,
+				516B7E00283337F8001A14D8 /* PlaySlider.swift in Sources */,
 				84A0BAA11D2FAE7600BC8DA1 /* VideoView.swift in Sources */,
 				E395858A253314400096811F /* JavascriptAPISidebarView.swift in Sources */,
 				E33BA5C4204315740069A0F6 /* AssrtSubtitle.swift in Sources */,

--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -17,11 +17,11 @@
 		49542986216C34950058F680 /* OpenInIINA.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 49542973216C34950058F680 /* OpenInIINA.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		496B19921E2968530035AF10 /* PIP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 496B19911E2968530035AF10 /* PIP.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		513A4FFA29B53F8100A8EA7D /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513A4FF929B53F8100A8EA7D /* Atomic.swift */; };
-		516B7E00283337F8001A14D8 /* PlaySlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516B7DFF283337F8001A14D8 /* PlaySlider.swift */; };
-		516B7E0228333813001A14D8 /* PlaySliderLoopKnob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 516B7E0128333813001A14D8 /* PlaySliderLoopKnob.swift */; };
 		519872FF26879B9B00F84BCC /* AccessibilityPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519872FE26879B9B00F84BCC /* AccessibilityPreferences.swift */; };
 		51C1BA3A291CA76700C1208A /* InfoDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C1BA39291CA76700C1208A /* InfoDictionary.swift */; };
 		51CACB9529D500290034CEE5 /* VideoPIPViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51CACB9429D500290034CEE5 /* VideoPIPViewController.swift */; };
+		51E63DFB29CFB031008AFC20 /* PlaySlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E63DFA29CFB031008AFC20 /* PlaySlider.swift */; };
+		51E63DFD29CFB04C008AFC20 /* PlaySliderLoopKnob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E63DFC29CFB04B008AFC20 /* PlaySliderLoopKnob.swift */; };
 		51F7974728C7E00200812D0D /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F7974628C7E00200812D0D /* Lock.swift */; };
 		6100FF2B1EDF9806002CF0FB /* dsa_pub.pem in Resources */ = {isa = PBXBuildFile; fileRef = 6100FF2A1EDF9806002CF0FB /* dsa_pub.pem */; };
 		8400D5C41E17C6D2006785F5 /* AboutWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8400D5C21E17C6D2006785F5 /* AboutWindowController.swift */; };
@@ -811,11 +811,11 @@
 		496B19911E2968530035AF10 /* PIP.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PIP.framework; path = ../../../../System/Library/PrivateFrameworks/PIP.framework; sourceTree = "<group>"; };
 		49F7E3BF2920D65C002DA28E /* Availability.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Availability.xcconfig; sourceTree = "<group>"; };
 		513A4FF929B53F8100A8EA7D /* Atomic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
-		516B7DFF283337F8001A14D8 /* PlaySlider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaySlider.swift; sourceTree = "<group>"; };
-		516B7E0128333813001A14D8 /* PlaySliderLoopKnob.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaySliderLoopKnob.swift; sourceTree = "<group>"; };
 		519872FE26879B9B00F84BCC /* AccessibilityPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPreferences.swift; sourceTree = "<group>"; };
 		51C1BA39291CA76700C1208A /* InfoDictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InfoDictionary.swift; sourceTree = "<group>"; };
 		51CACB9429D500290034CEE5 /* VideoPIPViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPIPViewController.swift; sourceTree = "<group>"; };
+		51E63DFA29CFB031008AFC20 /* PlaySlider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaySlider.swift; sourceTree = "<group>"; };
+		51E63DFC29CFB04B008AFC20 /* PlaySliderLoopKnob.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaySliderLoopKnob.swift; sourceTree = "<group>"; };
 		51F7974628C7E00200812D0D /* Lock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
 		5879479521A87DD700757A6F /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/MiniPlayerWindowController.strings; sourceTree = "<group>"; };
 		5879479621A87E6100757A6F /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/PreferenceWindowController.strings; sourceTree = "<group>"; };
@@ -2118,7 +2118,6 @@
 		84A0BAA61D2FAF8400BC8DA1 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
-				8407D13F1E3A684C0043895D /* ViewLayer.swift */,
 				84A886E21E24F2D3008755BB /* Sub */,
 				8497A4831D2FF573005F504F /* iina-Bridging-Header.h */,
 				513A4FF929B53F8100A8EA7D /* Atomic.swift */,
@@ -2403,9 +2402,9 @@
 				E3DBD23D218EF4F100B3AFBF /* AboutWindowContributorAvatarItem.xib */,
 				9E47DABF1E3CFA6D00457420 /* DurationDisplayTextField.swift */,
 				843FFD4C1D5DAA01001F3A44 /* RoundedTextFieldCell.swift */,
-				516B7DFF283337F8001A14D8 /* PlaySlider.swift */,
+				51E63DFA29CFB031008AFC20 /* PlaySlider.swift */,
+				51E63DFC29CFB04B008AFC20 /* PlaySliderLoopKnob.swift */,
 				8461C52D1D45FFF6006E91FF /* PlaySliderCell.swift */,
-				516B7E0128333813001A14D8 /* PlaySliderLoopKnob.swift */,
 				84F725551D4783EE000DEF1B /* VolumeSliderCell.swift */,
 				8434BAAC1D5E4546003BECF2 /* SlideUpButton.swift */,
 				8487BEC01D744FA800FD17B0 /* FlippedView.swift */,
@@ -2431,6 +2430,7 @@
 		84D377691D74163B007F7396 /* Video */ = {
 			isa = PBXGroup;
 			children = (
+				8407D13F1E3A684C0043895D /* ViewLayer.swift */,
 				84A0BAA01D2FAE7600BC8DA1 /* VideoView.swift */,
 			);
 			name = Video;
@@ -2892,7 +2892,6 @@
 				8492C2881E7721A600CE5825 /* ISO639Helper.swift in Sources */,
 				84F5D4991E44E8AC0060A838 /* KeyBindingDataLoader.swift in Sources */,
 				E34C0C3124934D7B0065A0C6 /* Switch.swift in Sources */,
-				516B7E0228333813001A14D8 /* PlaySliderLoopKnob.swift in Sources */,
 				84EC12831F4F939000137C1E /* FilterPresets.swift in Sources */,
 				E374160F20F3AF7E00B4F7F9 /* PrefUtilsViewController.swift in Sources */,
 				E3FC31461FE1501E00B9B86F /* PowerSource.swift in Sources */,
@@ -2935,6 +2934,7 @@
 				84A0BA901D2F8D4100BC8DA1 /* IINAError.swift in Sources */,
 				84C6D3621EAF8D63009BF721 /* HistoryController.swift in Sources */,
 				E38B3213214FB9EA000F6D27 /* PrefPluginPermissionView.swift in Sources */,
+				51E63DFD29CFB04C008AFC20 /* PlaySliderLoopKnob.swift in Sources */,
 				847644081D48B413004F6DF5 /* MPVOption.swift in Sources */,
 				84817C961DBDCA5F00CC2279 /* SettingsListCellView.swift in Sources */,
 				84A886F31E26CA24008755BB /* Regex.swift in Sources */,
@@ -2972,7 +2972,6 @@
 				51F7974728C7E00200812D0D /* Lock.swift in Sources */,
 				84C8D58F1D794CE600D98A0E /* MPVFilter.swift in Sources */,
 				845404AA1E4396F500B02B12 /* ScriptLoader.swift in Sources */,
-				516B7E00283337F8001A14D8 /* PlaySlider.swift in Sources */,
 				84A0BAA11D2FAE7600BC8DA1 /* VideoView.swift in Sources */,
 				E395858A253314400096811F /* JavascriptAPISidebarView.swift in Sources */,
 				E33BA5C4204315740069A0F6 /* AssrtSubtitle.swift in Sources */,
@@ -3004,6 +3003,7 @@
 				845FB0C71D39462E00C011E0 /* ControlBarView.swift in Sources */,
 				E3513AFB20F120F600F8C347 /* PreferenceViewController.swift in Sources */,
 				E38BD4AF20054BD9007635FC /* MainWindow.swift in Sources */,
+				51E63DFB29CFB031008AFC20 /* PlaySlider.swift in Sources */,
 				84F5D4A01E44F9DB0060A838 /* KeyBindingItem.swift in Sources */,
 				84E5221323FF3D080006FDA1 /* JavascriptAPIPlaylist.swift in Sources */,
 				84A0BA991D2FAAA700BC8DA1 /* MPVController.swift in Sources */,

--- a/iina/AppData.swift
+++ b/iina/AppData.swift
@@ -127,4 +127,5 @@ extension Notification.Name {
   static let iinaPluginChanged = Notification.Name("IINAPluginChanged")
   static let iinaPlayerStopped = Notification.Name("iinaPlayerStopped")
   static let iinaPlayerShutdown = Notification.Name("iinaPlayerShutdown")
+  static let iinaPlaySliderLoopKnobChanged = Notification.Name("iinaPlaySliderLoopKnobChanged")
 }

--- a/iina/Assets.xcassets/Colors/MainSliderLoopKnob.colorset/Contents.json
+++ b/iina/Assets.xcassets/Colors/MainSliderLoopKnob.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.410",
+          "green" : "0.410",
+          "red" : "0.410"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "1.000",
+          "blue" : "0.650",
+          "green" : "0.650",
+          "red" : "0.650"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iina/Assets.xcassets/Contents.json
+++ b/iina/Assets.xcassets/Contents.json
@@ -1,6 +1,6 @@
 {
   "info" : {
-    "version" : 1,
-    "author" : "xcode"
+    "author" : "xcode",
+    "version" : 1
   }
 }

--- a/iina/Base.lproj/MainWindowController.xib
+++ b/iina/Base.lproj/MainWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="18122" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="18122"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -70,7 +70,7 @@
         <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" tabbingMode="disallowed" id="F0z-JX-Cv5" customClass="MainWindow" customModule="IINA" customModuleProvider="target">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
             <rect key="contentRect" x="196" y="240" width="640" height="400"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1025"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1055"/>
             <view key="contentView" id="se5-gp-TjO">
                 <rect key="frame" x="0.0" y="0.0" width="640" height="400"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -442,7 +442,7 @@
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="BE1-yC-oJL" customClass="TimeLabelOverflowedView" customModule="IINA" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="500" height="29"/>
             <subviews>
-                <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eBP-6g-bAT">
+                <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eBP-6g-bAT" customClass="PlaySlider" customModule="IINA" customModuleProvider="target">
                     <rect key="frame" x="48" y="-1" width="404" height="28"/>
                     <sliderCell key="cell" continuous="YES" refusesFirstResponder="YES" state="on" alignment="left" maxValue="100" doubleValue="50" tickMarkPosition="above" sliderType="linear" id="f1c-xF-8a2" customClass="PlaySliderCell" customModule="IINA" customModuleProvider="target"/>
                     <connections>

--- a/iina/ExtendedColors.swift
+++ b/iina/ExtendedColors.swift
@@ -18,6 +18,7 @@ extension NSColor.Name {
   static let mainSliderBarChapterStroke = NSColor.Name("MainSliderBarChapterStroke")
   static let mainSliderKnob = NSColor.Name("MainSliderKnob")
   static let mainSliderKnobActive = NSColor.Name("MainSliderKnobActive")
+  static let mainSliderLoopKnob = NSColor.Name("MainSliderLoopKnob")
 
   static let titleBarBorder = NSColor.Name("TitleBarBorder")
 

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -136,7 +136,7 @@ extension MainMenuActionHandler {
   }
 
   @objc func menuABLoop(_ sender: NSMenuItem) {
-    player.abLoop()
+    player.mainWindow.abLoop()
   }
 
   @objc func menuFileLoop(_ sender: NSMenuItem) {

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -634,16 +634,16 @@ class MainWindowController: PlayerWindowController {
 
     // Observe the loop knobs on the progress bar and update mpv when the knobs move.
     addObserver(to: .default, forName: .iinaPlaySliderLoopKnobChanged, object: playSlider.abLoopA) { [weak self] _ in
-      guard let strongSelf = self else { return }
-      let seconds = strongSelf.percentToSeconds(strongSelf.playSlider.abLoopA.doubleValue)
-      strongSelf.player.abLoopA = seconds
-      strongSelf.player.sendOSD(.abLoopUpdate(.aSet, VideoTime(seconds).stringRepresentation))
+      guard let self = self else { return }
+      let seconds = self.percentToSeconds(self.playSlider.abLoopA.doubleValue)
+      self.player.abLoopA = seconds
+      self.player.sendOSD(.abLoopUpdate(.aSet, VideoTime(seconds).stringRepresentation))
     }
     addObserver(to: .default, forName: .iinaPlaySliderLoopKnobChanged, object: playSlider.abLoopB) { [weak self] _ in
-      guard let strongSelf = self else { return }
-      let seconds = strongSelf.percentToSeconds(strongSelf.playSlider.abLoopB.doubleValue)
-      strongSelf.player.abLoopB = seconds
-      strongSelf.player.sendOSD(.abLoopUpdate(.bSet, VideoTime(seconds).stringRepresentation))
+      guard let self = self else { return }
+      let seconds = self.percentToSeconds(self.playSlider.abLoopB.doubleValue)
+      self.player.abLoopB = seconds
+      self.player.sendOSD(.abLoopUpdate(.bSet, VideoTime(seconds).stringRepresentation))
     }
 
     player.events.emit(.windowLoaded)

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -632,7 +632,39 @@ class MainWindowController: PlayerWindowController {
       setWindowFrameForLegacyFullScreen()
     }
 
+    // Observe the loop knobs on the progress bar and update mpv when the knobs move.
+    addObserver(to: .default, forName: .iinaPlaySliderLoopKnobChanged, object: playSlider.abLoopA) { [weak self] _ in
+      guard let strongSelf = self else { return }
+      let seconds = strongSelf.percentToSeconds(strongSelf.playSlider.abLoopA.doubleValue)
+      strongSelf.player.abLoopA = seconds
+      strongSelf.player.sendOSD(.abLoopUpdate(.aSet, VideoTime(seconds).stringRepresentation))
+    }
+    addObserver(to: .default, forName: .iinaPlaySliderLoopKnobChanged, object: playSlider.abLoopB) { [weak self] _ in
+      guard let strongSelf = self else { return }
+      let seconds = strongSelf.percentToSeconds(strongSelf.playSlider.abLoopB.doubleValue)
+      strongSelf.player.abLoopB = seconds
+      strongSelf.player.sendOSD(.abLoopUpdate(.bSet, VideoTime(seconds).stringRepresentation))
+    }
+
     player.events.emit(.windowLoaded)
+  }
+
+  /// Returns the position in seconds for the given percent of the total duration of the video the percentage represents.
+  ///
+  /// The number of seconds returned must be considered an estimate that could change. The duration of the video is obtained from
+  /// the [mpv](https://mpv.io/manual/stable/) `duration` property. The documentation for this property cautions that
+  /// mpv is not always able to determine the duration and when it does return a duration it may be an estimate. If the duration is
+  /// unknown this method will fallback to using the current playback position, if that is known. Otherwise this method will return zero.
+  /// - Parameter percent: Position in the video as a percentage of the duration.
+  /// - Returns: The position in the video the given percentage represents.
+  private func percentToSeconds(_ percent: Double) -> Double {
+    if let duration = player.info.videoDuration?.second {
+      return duration * percent / 100
+    } else if let position = player.info.videoPosition?.second {
+      return position * percent / 100
+    } else {
+      return 0
+    }
   }
 
   /** Set material for OSC and title bar */
@@ -1122,13 +1154,21 @@ class MainWindowController: PlayerWindowController {
     guard let w = self.window, let cv = w.contentView else { return }
     if cv.trackingAreas.isEmpty {
       cv.addTrackingArea(NSTrackingArea(rect: cv.bounds,
-                                        options: [.activeAlways, .inVisibleRect, .mouseEnteredAndExited, .mouseMoved],
+                                        options: [.activeAlways, .enabledDuringMouseDrag, .inVisibleRect, .mouseEnteredAndExited, .mouseMoved],
                                         owner: self, userInfo: ["obj": 0]))
     }
     if playSlider.trackingAreas.isEmpty {
       playSlider.addTrackingArea(NSTrackingArea(rect: playSlider.bounds,
-                                                options: [.activeAlways, .inVisibleRect, .mouseEnteredAndExited, .mouseMoved],
+                                                options: [.activeAlways, .enabledDuringMouseDrag, .inVisibleRect, .mouseEnteredAndExited, .mouseMoved],
                                                 owner: self, userInfo: ["obj": 1]))
+    }
+    // Track the thumbs on the progress bar representing the A-B loop points and treat them as part
+    // of the slider.
+    if playSlider.abLoopA.trackingAreas.count <= 1 {
+      playSlider.abLoopA.addTrackingArea(NSTrackingArea(rect: playSlider.abLoopA.bounds, options:  [.activeAlways, .enabledDuringMouseDrag, .inVisibleRect, .mouseEnteredAndExited, .mouseMoved], owner: self, userInfo: ["obj": 1]))
+    }
+    if playSlider.abLoopB.trackingAreas.count <= 1 {
+      playSlider.abLoopB.addTrackingArea(NSTrackingArea(rect: playSlider.abLoopB.bounds, options: [.activeAlways, .enabledDuringMouseDrag, .inVisibleRect, .mouseEnteredAndExited, .mouseMoved], owner: self, userInfo: ["obj": 1]))
     }
 
     // update timer

--- a/iina/OSDMessage.swift
+++ b/iina/OSDMessage.swift
@@ -48,7 +48,8 @@ enum OSDMessage {
   case mute
   case unMute
   case screenshot
-  case abLoop(Int)
+  case abLoop(PlaybackInfo.LoopStatus)
+  case abLoopUpdate(PlaybackInfo.LoopStatus, String)
   case stop
   case chapter(String)
   case track(MPVTrack)
@@ -181,12 +182,25 @@ enum OSDMessage {
       return (NSLocalizedString("osd.screenshot", comment: "Screenshot Captured"), .normal)
 
     case .abLoop(let value):
-      if value == 1 {
-        return (NSLocalizedString("osd.abloop.a", comment: "AB-Loop: A"), .withText("{{position}} / {{duration}}"))
-      } else if value == 2 {
-        return (NSLocalizedString("osd.abloop.b", comment: "AB-Loop: B"), .withText("{{position}} / {{duration}}"))
-      } else {
+      // The A-B loop command was invoked.
+      switch (value) {
+      case .cleared:
         return (NSLocalizedString("osd.abloop.clear", comment: "AB-Loop: Cleared"), .normal)
+      case .aSet:
+        return (NSLocalizedString("osd.abloop.a", comment: "AB-Loop: A"), .withText("{{position}} / {{duration}}"))
+      case .bSet:
+        return (NSLocalizedString("osd.abloop.b", comment: "AB-Loop: B"), .withText("{{position}} / {{duration}}"))
+      }
+
+    case .abLoopUpdate(let value, let position):
+      // One of the A-B loop points has been updated to the given position.
+      switch (value) {
+      case .cleared:
+        Logger.fatal("Attempt to display invalid OSD message, type: .abLoopUpdate value: .cleared position \(position)")
+      case .aSet:
+        return (NSLocalizedString("osd.abloop.a", comment: "AB-Loop: A"), .withText("\(position) / {{duration}}"))
+      case .bSet:
+        return (NSLocalizedString("osd.abloop.b", comment: "AB-Loop: B"), .withText("\(position) / {{duration}}"))
       }
 
     case .stop:

--- a/iina/PlaySlider.swift
+++ b/iina/PlaySlider.swift
@@ -1,0 +1,88 @@
+//
+//  PlaySlider.swift
+//  iina
+//
+//  Created by low-batt on 10/11/21.
+//  Copyright © 2021 lhc. All rights reserved.
+//
+
+import Cocoa
+
+/// A custom [slider](https://developer.apple.com/design/human-interface-guidelines/macos/selectors/sliders/)
+/// for the onscreen controller.
+///
+/// This slider adds two thumbs (referred to as knobs in code) to the progress bar slider to show the A and B loop points of the
+/// [mpv](https://mpv.io/manual/stable/) A-B loop feature and allow the loop points to be adjusted. When the feature is
+/// disabled the additional thumbs are hidden.
+/// - Requires: The custom slider cell provided by `PlaySliderCell` **must** be used with this class.
+/// - Note: Unlike `NSSlider` the `draw` method of this class will do nothing if the view is hidden.
+final class PlaySlider: NSSlider {
+
+  /// Knob representing the A loop point for the mpv A-B loop feature.
+  var abLoopA: PlaySliderLoopKnob { abLoopAKnob }
+
+  /// Knob representing the B loop point for the mpv A-B loop feature.
+  var abLoopB: PlaySliderLoopKnob { abLoopBKnob }
+
+  /// The slider's cell correctly typed for convenience.
+  var customCell: PlaySliderCell { cell as! PlaySliderCell }
+
+  // MARK:- Private Properties
+
+  private var abLoopAKnob: PlaySliderLoopKnob!
+
+  private var abLoopBKnob: PlaySliderLoopKnob!
+
+  // MARK:- Initialization
+
+  required init?(coder: NSCoder) {
+    super.init(coder: coder)
+    abLoopAKnob = PlaySliderLoopKnob(slider: self, toolTip: "A-B loop A")
+    abLoopBKnob = PlaySliderLoopKnob(slider: self, toolTip: "A-B loop B")
+  }
+
+  // MARK:- Drawing
+
+  override func draw(_ dirtyRect: NSRect) {
+    // With the onscreen controller hidden and a movie playing spindumps showed time being spent
+    // drawing the slider even though it was not visible. Apparently NSSlider is missing the
+    // following check.
+    guard !isHiddenOrHasHiddenAncestor else { return }
+    super.draw(dirtyRect)
+    abLoopA.draw(dirtyRect)
+    abLoopB.draw(dirtyRect)
+  }
+
+  // MARK:- Mouse Events
+
+  override func mouseDown(with event: NSEvent) {
+    let clickLocation = convert(event.locationInWindow, from: nil)
+    // When the knobs are overlapping we assume the user is trying to move the play knob rather than
+    // change the loop points. So we intentionally test first for the mouse clicking on the play
+    // knob, then test the B knob and then test the A knob and lastly default to the slider itself,
+    // which will move the play knob.
+    if isMousePoint(clickLocation, in: customCell.knobRect(flipped: isFlipped)) {
+      super.mouseDown(with: event)
+      return
+    }
+    if !abLoopB.isHidden && isMousePoint(clickLocation, in: abLoopB.frame) {
+      abLoopB.beginDragging(with: event)
+      return
+    }
+    if !abLoopA.isHidden && isMousePoint(clickLocation, in: abLoopA.frame) {
+      abLoopA.beginDragging(with: event)
+      return
+    }
+    super.mouseDown(with: event)
+  }
+
+  override func viewDidUnhide() {
+    super.viewDidUnhide()
+    // When IINA is not the application being used and the onscreen controller is hidden if the
+    // mouse is moved over an IINA window the IINA will unhide the controller. If the slider is
+    // not marked as needing display the controller will show without the slider. I would of thought
+    // the NSView method would do this. The current Apple documentation does not say what the NSView
+    // method does or even if it needs to be called by subclasses.
+    needsDisplay = true
+  }
+}

--- a/iina/PlaySlider.swift
+++ b/iina/PlaySlider.swift
@@ -80,9 +80,9 @@ final class PlaySlider: NSSlider {
     super.viewDidUnhide()
     // When IINA is not the application being used and the onscreen controller is hidden if the
     // mouse is moved over an IINA window the IINA will unhide the controller. If the slider is
-    // not marked as needing display the controller will show without the slider. I would of thought
-    // the NSView method would do this. The current Apple documentation does not say what the NSView
-    // method does or even if it needs to be called by subclasses.
+    // not marked as needing display the controller will show without the slider. I would have
+    // thought the NSView method would do this. The current Apple documentation does not say what
+    // the NSView method does or even if it needs to be called by subclasses.
     needsDisplay = true
   }
 }

--- a/iina/PlaySliderLoopKnob.swift
+++ b/iina/PlaySliderLoopKnob.swift
@@ -1,0 +1,218 @@
+//
+//  PlaySliderKnob.swift
+//  iina
+//
+//  Created by low-batt on 10/14/21.
+//  Copyright © 2021 lhc. All rights reserved.
+//
+
+import Cocoa
+
+// These colors are for 10.13- only
+@available(macOS, obsoleted: 10.14)
+fileprivate extension NSColor {
+  // Use different colors to distinguish loop knobs from the primary knob.
+  static let darkKnobColor = NSColor(calibratedRed: 0.59, green: 0.59, blue: 0.59, alpha: 1)
+  static let lightKnobColor = NSColor(calibratedRed: 0.35, green: 0.35, blue: 0.35, alpha: 1)
+}
+
+/// This class adds an additional thumb (knob) to a slider.
+///
+/// This class is used to add thumbs representing the A and B loop points of the [mpv](https://mpv.io/manual/stable/) A-B
+/// loop feature when that feature is in use. When the feature is not being used the thumbs are hidden.
+/// - Requires: The custom slider provided by `PlaySlider` must be used with this class.
+/// - Note: This class is derived from `NSView` in part to gain support for help tags (tool tips).
+final class PlaySliderLoopKnob: NSView {
+
+  // Must accept first responder for help tags to work.
+  override var acceptsFirstResponder: Bool { true }
+
+  /// The location of this knob as a slider value which is always greater than or equal to the slider's `minValue` and less than or equal
+  /// to the slider's `maxValue`.
+  var doubleValue: Double {
+    get { value }
+    set {
+      value = constrainValue(newValue)
+      // Move the knob to the position on the bar that represents the new value.
+      moveKnob(to: computeX())
+    }
+  }
+
+  var isDragging: Bool = false
+
+  override var isFlipped: Bool {
+    // Match the behavior of the slider and use a flipped coordinate system.
+    get { slider.isFlipped }
+  }
+
+  // MARK:- Private Properties
+
+  private var cell: PlaySliderCell!
+
+  /// Number of points to add to the width of the knob's frame.
+  ///
+  /// If a user attempts to click on a loop knob but fails to put the cursor precisely on the loop knob, clicking will land on the slider
+  /// which moves the primary knob. Since the small size of the knobs makes this an easy mistake to make, the width of the frame of
+  /// loop knobs is sightly increased over the width of the primary knob to mitigate the problem of unintentional movement of the
+  /// primary knob. Loop knobs are still drawn with the same width as the primary knob.
+  private static let frameWidthAdjustment: CGFloat = 2
+
+  /// Number of points to offset X coordinate by due to enlargement of the frame.
+  private static let xAdjustment = frameWidthAdjustment / 2
+
+  private let knobHeight: CGFloat
+  
+  /// Percentage of the height of the primary knob to use for the loop knobs when drawing.
+  ///
+  /// The height of loop knobs is reduced in order to give prominence to the primary knob.
+  private static let knobHeightAdjustment: CGFloat = 0.75
+
+  // The X coordinate of the last mouse location when dragging.
+  private var lastDragLocation: CGFloat = 0
+
+  private var slider: PlaySlider!
+
+  private var value: Double = 0
+
+  /// The knob's x coordinate calculated based on the value.
+  private var x: CGFloat {
+    get {
+      let valueToX = computeX()
+      // If the size of the slider bar has changed the knob will no longer be in the correct
+      // position and will need to be moved.
+      if frame.origin.x != valueToX {
+        moveKnob(to: valueToX)
+      }
+      return valueToX
+    }
+    set {
+      let constrainedX = constrainX(newValue)
+      // Calculate the value selected by the new location.
+      let bar = cell.barRect(flipped: isFlipped)
+      // The knob is not allowed to slide past the end of the bar, so the usable width is reduced.
+      let effectiveWidth = bar.width - cell.knobWidth
+      // The knob's frame is larger than the drawn knob. Adjust x to start of drawn knob.
+      let percentage = Double((constrainedX + PlaySliderLoopKnob.xAdjustment) / effectiveWidth)
+      value = constrainValue(percentage * slider.maxValue)
+      moveKnob(to: constrainedX)
+    }
+  }
+
+  // MARK:- Initialization
+
+  /// Creates an additional thumb for the given
+  /// [slider](https://developer.apple.com/design/human-interface-guidelines/macos/selectors/sliders/)
+  /// - Parameters:
+  ///   - slider: The slider this thumb belongs to.
+  ///   - toolTip: The help tag to display for this thumb.
+  init(slider: PlaySlider, toolTip: String) {
+    self.slider = slider
+    self.cell = slider.customCell
+    // We want loop knobs to be shorter than the primary knob.
+    knobHeight = round(cell.knobHeight * PlaySliderLoopKnob.knobHeightAdjustment)
+    // The frame is calculated and set once the superclass is initialized.
+    super.init(frame: NSZeroRect)
+    self.toolTip = toolTip
+    // This knob is hidden unless the mpv A-B loop feature is activated.
+    isHidden = true
+    let rect = knobRect()
+    setFrameOrigin(NSPoint(x: rect.origin.x, y: rect.origin.y))
+    setFrameSize(NSSize(width: rect.width, height: rect.height))
+    slider.addSubview(self)
+  }
+
+  required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
+
+  private func constrainValue(_ value: Double) -> Double {
+    return value.clamped(to: cell.minValue...cell.maxValue)
+  }
+
+  /// Constrain the x coordinate to insure the knob stays within the bar.
+  /// - Parameter x: The proposed x coordinate.
+  /// - Returns: The given x coordinate constrained to keep the knob within the bar.
+  private func constrainX(_ x: CGFloat) -> CGFloat {
+    let bar = cell.barRect(flipped: isFlipped)
+    // The knob's frame is larger than the drawn knob so the frame can start before the bar and the
+    // knob will still be contained within the bar.
+    let minX = bar.minX - PlaySliderLoopKnob.xAdjustment
+    // The coordinate must be short of the end of the bar to keep the knob within the bar.
+    let maxX = bar.maxX - cell.knobWidth - PlaySliderLoopKnob.xAdjustment
+    return x.clamped(to: minX...maxX)
+  }
+
+  /// Compute the position of the knob on the bar that represents the current value.
+  /// - Returns: The x coordinate to use for the knob's frame.
+  private func computeX() -> CGFloat {
+    let percentage = CGFloat(value / slider.maxValue)
+    let bar = cell.barRect(flipped: isFlipped)
+    // The knob is not allowed to slide past the end of the bar, so the usable width is reduced.
+    let effectiveWidth = bar.width - cell.knobWidth
+    // The knob's frame is larger than the drawn knob, offset the frame location accordingly.
+    return constrainX(percentage * effectiveWidth - PlaySliderLoopKnob.xAdjustment)
+  }
+
+  // MARK:- Drawing
+
+  private func knobColor() -> NSColor {
+    // Starting with macOS Mojave 10.14 colors can be configured to automatically adjust for the
+    // current appearance.
+    if #available(macOS 10.14, *) {
+      return NSColor(named: .mainSliderLoopKnob)!
+    } else {
+      return slider.window!.effectiveAppearance.isDark ? .darkKnobColor : .lightKnobColor
+    }
+  }
+
+  override func draw(_ dirtyRect: NSRect) {
+    guard !isHiddenOrHasHiddenAncestor else { return }
+    let rect = knobRect()
+    // The frame is taller than the drawn knob. Adjust the y coordinate accordingly.
+    let adjustedY = rect.origin.y + (rect.height - knobHeight) / 2
+    // The frame is wider than the drawn knob. Adjust the x coordinate accordingly.
+    let adjustedX = rect.origin.x + PlaySliderLoopKnob.xAdjustment
+    let drawing = NSMakeRect(adjustedX, adjustedY, cell.knobWidth, knobHeight)
+    let path = NSBezierPath(roundedRect: drawing, xRadius: cell.knobRadius, yRadius: cell.knobRadius)
+    knobColor().setFill()
+    path.fill()
+  }
+
+  private func knobRect() -> NSRect {
+    let rect = cell.knobRect(flipped: isFlipped)
+    // The frame of a loop knob is larger than the drawn knob to make it easier to click on.
+    return NSMakeRect(x, rect.origin.y, rect.width + PlaySliderLoopKnob.frameWidthAdjustment, rect.height)
+  }
+
+  // MARK:- Mouse Events
+
+  override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+    // Match the behavior of the slider and respond to click-throughs.
+    slider.acceptsFirstMouse(for: event)
+  }
+
+  /// Begin dragging the knob.
+  ///
+  /// - Important: The method `mouseDown` is not overriden in order to allow `PlaySlider` to give preference to the primary
+  ///     knob when the knobs are overlapping
+  /// - Parameter event: An object encapsulating information about the mouse-down event initiating the drag.
+  func beginDragging(with event: NSEvent) {
+    let clickLocation = slider.convert(event.locationInWindow, from: nil)
+    lastDragLocation = constrainX(clickLocation.x)
+    isDragging = true
+  }
+
+  override func mouseDragged(with event: NSEvent) {
+    let newDragLocation = slider.convert(event.locationInWindow, from: nil)
+    x = frame.origin.x + newDragLocation.x - lastDragLocation
+    lastDragLocation = constrainX(newDragLocation.x)
+    NotificationCenter.default.post(Notification(name: .iinaPlaySliderLoopKnobChanged, object: self))
+  }
+
+  override func mouseUp(with event: NSEvent) {
+    isDragging = false
+  }
+
+  private func moveKnob(to x: CGFloat) {
+    setFrameOrigin(NSPoint(x: x, y: frame.origin.y))
+    slider.needsDisplay = true
+  }
+}

--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -10,6 +10,18 @@ import Foundation
 
 class PlaybackInfo {
 
+  /// Enumeration representing the status of the [mpv](https://mpv.io/manual/stable/) A-B loop command.
+  ///
+  /// The A-B loop command cycles mpv through these states:
+  /// - Cleared (looping disabled)
+  /// - A loop point set
+  /// - B loop point set (looping enabled)
+  enum LoopStatus {
+    case cleared
+    case aSet
+    case bSet
+  }
+
   unowned let player: PlayerCore
 
   init(_ pc: PlayerCore) {
@@ -129,7 +141,7 @@ class PlaybackInfo {
   var videoTracks: [MPVTrack] = []
   var subTracks: [MPVTrack] = []
 
-  var abLoopStatus: Int = 0 // 0: none, 1: A set, 2: B set (looping)
+  var abLoopStatus: LoopStatus = .cleared
 
   /** Selected track IDs. Use these (instead of `isSelected` of a track) to check if selected */
   var aid: Int?


### PR DESCRIPTION
This commit adds two additional thumbs to the progress bar representing
the A and B loop points when the A-B loop feature is active. This allows
the user to adjust the loop points.

This commit will:
- Add a new class PlaySliderLoopKnob that adds an additional thumb
- Add a new class PlaySlider that customizes NSSlider to add the thumbs
- Change MainWindowController.xib to use PlaySlider for the OSC
- Change PlayerCore to allow mpv loop points to be updated
- Change MainWindowController to observe the thumbs and update mpv
- Change PlayerWindowController to synchronize the thumbs with mpv
- Change MainMenuActions to call the window controller for A-B Loop
- Change PlaybackInfo to use an enum class for abLoopStatus
- Add a new message to OSDMessage

- [ ] This change has been discussed with the author.
- [ x] It implements / fixes issue #548.

---

**Description:**
See the associated issue for screenshots of what the OSC looks like with these changes.