### PR TITLE
Fix regression: key for menu items randomly chosen from bindings mapped to multiple keys

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -283,10 +283,17 @@ class PlayerCore: NSObject {
 
   static func setKeyBindings(_ keyMappings: [KeyMapping]) {
     Logger.log("Set key bindings")
-    var keyBindings: [String: KeyMapping] = [:]
-    keyMappings.forEach { keyBindings[$0.key] = $0 }
-    PlayerCore.keyBindings = keyBindings
-    (NSApp.delegate as? AppDelegate)?.menuController.updateKeyEquivalentsFrom(Array(keyBindings.values))
+    // If multiple bindings map to the same key, choose the last one
+    var keyBindingsDict: [String: KeyMapping] = [:]
+    keyMappings.forEach { keyBindingsDict[$0.key] = $0 }
+    PlayerCore.keyBindings = keyBindingsDict
+
+    // For menu item bindings, filter duplicate keys as above, but preserve order
+    var kbUniqueOrderedList: [KeyMapping] = []
+    for kb in keyMappings {
+      kbUniqueOrderedList.append(keyBindingsDict[kb.key]!)
+    }
+    (NSApp.delegate as? AppDelegate)?.menuController.updateKeyEquivalentsFrom(kbUniqueOrderedList)
   }
 
   func startMPV() {


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [X] It implements / fixes issue #3831

---

**Description:**
As @low-batt has pointed out, using an `OrderedDictionary` from swift-collections would be the most elegant solution, but if adding a dependency to that is not favorable, here is a solution which uses only the built-in data structures.