### PR TITLE
Fix custom key binding ignored, #3692

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		49542986216C34950058F680 /* OpenInIINA.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 49542973216C34950058F680 /* OpenInIINA.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		496B19921E2968530035AF10 /* PIP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 496B19911E2968530035AF10 /* PIP.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		519872FF26879B9B00F84BCC /* AccessibilityPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519872FE26879B9B00F84BCC /* AccessibilityPreferences.swift */; };
+		51AE489128065AA90077378A /* Algorithms in Frameworks */ = {isa = PBXBuildFile; productRef = 51AE489028065AA90077378A /* Algorithms */; };
 		6100FF2B1EDF9806002CF0FB /* dsa_pub.pem in Resources */ = {isa = PBXBuildFile; fileRef = 6100FF2A1EDF9806002CF0FB /* dsa_pub.pem */; };
 		8400D5C41E17C6D2006785F5 /* AboutWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8400D5C21E17C6D2006785F5 /* AboutWindowController.swift */; };
 		8400D5C61E1AB2F1006785F5 /* MainWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8400D5C81E1AB2F1006785F5 /* MainWindowController.xib */; };
@@ -1561,6 +1562,7 @@
 				B4E446E825CB53920069F06E /* PromiseKit in Frameworks */,
 				E3B25F5F24FF505D0068B9B0 /* librubberband.2.dylib in Frameworks */,
 				E3B25F7124FF505E0068B9B0 /* libzstd.1.dylib in Frameworks */,
+				51AE489128065AA90077378A /* Algorithms in Frameworks */,
 				E3B25F6C24FF505D0068B9B0 /* libfontconfig.1.dylib in Frameworks */,
 				E3B25F5A24FF505D0068B9B0 /* libavdevice.58.dylib in Frameworks */,
 				E3B25F5924FF505D0068B9B0 /* libwebpmux.3.dylib in Frameworks */,
@@ -2275,6 +2277,7 @@
 				B4E446F625CB54EF0069F06E /* Mustache */,
 				B4E4470025CE3F930069F06E /* Sparkle */,
 				8451E6D82604AEFC009A15D7 /* Just */,
+				51AE489028065AA90077378A /* Algorithms */,
 			);
 			productName = mpvx;
 			productReference = 84EB1ED61D2F51D3004FA5A1 /* IINA.app */;
@@ -2361,6 +2364,7 @@
 				B4E446F525CB54EF0069F06E /* XCRemoteSwiftPackageReference "GRMustache" */,
 				B4E446FF25CE3F930069F06E /* XCRemoteSwiftPackageReference "Sparkle" */,
 				8451E6D72604AEFC009A15D7 /* XCRemoteSwiftPackageReference "Just" */,
+				51AE488F28065AA90077378A /* XCRemoteSwiftPackageReference "swift-algorithms" */,
 			);
 			productRefGroup = 84EB1ED71D2F51D3004FA5A1 /* Products */;
 			projectDirPath = "";
@@ -3939,6 +3943,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		51AE488F28065AA90077378A /* XCRemoteSwiftPackageReference "swift-algorithms" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-algorithms.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
 		8451E6D72604AEFC009A15D7 /* XCRemoteSwiftPackageReference "Just" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/dduan/Just";
@@ -3982,6 +3994,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		51AE489028065AA90077378A /* Algorithms */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 51AE488F28065AA90077378A /* XCRemoteSwiftPackageReference "swift-algorithms" */;
+			productName = Algorithms;
+		};
 		8451E6D82604AEFC009A15D7 /* Just */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 8451E6D72604AEFC009A15D7 /* XCRemoteSwiftPackageReference "Just" */;


### PR DESCRIPTION
The commit in the pull request will:
- Add swift-algorithms to the list of packages
- Change MenuController.updateKeyEquivalentsFrom to ignore key bindings
  that have been overridden when searching for keys to be used as
  shortcuts for menu items

- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3692.

---

**Description:**
Note the addition of [Swift Algorithms](https://github.com/apple/swift-algorithms).