### PR TITLE
Fix bug: Playback History search returns no results for uppercase letters

### DIFF
--- a/iina/HistoryWindowController.swift
+++ b/iina/HistoryWindowController.swift
@@ -200,7 +200,8 @@ class HistoryWindowController: NSWindowController, NSOutlineViewDelegate, NSOutl
     }
     let newObjects = HistoryController.shared.history.filter { entry in
       let string = searchOption == .filename ? entry.name : entry.url.path
-      return string.lowercased().contains(searchString)
+      // Do a locale-aware, case and diacritic insensitive search:
+      return string.localizedStandardContains(searchString)
     }
     prepareData(fromHistory: newObjects)
     outlineView.reloadData()


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3800.

---

**Description:**
Looks like playback history searches are meant to be case-insensitive. But `String.lowercased()` was only called for one side of the comparison.