### PR TITLE
Fix window not resized when screen changes, #3715

### DIFF
--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -630,22 +630,6 @@ extension NSScreen {
       Logger.log("\(label): visible frame \(screen.visibleFrame)")
     }
   }
-
-  /// Set the frame of the given window and its content view to use all the usable area of this screen.
-  /// - parameter window: The window to set the frame of.
-  /// - parameter displayFlag: Specifies whether the window redraws the views that need to be displayed. When true the
-  ///   window sends a [displayIfNeeded()](https://developer.apple.com/documentation/appkit/nswindow/1419096-displayifneeded)
-  ///   message down its view hierarchy, thus redrawing all views.
-  /// - parameter animateFlag: Specifies whether the window performs a smooth resize. true to perform the animation, whose
-  ///   duration is specified by [animationResizeTime(_:)](https://developer.apple.com/documentation/appkit/nswindow/1419655-animationresizetime)
-  func setFrame(_ window: NSWindow, display displayFlag: Bool, animate animateFlag: Bool) {
-    window.setFrame(frame, display: displayFlag, animate: animateFlag)
-    guard let unusable = cameraHousingHeight  else { return }
-    // This screen contains an embedded camera. Shorten the height of the window's content view's
-    // frame to avoid having part of the window obscured by the camera housing.
-    let view = window.contentView!
-    view.setFrameSize(NSMakeSize(view.frame.width, frame.height - unusable))
-  }
 }
 
 extension NSWindow {

--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -630,6 +630,22 @@ extension NSScreen {
       Logger.log("\(label): visible frame \(screen.visibleFrame)")
     }
   }
+
+  /// Set the frame of the given window and its content view to use all the usable area of this screen.
+  /// - parameter window: The window to set the frame of.
+  /// - parameter displayFlag: Specifies whether the window redraws the views that need to be displayed. When true the
+  ///   window sends a [displayIfNeeded()](https://developer.apple.com/documentation/appkit/nswindow/1419096-displayifneeded)
+  ///   message down its view hierarchy, thus redrawing all views.
+  /// - parameter animateFlag: Specifies whether the window performs a smooth resize. true to perform the animation, whose
+  ///   duration is specified by [animationResizeTime(_:)](https://developer.apple.com/documentation/appkit/nswindow/1419655-animationresizetime)
+  func setFrame(_ window: NSWindow, display displayFlag: Bool, animate animateFlag: Bool) {
+    window.setFrame(frame, display: displayFlag, animate: animateFlag)
+    guard let unusable = cameraHousingHeight  else { return }
+    // This screen contains an embedded camera. Shorten the height of the window's content view's
+    // frame to avoid having part of the window obscured by the camera housing.
+    let view = window.contentView!
+    view.setFrameSize(NSMakeSize(view.frame.width, frame.height - unusable))
+  }
 }
 
 extension NSWindow {

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -590,12 +590,10 @@ class MainWindowController: PlayerWindowController {
       self.videoView.updateDisplayLink()
       // In normal full screen mode AppKit will automatically adjust the window frame if the window
       // is moved to a new screen such as when the window is on an external display and that display
-      // is discounnected. In legacy full screen mode IINA is responsible for adjusting the window's
+      // is disconnected. In legacy full screen mode IINA is responsible for adjusting the window's
       // frame.
-      guard self.fsState.isFullscreen, Preference.bool(for: .useLegacyFullScreen),
-            let window = self.window else { return }
-      let screen = window.screen ?? NSScreen.main!
-      screen.setFrame(window, display: true, animate: !AccessibilityPreferences.motionReductionEnabled)
+      guard self.fsState.isFullscreen, Preference.bool(for: .useLegacyFullScreen) else { return }
+      setWindowFrameForLegacyFullScreen()
     }
   }
 
@@ -1353,6 +1351,20 @@ class MainWindowController: PlayerWindowController {
     windowDidExitFullScreen(Notification(name: .iinaLegacyFullScreen))
   }
 
+  /// Set the window frame and if needed the content view frame to appropriately use the full screen.
+  ///
+  /// For screens that contain a camera housing the content view will be adjusted to not use that area of the screen.
+  private func setWindowFrameForLegacyFullScreen() {
+    guard let window = self.window else { return }
+    let screen = window.screen ?? NSScreen.main!
+    window.setFrame(screen.frame, display: true, animate: !AccessibilityPreferences.motionReductionEnabled)
+    guard let unusable = screen.cameraHousingHeight else { return }
+    // This screen contains an embedded camera. Shorten the height of the window's content view's
+    // frame to avoid having part of the window obscured by the camera housing.
+    let view = window.contentView!
+    view.setFrameSize(NSMakeSize(view.frame.width, screen.frame.height - unusable))
+  }
+
   private func legacyAnimateToFullscreen() {
     guard let window = self.window else { fatalError("make sure the window exists before animating") }
     // call delegate
@@ -1371,9 +1383,8 @@ class MainWindowController: PlayerWindowController {
     // auto hide menubar and dock
     NSApp.presentationOptions.insert(.autoHideMenuBar)
     NSApp.presentationOptions.insert(.autoHideDock)
-    // set frame
-    let screen = window.screen ?? NSScreen.main!
-    screen.setFrame(window, display: true, animate: !AccessibilityPreferences.motionReductionEnabled)
+    // set window frame and in some cases content view frame
+    setWindowFrameForLegacyFullScreen()
     // call delegate
     windowDidEnterFullScreen(Notification(name: .iinaLegacyFullScreen))
   }


### PR DESCRIPTION
The commit updates MainWindowController to resize the window
appropriately when the screen the window is on changes if in legacy
full screen mode.

The commit in the pull request will:
- Add a method setFrame to Extensions.NSScreen to set a window's
  frame and content view frame to use the full screen
- Add call to setFrame in observer for
  didChangeScreenParametersNotification

- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3715.

---

**Description:**
