### PR TITLE
Add HDR playback support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -108,3 +108,4 @@ browser/Firefox_Open_In_IINA/*
 *.dylib
 *.so
 
+*.xcarchive

--- a/iina/Base.lproj/InspectorWindowController.xib
+++ b/iina/Base.lproj/InspectorWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19455" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19455"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -45,11 +45,13 @@
                 <outlet property="trackTitleField" destination="gNk-wZ-LBX" id="AZX-FZ-poh"/>
                 <outlet property="vbitrateField" destination="4PF-1d-gZO" id="Db5-5Q-lUm"/>
                 <outlet property="vcodecField" destination="6sj-bN-LIv" id="fxo-G8-ka1"/>
+                <outlet property="vcolorspaceField" destination="wxy-f3-FrW" id="vvv-An-cnQ"/>
                 <outlet property="vdecoderField" destination="Ira-RI-5kc" id="2y9-xC-cGb"/>
                 <outlet property="vformatField" destination="hBf-Sx-lbf" id="xHD-mg-a5J"/>
                 <outlet property="vfpsField" destination="c90-dT-hDG" id="5Be-mD-frc"/>
                 <outlet property="voFPSField" destination="Y8Q-PG-bHl" id="EaE-mA-Ys9"/>
                 <outlet property="voField" destination="5yU-sy-R0n" id="Q0W-wm-5xc"/>
+                <outlet property="vprimariesField" destination="s9S-zN-lwA" id="U20-X9-4iz"/>
                 <outlet property="vsizeField" destination="Hmg-bS-UMv" id="LOi-KD-ZsF"/>
                 <outlet property="watchTableView" destination="oUp-DO-OKl" id="lCS-Jn-nRL"/>
                 <outlet property="window" destination="F0z-JX-Cv5" id="gIp-Ho-8D9"/>
@@ -59,25 +61,22 @@
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <window title="Inspector" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hidesOnDeactivate="YES" releasedWhenClosed="NO" frameAutosaveName="IINAInspectorPanel" animationBehavior="default" id="F0z-JX-Cv5" customClass="NSPanel">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" utility="YES" HUD="YES"/>
-            <rect key="contentRect" x="1539" y="436" width="424" height="389"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1025"/>
+            <rect key="contentRect" x="1539" y="436" width="350" height="430"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1728" height="1079"/>
             <view key="contentView" id="se5-gp-TjO">
-                <rect key="frame" x="0.0" y="0.0" width="424" height="401"/>
+                <rect key="frame" x="0.0" y="0.0" width="350" height="454"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <tabView drawsBackground="NO" controlSize="small" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="wHY-jo-uW0">
-                        <rect key="frame" x="12" y="12" width="400" height="353"/>
-                        <constraints>
-                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="400" id="oPY-Uu-Jby"/>
-                        </constraints>
+                        <rect key="frame" x="12" y="12" width="326" height="406"/>
                         <tabViewItems>
                             <tabViewItem label="General" identifier="1" id="f7a-XG-NCc">
                                 <view key="view" id="mRY-yK-FeT">
-                                    <rect key="frame" x="0.0" y="0.0" width="400" height="349"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="326" height="406"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="I9X-Rp-scA">
-                                            <rect key="frame" x="10" y="327" width="38" height="14"/>
+                                            <rect key="frame" x="10" y="382" width="44" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="VIDEO" id="gDG-Eq-1Bc">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -85,79 +84,66 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hBf-Sx-lbf">
-                                            <rect key="frame" x="92" y="301" width="298" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="c6m-YO-xqZ">
-                                                <font key="font" usesAppearanceFont="YES"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="6sj-bN-LIv">
-                                            <rect key="frame" x="92" y="281" width="298" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Label" id="SzU-uF-10g">
+                                            <rect key="frame" x="92" y="354" width="224" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Format Label" id="c6m-YO-xqZ">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Hmg-bS-UMv">
-                                            <rect key="frame" x="92" y="221" width="298" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="rcA-a7-rVn">
+                                            <rect key="frame" x="92" y="222" width="224" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Size Label" id="rcA-a7-rVn">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4PF-1d-gZO">
-                                            <rect key="frame" x="92" y="201" width="298" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="Aes-4j-UT6">
+                                            <rect key="frame" x="92" y="200" width="224" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="BR1 Label" id="Aes-4j-UT6">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="a3w-YC-7oN">
-                                            <rect key="frame" x="92" y="116" width="298" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="cwF-5C-5nd">
+                                            <rect key="frame" x="92" y="109" width="224" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Format Label" id="cwF-5C-5nd">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="GaY-iG-tAy">
-                                            <rect key="frame" x="92" y="96" width="298" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="etG-FX-Rzo">
+                                            <rect key="frame" x="92" y="87" width="224" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Codec Label" id="etG-FX-Rzo">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="L3Y-pD-V9R">
-                                            <rect key="frame" x="92" y="56" width="298" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="6mx-wH-SBP">
+                                            <rect key="frame" x="92" y="43" width="224" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Channels Label" id="6mx-wH-SBP">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="S6Z-fT-kcG">
-                                            <rect key="frame" x="92" y="36" width="298" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="4Ph-yc-lsv">
-                                                <font key="font" usesAppearanceFont="YES"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ghr-q6-WAW">
-                                            <rect key="frame" x="92" y="16" width="298" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="4di-sR-tOh">
+                                            <rect key="frame" x="92" y="21" width="224" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="BR2 Label" id="4Ph-yc-lsv">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aGE-iz-M2h">
-                                            <rect key="frame" x="10" y="301" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="356" width="78" height="14"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="74" id="ciu-up-5ds"/>
+                                            </constraints>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Format:" id="PQD-yB-mm6">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -165,7 +151,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="6EL-aj-Hjq">
-                                            <rect key="frame" x="10" y="116" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="110" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Format:" id="5H6-qJ-RDS">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -173,7 +159,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FwA-X7-Alr">
-                                            <rect key="frame" x="10" y="281" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="334" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Codec:" id="bki-sE-xCA">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -181,7 +167,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Zp5-es-UTa">
-                                            <rect key="frame" x="10" y="96" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="88" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Codec:" id="n0s-eM-42w">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -189,7 +175,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gxW-1z-Af9">
-                                            <rect key="frame" x="10" y="221" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="224" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Size:" id="f2P-qb-wRx">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -197,7 +183,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EiP-Mu-9cf">
-                                            <rect key="frame" x="10" y="56" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="44" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Channels:" id="it3-05-Pwu">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -205,7 +191,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="apr-sq-JIb">
-                                            <rect key="frame" x="10" y="36" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="22" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Bit Rate:" id="A4y-LL-x0z">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -213,7 +199,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Qke-bh-4oG">
-                                            <rect key="frame" x="10" y="201" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="202" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Bit Rate:" id="jyV-Pd-UvH">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -221,15 +207,15 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ira-RI-5kc">
-                                            <rect key="frame" x="92" y="261" width="298" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="iMk-qU-kVv">
+                                            <rect key="frame" x="92" y="311" width="224" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="HwD Label" id="iMk-qU-kVv">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="z1d-SG-OZB">
-                                            <rect key="frame" x="10" y="261" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="312" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Hw Decoder:" id="DHh-ne-10f">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -237,7 +223,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ldf-jT-tdl">
-                                            <rect key="frame" x="10" y="241" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="246" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Driver:" id="I2E-6Z-Gnn">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -245,7 +231,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="GSF-Y5-FGJ">
-                                            <rect key="frame" x="10" y="76" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="66" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Driver:" id="MME-KZ-jrG">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -253,18 +239,18 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5yU-sy-R0n">
-                                            <rect key="frame" x="92" y="241" width="298" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="3bw-Kl-SeY">
+                                            <rect key="frame" x="92" y="244" width="224" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Driver Label" id="3bw-Kl-SeY">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="IXe-pS-a3x">
-                                            <rect key="frame" x="12" y="166" width="376" height="5"/>
+                                            <rect key="frame" x="12" y="162" width="302" height="5"/>
                                         </box>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hGO-dV-reB">
-                                            <rect key="frame" x="10" y="142" width="40" height="14"/>
+                                            <rect key="frame" x="10" y="136" width="45" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="AUDIO" id="nrG-IH-kFg">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -272,15 +258,15 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="v4j-fa-olc">
-                                            <rect key="frame" x="92" y="76" width="298" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="MTG-ez-V2R">
+                                            <rect key="frame" x="92" y="65" width="224" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Driver Label" id="MTG-ez-V2R">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Nn4-TP-Hpd">
-                                            <rect key="frame" x="10" y="16" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="0.0" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Sample Rate:" id="llF-4b-Z8b">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -288,121 +274,208 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="c90-dT-hDG">
-                                            <rect key="frame" x="92" y="181" width="298" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="ZIA-g4-WqZ">
+                                            <rect key="frame" x="92" y="178" width="224" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="FPS Label" id="ZIA-g4-WqZ">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Xol-2r-g7u">
+                                            <rect key="frame" x="10" y="290" width="75" height="14"/>
+                                            <constraints>
+                                                <constraint firstAttribute="width" constant="71" id="ULh-mH-glh"/>
+                                            </constraints>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Primaries:" id="1kw-LO-KmJ">
+                                                <font key="font" metaFont="smallSystemBold"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dOE-eM-QQi">
-                                            <rect key="frame" x="10" y="181" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="180" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="FPS:" id="7QX-tu-rvs">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Hm9-gI-9j7">
+                                            <rect key="frame" x="10" y="268" width="78" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Colorspace:" id="mLo-Wc-BoO">
+                                                <font key="font" metaFont="smallSystemBold"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wxy-f3-FrW">
+                                            <rect key="frame" x="92" y="267" width="228" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Colorspace Label" id="iMO-Ze-egg">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ghr-q6-WAW">
+                                            <rect key="frame" x="92" y="-1" width="224" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="SampleRate Label" id="4di-sR-tOh">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="6sj-bN-LIv">
+                                            <rect key="frame" x="92" y="333" width="224" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Codec Label" id="SzU-uF-10g">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="s9S-zN-lwA">
+                                            <rect key="frame" x="92" y="289" width="224" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Primaries Label" id="b34-md-3Dx">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstItem="IXe-pS-a3x" firstAttribute="top" secondItem="c90-dT-hDG" secondAttribute="bottom" constant="12" id="0hW-m8-p3o"/>
-                                        <constraint firstItem="c90-dT-hDG" firstAttribute="top" secondItem="4PF-1d-gZO" secondAttribute="bottom" constant="6" id="1YV-et-u9o"/>
-                                        <constraint firstItem="6sj-bN-LIv" firstAttribute="top" secondItem="FwA-X7-Alr" secondAttribute="top" id="2Jt-y0-OK3"/>
+                                        <constraint firstItem="s9S-zN-lwA" firstAttribute="leading" secondItem="Xol-2r-g7u" secondAttribute="trailing" constant="11" id="1vt-IH-Iya"/>
+                                        <constraint firstItem="S6Z-fT-kcG" firstAttribute="centerY" secondItem="apr-sq-JIb" secondAttribute="centerY" id="2Oo-I6-UOA"/>
                                         <constraint firstItem="Ldf-jT-tdl" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="2hf-ZX-KTv"/>
                                         <constraint firstItem="a3w-YC-7oN" firstAttribute="leading" secondItem="6EL-aj-Hjq" secondAttribute="trailing" constant="8" id="2sg-ag-cr5"/>
                                         <constraint firstItem="I9X-Rp-scA" firstAttribute="top" secondItem="mRY-yK-FeT" secondAttribute="top" constant="8" id="3Kz-P5-r1d"/>
                                         <constraint firstItem="Ira-RI-5kc" firstAttribute="leading" secondItem="z1d-SG-OZB" secondAttribute="trailing" constant="8" id="4bA-8N-DF7"/>
                                         <constraint firstItem="6sj-bN-LIv" firstAttribute="leading" secondItem="FwA-X7-Alr" secondAttribute="trailing" constant="8" id="4mV-f5-Pah"/>
-                                        <constraint firstItem="v4j-fa-olc" firstAttribute="top" secondItem="GaY-iG-tAy" secondAttribute="bottom" constant="6" id="5sv-mQ-miz"/>
                                         <constraint firstItem="Zp5-es-UTa" firstAttribute="width" secondItem="6EL-aj-Hjq" secondAttribute="width" id="6AO-Ke-cUQ"/>
-                                        <constraint firstItem="Ira-RI-5kc" firstAttribute="top" secondItem="6sj-bN-LIv" secondAttribute="bottom" constant="6" id="8O8-Is-4ax"/>
+                                        <constraint firstItem="GSF-Y5-FGJ" firstAttribute="top" secondItem="Zp5-es-UTa" secondAttribute="bottom" constant="8" id="6BA-AD-lOL"/>
+                                        <constraint firstItem="v4j-fa-olc" firstAttribute="centerY" secondItem="GSF-Y5-FGJ" secondAttribute="centerY" id="7WF-b9-IRe"/>
                                         <constraint firstAttribute="trailing" secondItem="v4j-fa-olc" secondAttribute="trailing" constant="12" id="8Tf-Ky-7WP"/>
+                                        <constraint firstItem="6sj-bN-LIv" firstAttribute="centerY" secondItem="FwA-X7-Alr" secondAttribute="centerY" id="8ax-Nq-2MU"/>
+                                        <constraint firstItem="GSF-Y5-FGJ" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="leading" id="9UE-9C-GAq"/>
+                                        <constraint firstItem="Hm9-gI-9j7" firstAttribute="top" secondItem="Xol-2r-g7u" secondAttribute="bottom" constant="8" id="AWt-7R-ZTa"/>
                                         <constraint firstItem="EiP-Mu-9cf" firstAttribute="width" secondItem="6EL-aj-Hjq" secondAttribute="width" id="B7U-fB-UtT"/>
-                                        <constraint firstItem="S6Z-fT-kcG" firstAttribute="top" secondItem="L3Y-pD-V9R" secondAttribute="bottom" constant="6" id="Bcr-hs-xLy"/>
                                         <constraint firstItem="aGE-iz-M2h" firstAttribute="top" secondItem="I9X-Rp-scA" secondAttribute="bottom" constant="12" id="BeU-Ai-D6V"/>
                                         <constraint firstItem="4PF-1d-gZO" firstAttribute="top" secondItem="Qke-bh-4oG" secondAttribute="top" id="Bk1-vV-0Tx"/>
-                                        <constraint firstItem="Nn4-TP-Hpd" firstAttribute="width" secondItem="6EL-aj-Hjq" secondAttribute="width" id="COL-sz-Swk"/>
+                                        <constraint firstItem="EiP-Mu-9cf" firstAttribute="top" secondItem="GSF-Y5-FGJ" secondAttribute="bottom" constant="8" id="CUV-7x-VlA"/>
                                         <constraint firstItem="IXe-pS-a3x" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="Cac-kJ-o6N"/>
                                         <constraint firstItem="hGO-dV-reB" firstAttribute="top" secondItem="IXe-pS-a3x" secondAttribute="bottom" constant="12" id="Cwm-iG-Pfx"/>
-                                        <constraint firstItem="4PF-1d-gZO" firstAttribute="top" secondItem="Hmg-bS-UMv" secondAttribute="bottom" constant="6" id="DiR-e9-8Yv"/>
                                         <constraint firstItem="v4j-fa-olc" firstAttribute="leading" secondItem="GSF-Y5-FGJ" secondAttribute="trailing" constant="8" id="Dyx-ec-SEg"/>
                                         <constraint firstItem="apr-sq-JIb" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="EDW-pS-WKA"/>
-                                        <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="Ghr-q6-WAW" secondAttribute="bottom" constant="16" id="FXY-TE-UkS"/>
+                                        <constraint firstItem="GaY-iG-tAy" firstAttribute="centerY" secondItem="Zp5-es-UTa" secondAttribute="centerY" id="EIV-rr-gPU"/>
+                                        <constraint firstAttribute="trailing" secondItem="Ghr-q6-WAW" secondAttribute="trailing" constant="12" id="FUu-xZ-5Xl"/>
+                                        <constraint firstItem="Zp5-es-UTa" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="leading" id="FWX-bw-bIH"/>
+                                        <constraint firstItem="Nn4-TP-Hpd" firstAttribute="top" secondItem="apr-sq-JIb" secondAttribute="bottom" constant="8" id="GBu-9s-Fr1"/>
+                                        <constraint firstItem="gxW-1z-Af9" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="leading" id="GQ9-zo-mEU"/>
                                         <constraint firstAttribute="trailing" secondItem="hBf-Sx-lbf" secondAttribute="trailing" constant="12" id="Hb2-Jx-92q"/>
-                                        <constraint firstItem="a3w-YC-7oN" firstAttribute="top" secondItem="6EL-aj-Hjq" secondAttribute="top" id="Hla-Px-41r"/>
+                                        <constraint firstAttribute="trailing" secondItem="s9S-zN-lwA" secondAttribute="trailing" constant="12" id="IGE-Cy-hnw"/>
                                         <constraint firstItem="6EL-aj-Hjq" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="IVp-gv-R6l"/>
+                                        <constraint firstItem="dOE-eM-QQi" firstAttribute="top" secondItem="Qke-bh-4oG" secondAttribute="bottom" constant="8" id="IeA-aF-B4p"/>
+                                        <constraint firstItem="S6Z-fT-kcG" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="JCa-Tx-DnU"/>
                                         <constraint firstAttribute="trailing" secondItem="5yU-sy-R0n" secondAttribute="trailing" constant="12" id="JQ0-Sh-UIg"/>
                                         <constraint firstItem="5yU-sy-R0n" firstAttribute="leading" secondItem="Ldf-jT-tdl" secondAttribute="trailing" constant="8" id="JvH-4D-ruB"/>
                                         <constraint firstAttribute="trailing" secondItem="IXe-pS-a3x" secondAttribute="trailing" constant="12" id="KBV-cz-iXk"/>
                                         <constraint firstItem="dOE-eM-QQi" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="Kjz-Mb-fWY"/>
                                         <constraint firstItem="FwA-X7-Alr" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="KsH-MB-nUa"/>
+                                        <constraint firstItem="wxy-f3-FrW" firstAttribute="centerY" secondItem="Hm9-gI-9j7" secondAttribute="centerY" id="MDM-cn-OsR"/>
                                         <constraint firstItem="S6Z-fT-kcG" firstAttribute="leading" secondItem="apr-sq-JIb" secondAttribute="trailing" constant="8" id="MDj-Eu-KPY"/>
                                         <constraint firstItem="L3Y-pD-V9R" firstAttribute="leading" secondItem="EiP-Mu-9cf" secondAttribute="trailing" constant="8" id="NNT-Uy-giv"/>
+                                        <constraint firstItem="L3Y-pD-V9R" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="Ncn-iQ-S8E"/>
                                         <constraint firstItem="EiP-Mu-9cf" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="O08-wB-hSa"/>
                                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="I9X-Rp-scA" secondAttribute="trailing" constant="20" symbolic="YES" id="PSJ-nK-rFv"/>
+                                        <constraint firstItem="Xol-2r-g7u" firstAttribute="top" secondItem="z1d-SG-OZB" secondAttribute="bottom" constant="8" id="Q7j-tD-FPY"/>
+                                        <constraint firstItem="Nn4-TP-Hpd" firstAttribute="leading" secondItem="apr-sq-JIb" secondAttribute="leading" id="QYI-0x-rCQ"/>
                                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="hGO-dV-reB" secondAttribute="trailing" constant="20" symbolic="YES" id="QwD-zL-Ztq"/>
                                         <constraint firstItem="6EL-aj-Hjq" firstAttribute="top" secondItem="hGO-dV-reB" secondAttribute="bottom" constant="12" id="RSl-a2-Yuc"/>
-                                        <constraint firstItem="L3Y-pD-V9R" firstAttribute="top" secondItem="v4j-fa-olc" secondAttribute="bottom" constant="6" id="ReF-2x-peU"/>
-                                        <constraint firstItem="Nn4-TP-Hpd" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="ReF-mB-bRG"/>
                                         <constraint firstAttribute="trailing" secondItem="GaY-iG-tAy" secondAttribute="trailing" constant="12" id="Rwi-hJ-T2F"/>
                                         <constraint firstAttribute="trailing" secondItem="S6Z-fT-kcG" secondAttribute="trailing" constant="12" id="Ryg-im-8s1"/>
+                                        <constraint firstItem="GaY-iG-tAy" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="Sj5-Vc-ro8"/>
+                                        <constraint firstItem="Hm9-gI-9j7" firstAttribute="leading" secondItem="Ldf-jT-tdl" secondAttribute="leading" id="UBG-1H-tXQ"/>
                                         <constraint firstItem="GaY-iG-tAy" firstAttribute="leading" secondItem="Zp5-es-UTa" secondAttribute="trailing" constant="8" id="Vaf-by-Sni"/>
+                                        <constraint firstItem="IXe-pS-a3x" firstAttribute="top" secondItem="dOE-eM-QQi" secondAttribute="bottom" constant="15" id="VoV-xO-OWt"/>
+                                        <constraint firstItem="Hm9-gI-9j7" firstAttribute="leading" secondItem="Xol-2r-g7u" secondAttribute="leading" id="VvP-S8-Obo"/>
                                         <constraint firstItem="6EL-aj-Hjq" firstAttribute="width" secondItem="aGE-iz-M2h" secondAttribute="width" id="WYv-xd-gGz"/>
+                                        <constraint firstItem="a3w-YC-7oN" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="Wb3-tr-ceH"/>
                                         <constraint firstItem="gxW-1z-Af9" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="WgR-Zu-MYa"/>
                                         <constraint firstItem="GSF-Y5-FGJ" firstAttribute="width" secondItem="6EL-aj-Hjq" secondAttribute="width" id="Wl4-bL-h7a"/>
                                         <constraint firstItem="Zp5-es-UTa" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="Wu6-X4-E6P"/>
                                         <constraint firstItem="FwA-X7-Alr" firstAttribute="width" secondItem="aGE-iz-M2h" secondAttribute="width" id="WwN-iG-RWR"/>
+                                        <constraint firstItem="Ghr-q6-WAW" firstAttribute="centerY" secondItem="Nn4-TP-Hpd" secondAttribute="centerY" id="XL9-9Q-I2k"/>
                                         <constraint firstItem="apr-sq-JIb" firstAttribute="width" secondItem="6EL-aj-Hjq" secondAttribute="width" id="XcZ-hG-1xl"/>
                                         <constraint firstAttribute="trailing" secondItem="Ira-RI-5kc" secondAttribute="trailing" constant="12" id="Xu9-fa-hY9"/>
+                                        <constraint firstItem="4PF-1d-gZO" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="Y12-qn-U8K"/>
+                                        <constraint firstItem="dOE-eM-QQi" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="leading" id="Z1d-20-yCO"/>
+                                        <constraint firstItem="Xol-2r-g7u" firstAttribute="centerY" secondItem="s9S-zN-lwA" secondAttribute="centerY" id="ZI2-Cn-1bS"/>
+                                        <constraint firstItem="Nn4-TP-Hpd" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="leading" id="a0B-Ou-PQK"/>
+                                        <constraint firstItem="Zp5-es-UTa" firstAttribute="top" secondItem="6EL-aj-Hjq" secondAttribute="bottom" constant="8" id="a2v-4n-GuM"/>
                                         <constraint firstItem="dOE-eM-QQi" firstAttribute="width" secondItem="aGE-iz-M2h" secondAttribute="width" id="aYl-iT-dlL"/>
                                         <constraint firstItem="c90-dT-hDG" firstAttribute="top" secondItem="dOE-eM-QQi" secondAttribute="top" id="ag4-DH-fga"/>
                                         <constraint firstItem="gxW-1z-Af9" firstAttribute="width" secondItem="aGE-iz-M2h" secondAttribute="width" id="akY-wD-ybQ"/>
-                                        <constraint firstItem="GaY-iG-tAy" firstAttribute="top" secondItem="Zp5-es-UTa" secondAttribute="top" id="bJr-U3-K6P"/>
-                                        <constraint firstItem="Ghr-q6-WAW" firstAttribute="top" secondItem="S6Z-fT-kcG" secondAttribute="bottom" constant="6" id="bcb-0g-TNW"/>
-                                        <constraint firstItem="S6Z-fT-kcG" firstAttribute="top" secondItem="apr-sq-JIb" secondAttribute="top" id="bz4-GQ-Rsp"/>
+                                        <constraint firstItem="Ghr-q6-WAW" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="bQX-25-hTg"/>
                                         <constraint firstItem="z1d-SG-OZB" firstAttribute="width" secondItem="aGE-iz-M2h" secondAttribute="width" id="cKL-vM-mwO"/>
                                         <constraint firstItem="Hmg-bS-UMv" firstAttribute="leading" secondItem="gxW-1z-Af9" secondAttribute="trailing" constant="8" id="cfg-sm-rHH"/>
-                                        <constraint firstItem="Ira-RI-5kc" firstAttribute="top" secondItem="z1d-SG-OZB" secondAttribute="top" id="dOi-d0-F5H"/>
-                                        <constraint firstItem="5yU-sy-R0n" firstAttribute="top" secondItem="Ira-RI-5kc" secondAttribute="bottom" constant="6" id="dgf-nm-g2b"/>
+                                        <constraint firstItem="z1d-SG-OZB" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="leading" id="dYK-Xc-OZs"/>
+                                        <constraint firstItem="c90-dT-hDG" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="df8-rX-9EY"/>
                                         <constraint firstItem="5yU-sy-R0n" firstAttribute="top" secondItem="Ldf-jT-tdl" secondAttribute="top" id="dro-jH-hsY"/>
+                                        <constraint firstItem="Hmg-bS-UMv" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="eAg-yb-hsG"/>
                                         <constraint firstAttribute="trailing" secondItem="a3w-YC-7oN" secondAttribute="trailing" constant="12" id="eED-Na-2RZ"/>
                                         <constraint firstItem="Qke-bh-4oG" firstAttribute="width" secondItem="aGE-iz-M2h" secondAttribute="width" id="ej7-Oa-y3x"/>
-                                        <constraint firstItem="Ghr-q6-WAW" firstAttribute="top" secondItem="Nn4-TP-Hpd" secondAttribute="top" id="fPZ-oJ-tCn"/>
+                                        <constraint firstItem="Ldf-jT-tdl" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="leading" id="fB7-nN-IIT"/>
                                         <constraint firstItem="Ldf-jT-tdl" firstAttribute="width" secondItem="aGE-iz-M2h" secondAttribute="width" id="fY7-EG-phO"/>
+                                        <constraint firstItem="Ghr-q6-WAW" firstAttribute="leading" secondItem="Nn4-TP-Hpd" secondAttribute="trailing" constant="8" id="foT-Tf-JQv"/>
+                                        <constraint firstItem="z1d-SG-OZB" firstAttribute="top" secondItem="FwA-X7-Alr" secondAttribute="bottom" constant="8" id="gEv-KW-ulc"/>
                                         <constraint firstItem="I9X-Rp-scA" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="ge4-CS-u71"/>
                                         <constraint firstItem="hBf-Sx-lbf" firstAttribute="top" secondItem="aGE-iz-M2h" secondAttribute="top" id="gfN-Qg-rgg"/>
+                                        <constraint firstItem="s9S-zN-lwA" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="gvJ-s5-9JQ"/>
+                                        <constraint firstAttribute="trailing" secondItem="wxy-f3-FrW" secondAttribute="trailing" constant="8" id="h3Q-EH-DAh"/>
+                                        <constraint firstItem="Hm9-gI-9j7" firstAttribute="trailing" secondItem="Ldf-jT-tdl" secondAttribute="trailing" id="hMi-2J-yRo"/>
                                         <constraint firstItem="GSF-Y5-FGJ" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="i0p-ui-YMu"/>
+                                        <constraint firstItem="Nn4-TP-Hpd" firstAttribute="trailing" secondItem="apr-sq-JIb" secondAttribute="trailing" id="iNS-zp-cwE"/>
                                         <constraint firstItem="Hmg-bS-UMv" firstAttribute="top" secondItem="gxW-1z-Af9" secondAttribute="top" id="iUC-2p-Ecw"/>
                                         <constraint firstItem="4PF-1d-gZO" firstAttribute="leading" secondItem="Qke-bh-4oG" secondAttribute="trailing" constant="8" id="j1i-QZ-FtV"/>
                                         <constraint firstAttribute="trailing" secondItem="4PF-1d-gZO" secondAttribute="trailing" constant="12" id="jsh-VI-XQh"/>
                                         <constraint firstAttribute="trailing" secondItem="L3Y-pD-V9R" secondAttribute="trailing" constant="12" id="jvN-c9-5sL"/>
                                         <constraint firstItem="c90-dT-hDG" firstAttribute="leading" secondItem="dOE-eM-QQi" secondAttribute="trailing" constant="8" id="kqM-Nw-XUr"/>
+                                        <constraint firstItem="wxy-f3-FrW" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="lOe-BJ-1nS"/>
+                                        <constraint firstItem="Qke-bh-4oG" firstAttribute="top" secondItem="gxW-1z-Af9" secondAttribute="bottom" constant="8" id="mm4-st-lkq"/>
                                         <constraint firstItem="aGE-iz-M2h" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="mqs-Uu-Fxb"/>
-                                        <constraint firstItem="L3Y-pD-V9R" firstAttribute="top" secondItem="EiP-Mu-9cf" secondAttribute="top" id="mzJ-c5-wYd"/>
-                                        <constraint firstAttribute="trailing" secondItem="Ghr-q6-WAW" secondAttribute="trailing" constant="12" id="nuY-Ex-BIV"/>
                                         <constraint firstAttribute="trailing" secondItem="c90-dT-hDG" secondAttribute="trailing" constant="12" id="o2v-Jf-HiJ"/>
                                         <constraint firstItem="Qke-bh-4oG" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="odY-rn-vAx"/>
+                                        <constraint firstItem="v4j-fa-olc" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="oy0-v4-evT"/>
+                                        <constraint firstItem="Ira-RI-5kc" firstAttribute="centerY" secondItem="z1d-SG-OZB" secondAttribute="centerY" id="p6l-VR-6fk"/>
+                                        <constraint firstItem="6sj-bN-LIv" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="pIi-ue-WQt"/>
                                         <constraint firstItem="z1d-SG-OZB" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="pcf-6y-Q1g"/>
-                                        <constraint firstItem="v4j-fa-olc" firstAttribute="top" secondItem="GSF-Y5-FGJ" secondAttribute="top" id="q2W-iI-nOm"/>
+                                        <constraint firstItem="Qke-bh-4oG" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="leading" id="qm5-A1-cGH"/>
                                         <constraint firstItem="hBf-Sx-lbf" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="trailing" constant="8" id="r3N-FI-PJf"/>
-                                        <constraint firstItem="6sj-bN-LIv" firstAttribute="top" secondItem="hBf-Sx-lbf" secondAttribute="bottom" constant="6" id="rT3-fE-Tcm"/>
-                                        <constraint firstItem="Hmg-bS-UMv" firstAttribute="top" secondItem="5yU-sy-R0n" secondAttribute="bottom" constant="6" id="sQ8-me-asr"/>
+                                        <constraint firstItem="5yU-sy-R0n" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="r8i-x9-6Rp"/>
+                                        <constraint firstItem="apr-sq-JIb" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="leading" id="rBi-h4-iir"/>
+                                        <constraint firstItem="Ldf-jT-tdl" firstAttribute="top" secondItem="Hm9-gI-9j7" secondAttribute="bottom" constant="8" id="rdm-PD-bK4"/>
+                                        <constraint firstItem="a3w-YC-7oN" firstAttribute="centerY" secondItem="6EL-aj-Hjq" secondAttribute="centerY" id="sjN-af-eHt"/>
+                                        <constraint firstAttribute="bottom" secondItem="Nn4-TP-Hpd" secondAttribute="bottom" id="t6V-ol-Uji"/>
+                                        <constraint firstItem="Hm9-gI-9j7" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="leading" id="tmx-fb-lh3"/>
                                         <constraint firstAttribute="trailing" secondItem="6sj-bN-LIv" secondAttribute="trailing" constant="12" id="u7h-K0-24X"/>
+                                        <constraint firstItem="apr-sq-JIb" firstAttribute="top" secondItem="EiP-Mu-9cf" secondAttribute="bottom" constant="8" id="uJk-Nw-s4Z"/>
                                         <constraint firstItem="hGO-dV-reB" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="uNt-y6-N4V"/>
-                                        <constraint firstItem="Ghr-q6-WAW" firstAttribute="leading" secondItem="Nn4-TP-Hpd" secondAttribute="trailing" constant="8" id="vJB-Ps-8Nh"/>
+                                        <constraint firstItem="L3Y-pD-V9R" firstAttribute="centerY" secondItem="EiP-Mu-9cf" secondAttribute="centerY" id="vFV-7S-mb9"/>
+                                        <constraint firstItem="Ira-RI-5kc" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="vLD-eR-5PH"/>
                                         <constraint firstAttribute="trailing" secondItem="Hmg-bS-UMv" secondAttribute="trailing" constant="12" id="wVP-q3-lxd"/>
-                                        <constraint firstItem="Hmg-bS-UMv" firstAttribute="leading" secondItem="gxW-1z-Af9" secondAttribute="trailing" constant="8" id="xDy-5f-pwW"/>
-                                        <constraint firstItem="GaY-iG-tAy" firstAttribute="top" secondItem="a3w-YC-7oN" secondAttribute="bottom" constant="6" id="zRX-Im-wMp"/>
+                                        <constraint firstItem="wxy-f3-FrW" firstAttribute="leading" secondItem="Hm9-gI-9j7" secondAttribute="trailing" constant="8" symbolic="YES" id="wb6-CS-SWb"/>
+                                        <constraint firstItem="gxW-1z-Af9" firstAttribute="top" secondItem="Ldf-jT-tdl" secondAttribute="bottom" constant="8" id="yK3-UG-NL7"/>
+                                        <constraint firstItem="FwA-X7-Alr" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="leading" id="zIp-fJ-n7n"/>
+                                        <constraint firstItem="FwA-X7-Alr" firstAttribute="top" secondItem="aGE-iz-M2h" secondAttribute="bottom" constant="8" id="zjy-ws-J03"/>
+                                        <constraint firstItem="Xol-2r-g7u" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="leading" id="zmy-n6-ecX"/>
                                     </constraints>
                                 </view>
                             </tabViewItem>
                             <tabViewItem label="Tracks" identifier="2" id="UuR-M1-YLj">
                                 <view key="view" id="CWu-ZF-Vg7">
-                                    <rect key="frame" x="0.0" y="0.0" width="400" height="341"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="326" height="382"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="o1n-DX-V8d">
-                                            <rect key="frame" x="10" y="315" width="37" height="14"/>
+                                            <rect key="frame" x="10" y="354" width="42" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Track:" id="f7i-wX-uxQ">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -410,7 +483,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <popUpButton horizontalHuggingPriority="240" verticalHuggingPriority="750" horizontalCompressionResistancePriority="500" translatesAutoresizingMaskIntoConstraints="NO" id="hGJ-d0-aJu">
-                                            <rect key="frame" x="53" y="310" width="338" height="22"/>
+                                            <rect key="frame" x="57" y="348" width="261" height="22"/>
                                             <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="oaq-Mf-xDk">
                                                 <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                                 <font key="font" usesAppearanceFont="YES"/>
@@ -421,10 +494,10 @@
                                             </connections>
                                         </popUpButton>
                                         <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="bln-RN-oa7">
-                                            <rect key="frame" x="12" y="298" width="376" height="5"/>
+                                            <rect key="frame" x="12" y="337" width="302" height="5"/>
                                         </box>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="X2o-Mf-T1P">
-                                            <rect key="frame" x="10" y="274" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="313" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="ID:" id="mZG-ik-Led">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -432,7 +505,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="roj-p2-656">
-                                            <rect key="frame" x="94" y="274" width="296" height="14"/>
+                                            <rect key="frame" x="94" y="311" width="222" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="Go3-bS-2ev">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -440,7 +513,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oof-Fn-7Cw">
-                                            <rect key="frame" x="10" y="254" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="291" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Properties:" id="dtn-wS-j6U">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -448,7 +521,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3ZF-PG-IIG">
-                                            <rect key="frame" x="10" y="234" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="269" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Source ID:" id="jCY-og-BAa">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -456,7 +529,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="l4x-fQ-Uau">
-                                            <rect key="frame" x="10" y="214" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="247" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Title:" id="9eq-rd-zGy">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -464,7 +537,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Dl1-oz-GjJ">
-                                            <rect key="frame" x="10" y="194" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="225" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Language:" id="FIw-CH-b05">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -472,7 +545,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="brr-Ci-pQU">
-                                            <rect key="frame" x="10" y="174" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="203" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="File Path:" id="Jxp-Wf-BhU">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -480,7 +553,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="a9p-qC-0t4">
-                                            <rect key="frame" x="10" y="154" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="181" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Codec:" id="daB-hU-mku">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -488,7 +561,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="l34-Lu-Nzf">
-                                            <rect key="frame" x="10" y="134" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="159" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Decoder:" id="xix-0S-ehE">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -496,7 +569,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Rif-ov-KDp">
-                                            <rect key="frame" x="10" y="114" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="137" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="FPS:" id="1dz-Vt-0MO">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -504,7 +577,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OgS-y8-ape">
-                                            <rect key="frame" x="10" y="94" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="115" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Channels:" id="Luq-rQ-aO4">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -512,7 +585,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Xwe-B4-BI5">
-                                            <rect key="frame" x="94" y="254" width="42" height="14"/>
+                                            <rect key="frame" x="94" y="289" width="48" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Default" id="S3X-Df-UMB">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -520,7 +593,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bch-Xl-vY8">
-                                            <rect key="frame" x="140" y="254" width="41" height="14"/>
+                                            <rect key="frame" x="146" y="289" width="47" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Forced" id="0vG-Pg-DIl">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -528,7 +601,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lU2-XA-lgf">
-                                            <rect key="frame" x="185" y="254" width="51" height="14"/>
+                                            <rect key="frame" x="197" y="289" width="58" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Selected" id="P65-zr-dOH">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -536,7 +609,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fKd-iK-TBJ">
-                                            <rect key="frame" x="240" y="254" width="47" height="14"/>
+                                            <rect key="frame" x="259" y="289" width="54" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="External" id="PLL-fC-blc">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -544,7 +617,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="n48-Ey-Kcr">
-                                            <rect key="frame" x="94" y="234" width="296" height="14"/>
+                                            <rect key="frame" x="94" y="267" width="222" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="ujs-p7-wXC">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -552,7 +625,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="gNk-wZ-LBX">
-                                            <rect key="frame" x="94" y="214" width="296" height="14"/>
+                                            <rect key="frame" x="94" y="245" width="222" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Label" id="fYh-pA-yDU">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -560,7 +633,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="YOn-R8-CUB">
-                                            <rect key="frame" x="94" y="154" width="296" height="14"/>
+                                            <rect key="frame" x="94" y="179" width="222" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="UPK-o2-eTo">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -568,7 +641,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="6Jf-Z2-tkZ">
-                                            <rect key="frame" x="94" y="194" width="296" height="14"/>
+                                            <rect key="frame" x="94" y="223" width="222" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="KS6-aw-wh6">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -576,7 +649,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="LXL-wc-JRh">
-                                            <rect key="frame" x="94" y="174" width="296" height="14"/>
+                                            <rect key="frame" x="94" y="201" width="222" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Label" id="jMN-aN-DqI">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -584,7 +657,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1Ov-rH-BM1">
-                                            <rect key="frame" x="94" y="134" width="296" height="14"/>
+                                            <rect key="frame" x="94" y="157" width="222" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Label" id="7Iw-nT-Mdz">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -592,7 +665,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="VR8-mY-Zfn">
-                                            <rect key="frame" x="94" y="94" width="296" height="14"/>
+                                            <rect key="frame" x="94" y="113" width="222" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="21M-40-ac5">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -600,7 +673,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Hk9-2W-Vxc">
-                                            <rect key="frame" x="94" y="74" width="296" height="14"/>
+                                            <rect key="frame" x="94" y="91" width="222" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="MKd-dP-Mkb">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -608,7 +681,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fj8-mz-w6w">
-                                            <rect key="frame" x="10" y="74" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="93" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Sample Rate:" id="vrP-XL-Weg">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -616,7 +689,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="U7e-QU-Pta">
-                                            <rect key="frame" x="94" y="114" width="296" height="14"/>
+                                            <rect key="frame" x="94" y="135" width="222" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="u39-dg-rLQ">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -710,11 +783,11 @@
                             </tabViewItem>
                             <tabViewItem label="File" identifier="" id="WrI-Sr-O2S">
                                 <view key="view" id="foT-8J-MwC">
-                                    <rect key="frame" x="0.0" y="0.0" width="400" height="349"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="326" height="382"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nJF-Fe-glJ">
-                                            <rect key="frame" x="10" y="305" width="380" height="14"/>
+                                            <rect key="frame" x="10" y="336" width="306" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" selectable="YES" sendsActionOnEndEditing="YES" title="Multiline Label" id="JkC-3s-Ela">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -722,26 +795,18 @@
                                             </textFieldCell>
                                         </textField>
                                         <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="507-xz-zeA">
-                                            <rect key="frame" x="12" y="290" width="376" height="5"/>
+                                            <rect key="frame" x="12" y="321" width="302" height="5"/>
                                         </box>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="P6I-h4-MV9">
-                                            <rect key="frame" x="10" y="266" width="60" height="14"/>
+                                            <rect key="frame" x="10" y="297" width="60" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Size:" id="KqD-NM-WiK">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UBX-ge-nPN">
-                                            <rect key="frame" x="76" y="266" width="33" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="Zaf-qd-A4D">
-                                                <font key="font" usesAppearanceFont="YES"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3Lj-7X-tNH">
-                                            <rect key="frame" x="76" y="246" width="33" height="14"/>
+                                            <rect key="frame" x="95" y="275" width="37" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="QTi-nO-v8c">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -749,7 +814,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EaI-Lh-edg">
-                                            <rect key="frame" x="10" y="246" width="60" height="14"/>
+                                            <rect key="frame" x="10" y="275" width="60" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Format:" id="mgl-Et-20K">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -757,7 +822,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JYJ-iA-Cdg">
-                                            <rect key="frame" x="10" y="323" width="380" height="14"/>
+                                            <rect key="frame" x="10" y="356" width="306" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="File path:" id="4jf-w4-kkv">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -765,7 +830,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SEN-lo-1AP">
-                                            <rect key="frame" x="10" y="226" width="60" height="14"/>
+                                            <rect key="frame" x="10" y="253" width="60" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Duration:" id="OCm-zb-deg">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -773,7 +838,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IpH-Qz-kKo">
-                                            <rect key="frame" x="10" y="206" width="60" height="14"/>
+                                            <rect key="frame" x="10" y="233" width="60" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Chapters:" id="PBk-VC-4gu">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -781,7 +846,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2xR-1D-bSh">
-                                            <rect key="frame" x="10" y="186" width="60" height="14"/>
+                                            <rect key="frame" x="10" y="211" width="60" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Editions:" id="POj-mQ-zP9">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -789,7 +854,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="uzH-YO-YLT">
-                                            <rect key="frame" x="76" y="226" width="33" height="14"/>
+                                            <rect key="frame" x="95" y="253" width="37" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="sgp-Kk-awA">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -797,7 +862,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="PgQ-KO-dy8">
-                                            <rect key="frame" x="76" y="206" width="33" height="14"/>
+                                            <rect key="frame" x="95" y="231" width="37" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="IME-9M-YdQ">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -805,8 +870,16 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yhp-8h-TAd">
-                                            <rect key="frame" x="76" y="186" width="33" height="14"/>
+                                            <rect key="frame" x="95" y="209" width="37" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="xIH-Dc-ZRT">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UBX-ge-nPN">
+                                            <rect key="frame" x="95" y="296" width="37" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="Zaf-qd-A4D">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -814,54 +887,49 @@
                                         </textField>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstItem="JYJ-iA-Cdg" firstAttribute="leading" secondItem="foT-8J-MwC" secondAttribute="leading" constant="12" id="0VR-KB-HPu"/>
-                                        <constraint firstItem="PgQ-KO-dy8" firstAttribute="top" secondItem="IpH-Qz-kKo" secondAttribute="top" id="0aw-ZR-nLg"/>
-                                        <constraint firstItem="3Lj-7X-tNH" firstAttribute="top" secondItem="UBX-ge-nPN" secondAttribute="bottom" constant="6" id="5Mk-np-cr2"/>
-                                        <constraint firstItem="UBX-ge-nPN" firstAttribute="bottom" secondItem="P6I-h4-MV9" secondAttribute="bottom" id="6Fb-VM-NXt"/>
-                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="PgQ-KO-dy8" secondAttribute="trailing" constant="12" id="8Ac-Ec-HmU"/>
-                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="3Lj-7X-tNH" secondAttribute="trailing" constant="12" id="8Av-Qm-8Xz"/>
-                                        <constraint firstItem="yhp-8h-TAd" firstAttribute="top" secondItem="2xR-1D-bSh" secondAttribute="top" id="8xv-Qr-5FG"/>
-                                        <constraint firstItem="EaI-Lh-edg" firstAttribute="leading" secondItem="foT-8J-MwC" secondAttribute="leading" constant="12" id="B1s-86-kn6"/>
-                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="yhp-8h-TAd" secondAttribute="trailing" constant="12" id="B7c-ax-8SB"/>
-                                        <constraint firstItem="yhp-8h-TAd" firstAttribute="leading" secondItem="2xR-1D-bSh" secondAttribute="trailing" constant="10" id="CKQ-bv-hOu"/>
-                                        <constraint firstItem="SEN-lo-1AP" firstAttribute="width" secondItem="P6I-h4-MV9" secondAttribute="width" id="DJ7-si-3cW"/>
-                                        <constraint firstItem="2xR-1D-bSh" firstAttribute="width" secondItem="P6I-h4-MV9" secondAttribute="width" id="Eib-Dq-PxJ"/>
-                                        <constraint firstAttribute="trailing" secondItem="507-xz-zeA" secondAttribute="trailing" constant="12" id="G9R-Xi-Vhy"/>
-                                        <constraint firstItem="EaI-Lh-edg" firstAttribute="width" secondItem="P6I-h4-MV9" secondAttribute="width" id="Gif-AP-xUT"/>
-                                        <constraint firstAttribute="trailing" secondItem="nJF-Fe-glJ" secondAttribute="trailing" constant="12" id="H0V-PY-sFJ"/>
-                                        <constraint firstItem="SEN-lo-1AP" firstAttribute="leading" secondItem="foT-8J-MwC" secondAttribute="leading" constant="12" id="K05-du-y1T"/>
-                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="uzH-YO-YLT" secondAttribute="trailing" constant="12" id="MVK-zu-QrH"/>
-                                        <constraint firstItem="P6I-h4-MV9" firstAttribute="top" secondItem="507-xz-zeA" secondAttribute="bottom" constant="12" id="Mv7-t7-Vtp"/>
-                                        <constraint firstItem="3Lj-7X-tNH" firstAttribute="bottom" secondItem="EaI-Lh-edg" secondAttribute="bottom" id="Qez-bZ-xs3"/>
-                                        <constraint firstItem="PgQ-KO-dy8" firstAttribute="leading" secondItem="IpH-Qz-kKo" secondAttribute="trailing" constant="10" id="SE2-Oq-T0m"/>
-                                        <constraint firstItem="uzH-YO-YLT" firstAttribute="leading" secondItem="SEN-lo-1AP" secondAttribute="trailing" constant="10" id="SRO-b2-yOL"/>
-                                        <constraint firstItem="PgQ-KO-dy8" firstAttribute="top" secondItem="uzH-YO-YLT" secondAttribute="bottom" constant="6" id="TPp-5n-EUp"/>
-                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="UBX-ge-nPN" secondAttribute="trailing" constant="12" id="UgT-iY-pFN"/>
-                                        <constraint firstItem="uzH-YO-YLT" firstAttribute="bottom" secondItem="SEN-lo-1AP" secondAttribute="bottom" id="Ur1-iB-8Xe"/>
-                                        <constraint firstItem="uzH-YO-YLT" firstAttribute="top" secondItem="3Lj-7X-tNH" secondAttribute="bottom" constant="6" id="Vyq-Yq-MuH"/>
-                                        <constraint firstItem="IpH-Qz-kKo" firstAttribute="leading" secondItem="foT-8J-MwC" secondAttribute="leading" constant="12" id="X7E-oV-SDy"/>
-                                        <constraint firstItem="JYJ-iA-Cdg" firstAttribute="top" secondItem="foT-8J-MwC" secondAttribute="top" constant="12" id="X7w-cX-oGr"/>
-                                        <constraint firstItem="2xR-1D-bSh" firstAttribute="leading" secondItem="foT-8J-MwC" secondAttribute="leading" constant="12" id="XGw-ej-laS"/>
-                                        <constraint firstItem="507-xz-zeA" firstAttribute="leading" secondItem="foT-8J-MwC" secondAttribute="leading" constant="12" id="auI-3z-Cre"/>
-                                        <constraint firstItem="UBX-ge-nPN" firstAttribute="leading" secondItem="P6I-h4-MV9" secondAttribute="trailing" constant="10" id="bXL-mB-Nzy"/>
-                                        <constraint firstItem="IpH-Qz-kKo" firstAttribute="width" secondItem="P6I-h4-MV9" secondAttribute="width" id="eCV-eI-Klr"/>
-                                        <constraint firstItem="nJF-Fe-glJ" firstAttribute="leading" secondItem="foT-8J-MwC" secondAttribute="leading" constant="12" id="k4Z-59-Sl4"/>
-                                        <constraint firstItem="yhp-8h-TAd" firstAttribute="top" secondItem="PgQ-KO-dy8" secondAttribute="bottom" constant="6" id="kDT-pM-Bj9"/>
-                                        <constraint firstItem="507-xz-zeA" firstAttribute="top" secondItem="nJF-Fe-glJ" secondAttribute="bottom" constant="12" id="kRW-6k-MsP"/>
-                                        <constraint firstItem="3Lj-7X-tNH" firstAttribute="leading" secondItem="EaI-Lh-edg" secondAttribute="trailing" constant="10" id="pfa-HU-c9e"/>
-                                        <constraint firstItem="nJF-Fe-glJ" firstAttribute="top" secondItem="JYJ-iA-Cdg" secondAttribute="bottom" constant="4" id="ybK-hc-qLn"/>
-                                        <constraint firstAttribute="trailing" secondItem="JYJ-iA-Cdg" secondAttribute="trailing" constant="12" id="yzg-H7-v7f"/>
-                                        <constraint firstItem="P6I-h4-MV9" firstAttribute="leading" secondItem="foT-8J-MwC" secondAttribute="leading" constant="12" id="zkr-ut-Ukz"/>
+                                        <constraint firstItem="3Lj-7X-tNH" firstAttribute="leading" secondItem="uzH-YO-YLT" secondAttribute="leading" id="098-D8-MFD"/>
+                                        <constraint firstItem="SEN-lo-1AP" firstAttribute="baseline" secondItem="uzH-YO-YLT" secondAttribute="baseline" id="1d2-7Z-MXW"/>
+                                        <constraint firstItem="2xR-1D-bSh" firstAttribute="top" secondItem="IpH-Qz-kKo" secondAttribute="bottom" constant="8" symbolic="YES" id="1g1-Fb-bgm"/>
+                                        <constraint firstItem="PgQ-KO-dy8" firstAttribute="leading" secondItem="yhp-8h-TAd" secondAttribute="leading" id="39v-vb-d1W"/>
+                                        <constraint firstItem="IpH-Qz-kKo" firstAttribute="top" secondItem="SEN-lo-1AP" secondAttribute="bottom" constant="6" id="3dm-Dy-3it"/>
+                                        <constraint firstItem="UBX-ge-nPN" firstAttribute="leading" secondItem="P6I-h4-MV9" secondAttribute="trailing" constant="29" id="5z6-Es-8y2"/>
+                                        <constraint firstItem="SEN-lo-1AP" firstAttribute="top" secondItem="EaI-Lh-edg" secondAttribute="bottom" constant="8" symbolic="YES" id="7HW-6J-gZ9"/>
+                                        <constraint firstItem="JYJ-iA-Cdg" firstAttribute="top" secondItem="foT-8J-MwC" secondAttribute="top" constant="12" id="7eH-bs-Vdb"/>
+                                        <constraint firstItem="JYJ-iA-Cdg" firstAttribute="trailing" secondItem="nJF-Fe-glJ" secondAttribute="trailing" id="AX9-Gc-e50"/>
+                                        <constraint firstItem="EaI-Lh-edg" firstAttribute="baseline" secondItem="3Lj-7X-tNH" secondAttribute="baseline" id="D75-sx-C8F"/>
+                                        <constraint firstItem="JYJ-iA-Cdg" firstAttribute="leading" secondItem="foT-8J-MwC" secondAttribute="leading" constant="12" id="Dhr-xA-SGC"/>
+                                        <constraint firstItem="IpH-Qz-kKo" firstAttribute="top" secondItem="PgQ-KO-dy8" secondAttribute="top" id="FHv-yO-7Iz"/>
+                                        <constraint firstItem="EaI-Lh-edg" firstAttribute="top" secondItem="P6I-h4-MV9" secondAttribute="bottom" constant="8" symbolic="YES" id="G0T-yB-BN9"/>
+                                        <constraint firstItem="507-xz-zeA" firstAttribute="leading" secondItem="P6I-h4-MV9" secondAttribute="leading" id="KMD-4e-Q1D"/>
+                                        <constraint firstItem="UBX-ge-nPN" firstAttribute="top" secondItem="507-xz-zeA" secondAttribute="bottom" constant="11" id="LbO-AH-akR"/>
+                                        <constraint firstItem="IpH-Qz-kKo" firstAttribute="leading" secondItem="2xR-1D-bSh" secondAttribute="leading" id="M9R-xK-z5j"/>
+                                        <constraint firstItem="SEN-lo-1AP" firstAttribute="leading" secondItem="IpH-Qz-kKo" secondAttribute="leading" id="MsZ-Zx-rYy"/>
+                                        <constraint firstItem="P6I-h4-MV9" firstAttribute="centerY" secondItem="UBX-ge-nPN" secondAttribute="centerY" id="TVo-EO-OhY"/>
+                                        <constraint firstItem="507-xz-zeA" firstAttribute="top" secondItem="nJF-Fe-glJ" secondAttribute="bottom" constant="12" id="VGM-nM-VIz"/>
+                                        <constraint firstItem="P6I-h4-MV9" firstAttribute="trailing" secondItem="EaI-Lh-edg" secondAttribute="trailing" id="VzA-D3-y2g"/>
+                                        <constraint firstItem="SEN-lo-1AP" firstAttribute="trailing" secondItem="IpH-Qz-kKo" secondAttribute="trailing" id="WNP-Ik-PER"/>
+                                        <constraint firstItem="UBX-ge-nPN" firstAttribute="leading" secondItem="3Lj-7X-tNH" secondAttribute="leading" id="Y2W-S8-LWi"/>
+                                        <constraint firstItem="nJF-Fe-glJ" firstAttribute="top" secondItem="JYJ-iA-Cdg" secondAttribute="bottom" constant="4" id="ZvZ-Pq-WEE"/>
+                                        <constraint firstItem="EaI-Lh-edg" firstAttribute="trailing" secondItem="SEN-lo-1AP" secondAttribute="trailing" id="dDx-00-V1b"/>
+                                        <constraint firstItem="uzH-YO-YLT" firstAttribute="leading" secondItem="PgQ-KO-dy8" secondAttribute="leading" id="dqw-N6-0EQ"/>
+                                        <constraint firstItem="nJF-Fe-glJ" firstAttribute="trailing" secondItem="507-xz-zeA" secondAttribute="trailing" id="eZC-b7-mdu"/>
+                                        <constraint firstItem="JYJ-iA-Cdg" firstAttribute="leading" secondItem="nJF-Fe-glJ" secondAttribute="leading" id="fPN-2U-rPc"/>
+                                        <constraint firstItem="nJF-Fe-glJ" firstAttribute="leading" secondItem="507-xz-zeA" secondAttribute="leading" id="iOZ-re-91J"/>
+                                        <constraint firstItem="JYJ-iA-Cdg" firstAttribute="centerX" secondItem="foT-8J-MwC" secondAttribute="centerX" id="iX1-Y2-bj5"/>
+                                        <constraint firstItem="2xR-1D-bSh" firstAttribute="top" secondItem="yhp-8h-TAd" secondAttribute="top" id="lUC-Ud-Ief"/>
+                                        <constraint firstItem="IpH-Qz-kKo" firstAttribute="trailing" secondItem="2xR-1D-bSh" secondAttribute="trailing" id="rDd-UM-w28"/>
+                                        <constraint firstItem="P6I-h4-MV9" firstAttribute="leading" secondItem="EaI-Lh-edg" secondAttribute="leading" id="vBw-t1-jxL"/>
+                                        <constraint firstItem="EaI-Lh-edg" firstAttribute="leading" secondItem="SEN-lo-1AP" secondAttribute="leading" id="xkY-fm-J71"/>
                                     </constraints>
                                 </view>
                             </tabViewItem>
                             <tabViewItem label="Status" identifier="" id="VGm-BL-xOI">
                                 <view key="view" id="VWf-29-TwU">
-                                    <rect key="frame" x="0.0" y="0.0" width="400" height="353"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="400" height="387"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YAy-hh-4mE">
-                                            <rect key="frame" x="10" y="327" width="131" height="14"/>
+                                            <rect key="frame" x="10" y="361" width="131" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="A/V Sync Diff:" id="iVK-Ck-Lyq">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -869,7 +937,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="BSs-zY-Ycq">
-                                            <rect key="frame" x="147" y="327" width="243" height="14"/>
+                                            <rect key="frame" x="147" y="359" width="243" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="YcG-9Y-Qn6">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -877,7 +945,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Xx9-GE-Qp4">
-                                            <rect key="frame" x="10" y="307" width="131" height="14"/>
+                                            <rect key="frame" x="10" y="339" width="131" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Total A/V Sync:" id="sbO-Cn-gpI">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -885,7 +953,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cwU-SQ-A8V">
-                                            <rect key="frame" x="147" y="307" width="243" height="14"/>
+                                            <rect key="frame" x="147" y="337" width="243" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="V7s-Tp-SD6">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -893,7 +961,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="R9k-Bu-wSB">
-                                            <rect key="frame" x="10" y="287" width="131" height="14"/>
+                                            <rect key="frame" x="10" y="317" width="131" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Dropped Frames:" id="CrF-UR-udW">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -901,7 +969,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Evy-yh-2vU">
-                                            <rect key="frame" x="147" y="287" width="243" height="14"/>
+                                            <rect key="frame" x="147" y="315" width="243" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="OZx-CU-1b5">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -909,7 +977,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="l4a-xE-z4Y">
-                                            <rect key="frame" x="10" y="267" width="131" height="14"/>
+                                            <rect key="frame" x="10" y="295" width="131" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Mistimed Frames:" id="AYt-pH-UCi">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -917,7 +985,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="drh-59-1Az">
-                                            <rect key="frame" x="147" y="267" width="243" height="14"/>
+                                            <rect key="frame" x="147" y="293" width="243" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="R14-IF-0dZ">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -925,7 +993,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="r7h-Wk-a9A">
-                                            <rect key="frame" x="10" y="247" width="131" height="14"/>
+                                            <rect key="frame" x="10" y="273" width="131" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Display FPS:" id="AjU-1T-aGR">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -933,7 +1001,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Soa-90-mcv">
-                                            <rect key="frame" x="147" y="247" width="243" height="14"/>
+                                            <rect key="frame" x="147" y="271" width="243" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="wMU-ig-9zP">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -941,7 +1009,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="G90-uq-cW4">
-                                            <rect key="frame" x="10" y="227" width="131" height="14"/>
+                                            <rect key="frame" x="10" y="251" width="131" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Estimated Output FPS:" id="g8p-Ec-awO">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -949,7 +1017,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Y8Q-PG-bHl">
-                                            <rect key="frame" x="147" y="227" width="243" height="14"/>
+                                            <rect key="frame" x="147" y="249" width="243" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="qPy-MN-AEF">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -957,7 +1025,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="XLQ-aa-TdR">
-                                            <rect key="frame" x="10" y="207" width="131" height="14"/>
+                                            <rect key="frame" x="10" y="229" width="131" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Estimated Disp FPS" id="JN9-3E-OJp">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -965,7 +1033,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oRb-Bc-1u0">
-                                            <rect key="frame" x="147" y="207" width="243" height="14"/>
+                                            <rect key="frame" x="147" y="227" width="243" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="ElK-iN-YiE">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -973,10 +1041,10 @@
                                             </textFieldCell>
                                         </textField>
                                         <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="uvv-R0-JCz">
-                                            <rect key="frame" x="12" y="192" width="376" height="5"/>
+                                            <rect key="frame" x="12" y="212" width="376" height="5"/>
                                         </box>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Oof-hT-luu">
-                                            <rect key="frame" x="10" y="168" width="40" height="14"/>
+                                            <rect key="frame" x="10" y="188" width="40" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Watch" id="tNS-gW-PcC">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -984,13 +1052,13 @@
                                             </textFieldCell>
                                         </textField>
                                         <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9In-dC-gN9">
-                                            <rect key="frame" x="12" y="24" width="376" height="132"/>
+                                            <rect key="frame" x="12" y="-9" width="376" height="185"/>
                                             <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="MlR-S8-3gW">
-                                                <rect key="frame" x="0.0" y="0.0" width="376" height="132"/>
-                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="376" height="185"/>
+                                                <autoresizingMask key="autoresizingMask"/>
                                                 <subviews>
                                                     <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" id="oUp-DO-OKl">
-                                                        <rect key="frame" x="0.0" y="0.0" width="376" height="132"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="376" height="185"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <size key="intercellSpacing" width="3" height="2"/>
                                                         <color key="backgroundColor" white="0.69999999999999996" alpha="0.10000000000000001" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
@@ -1037,7 +1105,7 @@
                                             </scroller>
                                         </scrollView>
                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="PST-dF-CNB">
-                                            <rect key="frame" x="12" y="5.5" width="16" height="17"/>
+                                            <rect key="frame" x="12" y="-27.5" width="16" height="17"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="16" id="Ccu-0I-ete"/>
                                                 <constraint firstAttribute="height" constant="14" id="msy-CE-lBu"/>
@@ -1051,7 +1119,7 @@
                                             </connections>
                                         </button>
                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Tel-U0-EC3">
-                                            <rect key="frame" x="28" y="9.5" width="16" height="9"/>
+                                            <rect key="frame" x="28" y="-23.5" width="16" height="9"/>
                                             <constraints>
                                                 <constraint firstAttribute="height" constant="14" id="aAG-Y2-goP"/>
                                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="16" id="uIM-ym-BuW"/>
@@ -1128,7 +1196,7 @@
                         </tabViewItems>
                     </tabView>
                     <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0rt-Td-kr8">
-                        <rect key="frame" x="124" y="365" width="176" height="21"/>
+                        <rect key="frame" x="77" y="418" width="196" height="21"/>
                         <segmentedCell key="cell" controlSize="small" borderStyle="border" alignment="left" style="rounded" trackingMode="selectOne" id="Fqo-1c-3L1">
                             <font key="font" usesAppearanceFont="YES"/>
                             <segments>
@@ -1144,18 +1212,18 @@
                     </segmentedControl>
                 </subviews>
                 <constraints>
-                    <constraint firstItem="0rt-Td-kr8" firstAttribute="centerX" secondItem="se5-gp-TjO" secondAttribute="centerX" id="PF4-Rp-aRW"/>
-                    <constraint firstAttribute="trailing" secondItem="wHY-jo-uW0" secondAttribute="trailing" constant="12" id="YNX-u0-fs4"/>
-                    <constraint firstAttribute="bottom" secondItem="wHY-jo-uW0" secondAttribute="bottom" constant="12" id="b8p-kY-qTd"/>
-                    <constraint firstItem="wHY-jo-uW0" firstAttribute="top" secondItem="0rt-Td-kr8" secondAttribute="bottom" constant="2" id="p2h-Zg-oLg"/>
-                    <constraint firstItem="wHY-jo-uW0" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" constant="12" id="pAZ-o1-D4U"/>
-                    <constraint firstItem="0rt-Td-kr8" firstAttribute="top" secondItem="se5-gp-TjO" secondAttribute="top" constant="16" id="sLs-na-YDf"/>
+                    <constraint firstItem="0rt-Td-kr8" firstAttribute="top" secondItem="se5-gp-TjO" secondAttribute="top" constant="16" id="0k4-Se-0cu"/>
+                    <constraint firstItem="0rt-Td-kr8" firstAttribute="centerX" secondItem="wHY-jo-uW0" secondAttribute="centerX" id="1Qq-OI-Y6n"/>
+                    <constraint firstItem="wHY-jo-uW0" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" constant="12" id="8pZ-Xk-eQK"/>
+                    <constraint firstItem="wHY-jo-uW0" firstAttribute="top" secondItem="0rt-Td-kr8" secondAttribute="bottom" constant="2" id="Evo-Nf-OHK"/>
+                    <constraint firstAttribute="bottom" secondItem="wHY-jo-uW0" secondAttribute="bottom" constant="12" id="JMH-6g-SqZ"/>
+                    <constraint firstItem="0rt-Td-kr8" firstAttribute="centerX" secondItem="se5-gp-TjO" secondAttribute="centerX" id="n1w-p6-sYF"/>
                 </constraints>
             </view>
             <connections>
                 <outlet property="delegate" destination="-2" id="0bl-1N-AYu"/>
             </connections>
-            <point key="canvasLocation" x="143" y="233.5"/>
+            <point key="canvasLocation" x="106" y="252"/>
         </window>
         <collectionViewItem id="STR-xi-slv"/>
     </objects>

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "None";
 "quicksetting.hwdec" = "Hardware Decoding";
 "quicksetting.deinterlace" = "Deinterlace";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "Pause";

--- a/iina/Base.lproj/PrefCodecViewController.xib
+++ b/iina/Base.lproj/PrefCodecViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -27,11 +27,11 @@
         </customView>
         <userDefaultsController representsSharedInstance="YES" id="pxc-7C-SGP"/>
         <customView id="gZf-gF-XoY">
-            <rect key="frame" x="0.0" y="0.0" width="444" height="132"/>
+            <rect key="frame" x="0.0" y="0.0" width="444" height="202"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField identifier="SectionTitleVideo" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2BH-mP-kfr">
-                    <rect key="frame" x="-2" y="108" width="46" height="16"/>
+                    <rect key="frame" x="-2" y="178" width="46" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Video:" id="m5P-5f-5uo">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -39,7 +39,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="paR-ax-h5M">
-                    <rect key="frame" x="118" y="108" width="122" height="16"/>
+                    <rect key="frame" x="118" y="178" width="122" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Number of threads:" id="50C-1R-wlJ">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -47,7 +47,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NZA-64-tXh">
-                    <rect key="frame" x="246" y="105" width="58" height="21"/>
+                    <rect key="frame" x="246" y="175" width="58" height="21"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="58" id="GLI-3U-bmm"/>
                     </constraints>
@@ -68,7 +68,7 @@
                     </connections>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kas-7q-TbK">
-                    <rect key="frame" x="312" y="108" width="92" height="14"/>
+                    <rect key="frame" x="312" y="178" width="92" height="14"/>
                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Default: 0 (Auto)" id="bxW-np-SGm">
                         <font key="font" metaFont="label" size="11"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -76,13 +76,13 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EWs-Ib-pVZ">
-                    <rect key="frame" x="244" y="78" width="125" height="25"/>
+                    <rect key="frame" x="243" y="139" width="127" height="25"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="120" id="P27-F4-Ogg"/>
                     </constraints>
                     <popUpButtonCell key="cell" type="push" title="Disabled" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="rFu-rL-EJC" id="n21-ZO-Bva">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="menu"/>
                         <menu key="menu" id="MDO-ug-KAV">
                             <items>
                                 <menuItem title="Disabled" state="on" id="rFu-rL-EJC"/>
@@ -97,7 +97,7 @@
                     </connections>
                 </popUpButton>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="0Re-PY-hmC">
-                    <rect key="frame" x="118" y="66" width="328" height="14"/>
+                    <rect key="frame" x="118" y="128" width="328" height="14"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Label" id="n3r-mP-f8V">
                         <font key="font" metaFont="label" size="11"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -105,7 +105,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4rB-d2-drE">
-                    <rect key="frame" x="118" y="84" width="122" height="16"/>
+                    <rect key="frame" x="118" y="146" width="122" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Hardware decoder:" id="nwg-2K-G2G">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -113,7 +113,7 @@
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xXS-nP-Chk">
-                    <rect key="frame" x="118" y="38" width="152" height="18"/>
+                    <rect key="frame" x="118" y="99" width="156" height="18"/>
                     <buttonCell key="cell" type="check" title="Force dedicated GPU" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="YUr-aJ-xfC">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -123,8 +123,26 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="40Z-9R-jw0">
-                    <rect key="frame" x="118" y="8" width="328" height="28"/>
+                    <rect key="frame" x="118" y="68" width="328" height="28"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Always use the dedicated GPU for rendering (if it exists). This can improve performance but may reduce battery life." id="gCv-sJ-uQJ">
+                        <font key="font" metaFont="label" size="11"/>
+                        <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="H9a-N4-xDt">
+                    <rect key="frame" x="118" y="43" width="124" height="18"/>
+                    <buttonCell key="cell" type="check" title="Load ICC profile" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="3g4-jW-uJd">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="pxc-7C-SGP" name="value" keyPath="values.loadIccProfile" id="V7h-9X-mbz"/>
+                    </connections>
+                </button>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="IQ8-K4-5CX">
+                    <rect key="frame" x="118" y="12" width="328" height="28"/>
+                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Load the ICC profile for current display and use it to transform video RGB to screen output. (Only for SDR mode)" id="M2M-of-gjd">
                         <font key="font" metaFont="label" size="11"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -136,17 +154,21 @@
                 <constraint firstItem="2BH-mP-kfr" firstAttribute="top" secondItem="gZf-gF-XoY" secondAttribute="top" constant="8" id="0jh-iZ-prT"/>
                 <constraint firstItem="40Z-9R-jw0" firstAttribute="leading" secondItem="xXS-nP-Chk" secondAttribute="leading" id="1of-sZ-BN6"/>
                 <constraint firstItem="0Re-PY-hmC" firstAttribute="top" secondItem="4rB-d2-drE" secondAttribute="bottom" constant="4" id="5Mm-wm-VFG"/>
+                <constraint firstAttribute="bottom" secondItem="IQ8-K4-5CX" secondAttribute="bottom" constant="12" id="6dx-e8-7Ck"/>
                 <constraint firstItem="40Z-9R-jw0" firstAttribute="top" secondItem="xXS-nP-Chk" secondAttribute="bottom" constant="4" id="87O-GK-HSl"/>
+                <constraint firstAttribute="trailing" secondItem="IQ8-K4-5CX" secondAttribute="trailing" id="ASv-Wn-ieW"/>
                 <constraint firstItem="4rB-d2-drE" firstAttribute="leading" secondItem="paR-ax-h5M" secondAttribute="leading" id="Can-oM-yLm"/>
                 <constraint firstItem="EWs-Ib-pVZ" firstAttribute="leading" secondItem="4rB-d2-drE" secondAttribute="trailing" constant="8" id="Fj7-lr-KGg"/>
                 <constraint firstAttribute="trailing" secondItem="0Re-PY-hmC" secondAttribute="trailing" id="HJH-5L-Dd4"/>
                 <constraint firstItem="2BH-mP-kfr" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="gZf-gF-XoY" secondAttribute="leading" constant="120" id="KBf-6v-pL9"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="xXS-nP-Chk" secondAttribute="trailing" constant="12" id="QNu-hr-TdO"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="H9a-N4-xDt" secondAttribute="trailing" constant="12" id="TxZ-c7-rVn"/>
+                <constraint firstItem="IQ8-K4-5CX" firstAttribute="top" secondItem="H9a-N4-xDt" secondAttribute="bottom" constant="4" id="W29-Gj-v7X"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="kas-7q-TbK" secondAttribute="trailing" constant="20" symbolic="YES" id="XnT-jM-uWw"/>
-                <constraint firstAttribute="bottom" secondItem="40Z-9R-jw0" secondAttribute="bottom" constant="8" id="XxA-NY-JPN"/>
                 <constraint firstItem="paR-ax-h5M" firstAttribute="top" secondItem="2BH-mP-kfr" secondAttribute="top" id="ZwF-7T-SvE"/>
                 <constraint firstItem="xXS-nP-Chk" firstAttribute="leading" secondItem="0Re-PY-hmC" secondAttribute="leading" id="aYZ-dq-yBE"/>
                 <constraint firstItem="kas-7q-TbK" firstAttribute="leading" secondItem="NZA-64-tXh" secondAttribute="trailing" constant="10" id="c73-Gh-U6L"/>
+                <constraint firstItem="IQ8-K4-5CX" firstAttribute="leading" secondItem="H9a-N4-xDt" secondAttribute="leading" id="cpx-2e-hcB"/>
                 <constraint firstItem="xXS-nP-Chk" firstAttribute="top" secondItem="0Re-PY-hmC" secondAttribute="bottom" constant="12" id="fO3-5j-FCq"/>
                 <constraint firstItem="paR-ax-h5M" firstAttribute="leading" secondItem="gZf-gF-XoY" secondAttribute="leading" constant="120" id="fWo-4I-DAC"/>
                 <constraint firstItem="NZA-64-tXh" firstAttribute="baseline" secondItem="paR-ax-h5M" secondAttribute="baseline" id="hly-ga-NBA"/>
@@ -154,19 +176,21 @@
                 <constraint firstItem="NZA-64-tXh" firstAttribute="leading" secondItem="paR-ax-h5M" secondAttribute="trailing" constant="8" id="mRg-ce-YRy"/>
                 <constraint firstItem="2BH-mP-kfr" firstAttribute="leading" secondItem="gZf-gF-XoY" secondAttribute="leading" id="pDP-Rm-tDg"/>
                 <constraint firstItem="0Re-PY-hmC" firstAttribute="leading" secondItem="4rB-d2-drE" secondAttribute="leading" id="q9a-bj-3IP"/>
-                <constraint firstItem="4rB-d2-drE" firstAttribute="top" secondItem="paR-ax-h5M" secondAttribute="bottom" constant="8" id="rCv-37-pHD"/>
+                <constraint firstItem="4rB-d2-drE" firstAttribute="top" secondItem="paR-ax-h5M" secondAttribute="bottom" constant="16" id="rCv-37-pHD"/>
                 <constraint firstItem="kas-7q-TbK" firstAttribute="baseline" secondItem="paR-ax-h5M" secondAttribute="baseline" id="rWF-ZF-Tlb"/>
                 <constraint firstAttribute="trailing" secondItem="40Z-9R-jw0" secondAttribute="trailing" id="u8t-cI-LR5"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="EWs-Ib-pVZ" secondAttribute="trailing" constant="20" symbolic="YES" id="uSA-lp-egl"/>
+                <constraint firstItem="H9a-N4-xDt" firstAttribute="top" secondItem="40Z-9R-jw0" secondAttribute="bottom" constant="8" id="w3M-iD-Ho3"/>
+                <constraint firstItem="H9a-N4-xDt" firstAttribute="leading" secondItem="40Z-9R-jw0" secondAttribute="leading" id="ybt-SY-BgR"/>
             </constraints>
-            <point key="canvasLocation" x="783" y="255.5"/>
+            <point key="canvasLocation" x="783" y="394.5"/>
         </customView>
         <customView id="bsP-Kc-xXR">
-            <rect key="frame" x="0.0" y="0.0" width="462" height="187"/>
+            <rect key="frame" x="0.0" y="0.0" width="480" height="192"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField identifier="SectionTitleAudio" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0Ig-J7-VYp">
-                    <rect key="frame" x="-2" y="163" width="46" height="16"/>
+                    <rect key="frame" x="-2" y="168" width="46" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Audio:" id="sV5-dL-MUt">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -203,7 +227,7 @@
                     </textFieldCell>
                 </textField>
                 <tokenField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Mib-1U-RcV" customClass="LanguageTokenField" customModule="IINA" customModuleProvider="target">
-                    <rect key="frame" x="269" y="5" width="193" height="21"/>
+                    <rect key="frame" x="269" y="5" width="211" height="21"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="160" id="NAx-xr-hr8"/>
                     </constraints>
@@ -233,7 +257,7 @@
                     </textFieldCell>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="iAK-W4-XCh">
-                    <rect key="frame" x="267" y="71" width="48" height="18"/>
+                    <rect key="frame" x="267" y="71" width="52" height="18"/>
                     <buttonCell key="cell" type="check" title="AC3" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="1uU-MC-7Yh">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -244,7 +268,7 @@
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="FJ2-As-AUm">
-                    <rect key="frame" x="319" y="71" width="48" height="18"/>
+                    <rect key="frame" x="325" y="71" width="52" height="18"/>
                     <buttonCell key="cell" type="check" title="DTS" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Le8-wj-Pei">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -255,7 +279,7 @@
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="haq-Mp-LHn">
-                    <rect key="frame" x="371" y="71" width="73" height="18"/>
+                    <rect key="frame" x="383" y="71" width="77" height="18"/>
                     <buttonCell key="cell" type="check" title="DTS-HD" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="I34-op-NZK">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -266,7 +290,7 @@
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="GmR-Si-ivP">
-                    <rect key="frame" x="118" y="158" width="145" height="23"/>
+                    <rect key="frame" x="118" y="167" width="143" height="18"/>
                     <buttonCell key="cell" type="check" title="Initial volume:" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="g4c-vG-URh">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -276,7 +300,7 @@
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tPo-qr-GqN">
-                    <rect key="frame" x="269" y="156" width="58" height="21"/>
+                    <rect key="frame" x="269" y="165" width="58" height="21"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="58" id="OFp-VC-TGz"/>
                     </constraints>
@@ -334,13 +358,13 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton horizontalHuggingPriority="200" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Min-k4-E1V">
-                    <rect key="frame" x="267" y="34" width="75" height="25"/>
+                    <rect key="frame" x="266" y="33" width="76" height="25"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="lessThanOrEqual" constant="300" id="gCa-l2-dK8"/>
                     </constraints>
                     <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="iQf-Gb-IuO" id="Eau-zf-my0">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="menu"/>
                         <menu key="menu" id="Vgx-Qo-7h4">
                             <items>
                                 <menuItem title="Item 1" state="on" id="iQf-Gb-IuO"/>
@@ -410,7 +434,7 @@
                 <constraint firstItem="qQz-rr-NFX" firstAttribute="leading" secondItem="JFX-OT-X7j" secondAttribute="leading" id="o3R-T9-bFc"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="SEM-Qm-KeU" secondAttribute="trailing" constant="12" id="o5t-2S-zuj"/>
                 <constraint firstItem="GmR-Si-ivP" firstAttribute="top" secondItem="0Ig-J7-VYp" secondAttribute="top" id="o7u-TU-ZIO"/>
-                <constraint firstItem="JFX-OT-X7j" firstAttribute="top" secondItem="GmR-Si-ivP" secondAttribute="bottom" constant="8" id="qjh-2X-tg8"/>
+                <constraint firstItem="JFX-OT-X7j" firstAttribute="top" secondItem="GmR-Si-ivP" secondAttribute="bottom" constant="16" id="qjh-2X-tg8"/>
                 <constraint firstItem="Min-k4-E1V" firstAttribute="leading" secondItem="V2U-ze-ZXE" secondAttribute="trailing" constant="8" id="sU8-FC-tAa"/>
                 <constraint firstItem="Ld5-Mm-4Pt" firstAttribute="leading" secondItem="qQz-rr-NFX" secondAttribute="trailing" constant="8" id="sf9-lW-dIs"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="2Y8-fb-z9V" secondAttribute="trailing" constant="12" id="urz-59-vwm"/>

--- a/iina/Base.lproj/PrefUIViewController.xib
+++ b/iina/Base.lproj/PrefUIViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -48,11 +48,11 @@
         </customView>
         <userDefaultsController representsSharedInstance="YES" id="lH7-Vv-0M1"/>
         <customView id="D77-Iw-nrY">
-            <rect key="frame" x="0.0" y="0.0" width="588" height="396"/>
+            <rect key="frame" x="0.0" y="0.0" width="588" height="402"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField identifier="SectionTitleWindow" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="RFk-nU-SGL">
-                    <rect key="frame" x="-2" y="372" width="61" height="16"/>
+                    <rect key="frame" x="-2" y="378" width="61" height="16"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Window:" id="GKy-3g-4MB">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -60,7 +60,7 @@
                     </textFieldCell>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="RRL-GG-R45">
-                    <rect key="frame" x="118" y="58" width="276" height="18"/>
+                    <rect key="frame" x="118" y="61" width="280" height="16"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="14" id="EmC-Ki-nbg"/>
                     </constraints>
@@ -73,7 +73,7 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WJ8-tU-wDW">
-                    <rect key="frame" x="118" y="184" width="216" height="16"/>
+                    <rect key="frame" x="118" y="186" width="216" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Resize the window to fit video size:" id="Zjr-q7-WsD">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -81,13 +81,13 @@
                     </textFieldCell>
                 </textField>
                 <box title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="0kj-QC-B9P">
-                    <rect key="frame" x="117" y="86" width="466" height="94"/>
+                    <rect key="frame" x="117" y="88" width="466" height="94"/>
                     <view key="contentView" id="EMo-yB-IEL">
                         <rect key="frame" x="3" y="3" width="460" height="88"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button verticalHuggingPriority="750" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="Wn6-zz-utQ">
-                                <rect key="frame" x="14" y="46" width="192" height="18"/>
+                                <rect key="frame" x="15" y="47.5" width="190" height="15"/>
                                 <buttonCell key="cell" type="radio" title="When media is opened manually" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="CJE-ap-IH8">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="message" size="11"/>
@@ -97,7 +97,7 @@
                                 </connections>
                             </button>
                             <button verticalHuggingPriority="750" tag="2" translatesAutoresizingMaskIntoConstraints="NO" id="UhD-Lf-aPQ">
-                                <rect key="frame" x="14" y="28" width="68" height="18"/>
+                                <rect key="frame" x="15" y="29.5" width="67" height="15"/>
                                 <buttonCell key="cell" type="radio" title="Disabled" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="duf-3s-3bL">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="message" size="11"/>
@@ -115,7 +115,7 @@
                                 </textFieldCell>
                             </textField>
                             <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="PxB-We-0Hu">
-                                <rect key="frame" x="116" y="3" width="114" height="22"/>
+                                <rect key="frame" x="115" y="3" width="110" height="22"/>
                                 <popUpButtonCell key="cell" type="push" title="0.5x video size" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="1" imageScaling="proportionallyDown" inset="2" selectedItem="0eK-kv-btH" id="l3o-Df-DQv">
                                     <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="message" size="11"/>
@@ -139,7 +139,7 @@
                                 </connections>
                             </popUpButton>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="z5X-oj-MdV">
-                                <rect key="frame" x="14" y="64" width="59" height="18"/>
+                                <rect key="frame" x="15" y="65.5" width="58" height="15"/>
                                 <buttonCell key="cell" type="radio" title="Always" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="yIN-jg-MxS">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="message" size="11"/>
@@ -169,7 +169,7 @@
                     </view>
                 </box>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="Cut-Nf-Jsy">
-                    <rect key="frame" x="118" y="28" width="219" height="18"/>
+                    <rect key="frame" x="118" y="31" width="223" height="16"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="14" id="tyB-qf-FzP"/>
                     </constraints>
@@ -182,10 +182,10 @@
                     </connections>
                 </button>
                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fnx-bb-tli" customClass="CollapseView" customModule="IINA" customModuleProvider="target">
-                    <rect key="frame" x="120" y="338" width="460" height="50"/>
+                    <rect key="frame" x="120" y="342" width="460" height="52"/>
                     <subviews>
                         <button identifier="Trigger0" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dvv-kN-b5O">
-                            <rect key="frame" x="-2" y="34" width="135" height="18"/>
+                            <rect key="frame" x="-2" y="35" width="139" height="18"/>
                             <buttonCell key="cell" type="check" title="Initial window size:" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="zOq-Em-wUe">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                 <font key="font" metaFont="system"/>
@@ -201,7 +201,7 @@
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sCc-NR-e8c">
-                                        <rect key="frame" x="16" y="7" width="65" height="17"/>
+                                        <rect key="frame" x="16" y="7" width="59" height="17"/>
                                         <popUpButtonCell key="cell" type="roundRect" title="Width:" bezelStyle="roundedRect" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" selectedItem="B1c-oO-fIs" id="I4X-oi-ewe">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="message" size="11"/>
@@ -217,7 +217,7 @@
                                         </connections>
                                     </popUpButton>
                                     <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="l8O-vd-QJ1">
-                                        <rect key="frame" x="89" y="7" width="48" height="19"/>
+                                        <rect key="frame" x="83" y="8" width="48" height="19"/>
                                         <constraints>
                                             <constraint firstAttribute="width" constant="48" id="0dG-yY-0eb"/>
                                         </constraints>
@@ -234,7 +234,7 @@
                                         </connections>
                                     </textField>
                                     <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qkj-q1-pXO">
-                                        <rect key="frame" x="145" y="7" width="88" height="17"/>
+                                        <rect key="frame" x="139" y="7" width="83" height="17"/>
                                         <popUpButtonCell key="cell" type="roundRect" title="point" bezelStyle="roundedRect" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" selectedItem="s2E-9N-K86" id="LLd-2i-Cul">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="message" size="11"/>
@@ -280,10 +280,10 @@
                     </customSpacing>
                 </stackView>
                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="100" verticalStackHuggingPriority="249.99998474121094" horizontalHuggingPriority="100" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5zT-kW-YFh" customClass="CollapseView" customModule="IINA" customModuleProvider="target">
-                    <rect key="frame" x="120" y="216" width="460" height="114"/>
+                    <rect key="frame" x="120" y="218" width="460" height="116"/>
                     <subviews>
                         <button identifier="Trigger1" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tLm-Qr-UNX">
-                            <rect key="frame" x="-2" y="98" width="160" height="18"/>
+                            <rect key="frame" x="-2" y="99" width="164" height="18"/>
                             <buttonCell key="cell" type="check" title="Initial window position:" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Ofm-qE-RgQ">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                 <font key="font" metaFont="system"/>
@@ -307,7 +307,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField identifier="AccessoryLabelXR" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Or6-45-6yM">
-                                        <rect key="frame" x="195" y="52" width="99" height="14"/>
+                                        <rect key="frame" x="189" y="52" width="99" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="side of the screen" id="GXO-iT-BIr">
                                             <font key="font" metaFont="message" size="11"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -340,7 +340,7 @@
                                         </connections>
                                     </textField>
                                     <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IUQ-G3-u2E">
-                                        <rect key="frame" x="125" y="50" width="64" height="17"/>
+                                        <rect key="frame" x="125" y="49" width="58" height="17"/>
                                         <popUpButtonCell key="cell" type="roundRect" title="left" bezelStyle="roundedRect" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" selectedItem="sJe-bK-eHi" id="76K-Jf-BLc">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="message" size="11"/>
@@ -370,7 +370,7 @@
                                         </connections>
                                     </textField>
                                     <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YAe-Ba-x1s">
-                                        <rect key="frame" x="125" y="72" width="88" height="17"/>
+                                        <rect key="frame" x="125" y="71" width="83" height="17"/>
                                         <popUpButtonCell key="cell" type="roundRect" title="point" bezelStyle="roundedRect" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" selectedItem="UhG-bZ-2zY" id="m4d-5a-z57">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="message" size="11"/>
@@ -386,7 +386,7 @@
                                         </connections>
                                     </popUpButton>
                                     <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bnT-bC-1GM">
-                                        <rect key="frame" x="125" y="28" width="88" height="17"/>
+                                        <rect key="frame" x="125" y="27" width="83" height="17"/>
                                         <popUpButtonCell key="cell" type="roundRect" title="point" bezelStyle="roundedRect" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" selectedItem="X5B-TZ-ISz" id="BVR-o1-t9c">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="message" size="11"/>
@@ -410,7 +410,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Y9m-YR-TwG">
-                                        <rect key="frame" x="125" y="6" width="64" height="17"/>
+                                        <rect key="frame" x="125" y="5" width="58" height="17"/>
                                         <popUpButtonCell key="cell" type="roundRect" title="top" bezelStyle="roundedRect" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" selectedItem="oYc-L7-qQd" id="QKV-hq-SAL">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="message" size="11"/>
@@ -426,7 +426,7 @@
                                         </connections>
                                     </popUpButton>
                                     <textField identifier="AccessoryLabelYR" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wWi-dP-Ekg">
-                                        <rect key="frame" x="195" y="8" width="74" height="14"/>
+                                        <rect key="frame" x="189" y="8" width="74" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="of the screen" id="iRn-3s-oQH">
                                             <font key="font" metaFont="message" size="11"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -501,7 +501,7 @@
                     </customSpacing>
                 </stackView>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="CFe-du-HcB">
-                    <rect key="frame" x="118" y="6" width="301" height="18"/>
+                    <rect key="frame" x="118" y="7" width="305" height="18"/>
                     <buttonCell key="cell" type="check" title="Always show float on top status in the title bar" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="ih8-5a-PYY">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -554,10 +554,10 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="GbG-nw-ict">
-                    <rect key="frame" x="175" y="289" width="185" height="25"/>
+                    <rect key="frame" x="174" y="288" width="187" height="25"/>
                     <popUpButtonCell key="cell" type="push" title="Floating" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="7Dv-q2-5TV" id="XRT-QK-HPy">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="menu"/>
                         <menu key="menu" id="pgN-77-bP2">
                             <items>
                                 <menuItem title="Floating" state="on" id="7Dv-q2-5TV"/>
@@ -580,7 +580,7 @@
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="252" translatesAutoresizingMaskIntoConstraints="NO" id="nDu-Yq-tPI">
-                    <rect key="frame" x="118" y="58" width="205" height="18"/>
+                    <rect key="frame" x="118" y="57" width="209" height="18"/>
                     <buttonCell key="cell" type="check" title="Snap to center when dragging" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="mdD-if-Wqw">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -590,7 +590,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="OMM-mG-Uts">
-                    <rect key="frame" x="118" y="36" width="252" height="18"/>
+                    <rect key="frame" x="118" y="33" width="256" height="18"/>
                     <buttonCell key="cell" type="check" title="Show chapter position in progress bar" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="BVV-Z3-LHR">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -608,7 +608,7 @@
                     </textFieldCell>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="rft-T0-lds">
-                    <rect key="frame" x="118" y="6" width="297" height="26"/>
+                    <rect key="frame" x="118" y="7" width="301" height="20"/>
                     <buttonCell key="cell" type="check" title="Show remaining time instead of total duration" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="EAa-gN-8dL">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -681,7 +681,7 @@
                     <rect key="frame" x="305" y="151" width="84" height="19"/>
                     <buttonCell key="cell" type="roundRect" title="Customize…" bezelStyle="roundedRect" alignment="center" borderStyle="border" inset="2" id="1nM-AX-Ozm">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="label" size="12"/>
+                        <font key="font" metaFont="cellTitle"/>
                     </buttonCell>
                     <connections>
                         <action selector="customizeOSCToolbarAction:" target="-2" id="PNf-5j-NuN"/>
@@ -704,10 +704,10 @@
                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="speed" id="PCr-gs-9Yc"/>
                 </imageView>
                 <popUpButton verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="SyB-0R-TLF">
-                    <rect key="frame" x="273" y="116" width="172" height="25"/>
+                    <rect key="frame" x="272" y="115" width="173" height="25"/>
                     <popUpButtonCell key="cell" type="push" title="Speed" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="TWq-Xb-8Ee" id="8Ke-vJ-gp6">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="menu"/>
                         <menu key="menu" id="tw8-Om-zad">
                             <items>
                                 <menuItem title="Speed" state="on" id="TWq-Xb-8Ee"/>
@@ -802,11 +802,11 @@
             <point key="canvasLocation" x="15" y="368"/>
         </customView>
         <customView id="c8m-G4-or8">
-            <rect key="frame" x="0.0" y="0.0" width="515" height="116"/>
+            <rect key="frame" x="0.0" y="0.0" width="515" height="120"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField identifier="SectionTitleOSD" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zyi-J3-lSp">
-                    <rect key="frame" x="-2" y="76" width="124" height="32"/>
+                    <rect key="frame" x="-2" y="80" width="124" height="32"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="On Screen Display:" id="F2e-CS-KXl">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -814,7 +814,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qNv-Yk-nvp">
-                    <rect key="frame" x="222" y="59" width="58" height="21"/>
+                    <rect key="frame" x="222" y="61" width="58" height="21"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="58" id="J5e-Bd-2ub"/>
                     </constraints>
@@ -836,7 +836,7 @@
                     </connections>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bGH-kO-7Rd">
-                    <rect key="frame" x="118" y="62" width="98" height="16"/>
+                    <rect key="frame" x="118" y="64" width="98" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Auto hide after:" id="NUr-hY-gfo">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -844,7 +844,7 @@
                     </textFieldCell>
                 </textField>
                 <textField identifier="AccessoryLabelOSDAutoHide" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oz1-yC-uZC">
-                    <rect key="frame" x="286" y="62" width="11" height="16"/>
+                    <rect key="frame" x="286" y="64" width="11" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="s" id="ObY-7B-NTO">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -852,7 +852,7 @@
                     </textFieldCell>
                 </textField>
                 <textField identifier="AccessoryLabelTextSize" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HcO-CN-3qi">
-                    <rect key="frame" x="286" y="38" width="17" height="16"/>
+                    <rect key="frame" x="286" y="40" width="17" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="pt" id="I8t-ey-016">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -860,7 +860,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wDT-XM-dyY">
-                    <rect key="frame" x="222" y="35" width="58" height="21"/>
+                    <rect key="frame" x="222" y="37" width="58" height="21"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="58" id="rtB-DT-Hgf"/>
                     </constraints>
@@ -882,7 +882,7 @@
                     </connections>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2xg-kt-Cz4">
-                    <rect key="frame" x="118" y="6" width="313" height="18"/>
+                    <rect key="frame" x="118" y="7" width="317" height="18"/>
                     <buttonCell key="cell" type="check" title="Display time and battery info when in full screen" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="kOT-8q-E57">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -893,7 +893,7 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="63o-gu-DxA">
-                    <rect key="frame" x="118" y="38" width="98" height="16"/>
+                    <rect key="frame" x="118" y="40" width="98" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Text size:" id="suy-e8-j4i">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -901,7 +901,7 @@
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="MU2-yF-bjd">
-                    <rect key="frame" x="118" y="92" width="94" height="18"/>
+                    <rect key="frame" x="118" y="95" width="98" height="18"/>
                     <buttonCell key="cell" type="check" title="Enable OSD" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="xMh-SP-nkc">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -941,11 +941,11 @@
             <point key="canvasLocation" x="-30.5" y="670"/>
         </customView>
         <customView id="3uJ-UU-1zw">
-            <rect key="frame" x="0.0" y="0.0" width="586" height="55"/>
+            <rect key="frame" x="0.0" y="0.0" width="586" height="56"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField identifier="SectionTitleThumb" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="maZ-e8-1vw">
-                    <rect key="frame" x="-2" y="15" width="124" height="32"/>
+                    <rect key="frame" x="-2" y="16" width="124" height="32"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Thumbnail Preview:" id="kYu-0l-jQQ">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -953,7 +953,7 @@
                     </textFieldCell>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="mvX-qm-iUh">
-                    <rect key="frame" x="118" y="30" width="177" height="19"/>
+                    <rect key="frame" x="118" y="31" width="181" height="18"/>
                     <buttonCell key="cell" type="check" title="Enable thumbnail preview" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Xey-3m-f6G">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -982,7 +982,7 @@
                         </binding>
                     </connections>
                 </textField>
-                <textField identifier="AccessoryLabelThumbSize" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Oba-nc-n1C">
+                <textField identifier="MaximumCacheSizeMb" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Oba-nc-n1C">
                     <rect key="frame" x="322" y="8" width="24" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="MB" id="3jK-z5-NDH">
                         <font key="font" metaFont="system"/>
@@ -998,23 +998,65 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VqQ-ue-KEO">
+                    <rect key="frame" x="362" y="8" width="44" height="16"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Width:" id="f0s-sH-rz8">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QSd-B9-68V">
+                    <rect key="frame" x="412" y="6" width="58" height="21"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="58" id="173-i4-0c1"/>
+                    </constraints>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="7dK-R3-myd">
+                        <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="j4q-On-bD7"/>
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                    <connections>
+                        <binding destination="lH7-Vv-0M1" name="enabled" keyPath="values.enableThumbnailPreview" id="tbL-hW-LEk"/>
+                        <binding destination="lH7-Vv-0M1" name="value" keyPath="values.thumbnailWidth" id="aLp-SR-8fZ">
+                            <dictionary key="options">
+                                <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                            </dictionary>
+                        </binding>
+                    </connections>
+                </textField>
+                <textField identifier="MaximumCacheWidthPx" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3kE-zA-EH8">
+                    <rect key="frame" x="476" y="8" width="19" height="16"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="px" id="F9N-Mm-Fvd">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
             </subviews>
             <constraints>
                 <constraint firstItem="Oba-nc-n1C" firstAttribute="baseline" secondItem="bWp-lc-kLe" secondAttribute="baseline" id="2fJ-Tc-1Da"/>
                 <constraint firstItem="bWp-lc-kLe" firstAttribute="leading" secondItem="xqx-cU-0OC" secondAttribute="trailing" constant="8" id="5gx-ii-N0Y"/>
                 <constraint firstItem="xqx-cU-0OC" firstAttribute="leading" secondItem="mvX-qm-iUh" secondAttribute="leading" id="A34-EA-ctI"/>
+                <constraint firstItem="VqQ-ue-KEO" firstAttribute="centerY" secondItem="Oba-nc-n1C" secondAttribute="centerY" id="Aqt-vS-wbk"/>
                 <constraint firstItem="maZ-e8-1vw" firstAttribute="top" secondItem="3uJ-UU-1zw" secondAttribute="top" constant="8" id="CZG-V2-oQu"/>
                 <constraint firstItem="bWp-lc-kLe" firstAttribute="baseline" secondItem="xqx-cU-0OC" secondAttribute="baseline" id="G2Y-xj-UUl"/>
+                <constraint firstItem="3kE-zA-EH8" firstAttribute="centerY" secondItem="VqQ-ue-KEO" secondAttribute="centerY" id="Inj-VW-V2v"/>
                 <constraint firstItem="maZ-e8-1vw" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="3uJ-UU-1zw" secondAttribute="leading" constant="120" id="Pwz-CG-l82"/>
                 <constraint firstItem="mvX-qm-iUh" firstAttribute="leading" secondItem="3uJ-UU-1zw" secondAttribute="leading" constant="120" id="TeW-h0-jeX"/>
                 <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="maZ-e8-1vw" secondAttribute="bottom" constant="8" id="Ty1-mR-i3A"/>
                 <constraint firstItem="maZ-e8-1vw" firstAttribute="leading" secondItem="3uJ-UU-1zw" secondAttribute="leading" id="VMF-e9-dcW"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="3kE-zA-EH8" secondAttribute="trailing" constant="8" id="fgQ-os-aSK"/>
+                <constraint firstItem="VqQ-ue-KEO" firstAttribute="leading" secondItem="Oba-nc-n1C" secondAttribute="trailing" constant="20" id="gzY-vY-vB8"/>
                 <constraint firstItem="Oba-nc-n1C" firstAttribute="leading" secondItem="bWp-lc-kLe" secondAttribute="trailing" constant="8" id="j47-cM-6lS"/>
+                <constraint firstItem="QSd-B9-68V" firstAttribute="centerY" secondItem="VqQ-ue-KEO" secondAttribute="centerY" id="kNj-eJ-gn0"/>
                 <constraint firstItem="mvX-qm-iUh" firstAttribute="top" secondItem="maZ-e8-1vw" secondAttribute="top" id="sWO-ib-fQQ"/>
+                <constraint firstItem="QSd-B9-68V" firstAttribute="leading" secondItem="VqQ-ue-KEO" secondAttribute="trailing" constant="8" id="skQ-xf-Glx"/>
                 <constraint firstItem="xqx-cU-0OC" firstAttribute="top" secondItem="mvX-qm-iUh" secondAttribute="bottom" constant="8" id="wJr-Nj-3pz"/>
                 <constraint firstAttribute="bottom" secondItem="xqx-cU-0OC" secondAttribute="bottom" constant="8" id="wSc-cB-mLr"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Oba-nc-n1C" secondAttribute="trailing" id="wxc-GQ-2XV"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="mvX-qm-iUh" secondAttribute="trailing" id="zVT-gB-Pix"/>
+                <constraint firstItem="3kE-zA-EH8" firstAttribute="leading" secondItem="QSd-B9-68V" secondAttribute="trailing" constant="8" id="zpr-Wi-BPS"/>
             </constraints>
             <point key="canvasLocation" x="5" y="832"/>
         </customView>
@@ -1031,13 +1073,13 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FNR-0h-DtW">
-                    <rect key="frame" x="172" y="2" width="201" height="25"/>
+                    <rect key="frame" x="171" y="1" width="202" height="25"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="115" id="Xa5-Xs-E4o"/>
                     </constraints>
                     <popUpButtonCell key="cell" type="push" title="Dark" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="VvZ-mQ-wQB" id="Qe2-v8-Xh7">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="menu"/>
                         <menu key="menu" id="Cpu-U2-hGC">
                             <items>
                                 <menuItem title="Dark" state="on" id="VvZ-mQ-wQB"/>
@@ -1075,11 +1117,11 @@
             <point key="canvasLocation" x="15" y="-266"/>
         </customView>
         <customView id="1fz-oP-RhZ">
-            <rect key="frame" x="0.0" y="0.0" width="588" height="118"/>
+            <rect key="frame" x="0.0" y="0.0" width="588" height="122"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField identifier="SectionTitlePictureInPicture" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ghC-br-cK9">
-                    <rect key="frame" x="-2" y="78" width="124" height="32"/>
+                    <rect key="frame" x="-2" y="82" width="124" height="32"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" id="G8w-J7-1q1" userLabel="Picture-in- Picture:">
                         <font key="font" metaFont="systemBold"/>
                         <string key="title">Picture-in-
@@ -1089,7 +1131,7 @@ Picture:</string>
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="A7f-Up-23R">
-                    <rect key="frame" x="118" y="6" width="425" height="18"/>
+                    <rect key="frame" x="118" y="7" width="428" height="18"/>
                     <buttonCell key="cell" type="check" title="Toggle Picture-in-Picture by minimizing/un-minimizing the window" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="baY-O6-fcB">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -1099,7 +1141,7 @@ Picture:</string>
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="l21-mq-zWd">
-                    <rect key="frame" x="118" y="94" width="209" height="16"/>
+                    <rect key="frame" x="118" y="98" width="209" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="When entering Picture-in-Picture:" id="EUd-RD-g0T">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1107,13 +1149,13 @@ Picture:</string>
                     </textFieldCell>
                 </textField>
                 <box title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="eTQ-fy-fNJ">
-                    <rect key="frame" x="117" y="34" width="466" height="56"/>
+                    <rect key="frame" x="117" y="36" width="466" height="58"/>
                     <view key="contentView" id="ucO-5V-y9Y">
-                        <rect key="frame" x="3" y="3" width="460" height="50"/>
+                        <rect key="frame" x="3" y="3" width="460" height="52"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField identifier="AccessoryLabelWindowAction" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aYB-ub-yxd">
-                                <rect key="frame" x="14" y="28" width="50" height="14"/>
+                                <rect key="frame" x="14" y="30" width="50" height="14"/>
                                 <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Window:" id="AmS-Sl-b2h">
                                     <font key="font" metaFont="message" size="11"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1121,7 +1163,7 @@ Picture:</string>
                                 </textFieldCell>
                             </textField>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="o7N-Tm-Aly">
-                                <rect key="frame" x="68" y="26" width="80" height="18"/>
+                                <rect key="frame" x="69" y="29.5" width="79" height="15"/>
                                 <buttonCell key="cell" type="radio" title="Do nothing" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="Zc7-sP-Rdp">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="message" size="11"/>
@@ -1131,7 +1173,7 @@ Picture:</string>
                                 </connections>
                             </button>
                             <button verticalHuggingPriority="750" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="BMA-ed-2gf">
-                                <rect key="frame" x="153" y="26" width="47" height="18"/>
+                                <rect key="frame" x="155" y="29.5" width="46" height="15"/>
                                 <buttonCell key="cell" type="radio" title="Hide" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="xtL-XT-xzb">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="message" size="11"/>
@@ -1141,7 +1183,7 @@ Picture:</string>
                                 </connections>
                             </button>
                             <button verticalHuggingPriority="750" tag="2" translatesAutoresizingMaskIntoConstraints="NO" id="YWw-1J-3Gr">
-                                <rect key="frame" x="205" y="26" width="69" height="18"/>
+                                <rect key="frame" x="208" y="29.5" width="68" height="15"/>
                                 <buttonCell key="cell" type="radio" title="Minimize" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="H1F-mm-Saq">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="message" size="11"/>
@@ -1151,7 +1193,7 @@ Picture:</string>
                                 </connections>
                             </button>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="W5N-fX-5w2">
-                                <rect key="frame" x="13" y="5" width="178" height="18"/>
+                                <rect key="frame" x="15" y="7" width="177" height="16"/>
                                 <buttonCell key="cell" type="check" title="Automatically pause playback" bezelStyle="regularSquare" imagePosition="left" controlSize="small" state="on" inset="2" id="O8C-Vi-rSp">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="message" size="11"/>

--- a/iina/Base.lproj/QuickSettingViewController.xib
+++ b/iina/Base.lproj/QuickSettingViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19455" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19455"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -35,6 +35,7 @@
                 <outlet property="deinterlaceSwitch" destination="2FQ-VQ-dTd" id="snK-5x-1Gh"/>
                 <outlet property="gammaSlider" destination="SL7-DZ-5ff" id="CFA-xb-DCH"/>
                 <outlet property="hardwareDecodingSwitch" destination="0pq-Hh-3hb" id="53n-xc-rxs"/>
+                <outlet property="hdrSwitch" destination="0RB-r2-J8C" id="Yov-nL-YFt"/>
                 <outlet property="hueSlider" destination="ntv-89-1iw" id="dQo-yf-zVI"/>
                 <outlet property="rotateSegment" destination="bza-SA-tXE" id="Sdw-vn-MUV"/>
                 <outlet property="saturationSlider" destination="qeO-tk-I0D" id="uDF-fx-afd"/>
@@ -67,10 +68,10 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY" customClass="QuickSettingView" customModule="IINA" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="360" height="871"/>
+            <rect key="frame" x="0.0" y="0.0" width="360" height="823"/>
             <subviews>
                 <stackView distribution="equalSpacing" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="250" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dNi-Ib-2vd">
-                    <rect key="frame" x="0.0" y="823" width="360" height="48"/>
+                    <rect key="frame" x="0.0" y="775" width="360" height="48"/>
                     <subviews>
                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="129-cv-qAR">
                             <rect key="frame" x="0.0" y="0.0" width="0.0" height="48"/>
@@ -136,31 +137,31 @@
                     </customSpacing>
                 </stackView>
                 <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="L78-cf-BxB">
-                    <rect key="frame" x="0.0" y="820" width="360" height="5"/>
+                    <rect key="frame" x="0.0" y="772" width="360" height="5"/>
                 </box>
                 <tabView drawsBackground="NO" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="udA-m2-eJb">
-                    <rect key="frame" x="0.0" y="0.0" width="360" height="823"/>
+                    <rect key="frame" x="0.0" y="0.0" width="360" height="775"/>
                     <font key="font" metaFont="system"/>
                     <tabViewItems>
                         <tabViewItem label="Video" identifier="1" id="CYP-el-A6A">
                             <view key="view" id="NRI-ba-KMd">
-                                <rect key="frame" x="0.0" y="0.0" width="360" height="823"/>
+                                <rect key="frame" x="0.0" y="0.0" width="360" height="775"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="SHU-hX-9MT">
-                                        <rect key="frame" x="0.0" y="0.0" width="360" height="823"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="775"/>
                                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="8Es-YX-dNf">
-                                            <rect key="frame" x="0.0" y="0.0" width="360" height="823"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="360" height="775"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
-                                                <view translatesAutoresizingMaskIntoConstraints="NO" id="ZGz-La-n9c" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="100" width="360" height="723"/>
+                                                <view ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZGz-La-n9c" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
+                                                    <rect key="frame" x="0.0" y="52" width="360" height="821"/>
                                                     <subviews>
-                                                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="5v4-Te-950">
-                                                            <rect key="frame" x="0.0" y="0.0" width="360" height="723"/>
+                                                        <customView ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5v4-Te-950">
+                                                            <rect key="frame" x="0.0" y="52" width="360" height="769"/>
                                                             <subviews>
-                                                                <scrollView focusRingType="none" borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ykw-rb-M9D">
-                                                                    <rect key="frame" x="0.0" y="603" width="360" height="76"/>
+                                                                <scrollView focusRingType="none" ambiguous="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ykw-rb-M9D">
+                                                                    <rect key="frame" x="0.0" y="649" width="360" height="76"/>
                                                                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="jek-w4-LTf">
                                                                         <rect key="frame" x="0.0" y="0.0" width="360" height="76"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -189,9 +190,11 @@
                                                                                                 <rect key="frame" x="1" y="1" width="21" height="17"/>
                                                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                                                 <subviews>
-                                                                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kfS-xI-KPe">
+                                                                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="kfS-xI-KPe">
                                                                                                         <rect key="frame" x="0.0" y="0.0" width="21" height="17"/>
-                                                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                                                                        <constraints>
+                                                                                                            <constraint firstAttribute="height" constant="17" id="n4q-6o-nJA"/>
+                                                                                                        </constraints>
                                                                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="dlX-H5-BCo">
                                                                                                             <font key="font" metaFont="system"/>
                                                                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -202,6 +205,11 @@
                                                                                                         </connections>
                                                                                                     </textField>
                                                                                                 </subviews>
+                                                                                                <constraints>
+                                                                                                    <constraint firstItem="kfS-xI-KPe" firstAttribute="centerX" secondItem="99i-8I-ANv" secondAttribute="centerX" id="bVs-3O-cve"/>
+                                                                                                    <constraint firstItem="kfS-xI-KPe" firstAttribute="centerY" secondItem="99i-8I-ANv" secondAttribute="centerY" id="hsg-gb-1mY"/>
+                                                                                                    <constraint firstItem="kfS-xI-KPe" firstAttribute="leading" secondItem="99i-8I-ANv" secondAttribute="leading" constant="2" id="teA-7a-W8B"/>
+                                                                                                </constraints>
                                                                                                 <connections>
                                                                                                     <outlet property="textField" destination="kfS-xI-KPe" id="bhC-fw-C4F"/>
                                                                                                 </connections>
@@ -224,9 +232,11 @@
                                                                                                 <rect key="frame" x="25" y="1" width="22" height="17"/>
                                                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                                                 <subviews>
-                                                                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="s0D-BR-Bfy">
+                                                                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="s0D-BR-Bfy">
                                                                                                         <rect key="frame" x="0.0" y="0.0" width="22" height="17"/>
-                                                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                                                                        <constraints>
+                                                                                                            <constraint firstAttribute="height" constant="17" id="8dq-95-hrV"/>
+                                                                                                        </constraints>
                                                                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="Pf6-Fd-0mO">
                                                                                                             <font key="font" metaFont="systemBold"/>
                                                                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -237,6 +247,11 @@
                                                                                                         </connections>
                                                                                                     </textField>
                                                                                                 </subviews>
+                                                                                                <constraints>
+                                                                                                    <constraint firstItem="s0D-BR-Bfy" firstAttribute="centerY" secondItem="EOK-X6-h3U" secondAttribute="centerY" id="bJJ-tz-D19"/>
+                                                                                                    <constraint firstItem="s0D-BR-Bfy" firstAttribute="leading" secondItem="EOK-X6-h3U" secondAttribute="leading" constant="2" id="gTn-e6-tMo"/>
+                                                                                                    <constraint firstItem="s0D-BR-Bfy" firstAttribute="centerX" secondItem="EOK-X6-h3U" secondAttribute="centerX" id="rs5-dj-vfK"/>
+                                                                                                </constraints>
                                                                                                 <connections>
                                                                                                     <outlet property="textField" destination="s0D-BR-Bfy" id="Gdk-1b-JTF"/>
                                                                                                 </connections>
@@ -259,9 +274,11 @@
                                                                                                 <rect key="frame" x="50" y="1" width="308" height="17"/>
                                                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                                                 <subviews>
-                                                                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="r2o-di-dN5">
+                                                                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="r2o-di-dN5">
                                                                                                         <rect key="frame" x="0.0" y="0.0" width="308" height="17"/>
-                                                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                                                                        <constraints>
+                                                                                                            <constraint firstAttribute="height" constant="17" id="103-BE-POM"/>
+                                                                                                        </constraints>
                                                                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="jWy-C5-Xu9">
                                                                                                             <font key="font" metaFont="system"/>
                                                                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -272,6 +289,11 @@
                                                                                                         </connections>
                                                                                                     </textField>
                                                                                                 </subviews>
+                                                                                                <constraints>
+                                                                                                    <constraint firstItem="r2o-di-dN5" firstAttribute="centerX" secondItem="QLv-Qp-hCf" secondAttribute="centerX" id="Auo-az-e1w"/>
+                                                                                                    <constraint firstItem="r2o-di-dN5" firstAttribute="centerY" secondItem="QLv-Qp-hCf" secondAttribute="centerY" id="c2L-Zk-Us7"/>
+                                                                                                    <constraint firstItem="r2o-di-dN5" firstAttribute="leading" secondItem="QLv-Qp-hCf" secondAttribute="leading" constant="2" id="tF7-yO-AfY"/>
+                                                                                                </constraints>
                                                                                                 <connections>
                                                                                                     <outlet property="textField" destination="r2o-di-dN5" id="wA6-wm-GAV"/>
                                                                                                 </connections>
@@ -294,16 +316,16 @@
                                                                         <autoresizingMask key="autoresizingMask"/>
                                                                     </scroller>
                                                                 </scrollView>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ng5-FC-tts">
-                                                                    <rect key="frame" x="17" y="687" width="83" height="16"/>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ng5-FC-tts">
+                                                                    <rect key="frame" x="17" y="733" width="83" height="16"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Video track:" id="VzC-tM-KT7">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="g3A-4u-nNt">
-                                                                    <rect key="frame" x="20" y="536" width="254" height="24"/>
+                                                                <scrollView ambiguous="YES" borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="g3A-4u-nNt">
+                                                                    <rect key="frame" x="20" y="582" width="254" height="24"/>
                                                                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="qKQ-r0-Z3k">
                                                                         <rect key="frame" x="0.0" y="0.0" width="254" height="24"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -355,16 +377,16 @@
                                                                         <autoresizingMask key="autoresizingMask"/>
                                                                     </scroller>
                                                                 </scrollView>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8ZJ-PD-t0R">
-                                                                    <rect key="frame" x="17" y="567" width="91" height="16"/>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8ZJ-PD-t0R">
+                                                                    <rect key="frame" x="17" y="613" width="91" height="16"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Aspect Ratio:" id="YgL-iV-bca">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XAI-y0-tcy">
-                                                                    <rect key="frame" x="282" y="538" width="58" height="21"/>
+                                                                <textField verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XAI-y0-tcy">
+                                                                    <rect key="frame" x="282" y="584" width="58" height="21"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="58" id="6bj-r1-RIj"/>
                                                                     </constraints>
@@ -377,16 +399,16 @@
                                                                         <action selector="customAspectEditFinishedAction:" target="-2" id="8DL-tk-4rJ"/>
                                                                     </connections>
                                                                 </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oAm-jJ-3kE">
-                                                                    <rect key="frame" x="17" y="499" width="40" height="16"/>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oAm-jJ-3kE">
+                                                                    <rect key="frame" x="17" y="545" width="40" height="16"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Crop:" id="m9e-IB-IDJ">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <button verticalHuggingPriority="750" horizontalCompressionResistancePriority="720" translatesAutoresizingMaskIntoConstraints="NO" id="ItN-JT-puN">
-                                                                    <rect key="frame" x="254" y="463" width="93" height="32"/>
+                                                                <button verticalHuggingPriority="750" horizontalCompressionResistancePriority="720" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ItN-JT-puN">
+                                                                    <rect key="frame" x="254" y="509" width="93" height="32"/>
                                                                     <buttonCell key="cell" type="push" title="Custom..." bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="vFD-HU-RVz">
                                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                                         <font key="font" metaFont="system"/>
@@ -395,8 +417,8 @@
                                                                         <action selector="cropBtnAction:" target="-2" id="5b5-dQ-OPB"/>
                                                                     </connections>
                                                                 </button>
-                                                                <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="dsX-c1-BZP">
-                                                                    <rect key="frame" x="20" y="468" width="233" height="24"/>
+                                                                <scrollView ambiguous="YES" borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="dsX-c1-BZP">
+                                                                    <rect key="frame" x="20" y="514" width="233" height="24"/>
                                                                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="xML-5l-47G">
                                                                         <rect key="frame" x="0.0" y="0.0" width="233" height="24"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -448,16 +470,16 @@
                                                                         <autoresizingMask key="autoresizingMask"/>
                                                                     </scroller>
                                                                 </scrollView>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7vv-En-VYY">
-                                                                    <rect key="frame" x="17" y="431" width="64" height="16"/>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7vv-En-VYY">
+                                                                    <rect key="frame" x="17" y="477" width="64" height="16"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Rotation:" id="to3-rc-Agv">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bza-SA-tXE">
-                                                                    <rect key="frame" x="18" y="400" width="151" height="24"/>
+                                                                <segmentedControl verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bza-SA-tXE">
+                                                                    <rect key="frame" x="18" y="446" width="151" height="24"/>
                                                                     <segmentedCell key="cell" borderStyle="border" alignment="left" style="rounded" trackingMode="selectOne" id="z1L-0N-dfK">
                                                                         <font key="font" metaFont="system"/>
                                                                         <segments>
@@ -471,8 +493,8 @@
                                                                         <action selector="rotationChangedAction:" target="-2" id="aL1-XS-nLe"/>
                                                                     </connections>
                                                                 </segmentedControl>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wBg-Dk-cUX">
-                                                                    <rect key="frame" x="93" y="320" width="18" height="14"/>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wBg-Dk-cUX">
+                                                                    <rect key="frame" x="93" y="366" width="18" height="14"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="14" id="ScZ-Cn-Mii"/>
                                                                     </constraints>
@@ -482,16 +504,16 @@
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Njq-za-TIf">
-                                                                    <rect key="frame" x="167" y="323" width="19" height="11"/>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Njq-za-TIf">
+                                                                    <rect key="frame" x="167" y="369" width="19" height="11"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="4x" id="PLX-gY-e0h">
                                                                         <font key="font" metaFont="label" size="9"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UWh-M9-5Nw">
-                                                                    <rect key="frame" x="19" y="333" width="240" height="20"/>
+                                                                <slider verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UWh-M9-5Nw">
+                                                                    <rect key="frame" x="19" y="379" width="240" height="20"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="236" id="mhI-LR-I5w"/>
                                                                     </constraints>
@@ -500,16 +522,16 @@
                                                                         <action selector="speedChangedAction:" target="-2" id="asr-iq-ZNJ"/>
                                                                     </connections>
                                                                 </slider>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3EN-WD-QNI" userLabel="Speed Slider Indicator">
-                                                                    <rect key="frame" x="92" y="351" width="19" height="13"/>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3EN-WD-QNI" userLabel="Speed Slider Indicator">
+                                                                    <rect key="frame" x="92" y="397" width="19" height="13"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="1x" usesSingleLineMode="YES" id="ldQ-YL-IEp">
                                                                         <font key="font" metaFont="system" size="10"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mjX-Jf-925">
-                                                                    <rect key="frame" x="239" y="320" width="20" height="14"/>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mjX-Jf-925">
+                                                                    <rect key="frame" x="239" y="366" width="20" height="14"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="14" id="Duh-ya-4aq"/>
                                                                     </constraints>
@@ -519,16 +541,16 @@
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="d4r-sL-0Vo">
-                                                                    <rect key="frame" x="17" y="363" width="50" height="16"/>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="d4r-sL-0Vo">
+                                                                    <rect key="frame" x="17" y="409" width="50" height="16"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Speed:" id="1KQ-oZ-A2x">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nhb-Co-xbZ">
-                                                                    <rect key="frame" x="19" y="320" width="29" height="14"/>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nhb-Co-xbZ">
+                                                                    <rect key="frame" x="19" y="366" width="29" height="14"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="14" id="JVv-2s-ysw"/>
                                                                     </constraints>
@@ -538,8 +560,8 @@
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sIs-a1-rGR">
-                                                                    <rect key="frame" x="267" y="333" width="57" height="21"/>
+                                                                <textField verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sIs-a1-rGR">
+                                                                    <rect key="frame" x="267" y="379" width="57" height="21"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="57" id="Ood-Jd-gLJ"/>
                                                                     </constraints>
@@ -555,26 +577,18 @@
                                                                         <action selector="customSpeedEditFinishedAction:" target="-2" id="f1u-Mu-w4S"/>
                                                                     </connections>
                                                                 </textField>
-                                                                <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="IWj-Dg-ZDI">
-                                                                    <rect key="frame" x="0.0" y="210" width="360" height="5"/>
+                                                                <box verticalHuggingPriority="750" misplaced="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="IWj-Dg-ZDI">
+                                                                    <rect key="frame" x="0.0" y="199" width="360" height="5"/>
                                                                 </box>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dFy-zT-BqP">
-                                                                    <rect key="frame" x="17" y="172" width="64" height="16"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Equalizer" id="Xez-sb-mfB">
-                                                                        <font key="font" metaFont="systemBold"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sBU-NZ-sp3">
-                                                                    <rect key="frame" x="91" y="136" width="220" height="20"/>
+                                                                <slider verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sBU-NZ-sp3">
+                                                                    <rect key="frame" x="91" y="132" width="220" height="20"/>
                                                                     <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="0Sg-Ca-QjC"/>
                                                                     <connections>
                                                                         <action selector="equalizerSliderAction:" target="-2" id="bF8-qZ-hks"/>
                                                                     </connections>
                                                                 </slider>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KVn-1o-Qzh">
-                                                                    <rect key="frame" x="18" y="136" width="76" height="17"/>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KVn-1o-Qzh">
+                                                                    <rect key="frame" x="18" y="132" width="76" height="17"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="72" id="TvH-N9-GfJ"/>
                                                                         <constraint firstAttribute="height" constant="17" id="X61-kd-B4a"/>
@@ -585,15 +599,15 @@
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0Ww-YT-a8e">
-                                                                    <rect key="frame" x="91" y="108" width="220" height="20"/>
+                                                                <slider verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0Ww-YT-a8e">
+                                                                    <rect key="frame" x="91" y="104" width="220" height="20"/>
                                                                     <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="d8Q-Fw-bbA"/>
                                                                     <connections>
                                                                         <action selector="equalizerSliderAction:" target="-2" id="Mtl-BL-VYs"/>
                                                                     </connections>
                                                                 </slider>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8Uj-eX-hSm">
-                                                                    <rect key="frame" x="18" y="108" width="76" height="17"/>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8Uj-eX-hSm">
+                                                                    <rect key="frame" x="18" y="104" width="76" height="17"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="17" id="SUH-N6-OC2"/>
                                                                     </constraints>
@@ -603,15 +617,15 @@
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qeO-tk-I0D">
-                                                                    <rect key="frame" x="91" y="80" width="220" height="20"/>
+                                                                <slider verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qeO-tk-I0D">
+                                                                    <rect key="frame" x="91" y="76" width="220" height="20"/>
                                                                     <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="aEN-2P-ffr"/>
                                                                     <connections>
                                                                         <action selector="equalizerSliderAction:" target="-2" id="64F-Yg-BY8"/>
                                                                     </connections>
                                                                 </slider>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2Zt-RU-LEK">
-                                                                    <rect key="frame" x="18" y="80" width="76" height="17"/>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2Zt-RU-LEK">
+                                                                    <rect key="frame" x="18" y="76" width="76" height="17"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="17" id="EAl-du-IHD"/>
                                                                     </constraints>
@@ -621,15 +635,15 @@
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SL7-DZ-5ff">
-                                                                    <rect key="frame" x="91" y="52" width="220" height="20"/>
+                                                                <slider verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="SL7-DZ-5ff">
+                                                                    <rect key="frame" x="91" y="48" width="220" height="20"/>
                                                                     <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="IEh-at-wdd"/>
                                                                     <connections>
                                                                         <action selector="equalizerSliderAction:" target="-2" id="h5f-VW-qGS"/>
                                                                     </connections>
                                                                 </slider>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kYz-ZC-58W">
-                                                                    <rect key="frame" x="18" y="52" width="76" height="17"/>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kYz-ZC-58W">
+                                                                    <rect key="frame" x="18" y="48" width="76" height="17"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="17" id="uQX-b9-7MG"/>
                                                                     </constraints>
@@ -639,15 +653,15 @@
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ntv-89-1iw">
-                                                                    <rect key="frame" x="91" y="24" width="220" height="20"/>
+                                                                <slider verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ntv-89-1iw">
+                                                                    <rect key="frame" x="91" y="20" width="220" height="20"/>
                                                                     <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="MTr-Ze-dRm"/>
                                                                     <connections>
                                                                         <action selector="equalizerSliderAction:" target="-2" id="b6L-ZX-hlF"/>
                                                                     </connections>
                                                                 </slider>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nEK-El-M50">
-                                                                    <rect key="frame" x="18" y="24" width="76" height="17"/>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nEK-El-M50">
+                                                                    <rect key="frame" x="18" y="20" width="76" height="17"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="17" id="fmX-dE-dgH"/>
                                                                     </constraints>
@@ -657,8 +671,8 @@
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="RVg-iv-SLo">
-                                                                    <rect key="frame" x="325" y="134" width="15" height="23"/>
+                                                                <button verticalHuggingPriority="750" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="RVg-iv-SLo">
+                                                                    <rect key="frame" x="325" y="130" width="15" height="23"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="17" id="K2i-XQ-bmF"/>
                                                                     </constraints>
@@ -670,8 +684,8 @@
                                                                         <action selector="resetEqualizerBtnAction:" target="-2" id="7EI-ef-QfR"/>
                                                                     </connections>
                                                                 </button>
-                                                                <button verticalHuggingPriority="750" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="g2t-lZ-AEy">
-                                                                    <rect key="frame" x="325" y="106" width="15" height="23"/>
+                                                                <button verticalHuggingPriority="750" misplaced="YES" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="g2t-lZ-AEy">
+                                                                    <rect key="frame" x="325" y="102" width="15" height="23"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="17" id="No4-dM-lef"/>
                                                                     </constraints>
@@ -683,8 +697,8 @@
                                                                         <action selector="resetEqualizerBtnAction:" target="-2" id="WbP-Bb-JbW"/>
                                                                     </connections>
                                                                 </button>
-                                                                <button verticalHuggingPriority="750" tag="2" translatesAutoresizingMaskIntoConstraints="NO" id="N1k-37-4OP">
-                                                                    <rect key="frame" x="325" y="78" width="15" height="23"/>
+                                                                <button verticalHuggingPriority="750" misplaced="YES" tag="2" translatesAutoresizingMaskIntoConstraints="NO" id="N1k-37-4OP">
+                                                                    <rect key="frame" x="325" y="74" width="15" height="23"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="17" id="BH7-Hv-t8g"/>
                                                                     </constraints>
@@ -696,8 +710,8 @@
                                                                         <action selector="resetEqualizerBtnAction:" target="-2" id="MF6-Fz-yqb"/>
                                                                     </connections>
                                                                 </button>
-                                                                <button verticalHuggingPriority="750" tag="3" translatesAutoresizingMaskIntoConstraints="NO" id="Cec-wN-J62">
-                                                                    <rect key="frame" x="325" y="50" width="15" height="23"/>
+                                                                <button verticalHuggingPriority="750" misplaced="YES" tag="3" translatesAutoresizingMaskIntoConstraints="NO" id="Cec-wN-J62">
+                                                                    <rect key="frame" x="325" y="46" width="15" height="23"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="17" id="hEq-A3-uQc"/>
                                                                     </constraints>
@@ -709,8 +723,8 @@
                                                                         <action selector="resetEqualizerBtnAction:" target="-2" id="wMC-t4-VKN"/>
                                                                     </connections>
                                                                 </button>
-                                                                <button verticalHuggingPriority="750" tag="4" translatesAutoresizingMaskIntoConstraints="NO" id="Cs3-ib-x4Y">
-                                                                    <rect key="frame" x="325" y="22" width="15" height="23"/>
+                                                                <button verticalHuggingPriority="750" misplaced="YES" tag="4" translatesAutoresizingMaskIntoConstraints="NO" id="Cs3-ib-x4Y">
+                                                                    <rect key="frame" x="325" y="18" width="15" height="23"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="17" id="HBL-aN-fWE"/>
                                                                     </constraints>
@@ -722,58 +736,68 @@
                                                                         <action selector="resetEqualizerBtnAction:" target="-2" id="5MT-kZ-5Mh"/>
                                                                     </connections>
                                                                 </button>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="C7W-xd-6OE">
-                                                                    <rect key="frame" x="327" y="336" width="11" height="16"/>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="C7W-xd-6OE">
+                                                                    <rect key="frame" x="327" y="382" width="11" height="16"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="x" id="W7H-mU-v3D">
                                                                         <font key="font" metaFont="system"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <box boxType="custom" cornerRadius="6" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="H0J-Co-VYF">
-                                                                    <rect key="frame" x="20" y="229" width="320" height="74"/>
-                                                                    <view key="contentView" id="1d0-P6-ccO">
-                                                                        <rect key="frame" x="1" y="1" width="318" height="72"/>
+                                                                <box ambiguous="YES" boxType="custom" cornerRadius="6" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="H0J-Co-VYF">
+                                                                    <rect key="frame" x="20" y="220" width="320" height="129"/>
+                                                                    <view key="contentView" ambiguous="YES" id="1d0-P6-ccO">
+                                                                        <rect key="frame" x="1" y="1" width="318" height="127"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
-                                                                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="2FQ-VQ-dTd" customClass="Switch" customModule="IINA" customModuleProvider="target">
-                                                                                <rect key="frame" x="12" y="0.0" width="294" height="36"/>
-                                                                                <constraints>
-                                                                                    <constraint firstAttribute="height" constant="36" id="06s-6F-ftM"/>
-                                                                                </constraints>
+                                                                            <customView ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2FQ-VQ-dTd" customClass="Switch" customModule="IINA" customModuleProvider="target">
+                                                                                <rect key="frame" x="12" y="48" width="294" height="36"/>
                                                                                 <userDefinedRuntimeAttributes>
                                                                                     <userDefinedRuntimeAttribute type="string" keyPath="title" value="quicksetting.deinterlace"/>
                                                                                 </userDefinedRuntimeAttributes>
                                                                             </customView>
-                                                                            <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="vFH-Zl-rQn">
-                                                                                <rect key="frame" x="12" y="34" width="306" height="5"/>
+                                                                            <box verticalHuggingPriority="750" ambiguous="YES" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="vFH-Zl-rQn">
+                                                                                <rect key="frame" x="12" y="-18" width="306" height="5"/>
                                                                             </box>
-                                                                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="0pq-Hh-3hb" customClass="Switch" customModule="IINA" customModuleProvider="target">
-                                                                                <rect key="frame" x="12" y="36" width="294" height="36"/>
-                                                                                <constraints>
-                                                                                    <constraint firstAttribute="height" constant="36" id="U7r-jZ-xhE"/>
-                                                                                </constraints>
+                                                                            <customView ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0pq-Hh-3hb" customClass="Switch" customModule="IINA" customModuleProvider="target">
+                                                                                <rect key="frame" x="12" y="84" width="294" height="36"/>
                                                                                 <userDefinedRuntimeAttributes>
                                                                                     <userDefinedRuntimeAttribute type="string" keyPath="title" value="quicksetting.hwdec"/>
+                                                                                </userDefinedRuntimeAttributes>
+                                                                            </customView>
+                                                                            <customView ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0RB-r2-J8C" customClass="Switch" customModule="IINA" customModuleProvider="target">
+                                                                                <rect key="frame" x="12" y="11" width="294" height="36"/>
+                                                                                <userDefinedRuntimeAttributes>
+                                                                                    <userDefinedRuntimeAttribute type="string" keyPath="title" value="quicksetting.hdr"/>
                                                                                 </userDefinedRuntimeAttributes>
                                                                             </customView>
                                                                         </subviews>
                                                                         <constraints>
                                                                             <constraint firstAttribute="trailing" secondItem="vFH-Zl-rQn" secondAttribute="trailing" id="4f2-sV-zHk"/>
-                                                                            <constraint firstItem="2FQ-VQ-dTd" firstAttribute="top" secondItem="0pq-Hh-3hb" secondAttribute="bottom" id="6Aq-4Q-xrN"/>
+                                                                            <constraint firstItem="2FQ-VQ-dTd" firstAttribute="leading" secondItem="0RB-r2-J8C" secondAttribute="leading" id="7iy-KH-Ifw"/>
                                                                             <constraint firstItem="vFH-Zl-rQn" firstAttribute="leading" secondItem="1d0-P6-ccO" secondAttribute="leading" constant="12" id="NqH-9C-Ctk"/>
-                                                                            <constraint firstAttribute="trailing" secondItem="0pq-Hh-3hb" secondAttribute="trailing" constant="12" id="OGo-ee-ueb"/>
-                                                                            <constraint firstAttribute="trailing" secondItem="2FQ-VQ-dTd" secondAttribute="trailing" constant="12" id="P2b-67-XQC"/>
-                                                                            <constraint firstItem="0pq-Hh-3hb" firstAttribute="leading" secondItem="1d0-P6-ccO" secondAttribute="leading" constant="12" id="SlU-SW-jrE"/>
-                                                                            <constraint firstItem="2FQ-VQ-dTd" firstAttribute="leading" secondItem="1d0-P6-ccO" secondAttribute="leading" constant="12" id="V3B-WC-Ou8"/>
-                                                                            <constraint firstAttribute="bottom" secondItem="2FQ-VQ-dTd" secondAttribute="bottom" id="i1v-qd-Coq"/>
-                                                                            <constraint firstItem="2FQ-VQ-dTd" firstAttribute="top" secondItem="vFH-Zl-rQn" secondAttribute="bottom" id="tGq-n2-dGY"/>
-                                                                            <constraint firstItem="0pq-Hh-3hb" firstAttribute="top" secondItem="1d0-P6-ccO" secondAttribute="top" id="y52-nT-9C2"/>
+                                                                            <constraint firstItem="0RB-r2-J8C" firstAttribute="leading" secondItem="vFH-Zl-rQn" secondAttribute="leading" id="QSp-uh-Ycc"/>
+                                                                            <constraint firstItem="0pq-Hh-3hb" firstAttribute="trailing" secondItem="2FQ-VQ-dTd" secondAttribute="trailing" id="SNJ-yp-hzm"/>
+                                                                            <constraint firstItem="0pq-Hh-3hb" firstAttribute="top" secondItem="1d0-P6-ccO" secondAttribute="top" constant="8" id="Wqk-vr-Pfx"/>
+                                                                            <constraint firstItem="0RB-r2-J8C" firstAttribute="top" secondItem="2FQ-VQ-dTd" secondAttribute="bottom" constant="8" id="Yn5-cl-zIx"/>
+                                                                            <constraint firstItem="2FQ-VQ-dTd" firstAttribute="top" secondItem="0pq-Hh-3hb" secondAttribute="bottom" constant="8" id="ZIY-VZ-Qx2"/>
+                                                                            <constraint firstItem="2FQ-VQ-dTd" firstAttribute="trailing" secondItem="0RB-r2-J8C" secondAttribute="trailing" id="gXe-MM-2V6"/>
+                                                                            <constraint firstItem="0pq-Hh-3hb" firstAttribute="leading" secondItem="2FQ-VQ-dTd" secondAttribute="leading" id="lr3-44-oTV"/>
+                                                                            <constraint firstItem="0pq-Hh-3hb" firstAttribute="centerX" secondItem="1d0-P6-ccO" secondAttribute="centerX" id="nJs-Oy-x1J"/>
+                                                                            <constraint firstAttribute="bottom" secondItem="0RB-r2-J8C" secondAttribute="bottom" constant="8" id="tYP-h7-JWk"/>
                                                                         </constraints>
                                                                     </view>
                                                                     <color key="borderColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <color key="fillColor" red="0.99999600649999998" green="1" blue="1" alpha="0.10000000000000001" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 </box>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" misplaced="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dFy-zT-BqP">
+                                                                    <rect key="frame" x="17" y="168" width="64" height="16"/>
+                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Equalizer" id="Xez-sb-mfB">
+                                                                        <font key="font" metaFont="systemBold"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
                                                             </subviews>
                                                             <constraints>
                                                                 <constraint firstAttribute="trailing" secondItem="Cec-wN-J62" secondAttribute="trailing" constant="20" id="0VS-7a-ogO"/>
@@ -902,7 +926,7 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                         <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="Vtu-Wx-ydk">
-                                            <rect key="frame" x="344" y="0.0" width="16" height="823"/>
+                                            <rect key="frame" x="360" y="0.0" width="15" height="775"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                     </scrollView>
@@ -923,11 +947,11 @@
                                     <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wXn-sV-AmG">
                                         <rect key="frame" x="0.0" y="0.0" width="360" height="823"/>
                                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="oVx-Sp-Lhl">
-                                            <rect key="frame" x="0.0" y="0.0" width="360" height="823"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="345" height="808"/>
+                                            <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="NZU-RD-Dm3" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="318" width="360" height="505"/>
+                                                    <rect key="frame" x="0.0" y="303" width="360" height="505"/>
                                                     <subviews>
                                                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="my2-5o-bNb">
                                                             <rect key="frame" x="0.0" y="0.0" width="360" height="505"/>
@@ -944,7 +968,7 @@
                                                                     <rect key="frame" x="0.0" y="385" width="360" height="76"/>
                                                                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="vgF-KN-yHf">
                                                                         <rect key="frame" x="0.0" y="0.0" width="360" height="76"/>
-                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                        <autoresizingMask key="autoresizingMask"/>
                                                                         <subviews>
                                                                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="FLg-2m-Zaq">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="360" height="76"/>
@@ -970,9 +994,11 @@
                                                                                                 <rect key="frame" x="1" y="1" width="21" height="17"/>
                                                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                                                 <subviews>
-                                                                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JVk-Od-tIT">
+                                                                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="JVk-Od-tIT">
                                                                                                         <rect key="frame" x="0.0" y="0.0" width="21" height="17"/>
-                                                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                                                                        <constraints>
+                                                                                                            <constraint firstAttribute="height" constant="17" id="T05-pw-yqi"/>
+                                                                                                        </constraints>
                                                                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="vDh-JM-5Wz">
                                                                                                             <font key="font" metaFont="system"/>
                                                                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -983,6 +1009,11 @@
                                                                                                         </connections>
                                                                                                     </textField>
                                                                                                 </subviews>
+                                                                                                <constraints>
+                                                                                                    <constraint firstItem="JVk-Od-tIT" firstAttribute="centerY" secondItem="YPg-3T-gYm" secondAttribute="centerY" id="Dgg-hT-oXs"/>
+                                                                                                    <constraint firstItem="JVk-Od-tIT" firstAttribute="leading" secondItem="YPg-3T-gYm" secondAttribute="leading" constant="2" id="OqQ-IR-YDG"/>
+                                                                                                    <constraint firstItem="JVk-Od-tIT" firstAttribute="centerX" secondItem="YPg-3T-gYm" secondAttribute="centerX" id="bXd-yg-s15"/>
+                                                                                                </constraints>
                                                                                                 <connections>
                                                                                                     <outlet property="textField" destination="JVk-Od-tIT" id="T58-nt-RWg"/>
                                                                                                 </connections>
@@ -1005,9 +1036,11 @@
                                                                                                 <rect key="frame" x="25" y="1" width="22" height="17"/>
                                                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                                                 <subviews>
-                                                                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MSR-2Q-pOS">
+                                                                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="MSR-2Q-pOS">
                                                                                                         <rect key="frame" x="0.0" y="0.0" width="22" height="17"/>
-                                                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                                                                        <constraints>
+                                                                                                            <constraint firstAttribute="height" constant="17" id="Qey-1X-4IJ"/>
+                                                                                                        </constraints>
                                                                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="KyY-Ui-vAx">
                                                                                                             <font key="font" metaFont="systemBold"/>
                                                                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1018,6 +1051,11 @@
                                                                                                         </connections>
                                                                                                     </textField>
                                                                                                 </subviews>
+                                                                                                <constraints>
+                                                                                                    <constraint firstItem="MSR-2Q-pOS" firstAttribute="leading" secondItem="UuQ-IW-yZg" secondAttribute="leading" constant="2" id="Mvf-lE-lbg"/>
+                                                                                                    <constraint firstItem="MSR-2Q-pOS" firstAttribute="centerY" secondItem="UuQ-IW-yZg" secondAttribute="centerY" id="cNP-1c-nLH"/>
+                                                                                                    <constraint firstItem="MSR-2Q-pOS" firstAttribute="centerX" secondItem="UuQ-IW-yZg" secondAttribute="centerX" id="oow-vG-bQd"/>
+                                                                                                </constraints>
                                                                                                 <connections>
                                                                                                     <outlet property="textField" destination="MSR-2Q-pOS" id="saV-nP-ICX"/>
                                                                                                 </connections>
@@ -1040,9 +1078,11 @@
                                                                                                 <rect key="frame" x="50" y="1" width="308" height="17"/>
                                                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                                                 <subviews>
-                                                                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="6YE-jM-I4J">
+                                                                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="6YE-jM-I4J">
                                                                                                         <rect key="frame" x="0.0" y="0.0" width="308" height="17"/>
-                                                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                                                                        <constraints>
+                                                                                                            <constraint firstAttribute="height" constant="17" id="qoy-gV-v8T"/>
+                                                                                                        </constraints>
                                                                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="Spe-xo-cXu">
                                                                                                             <font key="font" metaFont="system"/>
                                                                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1053,6 +1093,11 @@
                                                                                                         </connections>
                                                                                                     </textField>
                                                                                                 </subviews>
+                                                                                                <constraints>
+                                                                                                    <constraint firstItem="6YE-jM-I4J" firstAttribute="centerY" secondItem="zgo-9v-dTl" secondAttribute="centerY" id="3Tj-8l-EjA"/>
+                                                                                                    <constraint firstItem="6YE-jM-I4J" firstAttribute="centerX" secondItem="zgo-9v-dTl" secondAttribute="centerX" id="u02-tc-teP"/>
+                                                                                                    <constraint firstItem="6YE-jM-I4J" firstAttribute="leading" secondItem="zgo-9v-dTl" secondAttribute="leading" constant="2" id="ys9-mH-qtI"/>
+                                                                                                </constraints>
                                                                                                 <connections>
                                                                                                     <outlet property="textField" destination="6YE-jM-I4J" id="c8V-Nb-jHJ"/>
                                                                                                 </connections>
@@ -1479,8 +1524,8 @@
                                     <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3kA-IY-poi">
                                         <rect key="frame" x="0.0" y="0.0" width="360" height="823"/>
                                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="epy-wp-Ja5">
-                                            <rect key="frame" x="0.0" y="0.0" width="360" height="823"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="345" height="823"/>
+                                            <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="pm4-x9-WJ5" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="-9" width="360" height="832"/>
@@ -1492,7 +1537,7 @@
                                                                     <rect key="frame" x="0.0" y="298" width="360" height="72"/>
                                                                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="dJV-R0-O3M">
                                                                         <rect key="frame" x="0.0" y="0.0" width="360" height="72"/>
-                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                        <autoresizingMask key="autoresizingMask"/>
                                                                         <subviews>
                                                                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="2vU-hm-gGB">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="360" height="72"/>
@@ -1518,9 +1563,11 @@
                                                                                                 <rect key="frame" x="1" y="1" width="21" height="17"/>
                                                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                                                 <subviews>
-                                                                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7Ky-LN-z9K">
+                                                                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="7Ky-LN-z9K">
                                                                                                         <rect key="frame" x="0.0" y="0.0" width="21" height="17"/>
-                                                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                                                                        <constraints>
+                                                                                                            <constraint firstAttribute="height" constant="17" id="xDM-iw-yhI"/>
+                                                                                                        </constraints>
                                                                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="Jvb-cP-PSf">
                                                                                                             <font key="font" metaFont="system"/>
                                                                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1531,6 +1578,11 @@
                                                                                                         </connections>
                                                                                                     </textField>
                                                                                                 </subviews>
+                                                                                                <constraints>
+                                                                                                    <constraint firstItem="7Ky-LN-z9K" firstAttribute="centerX" secondItem="0Gi-L0-dSi" secondAttribute="centerX" id="8hL-Nl-kv5"/>
+                                                                                                    <constraint firstItem="7Ky-LN-z9K" firstAttribute="leading" secondItem="0Gi-L0-dSi" secondAttribute="leading" constant="2" id="GTy-wf-hHe"/>
+                                                                                                    <constraint firstItem="7Ky-LN-z9K" firstAttribute="centerY" secondItem="0Gi-L0-dSi" secondAttribute="centerY" id="YSH-UG-soS"/>
+                                                                                                </constraints>
                                                                                                 <connections>
                                                                                                     <outlet property="textField" destination="7Ky-LN-z9K" id="dZy-6W-J6f"/>
                                                                                                 </connections>
@@ -1553,9 +1605,11 @@
                                                                                                 <rect key="frame" x="25" y="1" width="22" height="17"/>
                                                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                                                 <subviews>
-                                                                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ydk-iU-8pQ">
+                                                                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Ydk-iU-8pQ">
                                                                                                         <rect key="frame" x="0.0" y="0.0" width="22" height="17"/>
-                                                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                                                                        <constraints>
+                                                                                                            <constraint firstAttribute="height" constant="17" id="ske-v4-Svo"/>
+                                                                                                        </constraints>
                                                                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="Mbq-Qm-2xb">
                                                                                                             <font key="font" metaFont="systemBold"/>
                                                                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1566,6 +1620,11 @@
                                                                                                         </connections>
                                                                                                     </textField>
                                                                                                 </subviews>
+                                                                                                <constraints>
+                                                                                                    <constraint firstItem="Ydk-iU-8pQ" firstAttribute="centerX" secondItem="tbH-U7-ooT" secondAttribute="centerX" id="2Rt-uP-f3b"/>
+                                                                                                    <constraint firstItem="Ydk-iU-8pQ" firstAttribute="centerY" secondItem="tbH-U7-ooT" secondAttribute="centerY" id="Kuc-Dj-zzR"/>
+                                                                                                    <constraint firstItem="Ydk-iU-8pQ" firstAttribute="leading" secondItem="tbH-U7-ooT" secondAttribute="leading" constant="2" id="x82-pT-we7"/>
+                                                                                                </constraints>
                                                                                                 <connections>
                                                                                                     <outlet property="textField" destination="Ydk-iU-8pQ" id="WBI-LA-u5S"/>
                                                                                                 </connections>
@@ -1588,9 +1647,11 @@
                                                                                                 <rect key="frame" x="50" y="1" width="286" height="17"/>
                                                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                                                 <subviews>
-                                                                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="E2W-Vb-Tgt">
+                                                                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="E2W-Vb-Tgt">
                                                                                                         <rect key="frame" x="0.0" y="0.0" width="286" height="17"/>
-                                                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                                                                        <constraints>
+                                                                                                            <constraint firstAttribute="height" constant="17" id="boB-wV-lkU"/>
+                                                                                                        </constraints>
                                                                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="Qpg-8B-Eks">
                                                                                                             <font key="font" metaFont="system"/>
                                                                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1601,6 +1662,11 @@
                                                                                                         </connections>
                                                                                                     </textField>
                                                                                                 </subviews>
+                                                                                                <constraints>
+                                                                                                    <constraint firstItem="E2W-Vb-Tgt" firstAttribute="centerY" secondItem="Uvf-Ds-mrn" secondAttribute="centerY" id="5C9-pf-NOi"/>
+                                                                                                    <constraint firstItem="E2W-Vb-Tgt" firstAttribute="centerX" secondItem="Uvf-Ds-mrn" secondAttribute="centerX" id="8oM-kV-vMq"/>
+                                                                                                    <constraint firstItem="E2W-Vb-Tgt" firstAttribute="leading" secondItem="Uvf-Ds-mrn" secondAttribute="leading" constant="2" id="QKJ-Mv-BER"/>
+                                                                                                </constraints>
                                                                                                 <connections>
                                                                                                     <outlet property="textField" destination="E2W-Vb-Tgt" id="0MJ-5K-pni"/>
                                                                                                 </connections>
@@ -1627,7 +1693,7 @@
                                                                     <rect key="frame" x="0.0" y="182" width="360" height="72"/>
                                                                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="EKn-MX-Fao">
                                                                         <rect key="frame" x="0.0" y="0.0" width="360" height="72"/>
-                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                        <autoresizingMask key="autoresizingMask"/>
                                                                         <subviews>
                                                                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="Jve-qX-Agy">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="360" height="72"/>
@@ -1653,9 +1719,11 @@
                                                                                                 <rect key="frame" x="1" y="1" width="21" height="17"/>
                                                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                                                 <subviews>
-                                                                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="615-Ps-9YF">
+                                                                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="615-Ps-9YF">
                                                                                                         <rect key="frame" x="0.0" y="0.0" width="21" height="17"/>
-                                                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                                                                        <constraints>
+                                                                                                            <constraint firstAttribute="height" constant="17" id="GQJ-yJ-OQs"/>
+                                                                                                        </constraints>
                                                                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="f23-sU-Thx">
                                                                                                             <font key="font" metaFont="system"/>
                                                                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1666,6 +1734,11 @@
                                                                                                         </connections>
                                                                                                     </textField>
                                                                                                 </subviews>
+                                                                                                <constraints>
+                                                                                                    <constraint firstItem="615-Ps-9YF" firstAttribute="centerY" secondItem="OdH-WH-l2U" secondAttribute="centerY" id="7gZ-mK-0dK"/>
+                                                                                                    <constraint firstItem="615-Ps-9YF" firstAttribute="centerX" secondItem="OdH-WH-l2U" secondAttribute="centerX" id="DNe-gm-JVz"/>
+                                                                                                    <constraint firstItem="615-Ps-9YF" firstAttribute="leading" secondItem="OdH-WH-l2U" secondAttribute="leading" constant="2" id="fYA-kz-43a"/>
+                                                                                                </constraints>
                                                                                                 <connections>
                                                                                                     <outlet property="textField" destination="615-Ps-9YF" id="nhJ-wW-r7t"/>
                                                                                                 </connections>
@@ -1688,9 +1761,11 @@
                                                                                                 <rect key="frame" x="25" y="1" width="22" height="17"/>
                                                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                                                 <subviews>
-                                                                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CCb-vZ-l96">
+                                                                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="CCb-vZ-l96">
                                                                                                         <rect key="frame" x="0.0" y="0.0" width="22" height="17"/>
-                                                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                                                                        <constraints>
+                                                                                                            <constraint firstAttribute="height" constant="17" id="PXI-MQ-ZMv"/>
+                                                                                                        </constraints>
                                                                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="YOu-ft-k7r">
                                                                                                             <font key="font" metaFont="systemBold"/>
                                                                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1701,6 +1776,11 @@
                                                                                                         </connections>
                                                                                                     </textField>
                                                                                                 </subviews>
+                                                                                                <constraints>
+                                                                                                    <constraint firstItem="CCb-vZ-l96" firstAttribute="centerX" secondItem="7bA-1U-4oy" secondAttribute="centerX" id="NIi-MQ-azk"/>
+                                                                                                    <constraint firstItem="CCb-vZ-l96" firstAttribute="centerY" secondItem="7bA-1U-4oy" secondAttribute="centerY" id="cUv-Se-wrC"/>
+                                                                                                    <constraint firstItem="CCb-vZ-l96" firstAttribute="leading" secondItem="7bA-1U-4oy" secondAttribute="leading" constant="2" id="gPt-bv-rvb"/>
+                                                                                                </constraints>
                                                                                                 <connections>
                                                                                                     <outlet property="textField" destination="CCb-vZ-l96" id="BKB-n2-rPJ"/>
                                                                                                 </connections>
@@ -1723,9 +1803,11 @@
                                                                                                 <rect key="frame" x="50" y="1" width="286" height="17"/>
                                                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                                                 <subviews>
-                                                                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ig9-1H-Wpa">
+                                                                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="ig9-1H-Wpa">
                                                                                                         <rect key="frame" x="0.0" y="0.0" width="286" height="17"/>
-                                                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
+                                                                                                        <constraints>
+                                                                                                            <constraint firstAttribute="height" constant="17" id="jbW-AI-Hij"/>
+                                                                                                        </constraints>
                                                                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="51L-l6-3vz">
                                                                                                             <font key="font" metaFont="system"/>
                                                                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1736,6 +1818,11 @@
                                                                                                         </connections>
                                                                                                     </textField>
                                                                                                 </subviews>
+                                                                                                <constraints>
+                                                                                                    <constraint firstItem="ig9-1H-Wpa" firstAttribute="centerX" secondItem="pG0-Y6-Qgh" secondAttribute="centerX" id="7pK-nH-xdM"/>
+                                                                                                    <constraint firstItem="ig9-1H-Wpa" firstAttribute="leading" secondItem="pG0-Y6-Qgh" secondAttribute="leading" constant="2" id="iy5-YT-1bv"/>
+                                                                                                    <constraint firstItem="ig9-1H-Wpa" firstAttribute="centerY" secondItem="pG0-Y6-Qgh" secondAttribute="centerY" id="wuk-DC-VaS"/>
+                                                                                                </constraints>
                                                                                                 <connections>
                                                                                                     <outlet property="textField" destination="ig9-1H-Wpa" id="GcF-vc-iAf"/>
                                                                                                 </connections>
@@ -2275,7 +2362,7 @@
                 <constraint firstItem="udA-m2-eJb" firstAttribute="top" secondItem="L78-cf-BxB" secondAttribute="bottom" constant="-1" id="t0K-N5-1t2"/>
                 <constraint firstItem="udA-m2-eJb" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="tyn-5q-xAw"/>
             </constraints>
-            <point key="canvasLocation" x="102" y="465.5"/>
+            <point key="canvasLocation" x="102" y="441.5"/>
         </customView>
         <customObject id="15X-3x-QZ1" customClass="NSFontManager"/>
         <viewController id="KVt-CA-hSE" userLabel="Popover View Controller"/>
@@ -2286,14 +2373,6 @@
         </popover>
         <userDefaultsController representsSharedInstance="YES" id="CE5-Ex-Oo6"/>
     </objects>
-    <designables>
-        <designable name="0pq-Hh-3hb">
-            <size key="intrinsicContentSize" width="0.0" height="22"/>
-        </designable>
-        <designable name="2FQ-VQ-dTd">
-            <size key="intrinsicContentSize" width="0.0" height="22"/>
-        </designable>
-    </designables>
     <resources>
         <image name="NSRefreshFreestandingTemplate" width="15" height="15"/>
         <image name="tab_audio" width="18" height="18"/>

--- a/iina/FFmpegController.h
+++ b/iina/FFmpegController.h
@@ -24,7 +24,7 @@
  */
 - (void)didUpdateThumbnails:(nullable NSArray<FFThumbnail *> *)thumbnails forFile:(nonnull NSString *)filename withProgress:(NSInteger)progress;
 
-/** 
+/**
  Did generated thumbnails for the video.
  */
 - (void)didGenerateThumbnails:(nonnull NSArray<FFThumbnail *> *)thumbnails forFile:(nonnull NSString *)filename succeeded:(BOOL)succeeded;
@@ -38,8 +38,9 @@
 
 @property(nonatomic) NSInteger thumbnailCount;
 
-- (void)generateThumbnailForFile:(nonnull NSString *)file;
+- (void)generateThumbnailForFile:(nonnull NSString *)file
+                      thumbWidth:(int)thumbWidth;
 
-+ (NSDictionary *)probeVideoInfoForFile:(nonnull NSString *)file;
++ (nullable NSDictionary *)probeVideoInfoForFile:(nonnull NSString *)file;
 
 @end

--- a/iina/FFmpegController.m
+++ b/iina/FFmpegController.m
@@ -13,9 +13,9 @@
 #import <libavformat/avformat.h>
 #import <libswscale/swscale.h>
 #import <libavutil/imgutils.h>
+#import <libavutil/mastering_display_metadata.h>
 
 #define THUMB_COUNT_DEFAULT 100
-#define THUMB_WIDTH 240
 
 #define CHECK_NOTNULL(ptr,msg) if (ptr == NULL) {\
 NSLog(@"Error when getting thumbnails: %@", msg);\
@@ -45,7 +45,7 @@ return -1;\
   double _timestamp;
 }
 
-- (int)getPeeksForFile:(NSString *)file;
+- (int)getPeeksForFile:(NSString *)file thumbnailsWidth:(int)thumbnailsWidth;
 - (void)saveThumbnail:(AVFrame *)pFrame width:(int)width height:(int)height index:(int)index realTime:(int)second forFile:(NSString *)file;
 
 @end
@@ -69,6 +69,7 @@ return -1;\
 
 
 - (void)generateThumbnailForFile:(NSString *)file
+                      thumbWidth:(int)thumbWidth
 {
   [_queue cancelAllOperations];
   NSBlockOperation *op = [[NSBlockOperation alloc] init];
@@ -78,7 +79,7 @@ return -1;\
       return;
     }
     self->_timestamp = CACurrentMediaTime();
-    int success = [self getPeeksForFile:file];
+    int success = [self getPeeksForFile:file thumbnailsWidth:thumbWidth];
     if (self.delegate) {
       [self.delegate didGenerateThumbnails:[NSArray arrayWithArray:self->_thumbnails]
                                    forFile: file
@@ -88,8 +89,8 @@ return -1;\
   [_queue addOperation:op];
 }
 
-
 - (int)getPeeksForFile:(NSString *)file
+       thumbnailsWidth:(int)thumbnailsWidth
 {
   int i, ret;
 
@@ -97,8 +98,6 @@ return -1;\
   [_thumbnails removeAllObjects];
   [_thumbnailPartialResult removeAllObjects];
   [_addedTimestamps removeAllObjects];
-
-  // NSLog(@"Getting thumbnails for video...");
 
   // Register all formats and codecs. mpv should have already called it.
   // av_register_all();
@@ -124,6 +123,7 @@ return -1;\
 
   // Get the codec context for the video stream
   AVStream *pVideoStream = pFormatCtx->streams[videoStream];
+
   AVRational videoAvgFrameRate = pVideoStream->avg_frame_rate;
 
   // Check whether the denominator (AVRational.den) is zero to prevent division-by-zero
@@ -133,7 +133,7 @@ return -1;\
   }
 
   // Find the decoder for the video stream
-  AVCodec *pCodec = avcodec_find_decoder(pVideoStream->codecpar->codec_id);
+  const AVCodec *pCodec = avcodec_find_decoder(pVideoStream->codecpar->codec_id);
   CHECK_NOTNULL(pCodec, @"Unsupported codec")
 
   // Open codec
@@ -149,7 +149,7 @@ return -1;\
     NSLog(@"Error when getting thumbnails: Pixel format is null");
     return -1;
   }
-  
+
   ret = avcodec_open2(pCodecCtx, pCodec, &optionsDict);
   CHECK_SUCCESS(ret, @"Cannot open codec")
 
@@ -159,8 +159,8 @@ return -1;\
 
   // Allocate the output frame
   // We need to convert the video frame to RGBA to satisfy CGImage's data format
-  int thumbWidth = THUMB_WIDTH;
-  int thumbHeight = THUMB_WIDTH / ((float)pCodecCtx->width / pCodecCtx->height);
+  int thumbWidth = thumbnailsWidth;
+  int thumbHeight = (float)thumbWidth / ((float)pCodecCtx->width / pCodecCtx->height);
 
   AVFrame *pFrameRGB = av_frame_alloc();
   CHECK_NOTNULL(pFrameRGB, @"Cannot alloc RGBA frame")
@@ -265,15 +265,17 @@ return -1;\
       av_packet_unref(&packet);
     }
   }
+  // Free the scaler
+  sws_freeContext(sws_ctx);
 
   // Free the RGB image
   av_free(pFrameRGBBuffer);
-  av_free(pFrameRGB);
+  av_frame_free(&pFrameRGB);
   // Free the YUV frame
-  av_free(pFrame);
+  av_frame_free(&pFrame);
 
-  // Close the codec
-  avcodec_close(pCodecCtx);
+  // Free the codec
+  avcodec_free_context(&pCodecCtx);
   // Close the video file
   avformat_close_input(&pFormatCtx);
 
@@ -281,11 +283,17 @@ return -1;\
   return 0;
 }
 
-- (void)saveThumbnail:(AVFrame *)pFrame width:(int)width height:(int)height index:(int)index realTime:(int)second forFile: (NSString *)file
+
+- (void)saveThumbnail:(AVFrame *)pFrame width
+                     :(int)width height
+                     :(int)height index
+                     :(int)index realTime
+                     :(int)second forFile
+                     :(NSString *)file
 {
   // Create CGImage
   CGColorSpaceRef rgb = CGColorSpaceCreateDeviceRGB();
-  
+
   CGContextRef cgContext = CGBitmapContextCreate(pFrame->data[0],  // it's converted to RGBA so could be used directly
                                                  width, height,
                                                  8,  // 8 bit per component
@@ -296,12 +304,12 @@ return -1;\
 
   // Create NSImage
   NSImage *image = [[NSImage alloc] initWithCGImage:cgImage size: NSZeroSize];
-  
+
   // Free resources
   CFRelease(rgb);
   CFRelease(cgContext);
   CFRelease(cgImage);
-  
+
   // Add to list
   FFThumbnail *tb = [[FFThumbnail alloc] init];
   tb.image = image;

--- a/iina/InspectorWindowController.swift
+++ b/iina/InspectorWindowController.swift
@@ -31,6 +31,9 @@ class InspectorWindowController: NSWindowController, NSTableViewDelegate, NSTabl
   @IBOutlet weak var vformatField: NSTextField!
   @IBOutlet weak var vcodecField: NSTextField!
   @IBOutlet weak var vdecoderField: NSTextField!
+  @IBOutlet weak var vcolorspaceField: NSTextField!
+  @IBOutlet weak var vprimariesField: NSTextField!
+
   @IBOutlet weak var voField: NSTextField!
   @IBOutlet weak var vsizeField: NSTextField!
   @IBOutlet weak var vbitrateField: NSTextField!
@@ -124,7 +127,8 @@ class InspectorWindowController: NSWindowController, NSTableViewDelegate, NSTabl
         ]
 
         for (k, v) in strProperties {
-          let value = controller.getString(k)
+          var value = controller.getString(k)
+          if value == "" { value = nil }
           v.stringValue = value ?? "N/A"
           self.setLabelColor(v, by: value != nil)
         }
@@ -167,7 +171,6 @@ class InspectorWindowController: NSWindowController, NSTableViewDelegate, NSTabl
         }
         self.trackPopup.selectItem(at: 0)
         self.updateTrack()
-
       }
 
       let vbitrate = controller.getInt(MPVProperty.videoBitrate)
@@ -191,6 +194,20 @@ class InspectorWindowController: NSWindowController, NSTableViewDelegate, NSTabl
         v.stringValue = value ?? "N/A"
         self.setLabelColor(v, by: value != nil)
       }
+
+      let sigPeak = controller.getDouble(MPVProperty.videoParamsSigPeak);
+      self.vprimariesField.stringValue = sigPeak > 0
+        ? "\(controller.getString(MPVProperty.videoParamsPrimaries) ?? "?") / \(controller.getString(MPVProperty.videoParamsGamma) ?? "?") (\(sigPeak > 1 ? "H" : "S")DR)"
+        : "N/A";
+      self.setLabelColor(self.vprimariesField, by: sigPeak > 0)
+
+      if PlayerCore.lastActive.mainWindow.loaded && controller.fileLoaded {
+        let colorspace = PlayerCore.lastActive.mainWindow.videoView.videoLayer.colorspace?.name;
+        self.vcolorspaceField.stringValue = colorspace == nil ? "Unspecified (SDR)" : String(colorspace!) + " (HDR)"
+      } else {
+        self.vcolorspaceField.stringValue = "N/A"
+      }
+      self.setLabelColor(self.vcolorspaceField, by: controller.fileLoaded)
     }
   }
 

--- a/iina/Logger.swift
+++ b/iina/Logger.swift
@@ -42,7 +42,7 @@ struct Logger {
     }
   }
 
-  static let enabled = Preference.bool(for: .enableLogging)
+  static let enabled = Preference.bool(for: .enableAdvancedSettings) && Preference.bool(for: .enableLogging)
 
   static let logDirectory: URL = {
     let formatter = DateFormatter()

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -129,7 +129,7 @@ class MPVController: NSObject {
     // - Advanced
 
     // disable internal OSD
-    let useMpvOsd = Preference.bool(for: .useMpvOsd)
+    let useMpvOsd = Preference.bool(for: .enableAdvancedSettings) && Preference.bool(for: .useMpvOsd)
     if !useMpvOsd {
       chkErr(mpv_set_option_string(mpv, MPVOption.OSD.osdLevel, "0"))
     } else {
@@ -286,28 +286,30 @@ class MPVController: NSObject {
             "\(MPVOption.PlaybackControl.abLoopA),\(MPVOption.PlaybackControl.abLoopB)"))
 
     // Set user defined conf dir.
-    if Preference.bool(for: .useUserDefinedConfDir) {
-      if var userConfDir = Preference.string(for: .userDefinedConfDir) {
-        userConfDir = NSString(string: userConfDir).standardizingPath
-        mpv_set_option_string(mpv, "config", "yes")
-        let status = mpv_set_option_string(mpv, MPVOption.ProgramBehavior.configDir, userConfDir)
-        if status < 0 {
-          Utility.showAlert("extra_option.config_folder", arguments: [userConfDir])
-        }
+    if Preference.bool(for: .enableAdvancedSettings),
+       Preference.bool(for: .useUserDefinedConfDir),
+       var userConfDir = Preference.string(for: .userDefinedConfDir) {
+      userConfDir = NSString(string: userConfDir).standardizingPath
+      mpv_set_option_string(mpv, "config", "yes")
+      let status = mpv_set_option_string(mpv, MPVOption.ProgramBehavior.configDir, userConfDir)
+      if status < 0 {
+        Utility.showAlert("extra_option.config_folder", arguments: [userConfDir])
       }
     }
 
     // Set user defined options.
-    if let userOptions = Preference.value(for: .userOptions) as? [[String]] {
-      userOptions.forEach { op in
-        let status = mpv_set_option_string(mpv, op[0], op[1])
-        if status < 0 {
-          Utility.showAlert("extra_option.error", arguments:
-            [op[0], op[1], status])
+    if Preference.bool(for: .enableAdvancedSettings) {
+      if let userOptions = Preference.value(for: .userOptions) as? [[String]] {
+        userOptions.forEach { op in
+          let status = mpv_set_option_string(mpv, op[0], op[1])
+          if status < 0 {
+            Utility.showAlert("extra_option.error", arguments:
+              [op[0], op[1], status])
+          }
         }
+      } else {
+        Utility.showAlert("extra_option.cannot_read")
       }
-    } else {
-      Utility.showAlert("extra_option.cannot_read")
     }
 
     // Load external scripts
@@ -652,8 +654,8 @@ class MPVController: NSObject {
 
     case MPV_EVENT_START_FILE:
       player.info.isIdle = false
-      guard getString(MPVProperty.path) != nil else { break }
-      player.fileStarted()
+      guard let path = getString(MPVProperty.path) else { break }
+      player.fileStarted(path: path)
       let url = player.info.currentURL
       let message = player.info.isNetworkResource ? url?.absoluteString : url?.lastPathComponent
       player.sendOSD(.fileStart(message ?? "-"))
@@ -780,6 +782,10 @@ class MPVController: NSObject {
       player.info.vid = Int(getInt(MPVOption.TrackSelection.vid))
       player.postNotification(.iinaVIDChanged)
       player.sendOSD(.track(player.info.currentTrack(.video) ?? .noneVideoTrack))
+
+      if #available(macOS 10.15, *) {
+        player.refreshEdrMode()
+      }
 
     case MPVOption.TrackSelection.aid:
       player.info.aid = Int(getInt(MPVOption.TrackSelection.aid))

--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -100,6 +100,8 @@ class PlaybackInfo {
   var hwdecEnabled: Bool {
     hwdec != "no"
   }
+  var hdrAvailable: Bool = false
+  var hdrEnabled: Bool = true
 
   // video equalizer
   var brightness: Int = 0

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1039,12 +1039,12 @@ class PlayerCore: NSObject {
 
   // MARK: - Listeners
 
-  func fileStarted() {
+  func fileStarted(path: String) {
     Logger.log("File started", subsystem: subsystem)
     info.justStartedFile = true
     info.disableOSDForFileLoading = true
     currentMediaIsAudio = .unknown
-    guard let path = mpv.getString(MPVProperty.path) else { return }
+
     info.currentURL = path.contains("://") ?
       URL(string: path.addingPercentEncoding(withAllowedCharacters: .urlAllowed) ?? path) :
       URL(fileURLWithPath: path)
@@ -1173,6 +1173,14 @@ class PlayerCore: NSObject {
           }
         }
       }
+    }
+  }
+
+  @available(macOS 10.15, *)
+  func refreshEdrMode() {
+    guard mainWindow.loaded else { return }
+    DispatchQueue.main.async {
+      self.mainWindow.videoView.refreshEdrMode()
     }
   }
 
@@ -1428,7 +1436,7 @@ class PlayerCore: NSObject {
         }
       } else {
         Logger.log("Request new thumbnails", subsystem: subsystem)
-        ffmpegController.generateThumbnail(forFile: url.path)
+        ffmpegController.generateThumbnail(forFile: url.path, thumbWidth:Int32(Preference.integer(for: .thumbnailWidth)))
       }
     }
   }

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -132,13 +132,14 @@ struct Preference {
     static let enableThumbnailPreview = Key("enableThumbnailPreview")
     static let maxThumbnailPreviewCacheSize = Key("maxThumbnailPreviewCacheSize")
     static let enableThumbnailForRemoteFiles = Key("enableThumbnailForRemoteFiles")
+    static let thumbnailWidth = Key("thumbnailWidth")
 
     static let autoSwitchToMusicMode = Key("autoSwitchToMusicMode")
     static let musicModeShowPlaylist = Key("musicModeShowPlaylist")
     static let musicModeShowAlbumArt = Key("musicModeShowAlbumArt")
 
     static let displayTimeAndBatteryInFullScreen = Key("displayTimeAndBatteryInFullScreen")
-    
+
     static let windowBehaviorWhenPip = Key("windowBehaviorWhenPip")
     static let pauseWhenPip = Key("pauseWhenPip")
     static let togglePipByMinimizingWindow = Key("togglePipByMinimizingWindow")
@@ -148,6 +149,7 @@ struct Preference {
     static let videoThreads = Key("videoThreads")
     static let hardwareDecoder = Key("hardwareDecoder")
     static let forceDedicatedGPU = Key("forceDedicatedGPU")
+    static let loadIccProfile = Key("loadIccProfile")
 
     static let audioThreads = Key("audioThreads")
     static let audioLanguage = Key("audioLanguage")
@@ -607,14 +609,14 @@ struct Preference {
       }
     }
   }
-  
+
   enum WindowBehaviorWhenPip: Int, InitializingFromKey {
     case doNothing = 0
     case hide
     case minimize
-    
+
     static var defaultValue = WindowBehaviorWhenPip.doNothing
-    
+
     init?(key: Key) {
       self.init(rawValue: Preference.integer(for: key))
     }
@@ -709,11 +711,12 @@ struct Preference {
     .enableThumbnailPreview: true,
     .maxThumbnailPreviewCacheSize: 500,
     .enableThumbnailForRemoteFiles: false,
+    .thumbnailWidth: 240,
     .autoSwitchToMusicMode: true,
     .musicModeShowPlaylist: false,
     .musicModeShowAlbumArt: true,
     .displayTimeAndBatteryInFullScreen: false,
-    
+
     .windowBehaviorWhenPip: WindowBehaviorWhenPip.doNothing.rawValue,
     .pauseWhenPip: false,
     .togglePipByMinimizingWindow: false,
@@ -721,6 +724,7 @@ struct Preference {
     .videoThreads: 0,
     .hardwareDecoder: HardwareDecoderOption.auto.rawValue,
     .forceDedicatedGPU: false,
+    .loadIccProfile: true,
     .audioThreads: 0,
     .audioLanguage: "",
     .maxVolume: 100,

--- a/iina/QuickSettingViewController.swift
+++ b/iina/QuickSettingViewController.swift
@@ -78,6 +78,7 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
   @IBOutlet weak var switchHorizontalLine: NSBox!
   @IBOutlet weak var hardwareDecodingSwitch: Switch!
   @IBOutlet weak var deinterlaceSwitch: Switch!
+  @IBOutlet weak var hdrSwitch: Switch!
 
   @IBOutlet weak var brightnessSlider: NSSlider!
   @IBOutlet weak var contrastSlider: NSSlider!
@@ -209,6 +210,14 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
     hardwareDecodingSwitch.action = {
       self.player.toggleHardwareDecoding($0)
     }
+    hdrSwitch.isEnabled = player.info.hdrAvailable
+    hdrSwitch.checked = player.info.hdrAvailable && player.info.hdrEnabled
+    if #available(macOS 10.15, *) {
+      hdrSwitch.action = {
+        self.player.info.hdrEnabled = $0
+        self.player.refreshEdrMode()
+      }
+    }
 
     let speed = player.mpv.getDouble(MPVOption.PlaybackControl.speed)
     customSpeedTextField.doubleValue = speed
@@ -291,6 +300,14 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
       subTableView.reloadData()
       secSubTableView.reloadData()
       updateSubTabControl()
+    }
+  }
+
+  func pleaseChangeHdrAvailable(to available: Bool) {
+    player.info.hdrAvailable = available
+    if isViewLoaded {
+      hdrSwitch.isEnabled = available
+      hdrSwitch.checked = available && player.info.hdrEnabled
     }
   }
 
@@ -758,7 +775,6 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
       self.player.setSubFont($0 ?? "")
     }
   }
-
 
 }
 

--- a/iina/Switch.swift
+++ b/iina/Switch.swift
@@ -86,6 +86,23 @@ class Switch: NSView {
     }
   }
 
+  @IBInspectable var isEnabled: Bool {
+    get {
+      if #available(macOS 10.15, *) {
+        return (nsSwitch as? NSSwitch)?.isEnabled ?? false
+      } else {
+        return checkbox?.isEnabled ?? false
+      }
+    }
+    set {
+      if #available(macOS 10.15, *) {
+        (nsSwitch as? NSSwitch)?.isEnabled = newValue
+      } else {
+        checkbox?.isEnabled = newValue
+      }
+    }
+  }
+
   override var intrinsicContentSize: NSSize {
     if #available(macOS 10.15, *) {
       return NSSize(width: 0, height: 22)

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -1,4 +1,4 @@
- //
+//
 //  VideoView.swift
 //  iina
 //
@@ -39,6 +39,8 @@ class VideoView: NSView {
 
   var pendingRedrawAfterEnteringPIP = false;
 
+  lazy var hdrSubsystem = Logger.Subsystem(rawValue: "hdr")
+
   // MARK: - Attributes
 
   override var mouseDownCanMoveWindow: Bool {
@@ -62,11 +64,12 @@ class VideoView: NSView {
     // other settings
     autoresizingMask = [.width, .height]
     wantsBestResolutionOpenGLSurface = true
+    wantsExtendedDynamicRangeOpenGLSurface = true
 
     // dragging init
     registerForDraggedTypes([.nsFilenames, .nsURL, .string])
   }
-  
+
   convenience init(frame: CGRect, player: PlayerCore) {
     self.init(frame: frame)
     self.player = player
@@ -213,9 +216,8 @@ class VideoView: NSView {
   func updateDisplayLink() {
     guard let window = window, let link = link, let screen = window.screen else { return }
     let displayId = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as! UInt32
-    if (currentDisplay == displayId) {
-      return
-    }
+    if (currentDisplay == displayId) { return }
+    currentDisplay = displayId
 
     CVDisplayLinkSetCurrentCGDisplay(link, displayId)
     let actualData = CVDisplayLinkGetActualOutputVideoRefreshPeriod(link)
@@ -224,11 +226,11 @@ class VideoView: NSView {
 
     if (nominalData.flags & Int32(CVTimeFlags.isIndefinite.rawValue)) < 1 {
       let nominalFps = Double(nominalData.timeScale) / Double(nominalData.timeValue)
-      
+
       if actualData > 0 {
         actualFps = 1/actualData
       }
-      
+
       if abs(actualFps - nominalFps) > 1 {
         Logger.log("Falling back to nominal display refresh rate: \(nominalFps) from \(actualFps)")
         actualFps = nominalFps;
@@ -238,36 +240,135 @@ class VideoView: NSView {
       actualFps = 60;
     }
     player.mpv.setDouble(MPVOption.Video.overrideDisplayFps, actualFps)
-    
-    setICCProfile(displayId)
-    currentDisplay = displayId
+
+    if #available(macOS 10.15, *) {
+      refreshEdrMode()
+    } else {
+      setICCProfile(displayId)
+    }
   }
 
   func setICCProfile(_ displayId: UInt32) {
-    typealias ProfileData = (uuid: CFUUID, profileUrl: URL?)
-    guard let uuid = CGDisplayCreateUUIDFromDisplayID(displayId)?.takeRetainedValue() else { return }
+    if !Preference.bool(for: .loadIccProfile) {
+      player.mpv.setString(MPVOption.GPURendererOptions.iccProfile, "")
+    } else {
+      typealias ProfileData = (uuid: CFUUID, profileUrl: URL?)
+      guard let uuid = CGDisplayCreateUUIDFromDisplayID(displayId)?.takeRetainedValue() else { return }
 
-    var argResult: ProfileData = (uuid, nil)
-    withUnsafeMutablePointer(to: &argResult) { data in
-      ColorSyncIterateDeviceProfiles({ (dict: CFDictionary?, ptr: UnsafeMutableRawPointer?) -> Bool in
-        if let info = dict as? [String: Any], let current = info["DeviceProfileIsCurrent"] as? Int {
-          let deviceID = info["DeviceID"] as! CFUUID
-          let ptr = ptr!.bindMemory(to: ProfileData.self, capacity: 1)
-          let uuid = ptr.pointee.uuid
+      var argResult: ProfileData = (uuid, nil)
+      withUnsafeMutablePointer(to: &argResult) { data in
+        ColorSyncIterateDeviceProfiles({ (dict: CFDictionary?, ptr: UnsafeMutableRawPointer?) -> Bool in
+          if let info = dict as? [String: Any], let current = info["DeviceProfileIsCurrent"] as? Int {
+            let deviceID = info["DeviceID"] as! CFUUID
+            let ptr = ptr!.bindMemory(to: ProfileData.self, capacity: 1)
+            let uuid = ptr.pointee.uuid
 
-          if current == 1, deviceID == uuid {
-            let profileURL = info["DeviceProfileURL"] as! URL
-            ptr.pointee.profileUrl = profileURL
-            return false
+            if current == 1, deviceID == uuid {
+              let profileURL = info["DeviceProfileURL"] as! URL
+              ptr.pointee.profileUrl = profileURL
+              return false
+            }
           }
-        }
-        return true
-      }, data)
+          return true
+        }, data)
+      }
+
+      if let iccProfilePath = argResult.profileUrl?.path, FileManager.default.fileExists(atPath: iccProfilePath) {
+        player.mpv.setString(MPVOption.GPURendererOptions.iccProfile, iccProfilePath)
+      }
     }
 
-    if let iccProfilePath = argResult.profileUrl?.path, FileManager.default.fileExists(atPath: iccProfilePath) {
-      player.mpv.setString(MPVOption.GPURendererOptions.iccProfile, iccProfilePath)
+    if videoLayer.colorspace != nil {
+      videoLayer.colorspace = nil;
+      videoLayer.wantsExtendedDynamicRangeContent = false
+      player.mpv.setString(MPVOption.GPURendererOptions.targetTrc, "auto")
+      player.mpv.setString(MPVOption.GPURendererOptions.targetPrim, "auto")
     }
+  }
+}
+
+// MARK: - HDR
+
+@available(macOS 10.15, *)
+extension VideoView {
+  func refreshEdrMode() {
+    guard player.mainWindow.loaded else { return }
+    guard player.mpv.fileLoaded else { return }
+    guard let displayId = currentDisplay else { return };
+    let edrEnabled = requestEdrMode()
+    let edrAvailable = edrEnabled != false
+    if player.info.hdrAvailable != edrAvailable {
+      player.mainWindow.quickSettingView.pleaseChangeHdrAvailable(to: edrAvailable)
+    }
+    if edrEnabled != true { setICCProfile(displayId) }
+  }
+
+  func requestEdrMode() -> Bool? {
+    guard let mpv = player.mpv else { return false }
+
+    guard let primaries = mpv.getString(MPVProperty.videoParamsPrimaries), let gamma = mpv.getString(MPVProperty.videoParamsGamma) else { return false }
+
+    var name: CFString? = nil;
+    switch primaries {
+    case "display-p3":
+      switch gamma {
+      case "pq":
+        if #available(macOS 10.15.4, *) {
+          name = CGColorSpace.displayP3_PQ
+        } else {
+          name = CGColorSpace.displayP3_PQ_EOTF
+        }
+      case "hlg":
+        name = CGColorSpace.displayP3_HLG
+      default:
+        name = CGColorSpace.displayP3
+      }
+
+    case "bt.2020":
+      switch gamma {
+      case "pq":
+        if #available(macOS 11.0, *) {
+          name = CGColorSpace.itur_2100_PQ
+        } else if #available(macOS 10.15.4, *) {
+          name = CGColorSpace.itur_2020_PQ
+        } else {
+          name = CGColorSpace.itur_2020_PQ_EOTF
+        }
+      case "hlg":
+        if #available(macOS 11.0, *) {
+          name = CGColorSpace.itur_2100_HLG
+        } else if #available(macOS 10.15.6, *) {
+          name = CGColorSpace.itur_2020_HLG
+        } else {
+          fallthrough
+        }
+      default:
+        name = CGColorSpace.itur_2020
+      }
+
+    case "bt.709":
+      return false; // SDR
+
+    default:
+      Logger.log("Unknown HDR color space information gamma=\(gamma) primaries=\(primaries)", level: .debug, subsystem: hdrSubsystem);
+      return false;
+    }
+
+    guard (window?.screen?.maximumPotentialExtendedDynamicRangeColorComponentValue ?? 1.0) > 1.0 else {
+      Logger.log("HDR video was found but the display does not support EDR mode", level: .debug, subsystem: hdrSubsystem);
+      return false;
+    }
+
+    guard player.info.hdrEnabled else { return nil }
+
+    Logger.log("Will activate HDR color space instead of using ICC profile", level: .debug, subsystem: hdrSubsystem);
+
+    videoLayer.wantsExtendedDynamicRangeContent = true
+    videoLayer.colorspace = CGColorSpace(name: name!)
+    mpv.setString(MPVOption.GPURendererOptions.iccProfile, "")
+    mpv.setString(MPVOption.GPURendererOptions.targetTrc, gamma)
+    mpv.setString(MPVOption.GPURendererOptions.targetPrim, primaries)
+    return true;
   }
 }
 
@@ -281,4 +382,3 @@ fileprivate func displayLinkCallback(
   mpv.mpvReportSwap()
   return kCVReturnSuccess
 }
-

--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -31,17 +31,12 @@ class ViewLayer: CAOpenGLLayer {
     autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
   }
 
-  override init(layer: Any) {
+  override convenience init(layer: Any) {
+    self.init()
+
     let previousLayer = layer as! ViewLayer
 
     videoView = previousLayer.videoView
-
-    super.init()
-    isOpaque = true
-    isAsynchronous = false
-
-    autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
-
   }
 
   required init?(coder aDecoder: NSCoder) {
@@ -140,7 +135,7 @@ class ViewLayer: CAOpenGLLayer {
     blocked = true
     mpvGLQueue.suspend()
   }
-  
+
   func resume() {
     blocked = false
     draw(forced: true)

--- a/iina/ca.lproj/Localizable.strings
+++ b/iina/ca.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "Cap";
 "quicksetting.hwdec" = "Decodificació per maquinari";
 "quicksetting.deinterlace" = "Desentrellaçament";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "Pausa";

--- a/iina/cs.lproj/Localizable.strings
+++ b/iina/cs.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "Žádný";
 "quicksetting.hwdec" = "Hardwarově dekódovat";
 "quicksetting.deinterlace" = "Odebrat prokládání";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "Pozastaveno";

--- a/iina/da.lproj/Localizable.strings
+++ b/iina/da.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "Ingen";
 "quicksetting.hwdec" = "Hardware Decoding";
 "quicksetting.deinterlace" = "Deinterlace";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "Pause";

--- a/iina/de.lproj/Localizable.strings
+++ b/iina/de.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "Nein";
 "quicksetting.hwdec" = "Hardware Dekodierung";
 "quicksetting.deinterlace" = "Deinterlacing";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "Pause";

--- a/iina/en-GB.lproj/Localizable.strings
+++ b/iina/en-GB.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "None";
 "quicksetting.hwdec" = "Hardware Decoding";
 "quicksetting.deinterlace" = "Deinterlace";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "Pause";

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "None";
 "quicksetting.hwdec" = "Hardware Decoding";
 "quicksetting.deinterlace" = "Deinterlace";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "Pause";

--- a/iina/es.lproj/Localizable.strings
+++ b/iina/es.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "Ninguno";
 "quicksetting.hwdec" = "Decodificación de hardware";
 "quicksetting.deinterlace" = "Desentrelazar";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "Pausa";

--- a/iina/fa.lproj/Localizable.strings
+++ b/iina/fa.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "هیچ کدام";
 "quicksetting.hwdec" = "Hardware Decoding";
 "quicksetting.deinterlace" = "Deinterlace";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "مکث";

--- a/iina/fi.lproj/Localizable.strings
+++ b/iina/fi.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "None";
 "quicksetting.hwdec" = "Hardware Decoding";
 "quicksetting.deinterlace" = "Deinterlace";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "Pause";

--- a/iina/fr.lproj/Localizable.strings
+++ b/iina/fr.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "Aucun";
 "quicksetting.hwdec" = "Décodage Matériel";
 "quicksetting.deinterlace" = "Désentrelacer";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "En pause";

--- a/iina/hi.lproj/Localizable.strings
+++ b/iina/hi.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "कोई नहीं";
 "quicksetting.hwdec" = "Hardware Decoding";
 "quicksetting.deinterlace" = "Deinterlace";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "रोकें";

--- a/iina/hu.lproj/Localizable.strings
+++ b/iina/hu.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "None";
 "quicksetting.hwdec" = "Hardveres dekódolás";
 "quicksetting.deinterlace" = "Deinterlace";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "Szünet";

--- a/iina/id.lproj/Localizable.strings
+++ b/iina/id.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "None";
 "quicksetting.hwdec" = "Hardware Decoding";
 "quicksetting.deinterlace" = "Deinterlace";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "Pause";

--- a/iina/is.lproj/Localizable.strings
+++ b/iina/is.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "None";
 "quicksetting.hwdec" = "Hardware Decoding";
 "quicksetting.deinterlace" = "Deinterlace";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "Pause";

--- a/iina/it.lproj/Localizable.strings
+++ b/iina/it.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "Nessuno";
 "quicksetting.hwdec" = "Decodifica dell'Hardware";
 "quicksetting.deinterlace" = "Deinterlacciamento";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "Pausa";

--- a/iina/ja.lproj/Localizable.strings
+++ b/iina/ja.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "なし";
 "quicksetting.hwdec" = "ハードウェアデコード";
 "quicksetting.deinterlace" = "インターレース解除";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "一時停止";

--- a/iina/ko.lproj/Localizable.strings
+++ b/iina/ko.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "없음";
 "quicksetting.hwdec" = "하드웨어 디코딩";
 "quicksetting.deinterlace" = "디인터레이스";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "일시 정지됨";

--- a/iina/mk.lproj/Localizable.strings
+++ b/iina/mk.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "None";
 "quicksetting.hwdec" = "Hardware Decoding";
 "quicksetting.deinterlace" = "Deinterlace";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "Pause";

--- a/iina/nl.lproj/Localizable.strings
+++ b/iina/nl.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "Geen";
 "quicksetting.hwdec" = "Hardware acceleratie";
 "quicksetting.deinterlace" = "Deinterlace";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "Pauzeer";

--- a/iina/no.lproj/Localizable.strings
+++ b/iina/no.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "None";
 "quicksetting.hwdec" = "Hardware Decoding";
 "quicksetting.deinterlace" = "Deinterlace";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "Pause";

--- a/iina/pl.lproj/Localizable.strings
+++ b/iina/pl.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "Brak";
 "quicksetting.hwdec" = "Sprzętowe dekodowanie";
 "quicksetting.deinterlace" = "Usuwanie przeplotu";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "Pauza";

--- a/iina/pt-BR.lproj/Localizable.strings
+++ b/iina/pt-BR.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "Nenhum";
 "quicksetting.hwdec" = "Decodificação por hardware";
 "quicksetting.deinterlace" = "Desentrelaçar";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "Em Pausa";

--- a/iina/pt.lproj/Localizable.strings
+++ b/iina/pt.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "Nenhum";
 "quicksetting.hwdec" = "Descodificação de hardware";
 "quicksetting.deinterlace" = "Desentrelaçar";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "Pausa";

--- a/iina/ro.lproj/Localizable.strings
+++ b/iina/ro.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "Fără";
 "quicksetting.hwdec" = "Hardware Decoding";
 "quicksetting.deinterlace" = "Deinterlace";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "Pauză";

--- a/iina/ru.lproj/Localizable.strings
+++ b/iina/ru.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "Нет";
 "quicksetting.hwdec" = "Аппаратное декодирование";
 "quicksetting.deinterlace" = "Деинтерлейсинг";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "Пауза";

--- a/iina/sk.lproj/Localizable.strings
+++ b/iina/sk.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "Žiadne";
 "quicksetting.hwdec" = "Hardvérové dekódovanie";
 "quicksetting.deinterlace" = "Deinterlace";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "Pozastaviť";

--- a/iina/sr-CS.lproj/Localizable.strings
+++ b/iina/sr-CS.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "Nijеdan";
 "quicksetting.hwdec" = "Hardversko dekodiranje";
 "quicksetting.deinterlace" = "Rasplitanje";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "Pauziraj";

--- a/iina/sr.lproj/Localizable.strings
+++ b/iina/sr.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "None";
 "quicksetting.hwdec" = "Hardware Decoding";
 "quicksetting.deinterlace" = "Deinterlace";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "Pause";

--- a/iina/sv.lproj/Localizable.strings
+++ b/iina/sv.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "Inget";
 "quicksetting.hwdec" = "Hårdvaruavkodning";
 "quicksetting.deinterlace" = "Avfläta";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "Pausa";

--- a/iina/ta.lproj/Localizable.strings
+++ b/iina/ta.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "எதுவுமில்லை";
 "quicksetting.hwdec" = "Hardware Decoding";
 "quicksetting.deinterlace" = "Deinterlace";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "இடைநிறுத்து";

--- a/iina/tr.lproj/Localizable.strings
+++ b/iina/tr.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "Hiçbiri";
 "quicksetting.hwdec" = "Donanımsal Kod Çözücü";
 "quicksetting.deinterlace" = "Taramasızlık";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "Duraklat";

--- a/iina/uk.lproj/Localizable.strings
+++ b/iina/uk.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "—";
 "quicksetting.hwdec" = "Апаратне декодування";
 "quicksetting.deinterlace" = "Черезрядкова розгортка";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "Пауза";

--- a/iina/zh-Hans.lproj/InspectorWindowController.strings
+++ b/iina/zh-Hans.lproj/InspectorWindowController.strings
@@ -31,6 +31,9 @@
 /* Class = "NSTextFieldCell"; title = "Hw Decoder:"; ObjectID = "DHh-ne-10f"; */
 "DHh-ne-10f.title" = "硬件解码器:";
 
+/* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
+"mLo-Wc-BoO.title" = "色彩空间:";
+
 /* Class = "NSWindow"; title = "Inspector"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "检查器";
 
@@ -81,6 +84,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Editions:"; ObjectID = "POj-mQ-zP9"; */
 "POj-mQ-zP9.title" = "集数:";
+
+/* Class = "NSTextFieldCell"; title = "Primaries:"; ObjectID = "1kw-LO-KmJ"; */
+"1kw-LO-KmJ.title" = "色域:";
 
 /* Class = "NSTextFieldCell"; title = "Format:"; ObjectID = "PQD-yB-mm6"; */
 "PQD-yB-mm6.title" = "格式:";

--- a/iina/zh-Hans.lproj/Localizable.strings
+++ b/iina/zh-Hans.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "无";
 "quicksetting.hwdec" = "硬件解码";
 "quicksetting.deinterlace" = "反交错";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "暂停";

--- a/iina/zh-Hans.lproj/PrefCodecViewController.strings
+++ b/iina/zh-Hans.lproj/PrefCodecViewController.strings
@@ -51,3 +51,6 @@
 
 /* Class = "NSTextFieldCell"; title = "Preferred language:"; ObjectID = "wjt-O6-KbC"; */
 "wjt-O6-KbC.title" = "偏好语言:";
+
+/* Class = "NSButtonCell"; title = "Load ICC profile"; ObjectID = "3g4-jW-uJd"; */
+"3g4-jW-uJd.title" = "加载ICC色彩特性文件";

--- a/iina/zh-Hant.lproj/Localizable.strings
+++ b/iina/zh-Hant.lproj/Localizable.strings
@@ -35,6 +35,7 @@
 "quicksetting.item_none" = "無";
 "quicksetting.hwdec" = "硬體解碼";
 "quicksetting.deinterlace" = "去交錯";
+"quicksetting.hdr" = "HDR";
 
 // OSDMessage.swift
 "osd.pause" = "暫停";


### PR DESCRIPTION
- [x] This change has been discussed with the author.
- [x] It implements / fixes issue #3526.

---

**Description:**

* This PR contains all HDR related commits.

Several small changes were included too in order not to introduce merge conflicts when cherry-picking:

1. fix(pref): Don't load advanced settings when `enableAdvancedSettings` is disabled.
2. feat(pref): Support disabling ICC profile ( for SDR mode )
3. feat(perf): Support configuring thumb width

* UI related changes:

1. <img width="814" alt="image" src="https://user-images.githubusercontent.com/6134068/164985872-7b9b9289-443f-4512-9b34-0066a5ad4522.png">
2. <img width="407" alt="image" src="https://user-images.githubusercontent.com/6134068/164986003-aa7e375b-1329-4fc2-a6bc-b4a4d0b29add.png">
3. <img width="350" alt="image" src="https://user-images.githubusercontent.com/6134068/164985931-0bb0823a-1d26-4c71-a8b5-b3cc2fba7c27.png">
4. <img width="449" alt="image" src="https://user-images.githubusercontent.com/6134068/164985949-4f13a364-28b6-48d0-aa2e-19378ef73c56.png">

* TODO: Detect [maximum luminance supported by current monitor](https://mpv.io/manual/master/#options-target-peak) and [enable manual tone mapping](https://mpv.io/manual/master/#options-tone-mapping)