### PR TITLE
Resolve symlinks when comparing recent files against last played file

### DIFF
--- a/iina/InitialWindowController.swift
+++ b/iina/InitialWindowController.swift
@@ -251,7 +251,7 @@ class InitialWindowController: NSWindowController {
     recentFilesTableView.reloadData()
 
     if Logger.enabled && Logger.Level.preferred >= .verbose {
-      let last = lastPlaybackURL == nil ? "<none>" : lastPlaybackURL!.resolvingSymlinksInPath().path
+      let last = lastPlaybackURL.flatMap { $0.resolvingSymlinksInPath().path } ?? "<none>"
       Logger.log("InitialWindow.reloadData(): LastPlaybackURL: \(last)", level: .verbose)
 
       for (index, url) in NSDocumentController.shared.recentDocumentURLs.enumerated() {


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [X] It implements / fixes issue #3788.

---

**Description:**
The last played file is checked against the recent files list so that it doesn't appear twice, but if one is a symlink, it can give a false negative and result in a duplicate listing. This seems to be a bigger problem for files in /tmp and /var, which Apple now links to /private/tmp and /private/var, so they can have different paths depending on which MacOS API they came from.

This fix adds `resolvingSymlinksInPath()` to both sides of the comparison, which is needed to normalize both paths. Apple treats /var and /tmp a bit strangely. See [this discussion](https://stackoverflow.com/questions/43031045/for-what-paths-is-resolvingsymlinksinpath-wrong).