### PR TITLE
Fix Saved Audio Filters disabled in music mode, #3818

### DIFF
--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -235,6 +235,44 @@ extension MainMenuActionHandler {
   @objc func menuToggleDeinterlace(_ sender: NSMenuItem) {
     player.toggleDeinterlace(sender.state != .on)
   }
+
+  @objc
+  func menuToggleVideoFilterString(_ sender: NSMenuItem) {
+    if let string = (sender.representedObject as? String) {
+      menuToggleFilterString(string, forType: MPVProperty.vf)
+    }
+  }
+
+  private func menuToggleFilterString(_ string: String, forType type: String) {
+    let isVideo = type == MPVProperty.vf
+    if let filter = MPVFilter(rawString: string) {
+      // Removing a filter based on its position within the filter list is the preferred way to do
+      // it as per discussion with the mpv project. Search the list of filters and find the index
+      // of the specified filter (if present).
+      if let index = player.mpv.getFilters(type).firstIndex(of: filter) {
+        // remove
+        if isVideo {
+          _ = player.removeVideoFilter(filter, index)
+        } else {
+          _ = player.removeAudioFilter(filter, index)
+        }
+      } else {
+        // add
+        if isVideo {
+          if !player.addVideoFilter(filter) {
+            Utility.showAlert("filter.incorrect")
+          }
+        } else {
+          if !player.addAudioFilter(filter) {
+            Utility.showAlert("filter.incorrect")
+          }
+        }
+      }
+    }
+    if let vfWindow = (NSApp.delegate as? AppDelegate)?.vfWindow, vfWindow.loaded {
+      vfWindow.reloadTable()
+    }
+  }
 }
 
 // MARK: - Audio
@@ -264,6 +302,13 @@ extension MainMenuActionHandler {
 
   @objc func menuResetAudioDelay(_ sender: NSMenuItem) {
     player.setAudioDelay(0)
+  }
+
+  @objc
+  func menuToggleAudioFilterString(_ sender: NSMenuItem) {
+    if let string = (sender.representedObject as? String) {
+      menuToggleFilterString(string, forType: MPVProperty.af)
+    }
   }
 }
 

--- a/iina/MainWindowMenuActions.swift
+++ b/iina/MainWindowMenuActions.swift
@@ -148,49 +148,4 @@ extension MainWindowController {
       }
     }
   }
-
-  @objc
-  func menuToggleVideoFilterString(_ sender: NSMenuItem) {
-    if let string = (sender.representedObject as? String) {
-      menuToggleFilterString(string, forType: MPVProperty.vf)
-    }
-  }
-
-  @objc
-  func menuToggleAudioFilterString(_ sender: NSMenuItem) {
-    if let string = (sender.representedObject as? String) {
-      menuToggleFilterString(string, forType: MPVProperty.af)
-    }
-  }
-
-  private func menuToggleFilterString(_ string: String, forType type: String) {
-    let isVideo = type == MPVProperty.vf
-    if let filter = MPVFilter(rawString: string) {
-      // Removing a filter based on its position within the filter list is the preferred way to do
-      // it as per discussion with the mpv project. Search the list of filters and find the index
-      // of the specified filter (if present).
-      if let index = player.mpv.getFilters(type).firstIndex(of: filter) {
-        // remove
-        if isVideo {
-          _ = player.removeVideoFilter(filter, index)
-        } else {
-          _ = player.removeAudioFilter(filter, index)
-        }
-      } else {
-        // add
-        if isVideo {
-          if !player.addVideoFilter(filter) {
-            Utility.showAlert("filter.incorrect")
-          }
-        } else {
-          if !player.addAudioFilter(filter) {
-            Utility.showAlert("filter.incorrect")
-          }
-        }
-      }
-    }
-    if let vfWindow = (NSApp.delegate as? AppDelegate)?.vfWindow, vfWindow.loaded {
-      vfWindow.reloadTable()
-    }
-  }
 }

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -620,7 +620,7 @@ class MenuController: NSObject, NSMenuDelegate {
     for filter in filters {
       let menuItem = NSMenuItem()
       menuItem.title = filter.name
-      menuItem.action = isVideo ? #selector(MainWindowController.menuToggleVideoFilterString(_:)) : #selector(MainWindowController.menuToggleAudioFilterString(_:))
+      menuItem.action = isVideo ? #selector(MainMenuActionHandler.menuToggleVideoFilterString(_:)) : #selector(MainMenuActionHandler.menuToggleAudioFilterString(_:))
       menuItem.keyEquivalent = filter.shortcutKey
       menuItem.keyEquivalentModifierMask = filter.shortcutKeyModifiers
       menuItem.representedObject = filter.filterString


### PR DESCRIPTION
This commit will:
- Move menuToggleVideoFilterString from MainWindowMenuActions
  to MainMenuActionHandler
- Move menuToggleAudioFilterString from MainWindowMenuActions
  to MainMenuActionHandler
- Change MenuController to call the methods in their new
  location

- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3818.

---

**Description:**
