### PR TITLE
Fix CPU is consumed when paused, #3537

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -449,6 +449,10 @@ class PlayerCore: NSObject {
   
   func pause() {
     mpv.setFlag(MPVOption.PlaybackControl.pause, true)
+    // Follow energy efficiency best practices and ensure IINA is absolutely idle when the video is
+    // paused to avoid wasting energy with needless processing.
+    invalidateTimer()
+    mainWindow.videoView.stopDisplayLink()
   }
   
   func resume() {
@@ -457,6 +461,8 @@ class PlayerCore: NSObject {
       seek(absoluteSecond: 0)
     }
     mpv.setFlag(MPVOption.PlaybackControl.pause, false)
+    createSyncUITimer()
+    mainWindow.videoView.startDisplayLink()
   }
 
   func stop() {


### PR DESCRIPTION
Two systems were continuing to run when playback was paused.
The commit in the pull request:
- Changes `PlayerCore.pause` to invalidate the timer and stop the
  display link thread
- Changes `PlayerCore.resume` to create the synchronization timer
  and start the display link

- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3537.

---

**Description:**
