### PR TITLE
Fix legacy Full Screen is absolutely busted, #3543

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1576,7 +1576,26 @@ class MainWindowController: PlayerWindowController {
       window?.title = player.getMediaTitle()
     } else {
       window?.representedURL = player.info.currentURL
-      window?.setTitleWithRepresentedFilename(player.info.currentURL?.path ?? "")
+      // Workaround for issue #3543, IINA crashes reporting:
+      // NSInvalidArgumentException [NSNextStepFrame _displayName]: unrecognized selector
+      // When running on an M1 under Big Sur and using legacy full screen.
+      //
+      // Changes in Big Sur broke the legacy full screen feature. The MainWindowController method
+      // legacyAnimateToFullscreen had to be changed to get this feature working again. Under Big
+      // Sur that method now calls "window.styleMask.remove(.titled)". Removing titled from the
+      // style mask causes the AppKit method NSWindow.setTitleWithRepresentedFilename to trigger the
+      // exception listed above. This appears to be a defect in the Cocoa framework. The window's
+      // title can still be set directly without triggering the exception. The problem seems to be
+      // isolated to the setTitleWithRepresentedFilename method, possibly only when running on an
+      // Apple Silicon based Mac. Based on the Apple documentation setTitleWithRepresentedFilename
+      // appears to be a convenience method. As a workaround for the issue directly set the window
+      // properties we think that method is setting.
+      if Preference.bool(for: .useLegacyFullScreen), #available(macOS 11.0, *) {
+        window?.representedFilename = player.info.currentURL?.path ?? ""
+        window?.title = player.info.currentURL?.lastPathComponent ?? ""
+      } else {
+        window?.setTitleWithRepresentedFilename(player.info.currentURL?.path ?? "")
+      }
     }
     addDocIconToFadeableViews()
   }


### PR DESCRIPTION
The commit in the pull request changes the method updateTitle in the class
MainWindowController to use an alternative implementation when the
legacy full screen feature is enabled that avoids calling the method
NSWindow.setTitleWithRepresentedFilename. This works around a defect in
the Cocoa framework that results in IINA crashing with an
NSInvalidArgumentException.

- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3543.

---

**Description:**
