### PR TITLE
feat: allow user to override file extension filter

### DIFF
--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -125,6 +125,7 @@ class Utility {
     panel.canChooseDirectories = chooseDir
     panel.resolvesAliases = true
     panel.allowedFileTypes = allowedFileTypes
+    panel.allowsOtherFileTypes = true
     panel.allowsMultipleSelection = false
     panel.level = .modalPanel
     if let dir = dir {


### PR DESCRIPTION
Before, load subtitles allowed you to load an mkv and use it as a subtitle. I find it inconvenient now to use ffmpeg to extract the subtitle first.

Fixes #3792

- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #.

---

**Description:**
See issue
