### PR TITLE
Fix NSFileHandleOperationException crash, #3590

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -339,6 +339,16 @@ class PlayerCore: NSObject {
     isMpvTerminated = true
   }
 
+  /// Wait until this player core has been terminated.
+  ///
+  /// The method `terminateMPV` **must** be called before calling this method. That method calls `mpvQuit` which
+  /// executes asynchronously. This method waits until mpv has been destroyed.
+  /// - parameter timeout: The latest time to wait for this player core to terminate
+  /// - returns: Whether this player core has terminated or waiting timed out
+  func waitForTermination(timeout: DispatchTime) -> DispatchTimeoutResult {
+    mpv.waitForDestruction(timeout: timeout)
+  }
+
   // invalidate timer
   func invalidateTimer() {
     self.syncPlayTimeTimer?.invalidate()


### PR DESCRIPTION
The fix changes IINA to wait for mpv to cleanly shutdown before proceeding
with application shutdown.

The commit in the pull request:
- Adds a isDestroyed semaphore to MPVController
- Changes MPVController.handleEvent to signal the semaphore once the
  mpv context has been destroyed
- Adds a waitForDestruction method to  MPVController to wait for mpv to
  be destroyed
- Adds a waitForTermination method to PlayerCore that calls
  MPVController.waitForDestruction to wait for mpv to be destroyed
- Changes AppDelegate.applicationShouldTerminate to submit a task to wait
  for all players to terminate
- Changes applicationShouldTerminate to return terminateLater to tell the
  framework to hold up application termination until told to proceed

- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3590.

---

**Description:**
See issue for a discussion of the crash and the fix.