### PR TITLE
Update the network prefetch preference's default label

### DIFF
--- a/iina/Base.lproj/PrefNetworkViewController.xib
+++ b/iina/Base.lproj/PrefNetworkViewController.xib
@@ -113,7 +113,7 @@
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Aw2-n0-Y53">
                     <rect key="frame" x="377" y="8" width="68" height="14"/>
-                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Default: 100" id="fab-7d-mMQ">
+                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Default: 36000" id="fab-7d-mMQ">
                         <font key="font" metaFont="message" size="11"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>


### PR DESCRIPTION
- [x] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**
The default value for this preference appears to have changed in 14f785b (iina/Preference.swift line 755), but the label wasn't updated, leading to a mismatch:

<img width="491" alt="image" src="https://user-images.githubusercontent.com/17569187/171834089-38651753-f100-4520-bc8c-81292bff58ab.png">

This PR updates the label's text, though translations may also need to be updated on Crowdin.

(This is a copy of #3658. The author appears to have deleted their fork, permanently closing the PR.)