### PR TITLE
Fix CPU is consumed by OSC while hidden, #3601

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1500,6 +1500,8 @@ class MainWindowController: PlayerWindowController {
       return
     }
 
+    // Follow energy efficiency best practices and stop the timer that updates the OSC.
+    player.invalidateTimer()
     animationState = .willHide
     fadeableViews.forEach { (v) in
       v.isHidden = false
@@ -1532,9 +1534,9 @@ class MainWindowController: PlayerWindowController {
     fadeableViews.forEach { (v) in
       v.isHidden = false
     }
-    if !player.isInMiniPlayer && fsState.isFullscreen && displayTimeAndBatteryInFullScreen {
-      player.syncUI(.additionalInfo)
-    }
+    // The OSC was not updated while it was hidden to avoid wasting energy. Update it now.
+    player.syncUITime()
+    player.createSyncUITimer()
     standardWindowButtons.forEach { $0.isEnabled = true }
     NSAnimationContext.runAnimationGroup({ (context) in
       context.duration = UIAnimationDuration

--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -50,9 +50,9 @@ class PlaybackInfo {
   var cachedWindowScale: Double = 1.0
 
   func constrainVideoPosition() {
-    guard let duration = videoDuration else { return }
-    if videoPosition!.second < 0 { videoPosition!.second = 0 }
-    if videoPosition!.second > duration.second { videoPosition!.second = duration.second }
+    guard let duration = videoDuration, let position = videoPosition else { return }
+    if position.second < 0 { position.second = 0 }
+    if position.second > duration.second { position.second = duration.second }
   }
 
   var isSeeking: Bool = false


### PR DESCRIPTION
The fix in PR #3434 MUST be merged before merging this commit..

This commit will:
- Change MainWindowController.hideUI to stop the timer that updates
  the OSC
- Change MainWindowController.showUI to sync the UI and start the timer
- Change PlaybackInfo.constrainVideoPosition to check that`videoPosition
  is not nil

- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3601.

---

**Description:**
See issue for details. Don't miss the above note about merging PR #3434 first!