### PR TITLE
Fix: add `silent` parameter to PlayerCore.addToPlaylist to avoid unnecessary playlistView refreshes in AutoFileMatcher.swift

### DIFF
--- a/iina/AutoFileMatcher.swift
+++ b/iina/AutoFileMatcher.swift
@@ -120,12 +120,12 @@ class AutoFileMatcher {
         addedCurrentVideo = true
       } else if addedCurrentVideo {
         try checkTicket()
-        player.addToPlaylist(video.path)
+        player.addToPlaylist(video.path, silent: true)
       } else {
         let count = player.mpv.getInt(MPVProperty.playlistCount)
         let current = player.mpv.getInt(MPVProperty.playlistPos)
         try checkTicket()
-        player.addToPlaylist(video.path)
+        player.addToPlaylist(video.path, silent: true)
         player.mpv.command(.playlistMove, args: ["\(count)", "\(current)"], checkError: false) { err in
           if err == MPV_ERROR_COMMAND.rawValue { needQuit = true }
           if err != 0 {

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -842,9 +842,11 @@ class PlayerCore: NSObject {
     mpv.command(.loadfile, args: [path, "append"])
   }
 
-  func addToPlaylist(_ path: String) {
+  func addToPlaylist(_ path: String, silent: Bool = false) {
     _addToPlaylist(path)
-    postNotification(.iinaPlaylistChanged)
+    if !silent {
+      postNotification(.iinaPlaylistChanged)
+    }
   }
 
   private func _playlistMove(_ from: Int, to: Int) {


### PR DESCRIPTION

- [X] This change has been discussed with the author.
- [X] It implements / fixes issue discussed in #3762.

---

**Description:**

This change will:
- Add the `silent` parameter to `PlayerCore.addToPlaylist` to avoid calling `postNotification(.iinaPlaylistChanged)`
- Update `addFilesToPlaylist` in `AutoFileMatcher.swift` to use the silent parameter when batch calling `addToPlaylist`
