### PR TITLE
fixing app icon not showing in the front of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<img height="256" src="https://github.com/iina/iina/raw/master/iina/Assets.xcassets/AppIcon.appiconset/1024-1.png" />
+<img height="256" src="https://github.com/iina/iina/raw/master/iina/Assets.xcassets/AppIcon.appiconset/iina-icon-256.png" />
 </p>
 
 <h1 align="center">IINA</h1>


### PR DESCRIPTION
`1024-1.png` image is not found at `iina/Assets.xcassets/AppIcon.appiconset/`

- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**
