### PR TITLE
Fix video stutters when resuming after pausing, #3752

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -908,6 +908,16 @@ class MPVController: NSObject {
           player.sendOSD(paused ? .pause : .resume)
           DispatchQueue.main.sync {
             player.info.isPaused = paused
+            // Follow energy efficiency best practices and ensure IINA is absolutely idle when the
+            // video is paused to avoid wasting energy with needless processing. If paused shutdown
+            // the timer that synchronizes the UI and the high priority display link thread.
+            if paused {
+              player.invalidateTimer()
+              player.mainWindow.videoView.stopDisplayLink()
+            } else {
+              player.mainWindow.videoView.startDisplayLink()
+              player.createSyncUITimer()
+            }
           }
         }
         if player.mainWindow.loaded && Preference.bool(for: .alwaysFloatOnTop) {

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -449,10 +449,6 @@ class PlayerCore: NSObject {
 
   func pause() {
     mpv.setFlag(MPVOption.PlaybackControl.pause, true)
-    // Follow energy efficiency best practices and ensure IINA is absolutely idle when the video is
-    // paused to avoid wasting energy with needless processing.
-    invalidateTimer()
-    mainWindow.videoView.stopDisplayLink()
   }
 
   func resume() {
@@ -461,8 +457,6 @@ class PlayerCore: NSObject {
       seek(absoluteSecond: 0)
     }
     mpv.setFlag(MPVOption.PlaybackControl.pause, false)
-    createSyncUITimer()
-    mainWindow.videoView.startDisplayLink()
   }
 
   func stop() {


### PR DESCRIPTION
This commit will:
- Add code to MPVController.handlePropertyChange to suspend/resume
  active systems not needed while paused
- Remove code added to PlayerCore methods pause and resume that
  attempted to manage these active systems

This corrects a regression added by PR #3538 that could cause playback
to stutter, due to the display link not being restarted. The original
fix failed when the OSC was used to pause playback, which went through
PlayerCore.pause and then playback was resumed using the space bar which
by-passed PlayerCore.resume, leaving the display link shutdown.

- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3752.

---

**Description:**
This fixes a regression in the develop branch due to an incorrect fix.