### PR TITLE
Fix inconsistent vertical offset in Prefs Window panels: remove unnec…

### DIFF
--- a/iina/PrefAdvancedViewController.swift
+++ b/iina/PrefAdvancedViewController.swift
@@ -26,6 +26,10 @@ class PrefAdvancedViewController: PreferenceViewController, PreferenceWindowEmbe
     return NSImage(named: NSImage.Name("pref_advanced"))!
   }
 
+  var preferenceContentIsScrollable: Bool {
+    return false
+  }
+
   var hasResizableWidth: Bool = false
 
   var options: [[String]] = []

--- a/iina/PreferenceWindowController.swift
+++ b/iina/PreferenceWindowController.swift
@@ -160,7 +160,7 @@ class PreferenceWindowController: NSWindowController {
     completionTableView.delegate = self
     completionTableView.dataSource = self
 
-    contentViewBottomConstraint = contentView.bottomAnchor.constraint(equalTo: contentView.superview!.bottomAnchor)
+    contentViewBottomConstraint = contentView.bottomAnchor.constraint(equalTo: contentView.superview!.bottomAnchor, constant: -28)
 
     let labelDict = [String: [String: [String]]](uniqueKeysWithValues:  [
       ["general", "PrefGeneralViewController"],
@@ -246,13 +246,11 @@ class PreferenceWindowController: NSWindowController {
     contentView.subviews.forEach { $0.removeFromSuperview() }
     guard let vc = viewControllers[at: index] else { return }
     contentView.addSubview(vc.view)
-    Utility.quickConstraints(["H:|-20-[v]-20-|", "V:|-28-[v]-28-|"], ["v": vc.view])
+    Utility.quickConstraints(["H:|-20-[v]-20-|", "V:|-0-[v]-20-|"], ["v": vc.view])
 
     let isScrollable = vc.preferenceContentIsScrollable
     contentViewBottomConstraint?.isActive = !isScrollable
-    scrollView.verticalScrollElasticity = isScrollable ? .allowed : .none
-    // scroll to top
-    scrollView.documentView?.scroll(.zero)
+    scrollView.verticalScrollElasticity = .none
 
     // find label
     if let title = title, let label = findLabel(titled: title, in: vc.view) {


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3717.

---

**Description:**
Fix inconsistent vertical offset in Prefs Window panels: removed an unnecessary and unreliable scroll(.zero) request. This resulted in a consistent vertical offset which was too large and easily reduced. The pref panes should always be fixed size and not scrollable, because their superview is an NSScrollView which will provide the scroll. Also, they do not need an explicit scroll() because their superview will always have an implicit scroll of zero when they are redrawn in it.