### PR TITLE
Fix IINA crashes with 'Code Signature Invalid', #3551

### DIFF
--- a/iina/IINA.entitlements
+++ b/iina/IINA.entitlements
@@ -2,7 +2,7 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>com.apple.security.cs.allow-jit</key>
+	<key>com.apple.security.cs.allow-unsigned-executable-memory</key>
 	<true/>
 	<key>com.apple.security.cs.disable-library-validation</key>
 	<true/>


### PR DESCRIPTION
This commit will replace the entitlement "com.apple.security.cs.allow-jit" with
"com.apple.security.cs.allow-unsigned-executable-memory" in the
IINA.entitlements file.

This is required because the OpenResty LuaJIT library is not following Apple's
best practices for JIT compilers that allow use of the more restrictive
entitlement. This has been reported in this LuaJIT issue:

Code Signature Invalid crash using com.apple.security.cs.allow-jit
https://github.com/openresty/luajit2/issues/145

- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3551.

---

**Description:**
See issue for full discussion.