### PR TITLE
Fix camera housing blocks controller, #3558

### DIFF
--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -600,3 +600,14 @@ extension NSAppearance {
     }
   }
 }
+
+extension NSScreen {
+  /// Height of the camera housing on this screen if this screen has an embedded camera.
+  var cameraHousingHeight: CGFloat? {
+    if #available(macOS 12.0, *) {
+      return safeAreaInsets.top == 0.0 ? nil : safeAreaInsets.top
+    } else {
+      return nil
+    }
+  }
+}

--- a/iina/Info.plist
+++ b/iina/Info.plist
@@ -1153,5 +1153,7 @@ Released under GPLv3.</string>
 			</dict>
 		</dict>
 	</array>
+	<key>NSPrefersDisplaySafeAreaCompatibilityMode</key>
+	<false/>
 </dict>
 </plist>

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1321,6 +1321,12 @@ class MainWindowController: PlayerWindowController {
     // set frame
     let screen = window.screen ?? NSScreen.main!
     window.setFrame(screen.frame, display: true, animate: true)
+    if let unusable = screen.cameraHousingHeight {
+      // This screen contains an embedded camera. Shorten the height of the window's view's frame to
+      // avoid having part of the video obscured by the camera housing.
+      let view = window.contentView!
+      view.setFrameSize(NSMakeSize(view.frame.width, view.frame.height - unusable))
+    }
     // call delegate
     windowDidEnterFullScreen(Notification(name: .iinaLegacyFullScreen))
   }


### PR DESCRIPTION
The commit in the pull request:

- Extends NSScreen with a new optional computed property,
  cameraHousingHeight

- Changes MainWindowController.legacyAnimateToFullscreen to check if
  cameraHousingHeight indicates a camera housing intrudes into the
  screen and if so reduces the size of the full screen video window's
  view's frame appropriately.

- [x] This change has been discussed with the author.
- [x] It implements / fixes issue #3558.

---

**Description:**
This PR replaces PR #3559 and takes a different approach addressing code review comments in the original PR.