### PR TITLE
Fix crash in mpv_set_property during termination, #3596

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1044,7 +1044,7 @@ class MainWindowController: PlayerWindowController {
       }
     }
     // stop playing
-    if !player.isMpvTerminated {
+    if !player.isMpvTerminating {
       if case .fullscreen(legacy: true, priorWindowedFrame: _) = fsState {
         restoreDockSettings()
       }

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -186,7 +186,7 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
   func windowWillClose(_ notification: Notification) {
     player.switchedToMiniPlayerManually = false
     player.switchedBackFromMiniPlayerManually = false
-    if !player.isMpvTerminated {
+    if !player.isMpvTerminating {
       // not needed if called when terminating the whole app
       player.switchBackFromMiniPlayer(automatically: true, showMainWindow: false)
     }

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -123,7 +123,7 @@ class PlayerCore: NSObject {
 
   var displayOSD: Bool = true
 
-  var isMpvTerminated: Bool = false
+  var isMpvTerminating: Bool = false
 
   var isInMiniPlayer = false
   var switchedToMiniPlayerManually = false
@@ -329,14 +329,14 @@ class PlayerCore: NSObject {
 
   // Terminate mpv
   func terminateMPV(sendQuit: Bool = true) {
-    guard !isMpvTerminated else { return }
+    guard !isMpvTerminating else { return }
+    isMpvTerminating = true
     savePlaybackPosition()
     invalidateTimer()
     uninitVideo()
     if sendQuit {
       mpv.mpvQuit()
     }
-    isMpvTerminated = true
   }
 
   // invalidate timer
@@ -1282,7 +1282,9 @@ class PlayerCore: NSObject {
 
   func syncUI(_ option: SyncUIOption) {
     // if window not loaded, ignore
-    guard mainWindow.loaded else { return }
+    // No need for updating the UI if currently terminating mpv. Requesting property values from mpv
+    // can cause crashes depending upon how far into the asynchronous termination sequence mpv is.
+    guard mainWindow.loaded, !isMpvTerminating else { return }
     Logger.log("Syncing UI \(option)", level: .verbose, subsystem: subsystem)
 
     switch option {


### PR DESCRIPTION
The commit in the pull request will:
- Rename the PlayerCore property isMpvTerminated to isMpvTerminating to
  reflect that termination has been initiated and being processed
  asynchronously
- Change existing references to isMpvTerminated to use new name
- Change PlayerCore.terminateMPV to set isMpvTerminating to true right
  before starting the termination process
- Change PlayerCore.syncUI to do nothing if mpv is terminating
- Change MPVController.mpvQuit to remove observers MPVController
  registered before sending the quit command to mpv
- Change many MPVController methods to check to see if mpv is being
  terminated

- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3596.

---

**Description:**
