### PR TITLE
Fix  progress bar does not reach end #3331

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1286,6 +1286,14 @@ class PlayerCore: NSObject {
       if info.isNetworkResource {
         info.videoDuration?.second = mpv.getDouble(MPVProperty.duration)
       }
+      // When the end of a video file is reached mpv does not update the value of the property
+      // time-pos, leaving it reflecting the position of the last frame of the video. This is
+      // especially noticeable if the onscreen controller time labels are configured to show
+      // milliseconds. Adjust the position if the end of the file has been reached.
+      let eofReached = mpv.getFlag(MPVProperty.eofReached)
+      if eofReached, let duration = info.videoDuration?.second {
+        info.videoPosition?.second = duration
+      }
       info.constrainVideoPosition()
       DispatchQueue.main.async {
         if self.isInMiniPlayer {
@@ -1298,6 +1306,14 @@ class PlayerCore: NSObject {
     case .timeAndCache:
       info.videoPosition?.second = mpv.getDouble(MPVProperty.timePos)
       info.videoDuration?.second = mpv.getDouble(MPVProperty.duration)
+      // When the end of a video file is reached mpv does not update the value of the property
+      // time-pos, leaving it reflecting the position of the last frame of the video. This is
+      // especially noticeable if the onscreen controller time labels are configured to show
+      // milliseconds. Adjust the position if the end of the file has been reached.
+      let eofReached = mpv.getFlag(MPVProperty.eofReached)
+      if eofReached, let duration = info.videoDuration?.second {
+        info.videoPosition?.second = duration
+      }
       info.constrainVideoPosition()
       info.pausedForCache = mpv.getFlag(MPVProperty.pausedForCache)
       info.cacheUsed = ((mpv.getNode(MPVProperty.demuxerCacheState) as? [String: Any])?["fw-bytes"] as? Int) ?? 0


### PR DESCRIPTION
This commit will change the setting of PlaybackInfo.videoPosition in
PlayerCore.syncUI to take into account the value of the mpv eof-reached
property and adjust the position accordingly if the end of the video has been
reached.

- [ ] This change has been discussed with the author.
- [ x] It implements / fixes issue #3331.

---

**Description:**
