### PR TITLE
Fix a potential crash at FileHandle.read(type:).

### DIFF
--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -388,7 +388,7 @@ extension FileHandle {
       return nil
     }
     return data.withUnsafeBytes {
-      $0.bindMemory(to: T.self).first!
+      $0.bindMemory(to: T.self).first
     }
   }
 }


### PR DESCRIPTION
- [x] This change has been discussed with the author.
- [x] It implements / fixes issue #3754.

---

**Description:**
This PR fixes a potential crash at FileHandle.read(type:) due to force unwrapping `UnsafeBufferPointer.first`. 

After a second visit, this crash has already been fixed with the size check, but I think removing the force unwrap would be a more elegant option since this function already returns optional.