### PR TITLE
Fix crash in NowPlayingInfoManager during quit, #3607

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1731,6 +1731,7 @@ class NowPlayingInfoManager {
 
   static func updateInfo(withTitle: Bool = false) {
     let activePlayer = PlayerCore.lastActive
+    guard !activePlayer.isMpvTerminated else { return }
 
     if withTitle {
       if activePlayer.currentMediaIsAudio == .isAudio {


### PR DESCRIPTION
The commit will add a guard statement to the updateInfo method in
NowPlayingInfoManager to check if mpv termination has been initiated.

- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3607.

---

**Description:**
There are multiple PRs outstanding with changes in this area, so likely I will need to rebase and correct merge conflicts when these are merged.