### PR TITLE
Fix #3766. InitialWindowController crash.

### DIFF
--- a/iina/InitialWindowController.swift
+++ b/iina/InitialWindowController.swift
@@ -337,7 +337,11 @@ extension InitialWindowController: NSTableViewDelegate, NSTableViewDataSource {
             return
         }
         // default: let recentFilesTableView handle it
-        recentFilesTableView.keyDown(with: event)
+        if recentDocuments.count > 0 {
+          recentFilesTableView.keyDown(with: event)
+        } else {
+          super.keyDown(with: event)
+        }
       default:
         super.keyDown(with: event)
     }


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3766.

---

**Description:**
When `recentDocuments` is empty, ignore letting recentFilesTableView handle "UP" keydown.