### PR TITLE
Clean up MainMenuActions responder chain

### DIFF
--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -8,19 +8,7 @@
 
 import Cocoa
 
-
-class MainMenuActionHandler: NSResponder {
-
-  unowned var player: PlayerCore
-
-  init(playerCore: PlayerCore) {
-    self.player = playerCore
-    super.init()
-  }
-
-  required init?(coder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
+extension PlayerWindowController {
 
   @objc func menuShowInspector(_ sender: AnyObject) {
     let inspector = (NSApp.delegate as! AppDelegate).inspector
@@ -69,11 +57,8 @@ class MainMenuActionHandler: NSResponder {
     }
   }
 
-}
-
 // MARK: - Control
 
-extension MainMenuActionHandler {
   @objc func menuTogglePause(_ sender: NSMenuItem) {
     player.togglePause()
     // set speed to 0 if is fastforwarding
@@ -182,11 +167,9 @@ extension MainMenuActionHandler {
   @objc func menuPreviousChapter(_ sender: NSMenuItem) {
     player.mpv.command(.add, args: ["chapter", "-1"], checkError: false)
   }
-}
 
 // MARK: - Video
 
-extension MainMenuActionHandler {
   @objc func menuChangeAspect(_ sender: NSMenuItem) {
     if let aspectStr = sender.representedObject as? String {
       player.setVideoAspect(aspectStr)
@@ -235,11 +218,9 @@ extension MainMenuActionHandler {
   @objc func menuToggleDeinterlace(_ sender: NSMenuItem) {
     player.toggleDeinterlace(sender.state != .on)
   }
-}
 
 // MARK: - Audio
 
-extension MainMenuActionHandler {
   @objc func menuChangeVolume(_ sender: NSMenuItem) {
     if let volumeDelta = sender.representedObject as? Int {
       let newVolume = Double(volumeDelta) + player.info.volume
@@ -265,11 +246,9 @@ extension MainMenuActionHandler {
   @objc func menuResetAudioDelay(_ sender: NSMenuItem) {
     player.setAudioDelay(0)
   }
-}
 
 // MARK: - Sub
 
-extension MainMenuActionHandler {
   @objc func menuLoadExternalSub(_ sender: NSMenuItem) {
     Utility.quickOpenPanel(title: "Load external subtitle file", chooseDir: false) { url in
       self.player.loadExternalSubFile(url, delay: true)

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2617,7 +2617,7 @@ class MainWindowController: PlayerWindowController {
     case .toggleMusicMode:
       menuSwitchToMiniPlayer(.dummy)
     case .deleteCurrentFileHard:
-      menuActionHandler.menuDeleteCurrentFileHard(.dummy)
+      menuDeleteCurrentFileHard(.dummy)
     case .biggerWindow:
       let item = NSMenuItem()
       item.tag = 11

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -169,7 +169,7 @@ class MenuController: NSObject, NSMenuDelegate {
   func bindMenuItems() {
 
     [cycleSubtitles, cycleAudioTracks, cycleVideoTracks].forEach { item in
-      item?.action = #selector(MainMenuActionHandler.menuCycleTrack(_:))
+      item?.action = #selector(PlayerWindowController.menuCycleTrack(_:))
     }
 
     // File menu
@@ -181,8 +181,8 @@ class MenuController: NSObject, NSMenuDelegate {
     stringForOpenAlternative = openAlternative.title
     stringForOpenURLAlternative = openURLAlternative.title
 
-    savePlaylist.action = #selector(MainMenuActionHandler.menuSavePlaylist(_:))
-    deleteCurrentFile.action = #selector(MainMenuActionHandler.menuDeleteCurrentFile(_:))
+    savePlaylist.action = #selector(PlayerWindowController.menuSavePlaylist(_:))
+    deleteCurrentFile.action = #selector(PlayerWindowController.menuDeleteCurrentFile(_:))
 
     if Preference.bool(for: .enableCmdN) {
       newWindowSeparator.isHidden = false
@@ -193,16 +193,16 @@ class MenuController: NSObject, NSMenuDelegate {
 
     playbackMenu.delegate = self
 
-    pause.action = #selector(MainMenuActionHandler.menuTogglePause(_:))
-    stop.action = #selector(MainMenuActionHandler.menuStop(_:))
+    pause.action = #selector(PlayerWindowController.menuTogglePause(_:))
+    stop.action = #selector(PlayerWindowController.menuStop(_:))
 
     // -- seeking
-    forward.action = #selector(MainMenuActionHandler.menuStep(_:))
-    nextFrame.action = #selector(MainMenuActionHandler.menuStepFrame(_:))
-    backward.action = #selector(MainMenuActionHandler.menuStep(_:))
-    previousFrame.action = #selector(MainMenuActionHandler.menuStepFrame(_:))
-    jumpToBegin.action = #selector(MainMenuActionHandler.menuJumpToBegin(_:))
-    jumpTo.action = #selector(MainMenuActionHandler.menuJumpTo(_:))
+    forward.action = #selector(PlayerWindowController.menuStep(_:))
+    nextFrame.action = #selector(PlayerWindowController.menuStepFrame(_:))
+    backward.action = #selector(PlayerWindowController.menuStep(_:))
+    previousFrame.action = #selector(PlayerWindowController.menuStepFrame(_:))
+    jumpToBegin.action = #selector(PlayerWindowController.menuJumpToBegin(_:))
+    jumpTo.action = #selector(PlayerWindowController.menuJumpTo(_:))
 
     // -- speed
     (speedUp.representedObject,
@@ -210,28 +210,28 @@ class MenuController: NSObject, NSMenuDelegate {
      speedDown.representedObject,
      speedDownSlightly.representedObject) = (2.0, 1.1, 0.5, 0.9)
     [speedUp, speedDown, speedUpSlightly, speedDownSlightly, speedReset].forEach { item in
-      item?.action = #selector(MainMenuActionHandler.menuChangeSpeed(_:))
+      item?.action = #selector(PlayerWindowController.menuChangeSpeed(_:))
     }
 
     // -- screenshot
-    screenshot.action = #selector(MainMenuActionHandler.menuSnapshot(_:))
+    screenshot.action = #selector(PlayerWindowController.menuSnapshot(_:))
     gotoScreenshotFolder.action = #selector(AppDelegate.menuOpenScreenshotFolder(_:))
     // advancedScreenShot
 
     // -- list and chapter
-    abLoop.action = #selector(MainMenuActionHandler.menuABLoop(_:))
-    fileLoop.action = #selector(MainMenuActionHandler.menuFileLoop(_:))
+    abLoop.action = #selector(PlayerWindowController.menuABLoop(_:))
+    fileLoop.action = #selector(PlayerWindowController.menuFileLoop(_:))
     playlistMenu.delegate = self
     chapterMenu.delegate = self
-    playlistLoop.action = #selector(MainMenuActionHandler.menuPlaylistLoop(_:))
+    playlistLoop.action = #selector(PlayerWindowController.menuPlaylistLoop(_:))
     playlistPanel.action = #selector(MainWindowController.menuShowPlaylistPanel(_:))
     chapterPanel.action = #selector(MainWindowController.menuShowChaptersPanel(_:))
 
-    nextMedia.action = #selector(MainMenuActionHandler.menuNextMedia(_:))
-    previousMedia.action = #selector(MainMenuActionHandler.menuPreviousMedia(_:))
+    nextMedia.action = #selector(PlayerWindowController.menuNextMedia(_:))
+    previousMedia.action = #selector(PlayerWindowController.menuPreviousMedia(_:))
 
-    nextChapter.action = #selector(MainMenuActionHandler.menuNextChapter(_:))
-    previousChapter.action = #selector(MainMenuActionHandler.menuPreviousChapter(_:))
+    nextChapter.action = #selector(PlayerWindowController.menuNextChapter(_:))
+    previousChapter.action = #selector(PlayerWindowController.menuPreviousChapter(_:))
 
     // Video menu
 
@@ -261,7 +261,7 @@ class MenuController: NSObject, NSMenuDelegate {
     var aspectListObject = AppData.aspects
     aspectList.insert(Constants.String.default, at: 0)
     aspectListObject.insert("Default", at: 0)
-    bind(menu: aspectMenu, withOptions: aspectList, objects: aspectListObject, objectMap: nil, action: #selector(MainMenuActionHandler.menuChangeAspect(_:))) {
+    bind(menu: aspectMenu, withOptions: aspectList, objects: aspectListObject, objectMap: nil, action: #selector(PlayerWindowController.menuChangeAspect(_:))) {
       PlayerCore.active.info.unsureAspect == $0.representedObject as? String
     }
 
@@ -274,7 +274,7 @@ class MenuController: NSObject, NSMenuDelegate {
     // Allow custom crop size.
     cropList.append(Constants.String.custom)
     cropListForObject.append("Custom")
-    bind(menu: cropMenu, withOptions: cropList, objects: cropListForObject, objectMap: nil, action: #selector(MainMenuActionHandler.menuChangeCrop(_:))) {
+    bind(menu: cropMenu, withOptions: cropList, objects: cropListForObject, objectMap: nil, action: #selector(PlayerWindowController.menuChangeCrop(_:))) {
       return PlayerCore.active.info.unsureCrop == $0.representedObject as? String
     }
     // Separate "Custom..." from other crop sizes.
@@ -282,17 +282,17 @@ class MenuController: NSObject, NSMenuDelegate {
 
     // -- rotation
     let rotationTitles = AppData.rotations.map { "\($0)\(Constants.String.degree)" }
-    bind(menu: rotationMenu, withOptions: rotationTitles, objects: AppData.rotations, objectMap: nil, action: #selector(MainMenuActionHandler.menuChangeRotation(_:))) {
+    bind(menu: rotationMenu, withOptions: rotationTitles, objects: AppData.rotations, objectMap: nil, action: #selector(PlayerWindowController.menuChangeRotation(_:))) {
       PlayerCore.active.info.rotation == $0.representedObject as? Int
     }
 
     // -- flip and mirror
     flipMenu.delegate = self
-    flip.action = #selector(MainMenuActionHandler.menuToggleFlip(_:))
-    mirror.action = #selector(MainMenuActionHandler.menuToggleMirror(_:))
+    flip.action = #selector(PlayerWindowController.menuToggleFlip(_:))
+    mirror.action = #selector(PlayerWindowController.menuToggleMirror(_:))
 
     // -- deinterlace
-    deinterlace.action = #selector(MainMenuActionHandler.menuToggleDeinterlace(_:))
+    deinterlace.action = #selector(PlayerWindowController.menuToggleDeinterlace(_:))
 
     // -- delogo
     delogo.action = #selector(MainWindowController.menuSetDelogo(_:))
@@ -316,9 +316,9 @@ class MenuController: NSObject, NSMenuDelegate {
      increaseVolumeSlightly.representedObject,
      decreaseVolumeSlightly.representedObject) = (5, -5, 1, -1)
     [increaseVolume, decreaseVolume, increaseVolumeSlightly, decreaseVolumeSlightly].forEach { item in
-      item?.action = #selector(MainMenuActionHandler.menuChangeVolume(_:))
+      item?.action = #selector(PlayerWindowController.menuChangeVolume(_:))
     }
-    mute.action = #selector(MainMenuActionHandler.menuToggleMute(_:))
+    mute.action = #selector(PlayerWindowController.menuToggleMute(_:))
 
     // - audio delay
     (increaseAudioDelay.representedObject,
@@ -326,9 +326,9 @@ class MenuController: NSObject, NSMenuDelegate {
      decreaseAudioDelay.representedObject,
      decreaseAudioDelaySlightly.representedObject) = (0.5, 0.1, -0.5, -0.1)
     [increaseAudioDelay, decreaseAudioDelay, increaseAudioDelaySlightly, decreaseAudioDelaySlightly].forEach { item in
-      item?.action = #selector(MainMenuActionHandler.menuChangeAudioDelay(_:))
+      item?.action = #selector(PlayerWindowController.menuChangeAudioDelay(_:))
     }
-    resetAudioDelay.action = #selector(MainMenuActionHandler.menuResetAudioDelay(_:))
+    resetAudioDelay.action = #selector(PlayerWindowController.menuResetAudioDelay(_:))
 
     // - audio device
     audioDeviceMenu.delegate = self
@@ -344,16 +344,16 @@ class MenuController: NSObject, NSMenuDelegate {
 
     subMenu.delegate = self
     quickSettingsSub.action = #selector(MainWindowController.menuShowSubQuickSettings(_:))
-    loadExternalSub.action = #selector(MainMenuActionHandler.menuLoadExternalSub(_:))
+    loadExternalSub.action = #selector(PlayerWindowController.menuLoadExternalSub(_:))
     subTrackMenu.delegate = self
     secondSubTrackMenu.delegate = self
 
-    findOnlineSub.action = #selector(MainMenuActionHandler.menuFindOnlineSub(_:))
-    saveDownloadedSub.action = #selector(MainMenuActionHandler.saveDownloadedSub(_:))
+    findOnlineSub.action = #selector(PlayerWindowController.menuFindOnlineSub(_:))
+    saveDownloadedSub.action = #selector(PlayerWindowController.saveDownloadedSub(_:))
 
     // - text size
     [increaseTextSize, decreaseTextSize, resetTextSize].forEach {
-      $0.action = #selector(MainMenuActionHandler.menuChangeSubScale(_:))
+      $0.action = #selector(PlayerWindowController.menuChangeSubScale(_:))
     }
 
     // - delay
@@ -362,17 +362,17 @@ class MenuController: NSObject, NSMenuDelegate {
      decreaseSubDelay.representedObject,
      decreaseSubDelaySlightly.representedObject) = (0.5, 0.1, -0.5, -0.1)
     [increaseSubDelay, decreaseSubDelay, increaseSubDelaySlightly, decreaseSubDelaySlightly].forEach { item in
-      item?.action = #selector(MainMenuActionHandler.menuChangeSubDelay(_:))
+      item?.action = #selector(PlayerWindowController.menuChangeSubDelay(_:))
     }
-    resetSubDelay.action = #selector(MainMenuActionHandler.menuResetSubDelay(_:))
+    resetSubDelay.action = #selector(PlayerWindowController.menuResetSubDelay(_:))
 
     // encoding
     let encodingTitles = AppData.encodings.map { $0.title }
     let encodingObjects = AppData.encodings.map { $0.code }
-    bind(menu: encodingMenu, withOptions: encodingTitles, objects: encodingObjects, objectMap: nil, action: #selector(MainMenuActionHandler.menuSetSubEncoding(_:))) {
+    bind(menu: encodingMenu, withOptions: encodingTitles, objects: encodingObjects, objectMap: nil, action: #selector(PlayerWindowController.menuSetSubEncoding(_:))) {
       PlayerCore.active.info.subEncoding == $0.representedObject as? String
     }
-    subFont.action = #selector(MainMenuActionHandler.menuSubFont(_:))
+    subFont.action = #selector(PlayerWindowController.menuSubFont(_:))
     // Separate Auto from other encoding types
     encodingMenu.insertItem(NSMenuItem.separator(), at: 1)
 
@@ -384,7 +384,7 @@ class MenuController: NSObject, NSMenuDelegate {
       customTouchBar.isHidden = true
     }
 
-    inspector.action = #selector(MainMenuActionHandler.menuShowInspector(_:))
+    inspector.action = #selector(PlayerWindowController.menuShowInspector(_:))
     miniPlayer.action = #selector(MainWindowController.menuSwitchToMiniPlayer(_:))
   }
 
@@ -393,7 +393,7 @@ class MenuController: NSObject, NSMenuDelegate {
   private func updatePlaylist() {
     playlistMenu.removeAllItems()
     for (index, item) in PlayerCore.active.info.playlist.enumerated() {
-      playlistMenu.addItem(withTitle: item.filenameForDisplay, action: #selector(MainMenuActionHandler.menuPlaylistItem(_:)),
+      playlistMenu.addItem(withTitle: item.filenameForDisplay, action: #selector(PlayerWindowController.menuPlaylistItem(_:)),
                            tag: index, obj: nil, stateOn: item.isCurrent)
     }
   }
@@ -411,7 +411,7 @@ class MenuController: NSObject, NSMenuDelegate {
       let menuTitle = "\(padder(chapter.time.stringRepresentation)) – \(chapter.title)"
       let nextChapterTime = info.chapters[at: index+1]?.time ?? Constants.Time.infinite
       let isPlaying = info.videoPosition?.between(chapter.time, nextChapterTime) ?? false
-      let menuItem = NSMenuItem(title: menuTitle, action: #selector(MainMenuActionHandler.menuChapterSwitch(_:)), keyEquivalent: "")
+      let menuItem = NSMenuItem(title: menuTitle, action: #selector(PlayerWindowController.menuChapterSwitch(_:)), keyEquivalent: "")
       menuItem.tag = index
       menuItem.state = isPlaying ? .on : .off
       menuItem.attributedTitle = NSAttributedString(string: menuTitle, attributes: [.font: NSFont.monospacedDigitSystemFont(ofSize: 0, weight: .regular)])
@@ -422,14 +422,14 @@ class MenuController: NSObject, NSMenuDelegate {
   private func updateTracks(forMenu menu: NSMenu, type: MPVTrack.TrackType) {
     let info = PlayerCore.active.info
     menu.removeAllItems()
-    let noTrackMenuItem = NSMenuItem(title: Constants.String.trackNone, action: #selector(MainMenuActionHandler.menuChangeTrack(_:)), keyEquivalent: "")
+    let noTrackMenuItem = NSMenuItem(title: Constants.String.trackNone, action: #selector(PlayerWindowController.menuChangeTrack(_:)), keyEquivalent: "")
     noTrackMenuItem.representedObject = MPVTrack.emptyTrack(for: type)
     if info.trackId(type) == 0 {  // no track
       noTrackMenuItem.state = .on
     }
     menu.addItem(noTrackMenuItem)
     for track in info.trackList(type) {
-      menu.addItem(withTitle: track.readableTitle, action: #selector(MainMenuActionHandler.menuChangeTrack(_:)),
+      menu.addItem(withTitle: track.readableTitle, action: #selector(PlayerWindowController.menuChangeTrack(_:)),
                              tag: nil, obj: (track, type), stateOn: track.id == info.trackId(type))
     }
   }

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1325,7 +1325,7 @@ class PlayerCore: NSObject {
       !info.isNetworkResource && info.subTracks.isEmpty &&
       (info.videoDuration?.second ?? 0.0) >= Preference.double(for: .autoSearchThreshold) * 60 {
       DispatchQueue.main.async {
-        self.mainWindow.menuActionHandler.menuFindOnlineSub(.dummy)
+        self.mainWindow.menuFindOnlineSub(.dummy)
       }
     }
   }

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -16,8 +16,6 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
     fatalError("Subclass must implement")
   }
 
-  var menuActionHandler: MainMenuActionHandler!
-  
   var isOntop = false {
     didSet {
       player.mpv.setFlag(MPVOption.Window.ontop, isOntop)
@@ -156,12 +154,6 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
     loaded = true
     
     guard let window = window else { return }
-    
-    // Insert `menuActionHandler` into the responder chain
-    menuActionHandler = MainMenuActionHandler(playerCore: player)
-    let responder = window.nextResponder
-    window.nextResponder = menuActionHandler
-    menuActionHandler.nextResponder = responder
     
     window.initialFirstResponder = nil
     window.titlebarAppearsTransparent = true
@@ -512,17 +504,17 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
     case .openURL:
       appDelegate.openURL(self)
     case .flip:
-      menuActionHandler.menuToggleFlip(.dummy)
+      menuToggleFlip(.dummy)
     case .mirror:
-      menuActionHandler.menuToggleMirror(.dummy)
+      menuToggleMirror(.dummy)
     case .saveCurrentPlaylist:
-      menuActionHandler.menuSavePlaylist(.dummy)
+      menuSavePlaylist(.dummy)
     case .deleteCurrentFile:
-      menuActionHandler.menuDeleteCurrentFile(.dummy)
+      menuDeleteCurrentFile(.dummy)
     case .findOnlineSubs:
-      menuActionHandler.menuFindOnlineSub(.dummy)
+      menuFindOnlineSub(.dummy)
     case .saveDownloadedSub:
-      menuActionHandler.saveDownloadedSub(.dummy)
+      saveDownloadedSub(.dummy)
     default:
       break
     }

--- a/iina/QuickSettingViewController.swift
+++ b/iina/QuickSettingViewController.swift
@@ -695,7 +695,7 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
   }
 
   @IBAction func searchOnlineAction(_ sender: AnyObject) {
-    mainWindow.menuActionHandler.menuFindOnlineSub(.dummy)
+    mainWindow.menuFindOnlineSub(.dummy)
   }
 
   @IBAction func subDelayChangedAction(_ sender: NSSlider) {


### PR DESCRIPTION
Note: this was originally intended as the fix for #3729, but testing on MacOS Monterey shows that is no longer the case. I'm keeping this open mainly because it simplifies the code, which is a good thing, but now much lower priority. 

_From the commit message:_
Simplify MainMenuActions: change it to an extension of PlayerWindowController rather than a separate class, since it was already performing that role. Removes redundant lifecycle management and custom code for tinkering with the player window responder chain