### PR TITLE
Enable up/down & enter key in Welcome window (issue #3669)

### DIFF
--- a/iina/Base.lproj/InitialWindowController.xib
+++ b/iina/Base.lproj/InitialWindowController.xib
@@ -338,7 +338,7 @@
             </view>
             <connections>
                 <outlet property="delegate" destination="-2" id="0bl-1N-AYu"/>
-                <outlet property="initialFirstResponder" destination="VeK-rB-yjt" id="GMr-dI-Npg"/>
+                <outlet property="initialFirstResponder" destination="se5-gp-TjO" id="F1N-a0-gN8"/>
             </connections>
             <point key="canvasLocation" x="135" y="275"/>
         </window>

--- a/iina/Base.lproj/InitialWindowController.xib
+++ b/iina/Base.lproj/InitialWindowController.xib
@@ -338,6 +338,7 @@
             </view>
             <connections>
                 <outlet property="delegate" destination="-2" id="0bl-1N-AYu"/>
+                <outlet property="initialFirstResponder" destination="VeK-rB-yjt" id="GMr-dI-Npg"/>
             </connections>
             <point key="canvasLocation" x="135" y="275"/>
         </window>

--- a/iina/InitialWindowController.swift
+++ b/iina/InitialWindowController.swift
@@ -210,17 +210,16 @@ class InitialWindowController: NSWindowController {
   }
 }
 
-
 extension InitialWindowController: NSTableViewDelegate, NSTableViewDataSource {
 
   private class GrayHighlightRowView: NSTableRowView {
     override func drawSelection(in dirtyRect: NSRect) {
-        if self.selectionHighlightStyle != .none {
-          let selectionRect = NSInsetRect(self.bounds, 2.5, 2.5)
-          NSColor.initialWindowLastFileBackground.setFill()
-          let selectionPath = NSBezierPath.init(roundedRect: selectionRect, xRadius: 4, yRadius: 4)
-          selectionPath.fill()
-        }
+      if self.selectionHighlightStyle != .none {
+        let selectionRect = NSInsetRect(self.bounds, 2.5, 2.5)
+        NSColor.initialWindowLastFileBackground.setFill()
+        let selectionPath = NSBezierPath.init(roundedRect: selectionRect, xRadius: 4, yRadius: 4)
+        selectionPath.fill()
+      }
     }
   }
 
@@ -230,13 +229,7 @@ extension InitialWindowController: NSTableViewDelegate, NSTableViewDataSource {
   }
 
   func tableViewSelectionDidChange(_ notification: Notification) {
-    if recentFilesTableView.selectedRow >= 0 {
-      // remove "LastFle" button highlight
-      lastFileContainerView.layer?.backgroundColor = NSColor.initialWindowActionButtonBackground.cgColor
-    } else {
-      // re-highlight "LastFle" button
-      lastFileContainerView.layer?.backgroundColor = NSColor.initialWindowLastFileBackground.cgColor
-    }
+    updateHighlights()
   }
 
   func numberOfRows(in tableView: NSTableView) -> Int {
@@ -268,6 +261,16 @@ extension InitialWindowController: NSTableViewDelegate, NSTableViewDataSource {
       default:
         super.keyDown(with: event)
         break
+    }
+  }
+
+  func updateHighlights() {
+    if recentFilesTableView.selectedRow >= 0 {
+      // remove "LastFle" button highlight
+      lastFileContainerView.layer?.backgroundColor = NSColor.initialWindowActionButtonBackground.cgColor
+    } else {
+      // re-highlight "LastFle" button
+      lastFileContainerView.layer?.backgroundColor = NSColor.initialWindowLastFileBackground.cgColor
     }
   }
 
@@ -316,6 +319,9 @@ class InitialWindowViewActionButton: NSView {
 
   override func mouseExited(with event: NSEvent) {
     self.layer?.backgroundColor = normalBackground.cgColor
+    if let windowController = window?.windowController as? InitialWindowController {
+      windowController.updateHighlights()
+    }
   }
 
   override func mouseDown(with event: NSEvent) {

--- a/iina/InitialWindowController.swift
+++ b/iina/InitialWindowController.swift
@@ -228,10 +228,11 @@ extension InitialWindowController: NSTableViewDelegate, NSTableViewDataSource {
   override func keyDown(with event: NSEvent) {
     switch event.keyCode {
       case 36, 76:  // RETURN or (keypad ENTER)
-        // If user selected a row in the table using the keyboard, use that. Otherwise default to most recent file
         if recentFilesTableView.selectedRow >= 0 {
+          // If user selected a row in the table using the keyboard, use that
           openRecentItemFromTable(recentFilesTableView.selectedRow)
         } else if let lastURL = lastPlaybackURL {
+          // If no row selected in table, most recent file button is selected. Use that if it exists
           player.openURL(lastURL)
         } else if recentFilesTableView.numberOfRows > 0 {
           // Most recent file no longer exists? Try to load next one

--- a/iina/InitialWindowController.swift
+++ b/iina/InitialWindowController.swift
@@ -213,6 +213,32 @@ class InitialWindowController: NSWindowController {
 
 extension InitialWindowController: NSTableViewDelegate, NSTableViewDataSource {
 
+  private class GrayHighlightRowView: NSTableRowView {
+    override func drawSelection(in dirtyRect: NSRect) {
+        if self.selectionHighlightStyle != .none {
+          let selectionRect = NSInsetRect(self.bounds, 2.5, 2.5)
+          NSColor.initialWindowLastFileBackground.setFill()
+          let selectionPath = NSBezierPath.init(roundedRect: selectionRect, xRadius: 4, yRadius: 4)
+          selectionPath.fill()
+        }
+    }
+  }
+
+  func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
+    // uses custom highlight for table row
+    return GrayHighlightRowView()
+  }
+
+  func tableViewSelectionDidChange(_ notification: Notification) {
+    if recentFilesTableView.selectedRow >= 0 {
+      // remove "LastFle" button highlight
+      lastFileContainerView.layer?.backgroundColor = NSColor.initialWindowActionButtonBackground.cgColor
+    } else {
+      // re-highlight "LastFle" button
+      lastFileContainerView.layer?.backgroundColor = NSColor.initialWindowLastFileBackground.cgColor
+    }
+  }
+
   func numberOfRows(in tableView: NSTableView) -> Int {
     return recentDocuments.count
   }

--- a/iina/InitialWindowController.swift
+++ b/iina/InitialWindowController.swift
@@ -171,7 +171,6 @@ class InitialWindowController: NSWindowController {
   }
 
   @objc func onTableClicked() {
-    Logger.log("Clicked!")
     openRecentItemFromTable(recentFilesTableView.clickedRow)
   }
 
@@ -211,6 +210,7 @@ class InitialWindowController: NSWindowController {
   }
 }
 
+
 extension InitialWindowController: NSTableViewDelegate, NSTableViewDataSource {
 
   func numberOfRows(in tableView: NSTableView) -> Int {
@@ -226,8 +226,6 @@ extension InitialWindowController: NSTableViewDelegate, NSTableViewDataSource {
   }
 
   override func keyDown(with event: NSEvent) {
-    // Enable key events
-    Logger.log("Key pressed: \(event)")
     switch event.keyCode {
       case 36, 76:  // RETURN or (keypad ENTER)
         // If user selected a row in the table using the keyboard, use that. Otherwise default to most recent file
@@ -245,6 +243,7 @@ extension InitialWindowController: NSTableViewDelegate, NSTableViewDataSource {
         break
     }
   }
+
 }
 
 


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3669.

---

**Description:**
_[second attempt - prev PR got deleted when I renamed the branch]_
The Welcome window actually is displaying a button with the most recently played file, followed by a table of Recent File 2, Recent File 3, etc. The reason the up/down arrow keys caused a file to play was that the "selectionChanged" callback was being used as a proxy for detecting a user event.

I changed this so that:
- When window opens, we "pretend" the button with the most recent entry is selected, which makes sense because the table has no items selected. Thus, ENTER or RETURN at this point will open the most recent file, or if for some reason that is no longer available, tries to open the next most recent one.
- User can use UP and DOWN arrow keys to select recent files, which will highlight in the table, and then press ENTER or RETURN to open that file.
- Mouse clicks behave the same as before

One snag: once the user scrolls down to Recent File 2 or below, they can't scroll back up to Most Recent File. That's due to the fact that that entry is actually outside the table, and would have required a bunch of custom code to make it look good. Which I was prepared to do, but I also ran into a problem where once I give the table control of the arrow keys, it doesn't seem to want to give them back, and I'd need to intercept them to make that work. So maybe that's something for the future, but this should be much improved over the previous behavior.