### PR TITLE
Close support automatic screen refresh, #3414

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -15,6 +15,9 @@
 		49542986216C34950058F680 /* OpenInIINA.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 49542973216C34950058F680 /* OpenInIINA.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		496B19921E2968530035AF10 /* PIP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 496B19911E2968530035AF10 /* PIP.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		519872FF26879B9B00F84BCC /* AccessibilityPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519872FE26879B9B00F84BCC /* AccessibilityPreferences.swift */; };
+		51FC32D928231A4100B1B2BC /* RefreshRateMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FC32D828231A4100B1B2BC /* RefreshRateMatcher.swift */; };
+		51FC32DB282366F600B1B2BC /* DisplaySynchronizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51FC32DA282366F600B1B2BC /* DisplaySynchronizer.swift */; };
+		51FDECDB281F2DCC008CA84F /* Atomics in Frameworks */ = {isa = PBXBuildFile; productRef = 51FDECDA281F2DCC008CA84F /* Atomics */; };
 		6100FF2B1EDF9806002CF0FB /* dsa_pub.pem in Resources */ = {isa = PBXBuildFile; fileRef = 6100FF2A1EDF9806002CF0FB /* dsa_pub.pem */; };
 		8400D5C41E17C6D2006785F5 /* AboutWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8400D5C21E17C6D2006785F5 /* AboutWindowController.swift */; };
 		8400D5C61E1AB2F1006785F5 /* MainWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8400D5C81E1AB2F1006785F5 /* MainWindowController.xib */; };
@@ -536,6 +539,8 @@
 		49542983216C34950058F680 /* OpenInIINA.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = OpenInIINA.entitlements; sourceTree = "<group>"; };
 		496B19911E2968530035AF10 /* PIP.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PIP.framework; path = ../../../../System/Library/PrivateFrameworks/PIP.framework; sourceTree = "<group>"; };
 		519872FE26879B9B00F84BCC /* AccessibilityPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPreferences.swift; sourceTree = "<group>"; };
+		51FC32D828231A4100B1B2BC /* RefreshRateMatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RefreshRateMatcher.swift; sourceTree = "<group>"; };
+		51FC32DA282366F600B1B2BC /* DisplaySynchronizer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplaySynchronizer.swift; sourceTree = "<group>"; };
 		5879479521A87DD700757A6F /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/MiniPlayerWindowController.strings; sourceTree = "<group>"; };
 		5879479621A87E6100757A6F /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/PreferenceWindowController.strings; sourceTree = "<group>"; };
 		5EF9F7E521FB42E900748374 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/MainMenu.strings"; sourceTree = "<group>"; };
@@ -1548,6 +1553,7 @@
 				E3B25F4524FF505D0068B9B0 /* libpcre.1.dylib in Frameworks */,
 				E3B25F5124FF505D0068B9B0 /* libidn2.0.dylib in Frameworks */,
 				496B19921E2968530035AF10 /* PIP.framework in Frameworks */,
+				51FDECDB281F2DCC008CA84F /* Atomics in Frameworks */,
 				8403CEA72007CBD400645516 /* MediaPlayer.framework in Frameworks */,
 				B4E446F225CB53FF0069F06E /* Gzip in Frameworks */,
 				E3B25F4424FF505D0068B9B0 /* libb2.1.dylib in Frameworks */,
@@ -1849,6 +1855,8 @@
 				E342832E20B7149800139865 /* Logger.swift */,
 				E3F698862120D878005792C9 /* ExtendedColors.swift */,
 				E301EFD921312AB300BC8588 /* KeychainAccess.swift */,
+				51FC32DA282366F600B1B2BC /* DisplaySynchronizer.swift */,
+				51FC32D828231A4100B1B2BC /* RefreshRateMatcher.swift */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -2275,6 +2283,7 @@
 				B4E446F625CB54EF0069F06E /* Mustache */,
 				B4E4470025CE3F930069F06E /* Sparkle */,
 				8451E6D82604AEFC009A15D7 /* Just */,
+				51FDECDA281F2DCC008CA84F /* Atomics */,
 			);
 			productName = mpvx;
 			productReference = 84EB1ED61D2F51D3004FA5A1 /* IINA.app */;
@@ -2361,6 +2370,7 @@
 				B4E446F525CB54EF0069F06E /* XCRemoteSwiftPackageReference "GRMustache" */,
 				B4E446FF25CE3F930069F06E /* XCRemoteSwiftPackageReference "Sparkle" */,
 				8451E6D72604AEFC009A15D7 /* XCRemoteSwiftPackageReference "Just" */,
+				51FDECD9281F2DCC008CA84F /* XCRemoteSwiftPackageReference "swift-atomics" */,
 			);
 			productRefGroup = 84EB1ED71D2F51D3004FA5A1 /* Products */;
 			projectDirPath = "";
@@ -2538,6 +2548,7 @@
 				8450403D1E0A9EE20079C194 /* InspectorWindowController.swift in Sources */,
 				84C6D3671EB2A427009BF721 /* HistoryWindowController.swift in Sources */,
 				9E47DAC01E3CFA6D00457420 /* DurationDisplayTextField.swift in Sources */,
+				51FC32DB282366F600B1B2BC /* DisplaySynchronizer.swift in Sources */,
 				840AF5821E732C8F00F4AF92 /* JustXMLRPC.swift in Sources */,
 				E3513AF820EF79C500F8C347 /* PreferenceWindowController.swift in Sources */,
 				841A599D1E1FF5800079E177 /* SleepPreventer.swift in Sources */,
@@ -2588,6 +2599,7 @@
 				842F55A51EA17E7E0081D475 /* IINACommand.swift in Sources */,
 				8434BAAD1D5E4546003BECF2 /* SlideUpButton.swift in Sources */,
 				840D47981DFEEE6A000D9A64 /* KeyMapping.swift in Sources */,
+				51FC32D928231A4100B1B2BC /* RefreshRateMatcher.swift in Sources */,
 				84BEEC3F1DFEDE2F00F945CA /* PrefKeyBindingViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -3939,6 +3951,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		51FDECD9281F2DCC008CA84F /* XCRemoteSwiftPackageReference "swift-atomics" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/apple/swift-atomics.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
 		8451E6D72604AEFC009A15D7 /* XCRemoteSwiftPackageReference "Just" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/dduan/Just";
@@ -3982,6 +4002,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		51FDECDA281F2DCC008CA84F /* Atomics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 51FDECD9281F2DCC008CA84F /* XCRemoteSwiftPackageReference "swift-atomics" */;
+			productName = Atomics;
+		};
 		8451E6D82604AEFC009A15D7 /* Just */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 8451E6D72604AEFC009A15D7 /* XCRemoteSwiftPackageReference "Just" */;

--- a/iina/Base.lproj/KeyBinding.strings
+++ b/iina/Base.lproj/KeyBinding.strings
@@ -51,6 +51,7 @@
 "iina.fit-to-screen" = "Fit to Screen";
 "iina.toggle-flip" = "Toggle flip";
 "iina.toggle-mirror" = "Toggle mirror";
+"iina.toggle-match-refresh-rate" = "Toggle Match Refresh Rate";
 "iina.save-playlist" = "Save current playlist";
 "iina.delete-current-file" = "Delete current file";
 "iina.delete-current-file-hard" = "Delete current file directly without moving to trash";

--- a/iina/Base.lproj/MainMenu.xib
+++ b/iina/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -423,6 +423,9 @@ CA
                             <menuItem title="Delogo" id="ArE-2s-JIV">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                             </menuItem>
+                            <menuItem title="Match Refresh Rate" id="cuA-ze-ZZG">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="kNp-jq-01c"/>
                             <menuItem title="Video Filters…" keyEquivalent="F" id="PyY-pR-jz7">
                                 <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
@@ -720,6 +723,7 @@ CA
                 <outlet property="jumpTo" destination="2id-wn-xsC" id="wyH-9I-JHJ"/>
                 <outlet property="jumpToBegin" destination="2Ya-3g-1hy" id="atq-PX-lIt"/>
                 <outlet property="loadExternalSub" destination="k6x-hf-ATi" id="lVp-BV-A2C"/>
+                <outlet property="matchRefreshRate" destination="cuA-ze-ZZG" id="XaV-hF-MWN"/>
                 <outlet property="miniPlayer" destination="bGN-E4-V5A" id="gMc-FE-SVO"/>
                 <outlet property="mirror" destination="JJq-qH-toq" id="EWI-VS-c7Q"/>
                 <outlet property="mute" destination="WOL-Us-ByA" id="Hry-sv-WhY"/>

--- a/iina/DisplaySynchronizer.swift
+++ b/iina/DisplaySynchronizer.swift
@@ -1,0 +1,288 @@
+//
+//  DisplaySynchronizer.swift
+//  iina
+//
+//  Created by low-batt on 5/4/22.
+//  Copyright © 2022 lhc. All rights reserved.
+//
+
+import Foundation
+
+/// An object that supports synchronization of a display's refresh rate with the frame rate of a video.
+///
+/// This is one part of the implementation for the `Match Refresh Rate` feature. A `DisplaySynchronizer` object manages
+/// refresh rate synchronization for a specific display. Higher level aspects are managed by the class `RefreshRateMatcher`.
+///
+/// - Note: In anticipation of questions from users regarding why this feature did or didn't change the display's refresh rate this class
+///         includes extensive logging.
+class DisplaySynchronizer {
+
+  // MARK: - Static Properties and Methods
+
+  private static var displays: [CGDirectDisplayID: DisplaySynchronizer] = [:]
+
+  /// Returns a string containing the given display modes suitable for including in a log message.
+  private static func displayModesForLog(_ displayModes: [CGDisplayMode]) -> String {
+    displayModes.reduce("", { result, displayMode in
+      result + "\n  " + displayMode.shortDescription
+    })
+  }
+
+  /// Find the screen associated with this display.
+  /// - Parameter displayId: ID of the display to return the screen for.
+  /// - Returns: The `NSScreen` for the given display or `nil` if the screen could not be found
+  private static func findScreen(_ displayId: CGDirectDisplayID) -> NSScreen? {
+    let key: NSDeviceDescriptionKey = NSDeviceDescriptionKey(rawValue: "NSScreenNumber")
+    return NSScreen.screens.first(where: {
+      guard let deviceId = $0.deviceDescription[key] as? NSNumber else { return false }
+      return deviceId.uint32Value == displayId
+    })
+  }
+
+  /// Return the `DisplaySynchronizer` for the given display.
+  ///
+  /// If a `DisplaySynchronizer` does not exist for the given display, one will be constructed.
+  /// - Parameter displayId: ID of the display to return a synchronizer for.
+  /// - Returns: `DisplaySynchronizer` for the display with the given ID
+  static func getDisplaySynchronizer(_ displayId: CGDirectDisplayID) -> DisplaySynchronizer {
+    if let display = displays[displayId] {
+      return display
+    }
+    let display = DisplaySynchronizer(displayId)
+    displays[displayId] = display
+    return display
+  }
+
+  /// Get the localized name for the given display.
+  ///
+  /// As the `localizedName` property was added to `NSScreen` in macOS Catalina the name of the screen will not be available
+  /// when running on older versions of macOS.
+  /// - Parameter displayId: ID of the display to return the localized name of..
+  /// - Returns: A localized name describing the display or `nil` if a name could not be obtained.
+  private static func getLocalizedName(_ displayId: CGDirectDisplayID) -> String? {
+    if #available(macOS 10.15, *) {
+      return findScreen(displayId)?.localizedName
+    }
+    return nil
+  }
+
+  // MARK: - Constants
+
+  private let displayId: CGDirectDisplayID
+
+  /// Native modes supported by the display.
+  private let displayModes: [CGDisplayMode]
+
+  /// `true` if the display did not report any native resolutions.
+  private let foundNativeDisplayModes: Bool
+
+  /// A localized name describing this display or `nil` if a name could not be obtained.
+  ///
+  /// As the `localizedName` property was added to `NSScreen` in macOS Catalina the name of the screen will not be available
+  /// when running on older versions of macOS.
+  private let localizedName: String?
+
+  private let subsystem: Logger.Subsystem
+
+  // MARK: - Variables
+
+  /// The display mode the display is currently set to.
+  ///
+  /// This property will be `nil` if the display is invalid.
+  private var currentDisplayMode: CGDisplayMode? {
+    guard let currentDisplayMode = CGDisplayCopyDisplayMode(displayId) else {
+      log("Unable to obtain current display mode", level: .error)
+      return nil
+    }
+    return currentDisplayMode
+  }
+
+  /// The mode the display was in before the refresh rate was adjusted by this feature. Will be `nil` when the display is not currently
+  /// adjusted.
+  var displayModeForRestore: CGDisplayMode?
+
+  /// `true` of this display belongs to a mirrored set.
+  var isMirrored: Bool { (CGDisplayIsInMirrorSet(displayId) != 0) }
+
+  /// Construct a display synchronizer for the given display.
+  /// - Attention: Call the method `getDisplaySynchronizer` to obtain a `DisplaySynchronizer` object for a display.
+  /// - Parameter displayId: ID of the display to be synchronized.
+  private init(_ displayId: CGDirectDisplayID) {
+    self.displayId = displayId
+    subsystem = Logger.Subsystem(rawValue: "display\(displayId)")
+
+    // Obtain all the available modes on the display and filter out all except the native modes.
+    let allDisplayModes = CGDisplayCopyAllDisplayModes(displayId, nil) as! [CGDisplayMode]
+    var nativeDisplayModes = allDisplayModes
+    nativeDisplayModes.removeAll(where: { !$0.isNative })
+    var usableDisplayModes = nativeDisplayModes
+    usableDisplayModes.removeAll(where: { $0.refreshRate == 0 })
+    displayModes = usableDisplayModes
+    foundNativeDisplayModes = !nativeDisplayModes.isEmpty
+
+    // Try and obtain the name of the display (not available in older versions of macOS).
+    localizedName = DisplaySynchronizer.getLocalizedName(displayId)
+
+    // Log details about the display in case this particular display proves problematic.
+    log("Display vendor: \(CGDisplayVendorNumber(displayId)) model: \(CGDisplayModelNumber(displayId))")
+ 
+    let description = localizedName == nil ? "" : " on \(localizedName!)"
+    guard foundNativeDisplayModes else {
+      // Posts on the Internet indicated some displays do not properly report their display modes.
+      // Posts on the net indicate some displays may fail to set this flag. The iMac 5K 2017
+      // built-in display was given as an example of such problematic displays. If this happens log
+      // all the display modes. This means the feature will never find a matching display refresh
+      // rate.
+      log("No native display modes found\(description):\(DisplaySynchronizer.displayModesForLog(allDisplayModes))",
+          level: .warning)
+      return
+    }
+    guard !displayModes.isEmpty else {
+      // Older macOS versions always report 0 for the refresh rate. Not sure if this will be
+      // encountered under macOS 12 and later. Included this check just in case. This means the
+      // feature will never find a matching display refresh rate.
+      log("This Mac does not provide display refresh rates\(description):\(DisplaySynchronizer.displayModesForLog(nativeDisplayModes))",
+          level: .warning)
+      return
+    }
+    log("Available native display modes\(description):\(DisplaySynchronizer.displayModesForLog(displayModes))")
+  }
+
+  /// Find a display mode that matches one of the specified refresh rates.
+  /// - Parameter refreshRates: List of acceptable refresh rates.
+  /// - Returns: `CGDisplayMode` to set the display to or `nil` of no matching display mode was found.
+  private func findMatch(_ refreshRates: [Double]) -> CGDisplayMode? {
+   for refreshRate in refreshRates {
+      if let matched = displayModes.first(where: { abs($0.refreshRate.distance(to: refreshRate)) < 0.02 }) {
+        return matched
+      }
+    }
+    return nil
+  }
+
+  /// Find a matching display mode for the given video frame rate.
+  /// - Parameter refreshRate: The frame rate of the video.
+  /// - Returns: The matching display mode or `nil` if no match was found.
+  func findMatchingDisplayMode(_ videoFps: Double) -> CGDisplayMode? {
+    guard haveUsableDisplayModes() else { return nil }
+    // [23.976, 47.952, 24, 48], [29.97, 59.94, 30, 60]
+    // [24, 48], [25, 50], [30, 60]
+    var refreshRates = [videoFps, videoFps * 2]
+    let rounded = videoFps.rounded()
+    if videoFps != rounded {
+      refreshRates.append(rounded)
+      refreshRates.append(rounded * 2)
+    }
+    log("Video frame rate: \(rateFormatter.string(for: videoFps))")
+    guard let displayMode = findMatch(refreshRates) else {
+      log("No suitable display refresh rate found")
+      return nil
+    }
+    log("Best display refresh rate: \(displayMode.shortDescription)")
+    return displayMode
+  }
+
+  private func haveUsableDisplayModes() -> Bool {
+    guard foundNativeDisplayModes else {
+      // Posts on the Internet indicated some displays do not properly report their display modes.
+      log("No native display modes found, unable to search for a matching refresh rate", level: .warning)
+      return false
+    }
+    guard !displayModes.isEmpty else {
+      // Older macOS versions report 0 for the refresh rate. Not expecting this under macOS 12+, but
+      // including the check to be sure.
+      log("This Mac does not provide display refresh rates, unable to search for a matching refresh rate",
+          level: .warning)
+      return false
+    }
+    return true
+  }
+
+  /// Check to see if the display is set to the given mode.
+  /// - Parameter displayMode: The `CGDisplayMode` to check for.
+  /// - Returns: `true` if the display is set to the given mode, `false` otherwise.
+  func isCurrentDisplayMode(_ displayMode: CGDisplayMode) -> Bool {
+    guard let currentDisplayMode = currentDisplayMode else { return false }
+    guard currentDisplayMode.ioDisplayModeID == displayMode.ioDisplayModeID else { return false }
+    log("Display is already set to the best refresh rate for this video")
+    return true
+  }
+
+  /// Log message using this feature's log `subsystem`.
+  private func log(_ message: String, level: Logger.Level = .debug) {
+    Logger.log(message, level: level, subsystem: subsystem)
+  }
+
+  /// Set the display mode of the display.
+  /// - Parameter displayMode: Display mode to set the display to.
+  /// - Parameter isRestore: If `true` the mode is being set to restore the original display mode.
+  func setDisplayMode(displayMode: CGDisplayMode, isRestore: Bool = false) {
+    guard let currentDisplayMode = currentDisplayMode else {
+      log("Could not obtain current display mode")
+      return
+    }
+    if displayModeForRestore == nil {
+      displayModeForRestore = currentDisplayMode
+      log("Saved original display refresh rate: \(displayModeForRestore!.shortDescription)")
+    }
+    log("\(isRestore ? "Restoring original" : "Setting") display refresh rate\(isRestore ? "" : " to"): \(displayMode.shortDescription)")
+    CGDisplaySetDisplayMode(displayId, displayMode, nil).mustSucceed(#fileID, #line, "CGDisplaySetDisplayMode")
+  }
+}
+
+// MARK: - Rate Formatter
+
+fileprivate let rateFormatter = RateFormatter()
+
+/// A formatter for formatting refresh rates in log messages.
+///
+/// The primary reason for this formatter is to avoid logging floating point numbers with a large number of fractional digits making log
+/// messages hard to read.
+private class RateFormatter: NumberFormatter {
+
+  override init() {
+    super.init()
+    maximumFractionDigits = 3
+    numberStyle = .decimal
+    roundingMode = .down
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  func string(for rate: Double) -> String {
+    super.string(for: rate)! + " Hz"
+  }
+}
+
+// MARK: - Extensions
+
+extension CGDisplayMode {
+  /// Returns `true` if this is a native display mode.
+  /// - Important: Posts on the net indicate some displays may fail to set this flag. The iMac 5K 2017 built-in display was given as
+  ///               an example of such problematic displays.
+  /// - Returns: `true` if the flag `kDisplayModeNativeFlag` is set in `ioFlags`.
+  var isNative: Bool { ioFlags & UInt32(kDisplayModeNativeFlag) != 0 }
+
+  /// A very short description of this display mode appropriate for displaying in the OSD and log file.
+  var shortDescription: String { "\(width)x\(height) @ \(rateFormatter.string(for: refreshRate))" }
+}
+
+extension CGError {
+  /// Validate that this Core Graphics result code indicates the operation was completed successfully.
+  ///
+  /// If this return code indicates the operation failed then this is deemed a fatal internal error and this method will:
+  /// - Log an error message.
+  /// - Show the user an alert.
+  /// - Terminate the application when the user dismisses the alert.
+  /// - Parameter fileID: The name of the file and module in which the operation was invoked.
+  /// - Parameter line: The line number on which the method was called.
+  /// - Parameter method: The name of the method that returned the result code.
+  func mustSucceed(_ fileID: String, _ line: Int, _ method: String) {
+    guard self != .success else { return }
+    DispatchQueue.main.async {
+      Logger.fatal("\(fileID):\(line) \(method) fatal: \(self)")
+    }
+  }
+}

--- a/iina/IINACommand.swift
+++ b/iina/IINACommand.swift
@@ -25,6 +25,8 @@ enum IINACommand: String {
   case flip = "toggle-flip"
   case mirror = "toggle-mirror"
 
+  case toggleMatchRefreshRate = "toggle-match-refresh-rate"
+
   case biggerWindow = "bigger-window"
   case smallerWindow = "smaller-window"
   case fitToScreen = "fit-to-screen"

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -235,6 +235,10 @@ extension MainMenuActionHandler {
   @objc func menuToggleDeinterlace(_ sender: NSMenuItem) {
     player.toggleDeinterlace(sender.state != .on)
   }
+
+  @objc func menuToggleMatchRefreshRate(_ sender: NSMenuItem) {
+    Preference.set(!Preference.bool(for: .matchRefreshRate), for: .matchRefreshRate)
+  }
 }
 
 // MARK: - Audio

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -111,6 +111,8 @@ class MainWindowController: PlayerWindowController {
     return player.mpv.getInt(MPVProperty.videoParamsRotate)
   }()
 
+  private lazy var refreshRateMatcher = RefreshRateMatcher(player, videoView)
+
   // MARK: - Status
 
   override var isOntop: Bool {
@@ -1153,33 +1155,8 @@ class MainWindowController: PlayerWindowController {
       exitInteractiveMode(immediately: true)
     }
 
-    // Match refresh rate
-    if Preference.bool(for: .matchRefreshRate) {
-      // [23.976, 47.952, 24, 48], [29.97, 59.94, 30, 60]
-      // [24, 48], [25, 50], [30, 60]
-      let videoFps = player.mpv.getDouble(MPVProperty.containerFps)
-      let refreshRates = [videoFps, videoFps * 2, videoFps.rounded(), videoFps.rounded() * 2]
-
-      userDisplay = videoView.currentDisplay
-      userDisplayMode = CGDisplayCopyDisplayMode(userDisplay!)
-      userRefreshRate = player.mpv.getDouble(MPVProperty.displayFps)
-
-      if (userDisplayMode != nil) {
-        let displayModes = CGDisplayCopyAllDisplayModes(userDisplay!, nil) as! [CGDisplayMode]
-        matching: for refreshRate in refreshRates {
-          for displayMode in displayModes {
-            // 24 - 23.976 = 0.024, avoid matching 23.976 to 24 when 23.976 is available
-            // or vice versa on first pass, prefer 47.952 than 24 for 23.976
-            if ((displayMode.ioFlags & UInt32(kDisplayModeNativeFlag) != 0) &&
-                displayMode.refreshRate.distance(to: refreshRate) < 0.02) {
-              CGDisplaySetDisplayMode(userDisplay!, displayMode, nil)
-              player.mpv.setDouble(MPVOption.Video.displayFps, displayMode.refreshRate)
-              break matching
-            }
-          }
-        }
-      }
-    }
+    // Change the display refresh rate to match video frame rate (if feature enabled).
+    refreshRateMatcher.windowWillEnterFullScreen()
 
     // Set the appearance to match the theme so the titlebar matches the theme
     let iinaTheme = Preference.enum(for: .themeMaterial) as Preference.Theme
@@ -1238,6 +1215,10 @@ class MainWindowController: PlayerWindowController {
       fadeableViews.append(additionalInfoView)
     }
 
+    // Inform the rate matcher so it can complete any operations that were waiting for animations to
+    // finish.
+    refreshRateMatcher.windowDidEnterFullScreen()
+
     if Preference.bool(for: .playWhenEnteringFullScreen) && player.info.isPaused {
       player.resume()
     }
@@ -1260,12 +1241,6 @@ class MainWindowController: PlayerWindowController {
       exitInteractiveMode(immediately: true)
     }
 
-    // restore refresh rate
-    if userDisplayMode != nil {
-      CGDisplaySetDisplayMode(userDisplay!, userDisplayMode!, nil)
-      player.mpv.setDouble(MPVOption.Video.displayFps, userRefreshRate!)
-    }
-
     // show titleBarView
     if oscPosition == .top {
       oscTopMainViewTopConstraint.constant = OSCTopMainViewMarginTop
@@ -1284,6 +1259,10 @@ class MainWindowController: PlayerWindowController {
     fsState.startAnimatingToWindow()
 
     videoView.videoLayer.suspend()
+
+    // Restore the display refresh rate if it was changed.
+    refreshRateMatcher.windowWillExitFullScreen()
+
     player.mpv.setFlag(MPVOption.Window.keepaspect, false)
   }
 
@@ -1307,6 +1286,10 @@ class MainWindowController: PlayerWindowController {
     videoView.videoLayer.resume()
 
     fsState.finishAnimating()
+
+    // Inform the rate matcher so it can complete any operations that were waiting for animations to
+    // finish.
+    refreshRateMatcher.windowDidExitFullScreen()
 
     if Preference.bool(for: .blackOutMonitor) {
       removeBlackWindow()

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -116,6 +116,7 @@ class MenuController: NSObject, NSMenuDelegate {
   @IBOutlet weak var flip: NSMenuItem!
   @IBOutlet weak var deinterlace: NSMenuItem!
   @IBOutlet weak var delogo: NSMenuItem!
+  @IBOutlet weak var matchRefreshRate: NSMenuItem!
   @IBOutlet weak var videoFilters: NSMenuItem!
   @IBOutlet weak var savedVideoFiltersMenu: NSMenu!
   //Audio
@@ -297,6 +298,17 @@ class MenuController: NSObject, NSMenuDelegate {
     // -- delogo
     delogo.action = #selector(MainWindowController.menuSetDelogo(_:))
 
+    // -- match refresh rate
+    if #available(macOS 12, *) {
+      matchRefreshRate.action = #selector(MainMenuActionHandler.menuToggleMatchRefreshRate(_:))
+    } else {
+      // This feature searches the refresh rates the display supports for a rate that matches the
+      // frame rate of the video being played. Unfortunately before Monterey macOS was returning
+      // zero for the refreshRate property of CGDisplayMode. Without that information this feature
+      // can not function.
+      matchRefreshRate.isHidden = true
+    }
+
     // -- filter
     videoFilters.action = #selector(AppDelegate.showVideoFilterWindow(_:))
 
@@ -449,11 +461,13 @@ class MenuController: NSObject, NSMenuDelegate {
     let isInPIP = PlayerCore.active.mainWindow.pipStatus == .inPIP
     let isOntop = PlayerCore.active.isInMiniPlayer ? PlayerCore.active.miniPlayer.isOntop : PlayerCore.active.mainWindow.isOntop
     let isDelogo = PlayerCore.active.info.delogoFilter != nil
+    let isMatchRefreshRate = Preference.bool(for: .matchRefreshRate)
     alwaysOnTop.state = isOntop ? .on : .off
     deinterlace.state = PlayerCore.active.info.deinterlace ? .on : .off
     fullScreen.title = isInFullScreen ? Constants.String.exitFullScreen : Constants.String.fullScreen
     pictureInPicture?.title = isInPIP ? Constants.String.exitPIP : Constants.String.pip
     delogo.state = isDelogo ? .on : .off
+    matchRefreshRate.state = isMatchRefreshRate ? .on : .off
   }
 
   private func updateAudioMenu() {
@@ -643,6 +657,7 @@ class MenuController: NSObject, NSMenuDelegate {
       (smallerSize, true, ["smaller-window"], false, nil, nil),
       (fitToScreen, true, ["fit-to-screen"], false, nil, nil),
       (miniPlayer, true, ["toggle-music-mode"], false, nil, nil),
+      (matchRefreshRate, true, ["toggle-match-refresh-rate"], false, nil, nil),
       (cycleVideoTracks, false, ["cycle", "video"], false, nil, nil),
       (cycleAudioTracks, false, ["cycle", "audio"], false, nil, nil),
       (cycleSubtitles, false, ["cycle", "sub"], false, nil, nil),

--- a/iina/OSDMessage.swift
+++ b/iina/OSDMessage.swift
@@ -73,6 +73,7 @@ enum OSDMessage {
   case canceled
   case fileLoop(Bool)
   case playlistLoop(Bool)
+  case displayMode(String)
 
   func message() -> (String, OSDType) {
     switch self {
@@ -319,6 +320,9 @@ enum OSDMessage {
                enabled ? NSLocalizedString("general.on", comment: "On") : NSLocalizedString("general.off", comment: "Off")),
         .normal
       )
+
+    case .displayMode(let refreshRate):
+      return (refreshRate, .normal)
     }
   }
 }

--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2016 lhc. All rights reserved.
 //
 
+import Atomics
 import Foundation
 
 class PlaybackInfo {
@@ -78,6 +79,8 @@ class PlaybackInfo {
       isPaused = !newValue
     }
   }
+  // Used to disable OSD pause and resume messages for short internally generated pause/resume cycles.
+  var disableOSDPauseResume = ManagedAtomic(false)
 
   var justLaunched: Bool = true
   var justStartedFile: Bool = false

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -150,6 +150,7 @@ struct Preference {
     static let hardwareDecoder = Key("hardwareDecoder")
     static let forceDedicatedGPU = Key("forceDedicatedGPU")
     static let loadIccProfile = Key("loadIccProfile")
+    static let matchRefreshRate = Key("matchRefreshRate")
 
     static let audioThreads = Key("audioThreads")
     static let audioLanguage = Key("audioLanguage")
@@ -725,6 +726,7 @@ struct Preference {
     .hardwareDecoder: HardwareDecoderOption.auto.rawValue,
     .forceDedicatedGPU: false,
     .loadIccProfile: true,
+    .matchRefreshRate: false,
     .audioThreads: 0,
     .audioLanguage: "",
     .maxVolume: 100,

--- a/iina/RefreshRateMatcher.swift
+++ b/iina/RefreshRateMatcher.swift
@@ -1,0 +1,461 @@
+//
+//  RefreshRateMatcher.swift
+//  iina
+//
+//  Created by low-batt on 5/4/22.
+//  Copyright © 2022 lhc. All rights reserved.
+//
+
+import Cocoa
+
+/// An object that provides the implementation for the `Match Refresh Rate` feature.
+///
+/// When enabled the `Match Refresh Rate` feature will attempt to synchronize the display refresh rate with the frame rate of the
+/// video being played when in full screen mode.
+///
+/// A good reference for this feature is the mpv wiki post [Display synchronization](https://github.com/mpv-player/mpv/wiki/Display-synchronization).
+/// That post covers a broader set of issues. The issue this feature addresses is discussed in the section
+/// [xrandr.lua](https://github.com/mpv-player/mpv/wiki/Display-synchronization#xrandrlua), changing the rate
+/// at which the display updates. That section discusses the [mpv-plugin-xrandr](https://gitlab.com/lvml/mpv-plugin-xrandr)
+/// Lua script. That script performs the same function as this feature, but only supports Linux.
+///
+/// The frame rate of the video is based on the mpv [container-fps](https://mpv.io/manual/stable/#command-interface-container-fps)
+/// property for which the mpv manual says:
+///
+/// **container-fps**
+///
+/// _Container FPS. This can easily contain bogus values. For videos that use modern container formats or video codecs, this will
+/// often be incorrect._
+///
+/// Rather concerning, however this is the same property that is used by the [mpv-plugin-xrandr](https://gitlab.com/lvml/mpv-plugin-xrandr)
+/// script.
+///
+/// This feature must be prepared to adjust the display mode when:
+/// - Entering full screen mode
+/// - Exiting full screen node
+/// - Playing next video in the playlist
+/// - The feature is enabled/disabled using the video menu
+/// - The space the window is on becomes active/inactive
+/// - The display the window is on is connected/disconnected
+/// - The display joins or leaves a mirrored set
+///
+/// This class handles the high level aspects of the feature. The class `DisplaySynchronizer` handles finding a display mode
+/// appropriate for the frame rate of the video and changing the mode of the display.
+///
+/// - Note: Over concerns about whether all the cases where a display could change are handled this class currently includes
+///         extensive logging.
+class RefreshRateMatcher: NSObject {
+
+  // MARK: - Constants
+
+  private let player: PlayerCore
+  private let subsystem: Logger.Subsystem
+  private let videoView: VideoView
+
+  // MARK: - Variables
+
+  /// Remember the display the window is on to be able to detect when the window moves to another screen.
+  private var displayId: CGDirectDisplayID?
+
+  /// The  `Match Refresh Rate` feature is only active when the window is in full screen mode.
+  private var isInFullScreenMode = false
+
+  private var isMatchRefreshRateEnabled: Bool {
+    if #available(macOS 12, *) {
+      return Preference.bool(for: .matchRefreshRate)
+    }
+    // This feature searches the refresh rates the display supports for a rate that matches the
+    // frame rate of the video being played. Unfortunately before Monterey macOS was returning zero
+    // for the refreshRate property of CGDisplayMode. Without that information this feature can not
+    // function.
+    return false
+  }
+
+  /// Remember whether the display is in a mirror set or not to detect when the display joins or leaves a mirror set.
+  private var isMirrored = false
+
+  /// Remember whether the window is on the currently active space to detect space changes affecting window visibility.
+  private var isOnActiveSpace = true
+
+  /// Set when an OSD message was not posted because the screen is currently animating.
+  private var pendingOSD: CGDisplayMode?
+
+  /// Set when playback was paused and needs to be resumed once the screen finishes animating.
+  private var pendingResume = false
+
+  /// Remember the video frame rate to detect if the next video has the same rate.
+  private var videoFps: Double? = nil
+
+  /// Construct a `RefreshRateMatcher` object.
+  /// - Parameter player: The player for the window this object is associated with.
+  /// - Parameter videoView: The view of the window this object is associated with.
+  init(_ player: PlayerCore, _ videoView: VideoView) {
+    // For the logger associate this object with the particular player.
+    subsystem = Logger.Subsystem(rawValue: "refreshrate\(player.label!)")
+    self.player = player
+    self.videoView = videoView
+    super.init()
+    
+    // Keep track of the display ID of the display the window's screen is on in order to detect when
+    // the window moves to another screen.
+    displayId = getDisplayId()
+
+    // Need to know when the preference for this feature changes so the feature can be dynamically
+    // turned off if there are problems with the display.
+    UserDefaults.standard.addObserver(self, forKeyPath: PK.matchRefreshRate.rawValue, options: .new,
+                                      context: nil)
+
+    // Need to know when the next video in the playlist starts playing as the display may need to be
+    // changed to adapt to the frame rate of the next video.
+    NotificationCenter.default.addObserver(self, selector: #selector(RefreshRateMatcher.fileLoaded),
+                                           name: .iinaFileLoaded, object: nil)
+        
+    // Need to know if the window moves to a new screen, such as when the video started playing on
+    // an external monitor and that monitor was disconnected. If the feature is active the refresh
+    // rate of the screen the window moved to may need to be changed. This is also need to detect
+    // when the display joins or leaves a mirrored set. A more direct way of checking for these
+    // changes would be to use CGDisplayRegisterReconfigurationCallback, however the Apple
+    // documentation for CGDisplayReconfigurationCallBack indicates "Your callback function should
+    // avoid attempting to change display configurations". Since display reconfiguration may be
+    // needed we instead list for screen change notifications. The downside of this notification is
+    // that macOS posts this notification for multiple reasons including when the screen moves to a
+    // different GPU and when the dock hiding/revealing animation is active thus changing the
+    // dimensions of the visible frame. I did not find a way to filter these notifications so the
+    // screenChanged method may be called a lot.
+    NotificationCenter.default.addObserver(self, selector: #selector(RefreshRateMatcher.screenChanged),
+                                           name: NSApplication.didChangeScreenParametersNotification,
+                                           object: nil)
+    
+    // Need to know when the space the window is in becomes active/inactive to appropriately set and
+    // restore refresh rate changes.
+    NSWorkspace.shared.notificationCenter.addObserver(
+      self, selector: #selector(RefreshRateMatcher.spaceChanged),
+      name: NSWorkspace.activeSpaceDidChangeNotification, object: nil)
+  }
+
+  deinit {
+    UserDefaults.standard.removeObserver(self, forKeyPath: PK.matchRefreshRate.rawValue)
+  }
+
+  /// Complete any pending operations.
+  ///
+  /// A user will have a very hard time reading an OSD message that is posted when the screen is animating while entering or exiting
+  /// full screen mode. For this reason the OSD is not posted until the transition to or from full screen mode is completed.
+  ///
+  /// Playback must be paused while changing the display's refresh rate to avoid audio/video desynchronization. Resuming during the
+  /// transition to and from full screen mode triggered desynchronization. For this reason playback is not resumed until the transition to
+  /// or from full screen mode is completed.
+  private func completePendingOperations() {
+    if let displayMode = pendingOSD {
+      sendOSD(displayMode, false)
+      pendingOSD = nil
+    }
+    resumePlayback()
+  }
+
+  /// Listener for `fileLoaded` notifications.
+  ///
+  /// The display refresh rate may need to be updated if the fps of the video was not available when the window transitioned to full
+  /// screen mode or if this notification is due to starting to play the next video in the playlist and that video has a different frame rate.
+  @objc private func fileLoaded() {
+    // This notification is called from a background thread. Must queue the work to the main thread.
+    DispatchQueue.main.async { [self] in
+      // Only need to take action if the feature is enabled and the window is in full screen mode.
+      guard isMatchRefreshRateEnabled, isInFullScreenMode else { return }
+      log("Notified file loaded")
+
+      // If the current fps matches the saved fps then the display is already set appropriately.
+      let currentVideoFps = getVideoFps()
+      guard currentVideoFps != videoFps else { return }
+      videoFps = currentVideoFps
+      guard videoFps != nil else {
+        // Must have loaded the next video in a playlist and the frame rate for this video can not
+        // be determined. If the display was changed for the previous video then restore the display
+        // to the original refresh rate. OSD messages must be delayed to avoid colliding with the
+        // OSD file loading message.
+        restoreRefreshRate(delayOSD: true)
+        return
+      }
+
+      // The video frame rate is known and differs from the remembered rate. The usual case is that
+      // the next video in a playlist was just loaded. It could also be that the window went into
+      // full screen mode while the video was still loading so the video frame rate was not
+      // available at that time. Try and match the video's frame rate. OSD messages must be delayed
+      // to avoid colliding with the OSD file loading message.
+      let displayMode = matchRefreshRate(delayOSD: true)
+      if displayMode == nil {
+        // No matching refresh rate found, if the display was changed for the previous video then
+        // restore the display to the original refresh rate.
+        restoreRefreshRate(delayOSD: true)
+      }
+    }
+  }
+
+  /// Return the ID of the display the window is on.
+  /// - Returns: The `CGDirectDisplayID` of the display the window is on or `nil` if not available.
+  private func getDisplayId() -> CGDirectDisplayID? {
+    guard let window = videoView.window, let screen = window.screen else { return nil }
+    return (screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as! CGDirectDisplayID)
+  }
+
+  /// Return the frame rate of the current video.
+  /// - Returns: The fps of the video or `nil` if not available.
+  private func getVideoFps() -> Double? {
+    let containerFps = player.mpv.getDouble(MPVProperty.containerFps)
+    guard containerFps == 0.0 else { return containerFps }
+    log("Video frame rate can not be determined")
+    return nil
+  }
+
+  /// Log message using this feature's log `subsystem`.
+  private func log(_ message: String) {
+    Logger.log(message, subsystem: subsystem)
+  }
+
+  /// Try and find a display mode with a refresh rate appropriate for the current video and if one is found ensure the display is set to
+  /// that mode.
+  ///
+  /// The caller must be able to specify whether playback should be resumed and whether an OSD message should be displayed as
+  /// these actions may need to be postponed or suppressed depending upon the current circumstances.
+  /// - Parameters:
+  ///   - delayResume: If `true` playback will not be resumed if it needed to be paused.
+  ///   - noOSD: If `true` do not post an OSD message.
+  ///   - delayOSD: If `true` delay displaying this OSD message otherwise display immediately.
+  /// - Returns: The `CGDisplayMode` the matching display mode or `nil` if a suitable display mode was not found.
+  @discardableResult
+  private func matchRefreshRate(delayResume: Bool = false, noOSD: Bool = false, delayOSD: Bool = false) -> CGDisplayMode? {
+    guard let displayId = getDisplayId(), let videoFps = videoFps else { return nil }
+    let displaySynchronizer = DisplaySynchronizer.getDisplaySynchronizer(displayId)
+    isMirrored = displaySynchronizer.isMirrored
+    guard !isMirrored else {
+      log("Display is mirrored, will not attempt to match refresh rate")
+      return nil
+    }
+    guard let displayMode = displaySynchronizer.findMatchingDisplayMode(videoFps) else {
+      // A suitable display mode was not found.
+      return nil
+    }
+    // Check if the display is already configured with the desirable mode.
+    guard !displaySynchronizer.isCurrentDisplayMode(displayMode) else { return displayMode }
+    setDisplayMode(displaySynchronizer, displayMode, delayResume, isRestore: false)
+    player.mpv.setDouble(MPVOption.Video.overrideDisplayFps, displayMode.refreshRate)
+    guard !noOSD else {
+      // The OSD message will either be displayed later, or cancelled.
+      pendingOSD = displayMode
+      return displayMode
+    }
+    sendOSD(displayMode, delayOSD)
+    return displayMode
+  }
+
+  override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?,
+                             context: UnsafeMutableRawPointer?) {
+    guard let keyPath = keyPath, let change = change else { return }
+    switch keyPath {
+    case PK.matchRefreshRate.rawValue:
+      if let newValue = change[.newKey] as? Bool {
+        preferenceChanged(isMatchRefreshRateEnabled: newValue)
+      }
+    default:
+      return
+    }
+  }
+
+  /// Listener for changes to the preference controlling this feature.
+  /// - Parameter isMatchRefreshRateEnabled: Whether the feature is enabled or not.
+  private func preferenceChanged(isMatchRefreshRateEnabled: Bool) {
+    // Nothing needs to be done unless the window is currently in full screen mode.
+    guard isInFullScreenMode else { return }
+    guard isMatchRefreshRateEnabled else {
+      log("Match refresh rate disabled")
+      restoreRefreshRate()
+      return
+    }
+    log("Match refresh rate enabled")
+    displayId = getDisplayId()
+    guard let displayId = displayId  else { return }
+    let displaySynchronizer = DisplaySynchronizer.getDisplaySynchronizer(displayId)
+    isMirrored = displaySynchronizer.isMirrored
+    videoFps = getVideoFps()
+    guard videoFps != nil else { return }
+    matchRefreshRate()
+  }
+
+  /// If the refresh rate of the display was changed then this method will restore the display to its original refresh rate.
+  ///
+  /// The caller must be able to specify whether playback should be resumed and whether an OSD message should be displayed as
+  /// these actions may need to be postponed or suppressed depending upon the circumstances.
+  /// - Parameters:
+  ///   - delayResume: If `true` playback will not be resumed if it needed to be paused.
+  ///   - noOSD: If `true` do not post an OSD message.
+  ///   - delayOSD: If `true` delay displaying this OSD message otherwise display immediately.
+  private func restoreRefreshRate(delayResume: Bool = false, noOSD: Bool = false, delayOSD: Bool = false) {
+    guard let displayId = displayId else { return }
+    let displaySynchronizer = DisplaySynchronizer.getDisplaySynchronizer(displayId)
+    // The display mode saved in the synchronizer will be nil if the display's refresh rate was not
+    // changed does not need to be restored.
+    guard let displayMode = displaySynchronizer.displayModeForRestore else { return }
+    setDisplayMode(displaySynchronizer, displayMode, delayResume, isRestore: true)
+    player.mpv.setDouble(MPVOption.Video.overrideDisplayFps, displayMode.refreshRate)
+    displaySynchronizer.displayModeForRestore = nil
+    guard !noOSD else {
+      // The OSD message will either be displayed later, or cancelled.
+      pendingOSD = displayMode
+      return
+    }
+    sendOSD(displayMode, delayOSD)
+    return
+  }
+
+  private func resumePlayback() {
+    guard pendingResume else { return }
+    log("Resuming playback after changing display refresh rate")
+    player.resume(internalPauseResume: true)
+    pendingResume = false
+  }
+  
+  /// Listener for changes to screens.
+  ///
+  /// May need to adjust the refresh rate if the window moved to a different display, or the display joined or left a mirrored set.
+  @objc private func screenChanged() {
+    // Only need to take action if the feature is enabled and the window is in full screen mode.
+    guard isMatchRefreshRateEnabled, isInFullScreenMode, let currentDisplayId = getDisplayId() else { return }
+    if currentDisplayId != displayId {
+      // Since the window was in full screen mode it only changes screens when the display it was on
+      // was disconnected. That will reset the display mode, so clear any saved mode to avoid
+      // needlessly setting the display mode if this screen is connected again.
+      if let displayId = displayId {
+        let displaySynchronizer = DisplaySynchronizer.getDisplaySynchronizer(displayId)
+        displaySynchronizer.displayModeForRestore = nil
+      }
+      displayId = currentDisplayId
+      guard let displayId = displayId else { return }
+      log("Window moved to display \(displayId)")
+      let displaySynchronizer = DisplaySynchronizer.getDisplaySynchronizer(displayId)
+      // Keep track of the mirrored state of this new display.
+      isMirrored = displaySynchronizer.isMirrored
+      // Attempt to adjust the refresh rate of the screen the window is now on.
+      matchRefreshRate()
+      return
+    }
+    // The window is still on the same display. Check if the mirror state has changed.
+    guard let displayId = displayId else { return }
+    let displaySynchronizer = DisplaySynchronizer.getDisplaySynchronizer(displayId)
+    let currentMirrorState = displaySynchronizer.isMirrored
+    guard currentMirrorState != isMirrored else { return }
+    
+    // The display either joined or left a mirrored set.
+    isMirrored = currentMirrorState
+    guard isMirrored else {
+      log("Display is no longer mirrored, will attempt to match refresh rate")
+      matchRefreshRate()
+      return
+    }
+    log("Display is now mirrored, will not attempt to match refresh rate")
+    restoreRefreshRate()
+  }
+
+  /// Display an OSD message.
+  ///
+  /// If the display's refresh rate is being changed when moving to the next video in the playlist then OSD messages need to be delayed
+  /// to avoid colliding with the file loaded OSD message.
+  /// - Parameter delayOSD: If `true` delay displaying this OSD message otherwise display immediately.
+  private func sendOSD(_ displayMode: CGDisplayMode, _ delayOSD: Bool) {
+    guard delayOSD else {
+      player.sendOSD(.displayMode("\(displayMode.shortDescription)"))
+      return
+    }
+    let osdTimeout = Int(Preference.float(for: .osdAutoHideTimeout).rounded(.up))
+    DispatchQueue.main.asyncAfter(deadline: .now() + .seconds(osdTimeout)) {
+      self.player.sendOSD(.displayMode("\(displayMode.shortDescription)"))
+    }
+  }
+
+  /// Set the display mode of the display to the given mode.
+  /// - Parameters:
+  ///   - displaySynchronizer: The `DisplaySynchronizer` for the display.
+  ///   - displayMode: The `CGDisplayMode` to set the display to.
+  ///   - delayResume: If `true` playback will not be resumed if it needed to be paused.
+  ///   - isRestore: If `true` the mode is being set to restore the display to its original refresh rate.
+  private func setDisplayMode(_ displaySynchronizer: DisplaySynchronizer, _ displayMode: CGDisplayMode,
+                              _ delayResume: Bool, isRestore: Bool) {
+    if !player.info.isPaused {
+      log("Pausing playback to avoid audio/video desynchronization")
+      player.pause(internalPauseResume: true)
+      pendingResume = true
+    }
+    displaySynchronizer.setDisplayMode(displayMode: displayMode, isRestore: isRestore)
+    guard pendingResume, !delayResume else { return }
+    resumePlayback()
+  }
+
+  /// Listener for changes to spaces.
+  ///
+  /// If the space the window is in becomes active or inactive the display's refresh rate may need to be updated.
+  @objc private func spaceChanged() {
+    // Only need to take action if the feature is enabled, the window is in full screen mode and
+    // this change altered the status of the space the window is in.
+    guard isMatchRefreshRateEnabled, isInFullScreenMode, let window = videoView.window,
+          window.isOnActiveSpace != isOnActiveSpace else { return }
+    isOnActiveSpace = window.isOnActiveSpace
+    guard isOnActiveSpace else {
+      log("Space window is in became inactive")
+      // The space the window is on is not visible, so no reason to display an OSD message.
+      restoreRefreshRate(noOSD: true)
+      pendingOSD = nil
+      return
+    }
+    log("Space window is in became active")
+    matchRefreshRate()
+  }
+
+  /// Inform the `Match Refresh Rate` feature that the window entered full screen mode.
+  ///
+  /// Complete any operations that were waiting for animations to finish.
+  func windowDidEnterFullScreen() {
+    guard isMatchRefreshRateEnabled else { return }
+    completePendingOperations()
+  }
+
+  /// Inform the `Match Refresh Rate` feature that the window exited full screen mode.
+  ///
+  /// Complete any operations that were waiting for animations to finish.
+  func windowDidExitFullScreen() {
+    guard isMatchRefreshRateEnabled else { return }
+    completePendingOperations()
+    isInFullScreenMode = false
+  }
+
+  /// Inform the `Match Refresh Rate` feature that the window is entering full screen mode.
+  ///
+  /// The `Match Refresh Rate` feature only takes effect when the window is in full screen mode. This method will search for a
+  /// matching refresh rate on the display and if one is found then change the display's refresh rate.
+  func windowWillEnterFullScreen() {
+    isInFullScreenMode = true
+    guard isMatchRefreshRateEnabled else { return }
+    log("Entering full screen mode")
+    videoFps = getVideoFps()
+    guard videoFps != nil else {
+      // If in Preferences/General section under "When media is opened" the "Enter fullscreen"
+      // preference is enabled, then the window may go into full screen mode before mpv has been
+      // able to determine the video fps. That is one example of why the video fps may not be
+      // available. If that happens we will attempt to get the frame rate again when notified the
+      // file has loaded.
+      return
+    }
+    // Must postpone resuming playback and showing OSD messages until animations finish.
+    matchRefreshRate(delayResume: true, noOSD: true)
+  }
+
+  /// Inform the `Match Refresh Rate` feature that the window is exiting full screen mode.
+  ///
+  /// The `Match Refresh Rate` feature only takes effect when the window is in full screen mode. This method will restore the
+  /// display's refresh rate if it was changed to match the video.
+  func windowWillExitFullScreen() {
+    guard isMatchRefreshRateEnabled else { return }
+    log("Exiting full screen mode")
+
+    // Must postpone resuming playback and showing OSD messages until animations finish.
+    restoreRefreshRate(delayResume: true, noOSD: true)
+  }
+}

--- a/iina/config/iina-default-input.conf
+++ b/iina/config/iina-default-input.conf
@@ -53,6 +53,8 @@ Ctrl+Meta+t cycle ontop
 
 #@iina Alt+Meta+m toggle-music-mode
 
+#@iina Ctrl+Meta+r toggle-match-refresh-rate
+
 UP    add volume 5
 DOWN  add volume -5
 Alt+UP add volume 1

--- a/iina/en.lproj/KeyBinding.strings
+++ b/iina/en.lproj/KeyBinding.strings
@@ -51,6 +51,7 @@
 "iina.fit-to-screen" = "Fit to Screen";
 "iina.toggle-flip" = "Toggle flip";
 "iina.toggle-mirror" = "Toggle mirror";
+"iina.toggle-match-refresh-rate" = "Toggle Match Refresh Rate";
 "iina.save-playlist" = "Save current playlist";
 "iina.delete-current-file" = "Delete current file";
 "iina.delete-current-file-hard" = "Delete current file directly without moving to trash";


### PR DESCRIPTION
This commit builds on top of the core code developed by @jesec to
add support for detecting additional cases where the display needs to
be adjusted, notifying the user using the OSD and logging the decisions
made by the feature.

The original code has been refactored out of MainWindowController and
into a new DisplaySynchronizer class. That class contains the core code
that manages a display a selects an appropriate refresh rate. That class
is used by a new RefreshRateMatcher class that handles the higher level
aspects of the feature.

Control of the feature has been moved from IINA Preferences to a menu
item in the Video menu. This provides a way to quickly turn the feature
off if a display proves problematic.

IINA must be running under macOS 12 or above for this feature to be
available. Older versions of macOS return zero for a display's refresh
rate preventing this feature from working. When running on an older
version of macOS the menu item will be hidden.

The commits in the pull request will:
- Add a new item "Match Refresh Rate" to video menu
- Bind the menu item to the ctrl+meta+r key
- Add a new class DisplaySynchronizer to control displays
- Add a new class RefreshRateMatcher to control the feature
- Change MainWindowController to use RefreshRateMatcher
- Add a new OSD message to show the display refresh rate
- Change PlayerCore to support short internal pause/resume cycles
- Add the ability to suppress pause/resume OSD messages

- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3414.

---

**Description:**
