### PR TITLE
Fix media keys doesn't work, #3574

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -167,7 +167,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
       if RemoteCommandController.useSystemMediaControl {
         Logger.log("Setting up MediaPlayer integration")
         RemoteCommandController.setup()
-        NowPlayingInfoManager.updateState(.unknown)
+        NowPlayingInfoManager.updateInfo(state: .unknown)
       }
     }
 

--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -62,7 +62,7 @@ class PlaybackInfo {
       PlayerCore.checkStatusForSleep()
       if player == PlayerCore.lastActive {
         if #available(macOS 10.13, *), RemoteCommandController.useSystemMediaControl {
-          NowPlayingInfoManager.updateState(isPaused ? .paused : .playing)
+          NowPlayingInfoManager.updateInfo(state: isPaused ? .paused : .playing)
         }
         if #available(macOS 10.12, *), player.mainWindow.pipStatus == .inPIP {
           player.mainWindow.pip.playing = isPlaying

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1054,7 +1054,7 @@ class PlayerCore: NSObject {
     info.isNetworkResource = !info.currentURL!.isFileURL
 
     if #available(OSX 10.13, *), RemoteCommandController.useSystemMediaControl {
-      NowPlayingInfoManager.updateInfo(withTitle: true)
+      NowPlayingInfoManager.updateInfo(state: .playing, withTitle: true)
     }
 
     // Auto load
@@ -1729,7 +1729,7 @@ class NowPlayingInfoManager {
   static let center = MPNowPlayingInfoCenter.default()
   static private var info = [String: Any]()
 
-  static func updateInfo(withTitle: Bool = false) {
+  static func updateInfo(state: MPNowPlayingPlaybackState? = nil, withTitle: Bool = false) {
     let activePlayer = PlayerCore.lastActive
 
     if withTitle {
@@ -1755,10 +1755,9 @@ class NowPlayingInfoManager {
     info[MPNowPlayingInfoPropertyDefaultPlaybackRate] = 1
 
     center.nowPlayingInfo = info
-  }
 
-  static func updateState(_ state: MPNowPlayingPlaybackState) {
-    center.playbackState = state
-    updateInfo()
+    if state != nil {
+      center.playbackState = state!
+    }
   }
 }


### PR DESCRIPTION
The commit in the pull request:
- Adds the ability to set the state to `NowPlayingInfoManager.updateInfo`
- Eliminates the method  `NowPlayingInfoManager.updateState`
- Changes  `PlayerCore.fileStarted` to set the state to `playing`
- Changes references to `updateState` to use `updateInfo`

- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3574.

---

**Description:**
