### PR TITLE
Add support for key sequences via 4-item buffer

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -158,6 +158,9 @@
 		B4E446F725CB54EF0069F06E /* Mustache in Frameworks */ = {isa = PBXBuildFile; productRef = B4E446F625CB54EF0069F06E /* Mustache */; };
 		B4E4470125CE3F930069F06E /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = B4E4470025CE3F930069F06E /* Sparkle */; };
 		C789872F1E34EF170005769F /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = C78987311E34EF170005769F /* InfoPlist.strings */; };
+		D18333BC2834CDF40060A4E9 /* RingBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D18333BB2834CDF40060A4E9 /* RingBuffer.swift */; };
+		D18333BE2834CE620060A4E9 /* KeyInputController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D18333BD2834CE620060A4E9 /* KeyInputController.swift */; };
+		D19E23E9284F0A8400FD6999 /* IINAApplication.swift in Sources */ = {isa = PBXBuildFile; fileRef = D19E23E8284F0A8400FD6999 /* IINAApplication.swift */; };
 		E301EFDA21312AB300BC8588 /* KeychainAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = E301EFD921312AB300BC8588 /* KeychainAccess.swift */; };
 		E322A4F820A8442E00C67D32 /* PlaylistPlaybackProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E322A4F720A8442E00C67D32 /* PlaylistPlaybackProgressView.swift */; };
 		E32712B024EAA14500359DAB /* ScreenshootOSDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E32712AE24EAA14500359DAB /* ScreenshootOSDView.swift */; };
@@ -1197,6 +1200,9 @@
 		C7DBA5EB1F07C5FD00C2B416 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/InitialWindowController.strings; sourceTree = "<group>"; };
 		C7DC79CE1EC63821002DE23B /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/HistoryWindowController.strings; sourceTree = "<group>"; };
 		C7E90B522087EC5700A58B6B /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/SubChooseViewController.strings; sourceTree = "<group>"; };
+		D18333BB2834CDF40060A4E9 /* RingBuffer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RingBuffer.swift; sourceTree = "<group>"; };
+		D18333BD2834CE620060A4E9 /* KeyInputController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyInputController.swift; sourceTree = "<group>"; };
+		D19E23E8284F0A8400FD6999 /* IINAApplication.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IINAApplication.swift; sourceTree = "<group>"; };
 		D27556FC1EC6E1C300CAB2A4 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/HistoryWindowController.strings"; sourceTree = "<group>"; };
 		D27E35CE1E379B6D0064BE57 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/MainMenu.strings"; sourceTree = "<group>"; };
 		D27E35CF1E379B6D0064BE57 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/MainWindowController.strings"; sourceTree = "<group>"; };
@@ -1704,6 +1710,7 @@
 				E38BD4AE20054BD9007635FC /* MainWindow.swift */,
 				84CFC92523F8DDE000381E5B /* PlayerWindowController.swift */,
 				84A0BA9C1D2FAD4000BC8DA1 /* MainWindowController.swift */,
+				D18333BD2834CE620060A4E9 /* KeyInputController.swift */,
 				84D123B31ECAA405004E0D53 /* TouchBarSupport.swift */,
 				8400D5C81E1AB2F1006785F5 /* MainWindowController.xib */,
 				8466BE161D5CDD0300039D03 /* QuickSettingViewController.swift */,
@@ -1767,6 +1774,7 @@
 				E342832E20B7149800139865 /* Logger.swift */,
 				E3F698862120D878005792C9 /* ExtendedColors.swift */,
 				E301EFD921312AB300BC8588 /* KeychainAccess.swift */,
+				D18333BB2834CDF40060A4E9 /* RingBuffer.swift */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -2089,6 +2097,7 @@
 			children = (
 				84FF846D1D2FF698001B318A /* deps */,
 				84A0BAA21D2FAE8200BC8DA1 /* Assets */,
+				D19E23E8284F0A8400FD6999 /* IINAApplication.swift */,
 				84A0BAA71D2FAF9700BC8DA1 /* Controllers */,
 				84A0BAA81D2FAFCD00BC8DA1 /* Data */,
 				845ABEAD1D4D19CF00BFB15B /* Models */,
@@ -2424,12 +2433,15 @@
 				84C8D5911D796F9700D98A0E /* Aspect.swift in Sources */,
 				E3383689202651CF00ABC812 /* PrefOSCToolbarDraggingItemViewController.swift in Sources */,
 				519872FF26879B9B00F84BCC /* AccessibilityPreferences.swift in Sources */,
+				D19E23E9284F0A8400FD6999 /* IINAApplication.swift in Sources */,
 				842904E21F0EC01600478376 /* AutoFileMatcher.swift in Sources */,
 				8466BE181D5CDD0300039D03 /* QuickSettingViewController.swift in Sources */,
 				84A0BA9E1D2FAD4000BC8DA1 /* MainWindowController.swift in Sources */,
 				84E48D4E1E0F1090002C7A3F /* FilterWindowController.swift in Sources */,
 				E3F698872120D878005792C9 /* ExtendedColors.swift in Sources */,
+				D18333BC2834CDF40060A4E9 /* RingBuffer.swift in Sources */,
 				8476440C1D48F63D004F6DF5 /* OSDMessage.swift in Sources */,
+				D18333BE2834CE620060A4E9 /* KeyInputController.swift in Sources */,
 				84AE59491E0FD65800771B7E /* MainMenuActions.swift in Sources */,
 				E3CB75BD1FDACB82004DB10A /* SavedFilter.swift in Sources */,
 				E342832F20B7149800139865 /* Logger.swift in Sources */,

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -80,7 +80,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
   private func getReady() {
     menuController.bindMenuItems()
-    PlayerCore.loadKeyBindings()
+    PlayerCore.initSharedState()
     isReady = true
   }
 

--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -8,6 +8,15 @@
 
 import Cocoa
 
+infix operator %%
+
+extension Int {
+  /** Modulo operator. Swift's remainder operator (%) can return negative values, which is rarely what we want. */
+  static  func %% (_ left: Int, _ right: Int) -> Int {
+    return (left % right + right) % right
+  }
+}
+
 extension NSSlider {
   /** Returns the position of knob center by point */
   func knobPointPosition() -> CGFloat {

--- a/iina/IINAApplication.swift
+++ b/iina/IINAApplication.swift
@@ -1,0 +1,47 @@
+//
+//  IINAApplication.swift
+//  iina
+//
+//  Created by Matt Svoboda on 2022.06.06.
+//  Copyright © 2022 lhc. All rights reserved.
+//
+
+import Foundation
+import AppKit
+
+@objc(IINAApplication)
+class IINAApplication: NSApplication {
+  override func sendEvent(_ event: NSEvent) {
+    switch event.type {
+    case .keyDown:
+        if handleKeyDown(event) {
+            return
+        }
+      default:
+        break
+    }
+
+    // process via the normal chain:
+    super.sendEvent(event)
+  }
+
+  func handleKeyDown(_ keyDownEvent: NSEvent) -> Bool {
+    let keyStroke: String = KeyCodeHelper.mpvKeyCode(from: keyDownEvent)
+    Logger.log("GlobalKeyDown: \"\(keyStroke)\"", level: .verbose)
+
+    // Let main menu handle it first:
+    if let mainMenu = NSApplication.shared.mainMenu, mainMenu.performKeyEquivalent(with: keyDownEvent) {
+      Logger.log("Menu processed keyDown!", level: .verbose)
+
+      let activePlayer = PlayerCore.active
+      if activePlayer.mainWindow.hasKeyboardFocus {
+        // Notify player window that the main menu stole its keyboard event:
+        activePlayer.keyInputController.keyWasHandled(keyDownEvent)
+      }
+      return true
+    } else {
+      Logger.log("Menu didn't process keyDown. Sending to other responders", level: .verbose)
+      return false
+    }
+  }
+}

--- a/iina/Info.plist
+++ b/iina/Info.plist
@@ -481,7 +481,7 @@ Released under GPLv3.</string>
 	<key>NSPrefersDisplaySafeAreaCompatibilityMode</key>
 	<false/>
 	<key>NSPrincipalClass</key>
-	<string>NSApplication</string>
+	<string>IINAApplication</string>
 	<key>NSServices</key>
 	<array>
 		<dict>
@@ -533,7 +533,7 @@ Released under GPLv3.</string>
 				<string>public.audio</string>
 			</array>
 			<key>UTTypeDescription</key>
-			<string>Monkey's Audio Lossless Audio</string>
+			<string>Monkey&apos;s Audio Lossless Audio</string>
 			<key>UTTypeIdentifier</key>
 			<string>io.iina.ape</string>
 			<key>UTTypeTagSpecification</key>

--- a/iina/KeyInputController.swift
+++ b/iina/KeyInputController.swift
@@ -1,0 +1,180 @@
+//
+//  KeyInputController.swift
+//  iina
+//
+//  Created by Matthew Svoboda on 2022.05.17.
+//  Copyright © 2022 lhc. All rights reserved.
+//
+
+import Foundation
+
+/*
+ A single KeyInputController instance should be associated with a single PlayerCore, and while the player window has focus, its
+ PlayerWindowController is expected to direct key presses to this class's `resolveKeyEvent` method.
+ to match the user's key stroke(s) into recognized commands.
+
+ A [key mapping](x-source-tag://KeyMapping) is an association from user input to an IINA or MPV command.
+ This can include mouse events (though not handled by this class), single keystroke (which may include modifiers), or a sequence of keystrokes.
+ See [the MPV manual](https://mpv.io/manual/master/#key-names) for information on MPV's valid "key names".
+
+ // MARK: - Note on key sequences
+
+ From the MPV manual:
+
+ > It's also possible to bind a command to a sequence of keys:
+ >
+ > a-b-c show-text "command run after a, b, c have been pressed"
+ > (This is not shown in the general command syntax.)
+ >
+ > If a or a-b or b are already bound, this will run the first command that matches, and the multi-key command will never be called.
+ > Intermediate keys can be remapped to ignore in order to avoid this issue.
+ > The maximum number of (non-modifier) keys for combinations is currently 4.
+
+ Although IINA's active key bindings (as set in IINA's Preferences window) take effect immediately and apply to all player windows, each player
+ window maintains independent state, and in keeping with this, each player's KeyInputController maintains a separate buffer of pressed keystrokes
+ (going back as many as 4 keystrokes).
+
+ */
+class KeyInputController {
+
+  // MARK: - Shared state for all players
+
+  static private let sharedSubsystem = Logger.Subsystem(rawValue: "keyinput")
+
+  // Derived from IINA's currently active key bindings. We need to account for partial key sequences so that the user doesn't hear a beep
+  // while they are typing the beginning of the sequence. For example, if there is currently a binding for "x-y-z", then "x" and "x-y".
+  // This needs to be rebuilt each time the keybindings change.
+  static private var partialValidSequences = Set<String>()
+
+  // Reacts when there is a change to the global key bindings
+  static private var keyBindingsChangedObserver: NSObjectProtocol? = nil
+
+  static func initSharedState() {
+    if let existingObserver = keyBindingsChangedObserver {
+      NotificationCenter.default.removeObserver(existingObserver)
+    }
+    keyBindingsChangedObserver = NotificationCenter.default.addObserver(forName: .iinaKeyBindingChanged, object: nil, queue: .main) { _ in
+      KeyInputController.rebuildPartialValidSequences()
+    }
+
+    // initial build
+    KeyInputController.rebuildPartialValidSequences()
+  }
+
+  static private func onKeyBindingsChanged(_ sender: Notification) {
+    Logger.log("Key bindings changed. Rebuilding partial valid key sequences", level: .verbose, subsystem: sharedSubsystem)
+    KeyInputController.rebuildPartialValidSequences()
+  }
+
+  static private func rebuildPartialValidSequences() {
+    var partialSet = Set<String>()
+    for (keyCode, _) in PlayerCore.keyBindings {
+      if keyCode.contains("-") && keyCode != "default-bindings" {
+        let keySequence = keyCode.split(separator: "-")
+        if keySequence.count >= 2 && keySequence.count <= 4 {
+          var partial = ""
+          for key in keySequence {
+            if partial == "" {
+              partial = String(key)
+            } else {
+              partial = "\(partial)-\(key)"
+            }
+            if partial != keyCode && !PlayerCore.keyBindings.keys.contains(partial) {
+              partialSet.insert(partial)
+            }
+          }
+        }
+      }
+    }
+    Logger.log("Generated partialValidKeySequences: \(partialSet)", level: .verbose)
+    partialValidSequences = partialSet
+  }
+
+  // MARK: - Single player instance
+
+  private var lastKeysPressed = RingBuffer<String>(capacity: 4)
+
+  private var playerCore: PlayerCore!
+  private lazy var subsystem = Logger.Subsystem(rawValue: "\(playerCore.subsystem.rawValue)/\(KeyInputController.sharedSubsystem.rawValue)")
+
+  init(playerCore: PlayerCore) {
+    self.playerCore = playerCore
+  }
+
+  func log(_ msg: String, level: Logger.Level) {
+    Logger.log(msg, level: level, subsystem: subsystem)
+  }
+
+  // Called when this window has keyboard focus but it was already handled by someone else (probably the main menu).
+  // But it's still important to know that it happened
+  func keyWasHandled(_ keyDownEvent: NSEvent) {
+    log("Clearing list of pressed keys", level: .verbose)
+    lastKeysPressed.clear()
+  }
+
+  /*
+   Parses the user's most recent keystroke from the given keyDown event and determines if it (a) matches a key binding for a single keystroke,
+   or (b) when combined with the user's previous keystrokes, matches a key binding for a key sequence.
+
+   Returns:
+   - nil if keystroke is invalid (e.g., it does not resolve to an actively bound keystroke or key sequence, and could not be interpreted as starting
+     or continuing such a key sequence)
+   - (a non-null) KeyMapping whose action is "ignore" if it should be ignored by MPV and IINA
+   - (a non-null) KeyMapping whose action is not "ignore" if the keystroke matched an active (non-ignored) key binding or the final keystroke
+     in a key sequence.
+   */
+  func resolveKeyEvent(_ keyDownEvent: NSEvent) -> KeyMapping? {
+    assert (keyDownEvent.type == NSEvent.EventType.keyDown, "Expected a KeyDown event but got: \(keyDownEvent)")
+
+    let keyStroke: String = KeyCodeHelper.mpvKeyCode(from: keyDownEvent)
+    if keyStroke == "" {
+      log("Event could not be translated; ignoring: \(keyDownEvent)", level: .debug)
+      return nil
+    }
+
+    return resolveKeySequence(keyStroke)
+  }
+
+  // Try to match key sequences, up to 4 values. shortest match wins
+  private func resolveKeySequence(_ lastKeyStroke: String) -> KeyMapping? {
+    lastKeysPressed.insertHead(lastKeyStroke)
+
+    var keySequence = ""
+    var hasPartialValidSequence = false
+
+    for prevKey in lastKeysPressed.reversed() {
+      if keySequence.isEmpty {
+        keySequence = prevKey
+      } else {
+        keySequence = "\(prevKey)-\(keySequence)"
+      }
+
+      log("Checking sequence: \"\(keySequence)\"", level: .verbose)
+
+      if let keyBinding = PlayerCore.keyBindings[keySequence] {
+        if keyBinding.isIgnored {
+          log("Ignoring \"\(keyBinding.key)\"", level: .verbose)
+          hasPartialValidSequence = true
+        } else {
+          log("Found active binding for \"\(keyBinding.key)\" -> \(keyBinding.action)", level: .debug)
+          // Non-ignored action! Clear prev key buffer as per MPV spec
+          lastKeysPressed.clear()
+          return keyBinding
+        }
+      } else if !hasPartialValidSequence && KeyInputController.partialValidSequences.contains(keySequence) {
+        // No exact match, but at least is part of a key sequence.
+        hasPartialValidSequence = true
+      }
+    }
+
+    if hasPartialValidSequence {
+      // Send an explicit "ignore" for a partial sequence match, so player window doesn't beep
+      log("Contains partial sequence, ignoring: \"\(keySequence)\"", level: .verbose)
+      return KeyMapping(key: keySequence, rawAction: MPVCommand.ignore.rawValue, isIINACommand: false, comment: nil)
+    } else {
+      // Not even part of a valid sequence = invalid keystroke
+      log("No active binding for keystroke \"\(lastKeyStroke)\"", level: .debug)
+      return nil
+    }
+  }
+}

--- a/iina/KeyMapping.swift
+++ b/iina/KeyMapping.swift
@@ -8,6 +8,7 @@
 
 import Foundation
 
+/// - Tag: KeyMapping
 class KeyMapping: NSObject {
 
   static private let modifierOrder: [String: Int] = [
@@ -79,6 +80,10 @@ class KeyMapping: NSObject {
         return key
       }
     }
+  }
+
+  var isIgnored: Bool {
+    return privateRawAction == MPVCommand.ignore.rawValue
   }
 
   @objc var prettyCommand: String {

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -119,6 +119,10 @@ class MainWindowController: PlayerWindowController {
     }
   }
 
+  var hasKeyboardFocus: Bool {
+    window?.isKeyWindow ?? false
+  }
+
   /** For mpv's `geometry` option. We cache the parsed structure
    so never need to parse it every time. */
   var cachedGeometry: GeometryDef?

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -141,9 +141,12 @@ class PlayerCore: NSObject {
 
   static var keyBindings: [String: KeyMapping] = [:]
 
+  var keyInputController: KeyInputController!
+
   override init() {
     super.init()
     self.mpv = MPVController(playerCore: self)
+    self.keyInputController = KeyInputController(playerCore: self)
     self.mainWindow = MainWindowController(playerCore: self)
     self.miniPlayer = MiniPlayerWindowController(playerCore: self)
     self.initialWindow = InitialWindowController(playerCore: self)
@@ -268,7 +271,12 @@ class PlayerCore: NSObject {
     mpv.command(.loadfile, args: [path])
   }
 
-  static func loadKeyBindings() {
+  static func initSharedState() {
+    loadKeyBindings()
+    KeyInputController.initSharedState()
+  }
+
+  private static func loadKeyBindings() {
     Logger.log("Loading key bindings")
     let userConfigs = Preference.dictionary(for: .inputConfigs)
     let iinaDefaultConfPath = PrefKeyBindingViewController.defaultConfigs["IINA Default"]!
@@ -1419,7 +1427,7 @@ class PlayerCore: NSObject {
   func syncUI(_ option: SyncUIOption) {
     // if window not loaded, ignore
     guard mainWindow.loaded else { return }
-    Logger.log("Syncing UI \(option)", level: .verbose, subsystem: subsystem)
+//    Logger.log("Syncing UI \(option)", level: .verbose, subsystem: subsystem)
 
     switch option {
 

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -11,7 +11,7 @@ import Cocoa
 class PlayerWindowController: NSWindowController, NSWindowDelegate {
 
   unowned var player: PlayerCore
-  
+
   var videoView: VideoView {
     fatalError("Subclass must implement")
   }
@@ -254,10 +254,15 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
   }
 
   override func keyDown(with event: NSEvent) {
-    let keyCode = KeyCodeHelper.mpvKeyCode(from: event)
-    if let kb = PlayerCore.keyBindings[keyCode] {
-      handleKeyBinding(kb)
+    if let keyBinding = player.keyInputController.resolveKeyEvent(event) {
+      if !keyBinding.isIgnored {  // if "ignore", do nothing. No beep, no send
+        if !handleKeyBinding(keyBinding) {
+          // beep if cmd failed
+          super.keyDown(with: event)
+        }
+      }
     } else {
+      // invalid key
       super.keyDown(with: event)
     }
   }

--- a/iina/RingBuffer.swift
+++ b/iina/RingBuffer.swift
@@ -1,0 +1,179 @@
+//
+//  RingBuffer.swift
+//  iina
+//
+//  Created by Matt Svoboda on 2022.05.17.
+//  Copyright © 2022 lhc. All rights reserved.
+//
+
+/*
+ Fixed-capacity ring buffer, backed by an data, which can append and pop from both the head and the tail.
+ If already at full capacity:
+ - Appending an element to the head will overwrite the element at the tail
+ - Appending elements to the tail will overwrite the elements at the head
+ */
+public struct RingBuffer<T>: CustomStringConvertible, Sequence {
+  private var data: [T?]
+  private var tailIndex = 0
+  private var headIndex = 0
+  private var elementCount = 0
+
+  public var count: Int {
+    get {
+      return elementCount
+    }
+  }
+
+  public init(capacity: Int) {
+    data = [T?](repeating: nil, count: capacity)
+    resetCounters()
+  }
+
+  /*
+   Gets the element at the head, without removing it or changing state in any way.
+   */
+  public var head: T? {
+    get {
+      return data[headIndex]
+    }
+  }
+
+  /*
+   Gets the element at the tail, without removing it or changing state in any way.
+   */
+  public var tail: T? {
+    get {
+      return data[tailIndex]
+    }
+  }
+
+  public var isEmpty: Bool {
+    return elementCount == 0
+  }
+
+  public var isFull: Bool {
+    return elementCount == data.count
+  }
+
+  /*
+   Sets all elements to zero & clears all internal variables to their initial state, except for `capacity`
+   */
+  public mutating func clear() {
+    for i in 0..<data.count {
+      data[i] = nil
+    }
+    resetCounters()
+  }
+
+  private mutating func resetCounters() {
+    headIndex = 0
+    tailIndex = 0
+    elementCount = 0
+  }
+
+  /*
+   Adds the given element to the head and increments the pointer. If already full, then the tail is overwritten.
+   Returns true if the tail was overwritten; false if not.
+   */
+  @discardableResult
+  public mutating func insertHead(_ element: T) -> Bool {
+    let overwrite = isFull
+    if overwrite {
+      headIndex = (headIndex + 1) %% data.count
+      tailIndex = (tailIndex + 1) %% data.count  // also advance tail since it is being overwritten
+    } else {
+      if data[headIndex] != nil {
+        // was empty, but then insertTail happened. move over and use the next available space:
+        headIndex = (headIndex + 1) %% data.count
+      }
+      elementCount = elementCount + 1
+    }
+    data[headIndex] = element
+    return overwrite
+  }
+
+  /*
+   Adds the given element to the tail and advances the tail pointer.
+   If already full, then the head is overwritten and the head pointer retreats.
+   Returns true if the head was overwritten; false if not.
+   */
+  @discardableResult
+  public mutating func insertTail(_ element: T) -> Bool {
+    let overwrite = isFull
+    if overwrite {
+      tailIndex = (tailIndex - 1) %% data.count
+      headIndex = (headIndex - 1) %% data.count  // also retreat tail since it is being overwritten
+    } else {
+      if data[tailIndex] != nil {
+        // was empty, but then insertHead happened. move over and use the next available space:
+        tailIndex = (tailIndex - 1) %% data.count
+      }
+      elementCount = elementCount + 1
+    }
+    data[tailIndex] = element
+    return overwrite
+  }
+
+  /*
+   Pops and returns the element at the head, retreating the pointer to the head.
+   Returns nil if already empty.
+   */
+  @discardableResult
+  public mutating func removeHead() -> T? {
+    guard !isEmpty else {
+      return nil
+    }
+    defer {
+      data[headIndex] = nil
+      headIndex = (headIndex - 1) %% data.count
+      elementCount = elementCount - 1
+    }
+    return data[headIndex]
+  }
+
+  /*
+   Pops and returns the element at the tail, advancing the pointer to the tail.
+   Returns nil if already empty.
+   */
+  @discardableResult
+  public mutating func removeTail() -> T? {
+    guard !isEmpty else {
+      return nil
+    }
+    defer {
+      data[tailIndex] = nil
+      tailIndex = (tailIndex + 1) %% data.count
+      elementCount = elementCount - 1
+    }
+    return data[tailIndex]
+  }
+
+  public var description: String {
+    get {
+      var string = ""
+      for elem in self {
+        if string.isEmpty {
+          string = "\(elem)"
+        } else {
+          string.append(", \(elem)")
+        }
+      }
+      return "[\(string)]"
+    }
+  }
+
+  /*
+   Returns an iterator which yields elements one at a time, in order of tail -> head
+   */
+  public func makeIterator() -> AnyIterator<T> {
+    var index = tailIndex
+    let endIndex = index + elementCount
+    return AnyIterator {
+      guard index < endIndex else { return nil }
+      defer {
+        index = index + 1
+      }
+      return data[index %% data.count]
+    }
+  }
+}


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3716.

---

**Description:**
Added a simple circular buffer which tracks the last 4 pressed keys/key-combos and sends the shortest sequence which matches, mimicking MPV's own logic.