### PR TITLE
Close indicate on OSD when File Loop is toggled, #3229

### DIFF
--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -81,6 +81,8 @@
 "osd.canceled" = "Canceled";
 "osd.filter_added" = "Added Filter: %@";
 "osd.filter_removed" = "Removed Filter";
+"osd.file_loop" = "File Loop: %@";
+"osd.playlist_loop" = "Playlist Loop: %@";
 
 "preference.title" = "Preferences";
 "preference.general" = "General";

--- a/iina/OSDMessage.swift
+++ b/iina/OSDMessage.swift
@@ -71,7 +71,8 @@ enum OSDMessage {
   case fileError
   case networkError
   case canceled
-
+  case fileLoop(Bool)
+  case playlistLoop(Bool)
 
   func message() -> (String, OSDType) {
     switch self {
@@ -302,6 +303,20 @@ enum OSDMessage {
     case .canceled:
       return (
         NSLocalizedString("osd.canceled", comment: "Canceled"),
+        .normal
+      )
+
+    case .fileLoop(let enabled):
+      return (
+        String(format: NSLocalizedString("osd.file_loop", comment: "File Loop: %@"),
+               enabled ? NSLocalizedString("general.on", comment: "On") : NSLocalizedString("general.off", comment: "Off")),
+        .normal
+      )
+
+    case .playlistLoop(let enabled):
+      return (
+        String(format: NSLocalizedString("osd.playlist_loop", comment: "Playlist Loop: %@"),
+               enabled ? NSLocalizedString("general.on", comment: "On") : NSLocalizedString("general.off", comment: "Off")),
         .normal
       )
     }

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -599,12 +599,14 @@ class PlayerCore: NSObject {
   func toggleFileLoop() {
     let isLoop = mpv.getFlag(MPVOption.PlaybackControl.loopFile)
     mpv.setFlag(MPVOption.PlaybackControl.loopFile, !isLoop)
+    sendOSD(.fileLoop(!isLoop))
   }
 
   func togglePlaylistLoop() {
     let loopStatus = mpv.getString(MPVOption.PlaybackControl.loopPlaylist)
     let isLoop = (loopStatus == "inf" || loopStatus == "force")
     mpv.setString(MPVOption.PlaybackControl.loopPlaylist, isLoop ? "no" : "inf")
+    sendOSD(.playlistLoop(!isLoop))
   }
 
   func toggleShuffle() {

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -81,6 +81,8 @@
 "osd.canceled" = "Canceled";
 "osd.filter_added" = "Added Filter: %@";
 "osd.filter_removed" = "Removed Filter";
+"osd.file_loop" = "File Loop: %@";
+"osd.playlist_loop" = "Playlist Loop: %@";
 
 "preference.title" = "Preferences";
 "preference.general" = "General";


### PR DESCRIPTION
In addition to adding an OSD message for toggling file looping the
commit in the pull request also adds an OSD message for toggling
playlist looping. The text chosen for the OSD messages match up with
the names used in the menus, "File Loop" and "Playlist Loop". To
indicate the state of looping the new messages follow the convention of
other OSD messages and use a localized "On" or "Off". When file looping
is enabled the OSD will display:

File Loop: On

The commit in the pull request will:
- Add a new enumeration case `fileLoop` to  `OSDMessage`
- Add a new enumeration case `playlistLoop` to  `OSDMessage`
- Update   `OSDMessage.message` to handle  `fileLoop`
- Update   `OSDMessage.message` to handle  `playlistLoop`
- Add text for `osd.file_loop` and `osd.playlist_loop` to base localized
  strings
- Add text for `osd.file_loop` and `osd.playlist_loop` to en localized
  strings
- Change `PlayerCore.toggleFileLoop` to display the new OSD message
- Change `PlayerCore.togglePlaylistLoop` to display the new OSD message

- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3229.

---

**Description:**
Note that this also adds an OSD message when playlist loop is toggled.