### PR TITLE
Update copyright year to 2022

### DIFF
--- a/iina/Base.lproj/Contribution.rtf
+++ b/iina/Base.lproj/Contribution.rtf
@@ -23,7 +23,7 @@ Email:
 \ulnone \
 
 \f1\b0 The modern video player for macOS.\
-Copyright \'a9 2017-2021  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
+Copyright \'a9 2017-2022  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 \cf0 \
 \

--- a/iina/Info.plist
+++ b/iina/Info.plist
@@ -473,7 +473,7 @@
 		</dict>
 	</dict>
 	<key>NSHumanReadableCopyright</key>
-        <string>Copyright © 2017-2021
+        <string>Copyright © 2017-2022
 Collider LI, et al.
 Released under GPLv3.</string>
 	<key>NSMainNibFile</key>

--- a/iina/ca.lproj/Contribution.rtf
+++ b/iina/ca.lproj/Contribution.rtf
@@ -23,7 +23,7 @@ Email:
 \ulnone \
 
 \f1\b0 The modern video player for macOS.\
-Copyright \'a9 2017-2021  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
+Copyright \'a9 2017-2022  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 \cf0 \
 \

--- a/iina/cs.lproj/Contribution.rtf
+++ b/iina/cs.lproj/Contribution.rtf
@@ -23,7 +23,7 @@ E-mail:
 \ulnone \
 
 \f1\b0 Modern\'ed video p\uc0\u345 ehr\'e1va\u269  pro macOS.\
-Copyright \'a9 2017-2021  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
+Copyright \'a9 2017-2022  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 \cf0 \
 \

--- a/iina/da.lproj/Contribution.rtf
+++ b/iina/da.lproj/Contribution.rtf
@@ -24,7 +24,7 @@ Email:
 
 \f1\b0 \
 Dette er den moderne videoafspiller for macOS.\
-Copyright \'a9 2017-2021  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
+Copyright \'a9 2017-2022  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
 \
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 \cf0 \

--- a/iina/de.lproj/Contribution.rtf
+++ b/iina/de.lproj/Contribution.rtf
@@ -22,7 +22,7 @@ E-Mail:
 \ulnone \
 
 \f1\b0 Der moderne Videoplayer f\'fcr macOS\
-Copyright \'a9 2017-2021  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
+Copyright \'a9 2017-2022  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
 \
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 \cf0 \

--- a/iina/en.lproj/Contribution.rtf
+++ b/iina/en.lproj/Contribution.rtf
@@ -23,7 +23,7 @@ Email:
 \ulnone \
 
 \f1\b0 The modern video player for macOS.\
-Copyright \'a9 2017-2021  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
+Copyright \'a9 2017-2022  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 \cf0 \
 \

--- a/iina/es.lproj/Contribution.rtf
+++ b/iina/es.lproj/Contribution.rtf
@@ -22,7 +22,7 @@ Email:
 \ulnone \
 
 \f1\b0 El reproductor de video moderno para macOS.\
-Copyright \'a9 2017-2021  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
+Copyright \'a9 2017-2022  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
 \
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 \cf0 \

--- a/iina/fr.lproj/Contribution.rtf
+++ b/iina/fr.lproj/Contribution.rtf
@@ -22,7 +22,7 @@ Email :
 \ulnone \
 
 \f1\b0 Le lecteur vid\'e9o moderne pour macOS.\
-Copyright \'a9 2017-2021  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
+Copyright \'a9 2017-2022  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
 \
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 \cf0 \

--- a/iina/hi.lproj/Contribution.rtf
+++ b/iina/hi.lproj/Contribution.rtf
@@ -39,7 +39,7 @@
 \f1  
 \f3 \uc0\u2346 \u2381 \u2354 \u2375 \u2351 \u2352 
 \f1 .\
-Copyright \'a9 2017-2021  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
+Copyright \'a9 2017-2022  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
 \
 \
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0

--- a/iina/it.lproj/Contribution.rtf
+++ b/iina/it.lproj/Contribution.rtf
@@ -22,7 +22,7 @@ Email:
 \ulnone \
 
 \f1\b0 Il video player moderno per macOS.\
-Copyright \'a9 2017-2021  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
+Copyright \'a9 2017-2022  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
 \
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 \cf0 \

--- a/iina/ja.lproj/Contribution.rtf
+++ b/iina/ja.lproj/Contribution.rtf
@@ -28,7 +28,7 @@
 \ulnone \
 
 \f1\b0 The modern video player for macOS.\
-Copyright \'a9 2017-2021  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
+Copyright \'a9 2017-2022  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
 \
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 \cf0 \

--- a/iina/ko.lproj/Contribution.rtf
+++ b/iina/ko.lproj/Contribution.rtf
@@ -28,7 +28,7 @@
 \ulnone \
 
 \f1\b0 The modern video player for macOS.\
-Copyright \'a9 2017-2021  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
+Copyright \'a9 2017-2022  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
 \
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 \cf0 \

--- a/iina/nl.lproj/Contribution.rtf
+++ b/iina/nl.lproj/Contribution.rtf
@@ -23,7 +23,7 @@ Email:
 \ulnone \
 
 \f1\b0 De moderne video speler voor macOS.\
-Copyright \'a9 2017-2021  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
+Copyright \'a9 2017-2022  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
 \
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 \cf0 \

--- a/iina/pl.lproj/Contribution.rtf
+++ b/iina/pl.lproj/Contribution.rtf
@@ -27,7 +27,7 @@
 
 \f1\b0 \ulnone \
 Nowoczesny odtwarzacz wideo dla macOS.\
-Wszelkie prawa zastrze\uc0\u380 one \'a9 2017-2021 Collider LI, et al.\
+Wszelkie prawa zastrze\uc0\u380 one \'a9 2017-2022 Collider LI, et al.\
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardeftab720\partightenfactor0
 \cf0 \
 \

--- a/iina/pt-BR.lproj/Contribution.rtf
+++ b/iina/pt-BR.lproj/Contribution.rtf
@@ -25,7 +25,7 @@ Email:
 
 \f1\b0 \cf0 \ulnone O reprodutor moderno de v\'eddeos para macOS.\
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\qc\partightenfactor0
-\cf0 Copyright \'a9 2017-2021  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
+\cf0 Copyright \'a9 2017-2022  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
 \
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 \cf0 \

--- a/iina/ro.lproj/Contribution.rtf
+++ b/iina/ro.lproj/Contribution.rtf
@@ -23,7 +23,7 @@ Email:
 \ulnone \
 
 \f1\b0 Player-ul video modern pentru macOS.\
-Copyright \'a9 2017-2021  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
+Copyright \'a9 2017-2022  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 \cf0 \
 Acest program este software gratis: \'eel po\uc0\u539 i redistribui \u537 i/sau modifica sub termenii GNU General Public License cum este publicat\u259  de c\u259 tre Free Software Foundation, versiunea 3 a Licen\u539 ei, sau (la dispozi\u539 ia ta) o versiune viitoare.\

--- a/iina/ru.lproj/Contribution.rtf
+++ b/iina/ru.lproj/Contribution.rtf
@@ -22,7 +22,7 @@
 \ulnone \
 
 \f1\b0 \uc0\u1057 \u1086 \u1074 \u1088 \u1077 \u1084 \u1077 \u1085 \u1085 \u1099 \u1081  \u1074 \u1080 \u1076 \u1077 \u1086 \u1087 \u1083 \u1077 \u1077 \u1088  \u1076 \u1083 \u1103  macOS.\
-Copyright \'a9 2017-2021  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
+Copyright \'a9 2017-2022  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
 \
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 \cf0 \

--- a/iina/sk.lproj/Contribution.rtf
+++ b/iina/sk.lproj/Contribution.rtf
@@ -24,7 +24,7 @@ Email:
 \ulnone \
 
 \f1\b0 Modern\'fd video prehr\'e1va\uc0\u269  pre macOS.\
-Copyright \'a9 2017-2021  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
+Copyright \'a9 2017-2022  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
 \
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 \cf0 \

--- a/iina/sv.lproj/Contribution.rtf
+++ b/iina/sv.lproj/Contribution.rtf
@@ -23,7 +23,7 @@ E-post:
 \ulnone \
 
 \f1\b0 Den moderna videospelaren till macOS.\
-Copyright \'a9 2017-2021  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
+Copyright \'a9 2017-2022  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 \cf0 \
 \

--- a/iina/tr.lproj/Contribution.rtf
+++ b/iina/tr.lproj/Contribution.rtf
@@ -22,7 +22,7 @@ Email:
 \ulnone \
 
 \f1\b0 The modern video player for macOS.\
-Copyright \'a9 2017-2021  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
+Copyright \'a9 2017-2022  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
 \
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 \cf0 \

--- a/iina/uk.lproj/Contribution.rtf
+++ b/iina/uk.lproj/Contribution.rtf
@@ -23,7 +23,7 @@ E-mail:
 
 \f1\b0 \uc0\u1057 \u1091 \u1095 \u1072 \u1089 \u1085 \u1080 \u1081  \u1084 \u1077 \u1076 \u1110 \u1072 \u1087 \u1088 \u1086 \u1075 \u1088 \u1072 \u1074 \u1072 \u1095  \u1076 \u1083 \u1103  macOS.\
 
-\uc0\u1040 \u1074 \u1090 \u1086 \u1088 \u1089 \u1100 \u1082 \u1110  \u1087 \u1088 \u1072 \u1074 \u1072  \'a9 2017-2021  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
+\uc0\u1040 \u1074 \u1090 \u1086 \u1088 \u1089 \u1100 \u1082 \u1110  \u1087 \u1088 \u1072 \u1074 \u1072  \'a9 2017-2022  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
 \
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 \cf0 \

--- a/iina/zh-Hans.lproj/Contribution.rtf
+++ b/iina/zh-Hans.lproj/Contribution.rtf
@@ -28,7 +28,7 @@
 \ulnone \
 
 \f1\b0 The modern video player for macOS.\
-Copyright \'a9 2017-2021  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
+Copyright \'a9 2017-2022  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
 \
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 \cf0 \

--- a/iina/zh-Hant.lproj/Contribution.rtf
+++ b/iina/zh-Hant.lproj/Contribution.rtf
@@ -28,7 +28,7 @@
 \ulnone \
 
 \f1\b0 The modern video player for macOS.\
-Copyright \'a9 2017-2021  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
+Copyright \'a9 2017-2022  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
 \
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 \cf0 \

--- a/other/update_copyright.sh
+++ b/other/update_copyright.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# This script will update the copyright year displayed to users.
+# No files are committed. Files are only changed locally. Up to
+# you to review the changes and create a commit.
+
+# Support running from either the top of the source tree or the
+# "other" directory containing this script.
+indir=${PWD##*/}
+srcdir='iina'
+if [ "$indir" = 'other' ]; then
+    srcdir="../$srcdir"
+fi
+
+year=$(date +%Y)
+
+echo "Updating copyright year to $year"
+
+# Update the copyright displayed in the macOS "Get Info" window for the application.
+find "$(cd $srcdir; pwd)" -name Info.plist -exec sed -i '' "s/ 2017-2[0-9]\{3\}/ 2017-$year/" {} +
+
+# Update the copyright displayed in the about window.
+# This changes lots of files due to localization.
+find "$(cd $srcdir; pwd)" -name Contribution.rtf -exec sed -i '' "s/ 2017-2[0-9]\{3\}/ 2017-$year/" {} +


### PR DESCRIPTION
The copyright year displayed in the about window and the macOS "Get Info"
window for the application should reflect the year in which the particular
release of the application was built.

Apparently from a legal perspective updating the copyright year is no longer
required. But users are used to the copyright matching up with the year of the
build and this does provide the user with useful information about the age of
the release. Therefore IINA should continue to update the copyright year.

This commit will:
- Update the copyright year to 2022
- Add a bash script "update_copyright.sh" to the other directory

- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**
