### PR TITLE
Add a debugDescription property to mpv_node

### DIFF
--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -600,3 +600,80 @@ extension NSAppearance {
     }
   }
 }
+
+extension mpv_node: CustomDebugStringConvertible {
+
+  /// A textual representation of this instance, suitable for debugging.
+  ///
+  /// If the node is an array or a map the string will contine mulitple lines.
+  public var debugDescription: String { mpv_node.toString(self) }
+
+  /// Return a textual representation of the given`mpv_node`, suitable for debugging.
+  ///
+  /// If the node is an array or a map the string will contine mulitple lines. For arrays and maps the string will include all nodes
+  /// referenced by the given node.
+  /// - Parameter node: The `mpv_node` to return a textual representation of.
+  /// - Parameter indent: Used to control indentation of nested arrays and maps.
+  /// - Returns: A string representing the given node as well as any nodes that node references.
+  private static func toString(_ node: mpv_node, indent: String = "") -> String {
+    switch node.format {
+    case MPV_FORMAT_FLAG:
+      return "MPV_FORMAT_FLAG \(node.u.flag)"
+
+    case MPV_FORMAT_STRING:
+      return "MPV_FORMAT_STRING \(String(cString: node.u.string!))"
+
+    case MPV_FORMAT_INT64:
+      return "MPV_FORMAT_INT64 \(node.u.int64)"
+
+    case MPV_FORMAT_DOUBLE:
+      return "MPV_FORMAT_DOUBLE \(node.u.double_)"
+
+    case MPV_FORMAT_NODE_ARRAY:
+      let list = node.u.list!.pointee
+      var results = "MPV_FORMAT_NODE_ARRAY \(list.num) entries"
+      if list.num == 0 { return results }
+      let deeperIndent = "\(indent)  "
+      var ptr = list.values!
+      for i in 0 ..< list.num {
+        results += "\n\(deeperIndent)[\(i)] \(toString(ptr.pointee, indent: deeperIndent))"
+        ptr = ptr.successor()
+      }
+      return results
+
+    case MPV_FORMAT_NODE_MAP:
+      let map = node.u.list!.pointee
+      var results = "MPV_FORMAT_NODE_MAP \(map.num) entries"
+      // node map can be empty.
+      if map.num == 0 { return results }
+      let deeperIndent = "\(indent)  "
+      var kptr = map.keys!
+      var vptr = map.values!
+      for _ in 0 ..< map.num {
+        results += """
+          \n\(deeperIndent)\(String(cString: kptr.pointee!)) = \
+          \(toString(vptr.pointee, indent: deeperIndent))
+          """
+        kptr = kptr.successor()
+        vptr = vptr.successor()
+      }
+      return results
+
+    case MPV_FORMAT_BYTE_ARRAY:
+      let array = node.u.ba!.pointee
+      let data = array.data!
+      let size = array.size
+      var results = "MPV_FORMAT_BYTE_ARRAY \(size) bytes "
+      for i in 0 ..< size {
+        results += String(data.load(fromByteOffset: i, as: UInt8.self), radix: 16, uppercase: true)
+      }
+      return results
+
+    case MPV_FORMAT_NONE:
+      return "MPV_FORMAT_NONE"
+
+    default:
+      return "Unsupported node format \(node.format.rawValue)"
+    }
+  }
+}


### PR DESCRIPTION
This commit will extend mpv_node to add a custom debugDescription
property that provides a textual representation of the node suitable for
developer debugging.

This allows developers to add temporary debug logging such as:
mpv_get_property(mpv, MPVProperty.af, MPV_FORMAT_NODE, &node)
Logger.log("mpv_get_property af:\n\(String(reflecting: node))")

In order to see the full node tree returned by mpv.

- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**

This is an example of the node returned by `mpv_get_property` for the `af` property with two audio filters configured logged using the new debugDescription property:
```text
23:27:15.942 [iina][d] mpv_get_property af:
MPV_FORMAT_NODE_ARRAY 2 entries
  [0] MPV_FORMAT_NODE_MAP 3 entries
    name = MPV_FORMAT_STRING scaletempo
    enabled = MPV_FORMAT_FLAG 1
    params = MPV_FORMAT_NODE_MAP 5 entries
      stride = MPV_FORMAT_STRING 8
      overlap = MPV_FORMAT_STRING 1
      search = MPV_FORMAT_STRING 10
      scale = MPV_FORMAT_STRING 0.4
      speed = MPV_FORMAT_STRING pitch
  [1] MPV_FORMAT_NODE_MAP 3 entries
    name = MPV_FORMAT_STRING scaletempo
    enabled = MPV_FORMAT_FLAG 1
    params = MPV_FORMAT_NODE_MAP 5 entries
      stride = MPV_FORMAT_STRING 8
      overlap = MPV_FORMAT_STRING 1
      search = MPV_FORMAT_STRING 10
      scale = MPV_FORMAT_STRING 2
      speed = MPV_FORMAT_STRING pitch
```