### PR TITLE
Fix quit triggers "invalid context state" error, #3593

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -41,6 +41,8 @@ class MPVController: NSObject {
   var mpv: OpaquePointer!
   var mpvRenderContext: OpaquePointer?
 
+  private var openGLContext: CGLContextObj! = nil
+
   var mpvClientName: UnsafePointer<CChar>!
   var mpvVersion: String!
 
@@ -366,14 +368,38 @@ class MPVController: NSObject {
         mpv_render_param()
       ]
       mpv_render_context_create(&mpvRenderContext, mpv, &params)
+      openGLContext = CGLGetCurrentContext()
       mpv_render_context_set_update_callback(mpvRenderContext!, mpvUpdateCallback, mutableRawPointerOf(obj: player.mainWindow.videoView.videoLayer))
     }
   }
 
   func mpvUninitRendering() {
     guard let mpvRenderContext = mpvRenderContext else { return }
+    lockAndSetOpenGLContext()
+    defer { unlockOpenGLContext() }
     mpv_render_context_set_update_callback(mpvRenderContext, nil, nil)
     mpv_render_context_free(mpvRenderContext)
+  }
+
+  /// Lock the OpenGL context associated with the mpv renderer and set it to be the current context for this thread.
+  ///
+  /// This method is needed to meet this requirement from `mpv/render.h`:
+  ///
+  /// If the OpenGL backend is used, for all functions the OpenGL context must be "current" in the calling thread, and it must be the
+  /// same OpenGL context as the `mpv_render_context` was created with. Otherwise, undefined behavior will occur.
+  ///
+  /// - Reference: [mpv render.h](https://github.com/mpv-player/mpv/blob/master/libmpv/render.h)
+  /// - Reference: [Concurrency and OpenGL](https://developer.apple.com/library/archive/documentation/GraphicsImaging/Conceptual/OpenGL-MacProgGuide/opengl_threading/opengl_threading.html)
+  /// - Reference: [OpenGL Context](https://www.khronos.org/opengl/wiki/OpenGL_Context)
+  /// - Attention: Do not forget to unlock the OpenGL context by calling `unlockOpenGLContext`
+  func lockAndSetOpenGLContext() {
+    CGLLockContext(openGLContext)
+    CGLSetCurrentContext(openGLContext)
+  }
+
+  /// Unlock the OpenGL context associated with the mpv renderer.
+  func unlockOpenGLContext() {
+    CGLUnlockContext(openGLContext)
   }
 
   func mpvReportSwap() {


### PR DESCRIPTION
The commit in the pull request:
- Adds an openGLContext property to MPVController for the OpenGL
  context
- Changes MPVController.mpvInitRendering to save the OpenGL context
- Adds a new method lockAndSetOpenGLContext to MPVController
- Adds a new method unlockOpenGLContext to MPVController
- Changes MPVController.mpvUninitRendering to use the new methods to
  appropriately manage the OpenGL context

- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3593.

---

**Description:**
