### PR TITLE
Focus the window to ensure cursor can be hidden in fullscreen

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -947,6 +947,9 @@ class MainWindowController: PlayerWindowController {
 
   override func mouseMoved(with event: NSEvent) {
     guard !isInInteractiveMode else { return }
+    if fsState.isFullscreen {
+      NSApplication.shared.activate(ignoringOtherApps: true)
+    }
     let mousePos = playSlider.convert(event.locationInWindow, from: nil)
     if isMouseInSlider {
       updateTimeLabel(mousePos.x, originalPos: event.locationInWindow)


### PR DESCRIPTION
"NSCursor.setHiddenUntilMouseMoves" is only effective when the
calling window is the focused window.

When user moves back from another screen or space, the window may
not be focused. As a result, the cursor can't be hidden before the
user clicks the window.

It can be reasonably expected that the user would want to focus on
the window when the mouse moves inside the window and the window is
in fullscreen.

As such, focus the window on mouse movement inside the window when
the window is in fullscreen.

Bug: #1415
