### PR TITLE
Fix wrong aspect ratio when video rotation changed outside GUI, #1168

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -72,6 +72,7 @@ class MPVController: NSObject {
     MPVProperty.chapter: MPV_FORMAT_INT64,
     MPVOption.Video.deinterlace: MPV_FORMAT_FLAG,
     MPVOption.Video.hwdec: MPV_FORMAT_STRING,
+    MPVOption.Video.videoRotate: MPV_FORMAT_INT64,
     MPVOption.Audio.mute: MPV_FORMAT_FLAG,
     MPVOption.Audio.volume: MPV_FORMAT_DOUBLE,
     MPVOption.Audio.audioDelay: MPV_FORMAT_DOUBLE,
@@ -826,6 +827,9 @@ class MPVController: NSObject {
         player.info.hwdec = data
         player.sendOSD(.hwdec(player.info.hwdecEnabled))
       }
+
+    case MPVOption.Video.videoRotate:
+      player.info.rotation = Int(getInt(MPVOption.Video.videoRotate))
 
     case MPVOption.Audio.mute:
       player.syncUI(.muteButton)

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -656,7 +656,6 @@ class PlayerCore: NSObject {
   func setVideoRotate(_ degree: Int) {
     if AppData.rotations.firstIndex(of: degree)! >= 0 {
       mpv.setInt(MPVOption.Video.videoRotate, degree)
-      info.rotation = degree
     }
   }
 


### PR DESCRIPTION
Observe `MPVOption.Video.videoRotate` to make sure `PlayerInfo.rotation` and `MPVOption.Video.videoRotate` are in sync, even if video rotation is changed outside IINA UI (e.g. commands emitted through hotkeys).

- [ ] This change has been discussed with the author.
- [X] It implements / fixes issue #1168.
