### PR TITLE
Fix audio filters cannot be removed, #3620

### DIFF
--- a/iina/MainWindowMenuActions.swift
+++ b/iina/MainWindowMenuActions.swift
@@ -166,12 +166,15 @@ extension MainWindowController {
   private func menuToggleFilterString(_ string: String, forType type: String) {
     let isVideo = type == MPVProperty.vf
     if let filter = MPVFilter(rawString: string) {
-      if player.mpv.getFilters(type).contains(where: { $0.stringFormat == string }) {
+      // Removing a filter based on its position within the filter list is the preferred way to do
+      // it as per discussion with the mpv project. Search the list of filters and find the index
+      // of the specified filter (if present).
+      if let index = player.mpv.getFilters(type).firstIndex(of: filter) {
         // remove
         if isVideo {
-          _ = player.removeVideoFilter(filter)
+          _ = player.removeVideoFilter(filter, index)
         } else {
-          _ = player.removeAudioFilter(filter)
+          _ = player.removeAudioFilter(filter, index)
         }
       } else {
         // add

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -495,8 +495,10 @@ class MenuController: NSObject, NSMenuDelegate {
     let filters = PlayerCore.active.mpv.getFilters(type)
     let menu: NSMenu! = type == MPVProperty.vf ? savedVideoFiltersMenu : savedAudioFiltersMenu
     for item in menu.items {
-      if let string = (item.representedObject as? String) {
-        item.state = filters.contains { $0.stringFormat == string } ? .on : .off
+      if let string = (item.representedObject as? String), let asObject = MPVFilter(rawString: string) {
+        // Filters that support multiple parameters have more than one valid string representation.
+        // Must compare filters using their object representation.
+        item.state = filters.contains { $0 == asObject } ? .on : .off
       }
     }
   }

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -885,8 +885,20 @@ class PlayerCore: NSObject {
     info.audioEqFilters = nil
   }
 
-  func addVideoFilter(_ filter: MPVFilter) -> Bool {
-    Logger.log("Adding video filter \(filter.stringFormat)...", subsystem: subsystem)
+  /// Add a video filter given as a `MPVFilter` object.
+  ///
+  /// This method will prompt the user to change IINA's video preferences if hardware decoding is set to `auto`.
+  /// - Parameter filter: The filter to add.
+  /// - Returns: `true` if the filter was successfully added, `false` otherwise.
+  func addVideoFilter(_ filter: MPVFilter) -> Bool { addVideoFilter(filter.stringFormat) }
+
+  /// Add a video filter given as a string.
+  ///
+  /// This method will prompt the user to change IINA's video preferences if hardware decoding is set to `auto`.
+  /// - Parameter filter: The filter to add.
+  /// - Returns: `true` if the filter was successfully added, `false` otherwise.
+  func addVideoFilter(_ filter: String) -> Bool {
+    Logger.log("Adding video filter \(filter)...", subsystem: subsystem)
     // check hwdec
     let askHwdec: (() -> Bool) = {
       let panel = NSAlert()
@@ -923,30 +935,133 @@ class PlayerCore: NSObject {
     }
     // try apply filter
     var result = true
-    mpv.command(.vf, args: ["add", filter.stringFormat], checkError: false) { result = $0 >= 0 }
+    mpv.command(.vf, args: ["add", filter], checkError: false) { result = $0 >= 0 }
     Logger.log(result ? "Succeeded" : "Failed", subsystem: self.subsystem)
     return result
   }
 
+  /// Remove a video filter based on its position in the list of filters.
+  ///
+  /// Removing a filter based on its position within the filter list is the preferred way to do it as per discussion with the mpv project.
+  /// - Parameter filter: The filter to be removed, required only for logging.
+  /// - Parameter index: The index of the filter to be removed.
+  /// - Returns: `true` if the filter was successfully removed, `false` otherwise.
+  func removeVideoFilter(_ filter: MPVFilter, _ index: Int) -> Bool {
+    removeVideoFilter(filter.stringFormat, index)
+  }
+
+  /// Remove a video filter based on its position in the list of filters.
+  ///
+  /// Removing a filter based on its position within the filter list is the preferred way to do it as per discussion with the mpv project.
+  /// - Parameter filter: The filter to be removed, required only for logging.
+  /// - Parameter index: The index of the filter to be removed.
+  /// - Returns: `true` if the filter was successfully removed, `false` otherwise.
+  func removeVideoFilter(_ filter: String, _ index: Int) -> Bool {
+    Logger.log("Removing video filter \(filter)...", subsystem: subsystem)
+    let result = mpv.removeFilter(MPVProperty.vf, index)
+    Logger.log(result ? "Succeeded" : "Failed", subsystem: self.subsystem)
+    return result
+  }
+
+  /// Remove a video filter given as a `MPVFilter` object.
+  ///
+  /// If the filter is not labeled then removing using a `MPVFilter` object can be problematic if the filter has multiple parameters.
+  /// Filters that support multiple parameters have more than one valid string representation due to there being no requirement on the
+  /// order in which those parameters are given in a filter. If the order of parameters in the string representation of the filter IINA uses in
+  /// the command sent to mpv does not match the order mpv expects the remove command will not find the filter to be removed. For
+  /// this reason the remove methods that identify the filter to be removed based on its position in the filter list are the preferred way to
+  /// remove a filter.
+  /// - Parameter filter: The filter to remove.
+  /// - Returns: `true` if the filter was successfully removed, `false` otherwise.
   func removeVideoFilter(_ filter: MPVFilter) -> Bool {
-    var result = true
     if let label = filter.label {
-      mpv.command(.vf, args: ["remove", "@" + label], checkError: false) { result = $0 >= 0 }
-    } else {
-      mpv.command(.vf, args: ["remove", filter.stringFormat], checkError: false) { result = $0 >= 0 }
+      return removeVideoFilter("@" + label)
     }
+    return removeVideoFilter(filter.stringFormat)
+  }
+
+  /// Remove a video filter given as a string.
+  ///
+  /// If the filter is not labeled then removing using a string can be problematic if the filter has multiple parameters. Filters that support
+  /// multiple parameters have more than one valid string representation due to there being no requirement on the order in which those
+  /// parameters are given in a filter. If the order of parameters in the string representation of the filter IINA uses in the command sent to
+  /// mpv does not match the order mpv expects the remove command will not find the filter to be removed. For this reason the remove
+  /// methods that identify the filter to be removed based on its position in the filter list are the preferred way to remove a filter.
+  /// - Parameter filter: The filter to remove.
+  /// - Returns: `true` if the filter was successfully removed, `false` otherwise.
+  func removeVideoFilter(_ filter: String) -> Bool {
+    Logger.log("Removing video filter \(filter)...", subsystem: subsystem)
+    var result = true
+    mpv.command(.vf, args: ["remove", filter], checkError: false) { result = $0 >= 0 }
+    Logger.log(result ? "Succeeded" : "Failed", subsystem: self.subsystem)
     return result
   }
 
-  func addAudioFilter(_ filter: MPVFilter) -> Bool {
+  /// Add an audio filter given as a `MPVFilter` object.
+  /// - Parameter filter: The filter to add.
+  /// - Returns: `true` if the filter was successfully added, `false` otherwise.
+  func addAudioFilter(_ filter: MPVFilter) -> Bool { addAudioFilter(filter.stringFormat) }
+
+  /// Add an audio filter given as a string.
+  /// - Parameter filter: The filter to add.
+  /// - Returns: `true` if the filter was successfully added, `false` otherwise.
+  func addAudioFilter(_ filter: String) -> Bool {
+    Logger.log("Adding audio filter \(filter)...", subsystem: subsystem)
     var result = true
-    mpv.command(.af, args: ["add", filter.stringFormat], checkError: false) { result = $0 >= 0 }
+    mpv.command(.af, args: ["add", filter], checkError: false) { result = $0 >= 0 }
+    Logger.log(result ? "Succeeded" : "Failed", subsystem: self.subsystem)
     return result
   }
 
-  func removeAudioFilter(_ filter: MPVFilter) -> Bool {
+  /// Remove an audio filter based on its position in the list of filters.
+  ///
+  /// Removing a filter based on its position within the filter list is the preferred way to do it as per discussion with the mpv project.
+  /// - Parameter filter: The filter to be removed, required only for logging.
+  /// - Parameter index: The index of the filter to be removed.
+  /// - Returns: `true` if the filter was successfully removed, `false` otherwise.
+  func removeAudioFilter(_ filter: MPVFilter, _ index: Int) -> Bool {
+    removeAudioFilter(filter.stringFormat, index)
+  }
+
+  /// Remove an audio filter based on its position in the list of filters.
+  ///
+  /// Removing a filter based on its position within the filter list is the preferred way to do it as per discussion with the mpv project.
+  /// - Parameter filter: The filter to be removed, required only for logging.
+  /// - Parameter index: The index of the filter to be removed.
+  /// - Returns: `true` if the filter was successfully removed, `false` otherwise.
+  func removeAudioFilter(_ filter: String, _ index: Int) -> Bool {
+    Logger.log("Removing audio filter \(filter)...", subsystem: subsystem)
+    let result = mpv.removeFilter(MPVProperty.af, index)
+    Logger.log(result ? "Succeeded" : "Failed", subsystem: self.subsystem)
+    return result
+  }
+
+  /// Remove an audio filter given as a `MPVFilter` object.
+  ///
+  /// If the filter is not labeled then removing using a `MPVFilter` object can be problematic if the filter has multiple parameters.
+  /// Filters that support multiple parameters have more than one valid string representation due to there being no requirement on the
+  /// order in which those parameters are given in a filter. If the order of parameters in the string representation of the filter IINA uses in
+  /// the command sent to mpv does not match the order mpv expects the remove command will not find the filter to be removed. For
+  /// this reason the remove methods that identify the filter to be removed based on its position in the filter list are the preferred way to
+  /// remove a filter.
+  /// - Parameter filter: The filter to remove.
+  /// - Returns: `true` if the filter was successfully removed, `false` otherwise.
+  func removeAudioFilter(_ filter: MPVFilter) -> Bool { removeAudioFilter(filter.stringFormat) }
+
+  /// Remove an audio filter given as a string.
+  ///
+  /// If the filter is not labeled then removing using a string can be problematic if the filter has multiple parameters. Filters that support
+  /// multiple parameters have more than one valid string representation due to there being no requirement on the order in which those
+  /// parameters are given in a filter. If the order of parameters in the string representation of the filter IINA uses in the command sent to
+  /// mpv does not match the order mpv expects the remove command will not find the filter to be removed. For this reason the remove
+  /// methods that identify the filter to be removed based on its position in the filter list are the preferred way to remove a filter.
+  /// - Parameter filter: The filter to remove.
+  /// - Returns: `true` if the filter was successfully removed, `false` otherwise.
+  func removeAudioFilter(_ filter: String) -> Bool {
+    Logger.log("Removing audio filter \(filter)...", subsystem: subsystem)
     var result = true
-    mpv.command(.af, args: ["remove", filter.stringFormat], checkError: false)  { result = $0 >= 0 }
+    mpv.command(.af, args: ["remove", filter], checkError: false)  { result = $0 >= 0 }
+    Logger.log(result ? "Succeeded" : "Failed", subsystem: self.subsystem)
     return result
   }
 

--- a/iina/SavedFilter.swift
+++ b/iina/SavedFilter.swift
@@ -32,6 +32,10 @@ class SavedFilter: NSObject {
   var shortcutKey: String
   var shortcutKeyModifiers: NSEvent.ModifierFlags
 
+  override var debugDescription: String {
+    Mirror(reflecting: self).children.map({"\($0.label!)=\($0.value)"}).joined(separator: ", ")
+  }
+
   init(name: String, filterString: String, shortcutKey: String, modifiers: NSEvent.ModifierFlags) {
     self.name = name
     self.filterString = filterString


### PR DESCRIPTION
This commit will:
- Add a new method removeFilter to MPVController that removes a filter
  based on its position within the list of filters
- Add methods for removing audio and video filters based on their position
  within the list of filters to PlayerCore
- Change FilterWindowController.removeFilterAction to use the new methods
- Add a parseRawParamString method to MPVFilter
- Add an isEqual method to MPVFilter
- Change  MPVFilter.init(rawString:) to properly handle filters with labels
- Add a debugDescription  property to  MPVFilter
- Change FilterWindowController.toggleSavedFilterAction to locate the saved
  filter using MPVFilter objects instead of strings
- Change FilterWindowController.reloadTable to locate saved filters using
  MPVFilter objects instead of strings
- Add a filtersAsString method to FilterWindowController
- Add a debugDescription property to SavedFilter

With these changes IINA removes filters based on their position within the
filter list. For saved filters IINA parses the parameters in the saved string
representation into a swift dictionary so the parameters of filters can be
compared by comparing dictionaries instead of using strings which can fail if
the order of parameters does not match.

- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3620.

---

**Description:**
This is a significant change. An intense mean detailed review of the PR is called for.