### PR TITLE
Enable up/down & enter key in Welcome window (issue #3669)

### DIFF
--- a/iina/Base.lproj/InitialWindowController.xib
+++ b/iina/Base.lproj/InitialWindowController.xib
@@ -338,6 +338,7 @@
             </view>
             <connections>
                 <outlet property="delegate" destination="-2" id="0bl-1N-AYu"/>
+                <outlet property="initialFirstResponder" destination="VeK-rB-yjt" id="GMr-dI-Npg"/>
             </connections>
             <point key="canvasLocation" x="135" y="275"/>
         </window>


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3669.

---

**Description:**
The Welcome window actually is displaying a button with the most recently played file, followed by a table of Recent File 2, Recent File 3, etc. The reason the up/down arrow keys caused a file to play was that the "selectionChanged" callback was being used as a proxy for detecting a user event.

I changed this so that:
- When window opens, we "pretend" the button with the most recent entry is selected, which makes sense because the table has no items selected. Thus, ENTER or RETURN at this point will open the most recent file, or if for some reason that is no longer available, tries to open the next most recent one.
- User can use UP and DOWN arrow keys to select recent files, which will highlight in the table, and then press ENTER or RETURN to open that file.
- Mouse clicks behave the same as before

One snag: once the user scrolls down to Recent File 2 or below, they can't scroll back up to Most Recent File. That's due to the fact that that entry is actually outside the table, and would have required a bunch of custom code to make it look good. Which I was prepared to do, but I also ran into a problem where once I give the table control of the arrow keys, it doesn't seem to want to give them back, and I'd need to intercept them to make that work. So maybe that's something for the future, but this should be much improved over the previous behavior.