### PR TITLE
Overhaul key input handling: support runtime script bindings, key sequences, streamline event flow, fix parsing issues

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -158,6 +158,12 @@
 		B4E446F725CB54EF0069F06E /* Mustache in Frameworks */ = {isa = PBXBuildFile; productRef = B4E446F625CB54EF0069F06E /* Mustache */; };
 		B4E4470125CE3F930069F06E /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = B4E4470025CE3F930069F06E /* Sparkle */; };
 		C789872F1E34EF170005769F /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = C78987311E34EF170005769F /* InfoPlist.strings */; };
+		D140E81C285A0BEF00067094 /* LinkedList.swift in Sources */ = {isa = PBXBuildFile; fileRef = D140E81B285A0BEF00067094 /* LinkedList.swift */; };
+		D18333BC2834CDF40060A4E9 /* RingBuffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = D18333BB2834CDF40060A4E9 /* RingBuffer.swift */; };
+		D18333BE2834CE620060A4E9 /* KeyInputController.swift in Sources */ = {isa = PBXBuildFile; fileRef = D18333BD2834CE620060A4E9 /* KeyInputController.swift */; };
+		D1FD2DD828521AD500CF7B35 /* MPVLogHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1FD2DD728521AD500CF7B35 /* MPVLogHandler.swift */; };
+		D1FD2DDA28521B5900CF7B35 /* MPVLogLevel.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1FD2DD928521B5900CF7B35 /* MPVLogLevel.swift */; };
+		D1FD2DDC28533EE700CF7B35 /* MPVInputSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1FD2DDB28533EE700CF7B35 /* MPVInputSection.swift */; };
 		E301EFDA21312AB300BC8588 /* KeychainAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = E301EFD921312AB300BC8588 /* KeychainAccess.swift */; };
 		E322A4F820A8442E00C67D32 /* PlaylistPlaybackProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E322A4F720A8442E00C67D32 /* PlaylistPlaybackProgressView.swift */; };
 		E32712B024EAA14500359DAB /* ScreenshootOSDView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E32712AE24EAA14500359DAB /* ScreenshootOSDView.swift */; };
@@ -1197,6 +1203,12 @@
 		C7DBA5EB1F07C5FD00C2B416 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/InitialWindowController.strings; sourceTree = "<group>"; };
 		C7DC79CE1EC63821002DE23B /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/HistoryWindowController.strings; sourceTree = "<group>"; };
 		C7E90B522087EC5700A58B6B /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/SubChooseViewController.strings; sourceTree = "<group>"; };
+		D140E81B285A0BEF00067094 /* LinkedList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkedList.swift; sourceTree = "<group>"; };
+		D18333BB2834CDF40060A4E9 /* RingBuffer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RingBuffer.swift; sourceTree = "<group>"; };
+		D18333BD2834CE620060A4E9 /* KeyInputController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyInputController.swift; sourceTree = "<group>"; };
+		D1FD2DD728521AD500CF7B35 /* MPVLogHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPVLogHandler.swift; sourceTree = "<group>"; };
+		D1FD2DD928521B5900CF7B35 /* MPVLogLevel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPVLogLevel.swift; sourceTree = "<group>"; };
+		D1FD2DDB28533EE700CF7B35 /* MPVInputSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPVInputSection.swift; sourceTree = "<group>"; };
 		D27556FC1EC6E1C300CAB2A4 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/HistoryWindowController.strings"; sourceTree = "<group>"; };
 		D27E35CE1E379B6D0064BE57 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/MainMenu.strings"; sourceTree = "<group>"; };
 		D27E35CF1E379B6D0064BE57 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/MainWindowController.strings"; sourceTree = "<group>"; };
@@ -1704,6 +1716,7 @@
 				E38BD4AE20054BD9007635FC /* MainWindow.swift */,
 				84CFC92523F8DDE000381E5B /* PlayerWindowController.swift */,
 				84A0BA9C1D2FAD4000BC8DA1 /* MainWindowController.swift */,
+				D18333BD2834CE620060A4E9 /* KeyInputController.swift */,
 				84D123B31ECAA405004E0D53 /* TouchBarSupport.swift */,
 				8400D5C81E1AB2F1006785F5 /* MainWindowController.xib */,
 				8466BE161D5CDD0300039D03 /* QuickSettingViewController.swift */,
@@ -1767,6 +1780,8 @@
 				E342832E20B7149800139865 /* Logger.swift */,
 				E3F698862120D878005792C9 /* ExtendedColors.swift */,
 				E301EFD921312AB300BC8588 /* KeychainAccess.swift */,
+				D18333BB2834CDF40060A4E9 /* RingBuffer.swift */,
+				D140E81B285A0BEF00067094 /* LinkedList.swift */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -1783,6 +1798,7 @@
 				84FBCB371EEACDDD0076C77C /* FFmpegController.m */,
 				842904E11F0EC01600478376 /* AutoFileMatcher.swift */,
 				846121BC1F35FCA500ABB39C /* DraggingDetect.swift */,
+				D1FD2DD728521AD500CF7B35 /* MPVLogHandler.swift */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";
@@ -1795,6 +1811,8 @@
 				844DE1BE1D3E2B9900272589 /* MPVEvent.swift */,
 				84F7258E1D486185000DEF1B /* MPVProperty.swift */,
 				E3CB258E222799B800A62C47 /* MPVHook.swift */,
+				D1FD2DD928521B5900CF7B35 /* MPVLogLevel.swift */,
+				D1FD2DDB28533EE700CF7B35 /* MPVInputSection.swift */,
 				84EB1F041D2F5C5B004FA5A1 /* AppData.swift */,
 				84A0BA8F1D2F8D4100BC8DA1 /* IINAError.swift */,
 				84AABE8A1DBF634600D138FD /* CharEncoding.swift */,
@@ -2420,16 +2438,20 @@
 				84EC12831F4F939000137C1E /* FilterPresets.swift in Sources */,
 				E374160F20F3AF7E00B4F7F9 /* PrefUtilsViewController.swift in Sources */,
 				E3FC31461FE1501E00B9B86F /* PowerSource.swift in Sources */,
+				D1FD2DDA28521B5900CF7B35 /* MPVLogLevel.swift in Sources */,
 				8476440A1D48CC3D004F6DF5 /* MPVCommand.swift in Sources */,
 				84C8D5911D796F9700D98A0E /* Aspect.swift in Sources */,
 				E3383689202651CF00ABC812 /* PrefOSCToolbarDraggingItemViewController.swift in Sources */,
+				D140E81C285A0BEF00067094 /* LinkedList.swift in Sources */,
 				519872FF26879B9B00F84BCC /* AccessibilityPreferences.swift in Sources */,
 				842904E21F0EC01600478376 /* AutoFileMatcher.swift in Sources */,
 				8466BE181D5CDD0300039D03 /* QuickSettingViewController.swift in Sources */,
 				84A0BA9E1D2FAD4000BC8DA1 /* MainWindowController.swift in Sources */,
 				84E48D4E1E0F1090002C7A3F /* FilterWindowController.swift in Sources */,
 				E3F698872120D878005792C9 /* ExtendedColors.swift in Sources */,
+				D18333BC2834CDF40060A4E9 /* RingBuffer.swift in Sources */,
 				8476440C1D48F63D004F6DF5 /* OSDMessage.swift in Sources */,
+				D18333BE2834CE620060A4E9 /* KeyInputController.swift in Sources */,
 				84AE59491E0FD65800771B7E /* MainMenuActions.swift in Sources */,
 				E3CB75BD1FDACB82004DB10A /* SavedFilter.swift in Sources */,
 				E342832F20B7149800139865 /* Logger.swift in Sources */,
@@ -2448,6 +2470,7 @@
 				840820111ECF6C1800361416 /* FileGroup.swift in Sources */,
 				E374160C20F138A900B4F7F9 /* CollapseView.swift in Sources */,
 				84A0BA901D2F8D4100BC8DA1 /* IINAError.swift in Sources */,
+				D1FD2DDC28533EE700CF7B35 /* MPVInputSection.swift in Sources */,
 				84C6D3621EAF8D63009BF721 /* HistoryController.swift in Sources */,
 				847644081D48B413004F6DF5 /* MPVOption.swift in Sources */,
 				84817C961DBDCA5F00CC2279 /* SettingsListCellView.swift in Sources */,
@@ -2499,6 +2522,7 @@
 				84FBF23E1EF06A90003EA491 /* ThumbnailCache.swift in Sources */,
 				845FB0C71D39462E00C011E0 /* ControlBarView.swift in Sources */,
 				E3513AFB20F120F600F8C347 /* PreferenceViewController.swift in Sources */,
+				D1FD2DD828521AD500CF7B35 /* MPVLogHandler.swift in Sources */,
 				E38BD4AF20054BD9007635FC /* MainWindow.swift in Sources */,
 				84F5D4A01E44F9DB0060A838 /* KeyBindingItem.swift in Sources */,
 				84A0BA991D2FAAA700BC8DA1 /* MPVController.swift in Sources */,

--- a/iina/AppData.swift
+++ b/iina/AppData.swift
@@ -105,9 +105,12 @@ extension Notification.Name {
   static let iinaMediaTitleChanged = Notification.Name("IINAMediaTitleChanged")
   static let iinaVFChanged = Notification.Name("IINAVfChanged")
   static let iinaAFChanged = Notification.Name("IINAAfChanged")
-  static let iinaKeyBindingInputChanged = Notification.Name("IINAkeyBindingInputChanged")
+  static let iinaInputConfListChanged = Notification.Name("IINAInputConfListChanged")
+  static let iinaCurrentInputConfChanged = Notification.Name("IINACurrentInputConfChanged")
+  static let iinaKeyBindingInputChanged = Notification.Name("IINAKeyBindingInputChanged")
   static let iinaFileLoaded = Notification.Name("IINAFileLoaded")
   static let iinaHistoryUpdated = Notification.Name("IINAHistoryUpdated")
   static let iinaLegacyFullScreen = Notification.Name("IINALegacyFullScreen")
+  static let iinaGlobalKeyBindingsChanged = Notification.Name("iinaGlobalKeyBindingsChanged")
   static let iinaKeyBindingChanged = Notification.Name("iinaKeyBindingChanged")
 }

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -179,6 +179,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     Logger.log("App launched")
 
     Logger.log("Using \(PlayerCore.active.mpv.mpvVersion!)")
+    Logger.log("Log level of mpv pass-through: \(MPVLogHandler.iinaMpvLogLevel)")
 
     if !isReady {
       getReady()

--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -8,6 +8,15 @@
 
 import Cocoa
 
+infix operator %%
+
+extension Int {
+  /** Modulo operator. Swift's remainder operator (%) can return negative values, which is rarely what we want. */
+  static  func %% (_ left: Int, _ right: Int) -> Int {
+    return (left % right + right) % right
+  }
+}
+
 extension NSSlider {
   /** Returns the position of knob center by point */
   func knobPointPosition() -> CGFloat {
@@ -414,6 +423,10 @@ extension String {
 
   var mpvFixedLengthQuoted: String {
     return "%\(count)%\(self)"
+  }
+
+  func equalsIgnoreCase(_ other: String) -> Bool {
+    return localizedCompare(other) == .orderedSame
   }
 
   mutating func deleteLast(_ num: Int) {

--- a/iina/KeyCodeHelper.swift
+++ b/iina/KeyCodeHelper.swift
@@ -9,6 +9,19 @@
 import Foundation
 import Carbon
 
+// mpv modifiers in normal form:
+fileprivate let CTRL_KEY = "Ctrl"
+fileprivate let ALT_KEY = "Alt"
+fileprivate let SHIFT_KEY = "Shift"
+fileprivate let META_KEY = "Meta"
+
+fileprivate let modifierOrder: [String: Int] = [
+  CTRL_KEY: 0,
+  ALT_KEY: 1,
+  SHIFT_KEY: 2,
+  META_KEY: 3
+]
+
 fileprivate let modifierSymbols: [(NSEvent.ModifierFlags, String)] = [(.control, "⌃"), (.option, "⌥"), (.shift, "⇧"), (.command, "⌘")]
 
 class KeyCodeHelper {
@@ -185,10 +198,10 @@ class KeyCodeHelper {
   }()
 
   static let mpvSymbolToKeyName: [String: String] = [
-    "META": "⌘",
-    "SHIFT": "⇧",
-    "ALT": "⌥",
-    "CTRL":"⌃",
+    META_KEY: "⌘",
+    SHIFT_KEY: "⇧",
+    ALT_KEY: "⌥",
+    CTRL_KEY:"⌃",
     "SHARP": "#",
     "ENTER": "↩︎",
     "KP_ENTER": "↩︎",
@@ -265,37 +278,157 @@ class KeyCodeHelper {
     // modifiers
     // the same order as `KeyMapping.modifierOrder`
     if modifiers.contains(.control) {
-      keyString += "Ctrl+"
+      keyString += "\(CTRL_KEY)+"
     }
     if modifiers.contains(.option) {
-      keyString += "Alt+"
+      keyString += "\(ALT_KEY)+"
     }
     if modifiers.contains(.shift) {
-      keyString += "Shift+"
+      keyString += "\(SHIFT_KEY)+"
     }
     if modifiers.contains(.command) {
-      keyString += "Meta+"
+      keyString += "\(META_KEY)+"
     }
     // char
     keyString += keyChar
     return keyString
   }
 
-  static func macOSKeyEquivalent(from mpvKeyCode: String, usePrintableKeyName: Bool = false) -> (key: String, modifiers: NSEvent.ModifierFlags)? {
-    if mpvKeyCode == "+" {
-      return ("+", [])
+  private static func getNextSeparatorIndex(_ unparsedRemainder: Substring) -> String.Index? {
+    if let dashIndex = unparsedRemainder.firstIndex(of: "-") {
+      if let indexBeyondEnd = unparsedRemainder.index(dashIndex, offsetBy: 1, limitedBy: unparsedRemainder.endIndex) {
+        // apparently "limitedBy" above doesn't work as advertised; have to check again
+        if indexBeyondEnd < unparsedRemainder.endIndex {
+          if unparsedRemainder[indexBeyondEnd] == "-" {
+            return indexBeyondEnd
+          }
+        }
+        return dashIndex
+      }
     }
-    let splitted = mpvKeyCode.replacingOccurrences(of: "++", with: "+PLUS").components(separatedBy: "+")
+    return nil
+  }
+
+  // See mpv/input/keycodes.c: mp_input_get_keys_from_string()
+  public static func splitKeystrokes(_ keystrokes: String) -> [String] {
+    var unparsedRemainder = Substring(keystrokes)
+    var splitKeystrokeList: [String] = []
+
+    while !unparsedRemainder.isEmpty && splitKeystrokeList.count < MP_MAX_KEY_DOWN {
+      var endIndex = unparsedRemainder.endIndex
+
+      if let dashIndex = getNextSeparatorIndex(unparsedRemainder), dashIndex != unparsedRemainder.startIndex {
+        endIndex = dashIndex
+      }
+
+      let ks = String(unparsedRemainder[unparsedRemainder.startIndex..<endIndex])
+      guard !ks.isEmpty else {
+          Logger.log("While splitting keystrokes: Last keystroke is empty! Returning list: \(splitKeystrokeList)", level: .error)
+          return splitKeystrokeList
+      }
+      splitKeystrokeList.append(ks)
+
+      guard let indexBeyondEnd = unparsedRemainder.index(endIndex, offsetBy: 1, limitedBy: unparsedRemainder.endIndex) else {
+        break
+      }
+
+      unparsedRemainder = unparsedRemainder[indexBeyondEnd...]
+    }
+    return splitKeystrokeList
+  }
+
+  // Normalizes a single "press" of possibly multiple keys (as joined with '+')
+  private static func normalizeSingleMpvKeystroke(_ mpvKeystroke: String) -> String {
+    if mpvKeystroke == "+" {
+      return mpvKeystroke
+    }
+    var normalizedList: [String] = []
+    let splitted = mpvKeystroke.replacingOccurrences(of: "++", with: "+PLUS").components(separatedBy: "+")
+    var key = splitted.last!
+    splitted.dropLast().forEach { k in
+      // Modifiers have first letter capitalized. All other special chars are capitalized
+      if k.equalsIgnoreCase(SHIFT_KEY) {
+        // For alphabetic chars, remove the "Shift+" and replace with actual uppercase char
+        if key.count == 1, key.lowercased() != key.uppercased() {
+          key = key.uppercased()
+        } else {
+          normalizedList.append(SHIFT_KEY)
+        }
+      } else if k.equalsIgnoreCase(META_KEY) {
+        normalizedList.append(META_KEY)
+      } else if k.equalsIgnoreCase(CTRL_KEY) {
+        normalizedList.append(CTRL_KEY)
+      } else if k.equalsIgnoreCase(ALT_KEY) {
+        normalizedList.append(ALT_KEY)
+      } else {
+        normalizedList.append(k.uppercased())
+      }
+    }
+    if key.count > 1 {
+      // assume it's a special char
+      key = key.uppercased()
+    }
+    normalizedList.append(key)
+
+    normalizedList = normalizedList.sorted { modifierOrder[$0, default: 9] < modifierOrder[$1, default: 9] }
+    return normalizedList.joined(separator: "+")
+  }
+
+  public static func splitAndNormalizeMpvString(_ mpvKeystrokes: String) -> [String] {
+    let keystrokesList = splitKeystrokes(mpvKeystrokes)
+
+    var normalizedList: [String] = []
+    for keystroke in keystrokesList {
+      normalizedList.append(normalizeSingleMpvKeystroke(keystroke))
+    }
+    return normalizedList
+  }
+
+  /*
+   MPV accepts several forms for the same keystroke. This ensures that it is reduced a single standardized form
+   (such that it can be used in a set or map, and which matches what `mpvKeyCode()` returns).
+
+   Definitions used here:
+   - A "key" is just any individual key on a keyboard (including keyboards from different locales around the world).
+   - A "keystroke" for our purposes is any combination of up to 4 different keys which are held down simultaneously, of which only one is a
+     "regular" (non-modifier) key, and the rest are "modifier keys". Note that currently we don't enforce the restriction on only one regular key.
+   - The 4 "modifier keys" include: "Meta" (aka Command), "Ctrl", "Alt" (aka Option), "Shift"
+   - A "key sequence" is an ordered list of up to 4 keystrokes. Whereas a "keystroke" is a set of keys typed in parallel, a "key sequence" is a set
+     of keystrokes typed serially.
+
+   Normal Form Rules:
+   1. The input string is parsed as a sequence of up to 4 keystrokes, each of which is separated by the character "-".
+      Note that "-" is itself a valid keystroke, so that e.g. this is a valid 4-key sequence: "-------"
+   2. Each resulting keystroke shall be parsed into up to 4 keys, each of which is separated by the character "+".
+      Note that the "+" character is accepted as a valid key, but it is normalized to "PLUS".
+   3. Each of the 4 modifiers shall be written with the first letter in uppercase and the remaining letters in lowercase.
+   4. There always shall be exactly 1 "regular" key in each keystroke, and it is always the last key in the keystroke.
+   5. A keystroke can contain between 0 and 3 modifiers (up to 1 of each kind).
+   6. The modifiers, if present, shall respect the following order from left to right: "Ctrl", "Alt", "Shift", "Meta"
+      (e.g., "Meta+Ctrl+J" is invalid, but "Ctrl+Alt+DEL" is valid)
+   7. If the regular key in the keystroke is of the set of characters which have separate and distinct uppercase and lowercase versions, then
+      the keystroke shall never contain an explicit "Shift" modifier but instead shall use the uppercase character.
+   8. Any remaining special keys not previously mentioned and which have more than one character in their name shall be written in all uppercase.
+      (examples: SHARP, SPACE, PGDOWN)
+   */
+  public static func normalizeMpv(_ mpvKeystrokes: String) -> String {
+    let normalizedList = splitAndNormalizeMpvString(mpvKeystrokes)
+    return normalizedList.joined(separator: "-")
+  }
+
+  // IMPORTANT: `mpvKeyCode` must be normalized first!
+  static func macOSKeyEquivalent(from mpvKeyCode: String, usePrintableKeyName: Bool = false) -> (key: String, modifiers: NSEvent.ModifierFlags)? {
+    let splitted = mpvKeyCode.components(separatedBy: "+")
     var key: String
     var modifiers: NSEvent.ModifierFlags = []
     guard !splitted.isEmpty else { return nil }
     key = splitted.last!
     splitted.dropLast().forEach { k in
       switch k {
-      case "Meta": modifiers.insert(.command)
-      case "Ctrl": modifiers.insert(.control)
-      case "Alt": modifiers.insert(.option)
-      case "Shift": modifiers.insert(.shift)
+      case META_KEY: modifiers.insert(.command)
+      case CTRL_KEY: modifiers.insert(.control)
+      case ALT_KEY: modifiers.insert(.option)
+        case SHIFT_KEY: modifiers.insert(.shift)
       default: break
       }
     }

--- a/iina/KeyInputController.swift
+++ b/iina/KeyInputController.swift
@@ -1,0 +1,473 @@
+//
+//  KeyInputController.swift
+//  iina
+//
+//  Created by Matt Svoboda on 2022.05.17.
+//  Copyright © 2022 lhc. All rights reserved.
+//
+
+import Foundation
+
+let MP_MAX_KEY_DOWN = 4
+fileprivate let DEFAULT_SECTION = "default"
+
+/*
+ A single KeyInputController instance should be associated with a single PlayerCore, and while the player window has focus, its
+ PlayerWindowController is expected to direct key presses to this class's `resolveKeyEvent` method.
+ to match the user's key stroke(s) into recognized commands..
+
+ This class also keeps track of any binidngs set by Lua scripts. It expects to be notified of new mpv "input sections" and updates to their
+ states, via `defineSection()`, `enableSection()`, and `disableSection()`. These are incorporated into key binding resolution via resolveKeyEvent(.
+
+ The data structures in this class should look similar to mpv's `struct input_ctx`, because they are based on it and attempt to mirror
+ its functionality.
+
+ A [key mapping](x-source-tag://KeyMapping) is an association from user input to an IINA or mpv command.
+ This can include mouse events (though not handled by this class), single keystroke (which may include modifiers), or a sequence of keystrokes.
+ See [the mpv manual](https://mpv.io/manual/master/#key-names) for information on mpv's valid "key names".
+
+ ** Input sections **
+
+ Internally, mpv organizes key bindings into blocks called "input sections", or just "sections", which are identified by name. Because IINA
+ doesn't currently support profiles, most IINA users (unless they are using Lua scripts) will only ever care about the implicit "default" section
+ whose contents are dictated via input.conf.
+
+ Confusingly, the input file can contain a label, "default-bindings start", which will put the bindings under it into a lower-priority group
+ which is referred to by different names at different places in the code: it is either "builtin", "weak", or implied by a "default" flag (or missing
+ the "force" flag) when defined. While the user-facing elements (mpv manual, config options) refers to these as "default bindings", it's not
+ particularly wise to think of them as defaults, because they can be added and removed just as easily as other bindings; they simply have lower
+ priority than their "force" counterparts. And in fact that is encouraged by mpv for authors who are writing Lua scripts.
+
+ Inside this class we'll refer to "strong" (or non-defaults) bindings as having force==true, and "weak" bindings as having force==false.
+ While mpv technically allows a mix of force and non-force bindings inside each section, for Lua scripts it is restricted to one type per section.
+ We'll just use that para
+
+ ** Key sequences **
+
+ From the mpv manual:
+
+ > It's also possible to bind a command to a sequence of keys:
+ >
+ > a-b-c show-text "command run after a, b, c have been pressed"
+ > (This is not shown in the general command syntax.)
+ >
+ > If a or a-b or b are already bound, this will run the first command that matches, and the multi-key command will never be called.
+ > Intermediate keys can be remapped to ignore in order to avoid this issue.
+ > The maximum number of (non-modifier) keys for combinations is currently 4.
+
+ Although IINA's active key bindings (as set in IINA's Preferences window) take effect immediately and apply to all player windows, each player
+ window maintains independent state, and in keeping with this, each player's KeyInputController maintains a separate buffer of pressed keystrokes
+ (going back as many as 4 keystrokes).
+
+ */
+class KeyInputController {
+  private struct KeyBindingMeta {
+    let binding: KeyMapping
+    let srcSectionName: String
+
+    init(_ kb: KeyMapping, from sectionName: String) {
+      binding = kb
+      srcSectionName = sectionName
+    }
+  }
+
+  // MARK: - Shared state for all players
+
+  static private let sharedSubsystem = Logger.Subsystem(rawValue: "keyinput")
+
+  // MARK: - Single player instance
+
+  private unowned let playerCore: PlayerCore!
+  private let subsystem: Logger.Subsystem
+
+  private let dq = DispatchQueue(label: "KeyInputSection", qos: .userInitiated)
+
+  // Reacts when there is a change to the global key bindings
+  private var keyBindingsChangedObserver: NSObjectProtocol? = nil
+
+  /*
+   mpv equivalent: `int key_history[MP_MAX_KEY_DOWN];`
+   Here, the the newest keypress is at the "head", with the "tail" being the oldest.
+   */
+  private var keyPressHistory = RingBuffer<String>(capacity: MP_MAX_KEY_DOWN)
+
+  /* mpv euivalent:   `struct cmd_bind_section **sections` */
+  private var sectionsDefined: [String : MPVInputSection] = [:]
+
+  /* mpv equivalent: `struct active_section active_sections[MAX_ACTIVE_SECTIONS];` (MAX_ACTIVE_SECTIONS = 50) */
+  private var sectionsEnabled = LinkedList<String>()
+
+  /* mpv includes this in its active_sections array but we break it out separately.
+   Sections which are enabled with "exclusive" = the section is used and all previous sections are ignored
+   */
+  private var sectionsEnabledExclusive = LinkedList<String>()
+
+  private var currentKeyBindingDict: [String: KeyBindingMeta] = [:]
+
+  init(playerCore: PlayerCore, _ globalKeyBindings: [KeyMapping]) {
+    self.playerCore = playerCore
+    self.subsystem = Logger.Subsystem(rawValue: "\(playerCore.subsystem.rawValue)/\(KeyInputController.sharedSubsystem.rawValue)")
+
+    keyBindingsChangedObserver = NotificationCenter.default.addObserver(forName: .iinaGlobalKeyBindingsChanged, object: nil, queue: .main, using: onGlobalKeyBindingsChanged)
+
+    // initial load
+    self.dq.async {
+      self.setDefaultBindings(globalKeyBindings)
+      self.enableSection_Unsafe(DEFAULT_SECTION, [])
+      assert (self.sectionsEnabled.count == 1)
+      assert (self.sectionsDefined.count == 1)
+    }
+  }
+
+  deinit {
+    dq.async {
+      if let existingObserver = self.keyBindingsChangedObserver {
+        self.log("Removing keyBindingsChangedObserver", level: .verbose)
+        NotificationCenter.default.removeObserver(existingObserver)
+        self.keyBindingsChangedObserver = nil
+      }
+      // facilitate garbage collection
+      self.keyPressHistory.clear()
+      self.sectionsDefined = [:]
+      self.sectionsEnabled.clear()
+      self.sectionsEnabledExclusive.clear()
+      self.currentKeyBindingDict = [:]
+    }
+  }
+
+  private func log(_ msg: String, level: Logger.Level = .debug) {
+    Logger.log(msg, level: level, subsystem: subsystem)
+  }
+
+  // Called when this window has keyboard focus but it was already handled by someone else (probably the main menu).
+  // But it's still important to know that it happened
+  func keyWasHandled(_ keyDownEvent: NSEvent) {
+    log("Clearing list of pressed keys", level: .verbose)
+    keyPressHistory.clear()
+  }
+
+  /*
+   Parses the user's most recent keystroke from the given keyDown event and determines if it (a) matches a key binding for a single keystroke,
+   or (b) when combined with the user's previous keystrokes, matches a key binding for a key sequence.
+
+   Returns:
+   - nil if keystroke is invalid (e.g., it does not resolve to an actively bound keystroke or key sequence, and could not be interpreted as starting
+     or continuing such a key sequence)
+   - (a non-null) KeyMapping whose action is "ignore" if it should be ignored by mpv and IINA
+   - (a non-null) KeyMapping whose action is not "ignore" if the keystroke matched an active (non-ignored) key binding or the final keystroke
+     in a key sequence.
+   */
+  func resolveKeyEvent(_ keyDownEvent: NSEvent) -> KeyMapping? {
+    assert (keyDownEvent.type == NSEvent.EventType.keyDown, "Expected a KeyDown event but got: \(keyDownEvent)")
+
+    let keySequence: String = KeyCodeHelper.mpvKeyCode(from: keyDownEvent)
+    if keySequence == "" {
+      log("Event could not be translated; ignoring: \(keyDownEvent)")
+      return nil
+    }
+
+    return resolveFirstMatchingKeySequence(endingWith: keySequence)
+  }
+
+  // Try to match key sequences, up to 4 keystrokes. shortest match wins
+  private func resolveFirstMatchingKeySequence(endingWith lastKeyStroke: String) -> KeyMapping? {
+    keyPressHistory.insertHead(lastKeyStroke)
+
+    var keySequence = ""
+    var hasPartialValidSequence = false
+
+    for prevKey in keyPressHistory.reversed() {
+      if keySequence.isEmpty {
+        keySequence = prevKey
+      } else {
+        keySequence = "\(prevKey)-\(keySequence)"
+      }
+
+      log("Checking sequence: \"\(keySequence)\"", level: .verbose)
+
+      if let meta = currentKeyBindingDict[keySequence] {
+        if meta.binding.isIgnored {
+          log("Ignoring \"\(meta.binding.normalizedMpvKey)\" (from: \"\(meta.srcSectionName)\")", level: .verbose)
+          hasPartialValidSequence = true
+        } else {
+          log("Resolved keySeq \"\(meta.binding.normalizedMpvKey)\" -> \(meta.binding.action) (from: \"\(meta.srcSectionName)\")")
+          // Non-ignored action! Clear prev key buffer as per mpv spec
+          keyPressHistory.clear()
+          return meta.binding
+        }
+      }
+    }
+
+    if hasPartialValidSequence {
+      // Send an explicit "ignore" for a partial sequence match, so player window doesn't beep
+      log("Contains partial sequence, ignoring: \"\(keySequence)\"", level: .verbose)
+      return KeyMapping(rawKey: keySequence, rawAction: MPVCommand.ignore.rawValue, isIINACommand: false, comment: nil)
+    } else {
+      // Not even part of a valid sequence = invalid keystroke
+      log("No active binding for keystroke \"\(lastKeyStroke)\"")
+      logCurrentBindings()
+      return nil
+    }
+  }
+
+  func onGlobalKeyBindingsChanged(_ notification: Notification) {
+    log("Global bindings changed: queuing up keybindings rebuild", level: .verbose)
+    guard let globalDefaultBindings = notification.object as? [KeyMapping] else {
+      log("onGlobalKeyBindingsChanged(): missing object!", level: .error)
+      return
+    }
+    self.dq.async {
+      self.setDefaultBindings(globalDefaultBindings)
+      self.rebuildCurrentBindings()
+    }
+  }
+
+  private func setDefaultBindings(_ globalDefaultBindings: [KeyMapping]) {
+    self.log("Setting default section with \(globalDefaultBindings.count) bindings", level: .verbose)
+    // PlayerCore.keyBindings: Treat this as `section=="default", weak==false`.
+    let defaultSection = MPVInputSection(name: DEFAULT_SECTION, globalDefaultBindings, isForce: true)
+    // Like other sections, overwrite with latest changes. UNLIKE other sections, do not change its position in the stack.
+    sectionsDefined[defaultSection.name] = defaultSection
+  }
+
+  /*
+   This attempts to mimick the logic in mpv's `get_cmd_from_keys()` function in input/input.c
+   Expected to be run inside the the private dispatch queue.
+   */
+  private func rebuildCurrentBindings() {
+    var rebuiltBindings: [String: KeyBindingMeta] = [:]
+
+    assert (sectionsDefined[DEFAULT_SECTION] != nil, "Missing default bindings section!")
+
+    if let topExclusiveSectionName = sectionsEnabledExclusive.first {
+      if let topExclusiveSection = sectionsDefined[topExclusiveSectionName] {
+        log("RebuildBindings: adding exclusively: \"\(topExclusiveSection)\"", level: .verbose)
+        for keyBinding in topExclusiveSection.keyBindings {
+          rebuiltBindings[keyBinding.normalizedMpvKey] = KeyBindingMeta(keyBinding, from: topExclusiveSection.name)
+        }
+      } else {
+        // indicates serious internal error
+        log("RebuildBindings: failed to find exclusive section: \"\(topExclusiveSectionName)\"", level: .error)
+      }
+    } else {
+      for inputSectionName in sectionsEnabled {
+        if let inputSection = sectionsDefined[inputSectionName] {
+          if inputSection.keyBindings.isEmpty {
+            log("RebuildBindings: skipping \(inputSection.name) as it has no bindings", level: .verbose)
+          } else {
+            log("RebuildBindings: adding from \(inputSection)", level: .verbose)
+            addBindings(from: inputSection, to: &rebuiltBindings)
+          }
+        } else {
+          // indicates serious internal error
+          log("RebuildBindings: failed to find section: \"\(inputSectionName)\"", level: .error)
+        }
+      }
+    }
+
+    // Do this last, after everything has been inserted, so that there is no risk of blocking other bindings from being inserted.
+    KeyInputController.fillInPartialSequences(&rebuiltBindings)
+
+    // hopefully this will be an atomic replacement
+    currentKeyBindingDict = rebuiltBindings
+
+    log("Finished rebuilding input bindings (\(currentKeyBindingDict.count) total)")
+    logCurrentBindings()
+  }
+
+  private func addBindings(from inputSection: MPVInputSection, to bindingsDict: inout [String: KeyBindingMeta]) {
+    // Iterate from top of stack to bottom:
+    for keyBinding in inputSection.keyBindings {
+      addBinding(keyBinding, from: inputSection, to: &bindingsDict)
+    }
+  }
+
+  private func addBinding(_ keyBinding: KeyMapping, from inputSection: MPVInputSection, to bindingsDict: inout [String: KeyBindingMeta]) {
+    let mpvKey = keyBinding.normalizedMpvKey
+    if let prevBind = bindingsDict[mpvKey] {
+      guard let prevBindSrcSection = sectionsDefined[prevBind.srcSectionName] else {
+        log("RebuildBindings: Could not find previously added section: \"\(prevBind.srcSectionName)\". This is a bug", level: .error)
+        return
+      }
+      // For each binding, use the topmost weak binding found, or the topmost strong ("force") binding found
+      if prevBindSrcSection.isForce || !inputSection.isForce {
+        log("RebuildBindings: Skipping key: \"\(mpvKey)\" from section \"\(inputSection.name)\" (force=\(inputSection.isForce)): it was already set by higher-priority section \"\(prevBindSrcSection.name)\" (force=\(prevBindSrcSection.isForce))", level: .verbose)
+        return
+      }
+    }
+    bindingsDict[mpvKey] = KeyBindingMeta(keyBinding, from: inputSection.name)
+  }
+
+  private func logCurrentBindings() {
+    if Logger.enabled && Logger.Level.preferred >= .verbose {
+      let bindingList = currentKeyBindingDict.map { ("\t<\($1.srcSectionName)> \($0) -> \($1.binding.readableAction)") }
+      log("Current bindings:\n\(bindingList.joined(separator: "\n"))", level: .verbose)
+    }
+  }
+
+  private static func fillInPartialSequences(_ keyBindingsDict: inout [String: KeyBindingMeta]) {
+    for (keySequence, keyBindingMeta) in keyBindingsDict {
+      if keySequence.contains("-") && keySequence != "default-bindings" {
+        let keySequenceSplit = KeyCodeHelper.splitAndNormalizeMpvString(keySequence)
+        if keySequenceSplit.count >= 2 && keySequenceSplit.count <= 4 {
+          var partial = ""
+          for key in keySequenceSplit {
+            if partial == "" {
+              partial = String(key)
+            } else {
+              partial = "\(partial)-\(key)"
+            }
+            if partial != keySequence && !keyBindingsDict.keys.contains(partial) {
+              // Set an explicit "ignore" for a partial sequence match. This is all done so that the player window doesn't beep.
+              let partialBinding = KeyMapping(rawKey: partial, rawAction: MPVCommand.ignore.rawValue, isIINACommand: false, comment: "(partial sequence)")
+              keyBindingsDict[partial] = KeyBindingMeta(partialBinding, from: keyBindingMeta.srcSectionName)
+            }
+          }
+        }
+      }
+    }
+  }
+
+  /*
+   From the mpv manual:
+     Input sections group a set of bindings, and enable or disable them at once.
+     In input.conf, each key binding is assigned to an input section, rather than actually having explicit text sections.
+   ...
+
+     define-section <name> <contents> [<flags>]
+     Possible flags:
+     * `default`: (also used if parameter omitted)
+       Use a key binding defined by this section only if the user hasn't already bound this key to a command.
+     * `force`: Always bind a key. (The input section that was made active most recently wins if there are ambiguities.)
+
+     This command can be used to dispatch arbitrary keys to a script or a client API user. If the input section defines script-binding commands,
+     it is also possible to get separate events on key up/down, and relatively detailed information about the key state. The special key name
+     `unmapped` can be used to match any unmapped key.
+
+   Contents will always contain a list of:
+     script-binding <name>
+     * Invoke a script-provided key binding. This can be used to remap key bindings provided by external Lua scripts.
+     * The argument is the name of the binding.
+
+       It can optionally be prefixed with the name of the script, using / as separator, e.g. script-binding scriptname/bindingname.
+       Note that script names only consist of alphanumeric characters and _.
+
+   Example script-binding log line from webm script:
+    `ESC script-binding webm/ESC`
+   Here, `ESC` is the key, `webm/ESC` is the name, which consists of the script name as prefix, then slash, then the binding name.
+
+   See: `mp_input_define_section` in mpv source
+   */
+  func defineSection(_ inputSection: MPVInputSection) {
+    dq.sync {
+      // mpv behavior is to remove a section from the enabled list if it is updated with no content
+      if inputSection.keyBindings.isEmpty && sectionsDefined[inputSection.name] != nil {
+        // remove existing enabled section with same name
+        log("New definition of \"\(inputSection.name)\" contains no bindings: disabling & removing it")
+        disableSection_Unsafe(inputSection.name)
+      }
+      sectionsDefined[inputSection.name] = inputSection
+      rebuildCurrentBindings()
+    }
+  }
+
+  /*
+   From the mpv manual (and also mpv code comments):
+     Enable all key bindings in the named input section.
+
+     The enabled input sections form a stack. Bindings in sections on the top of the stack are preferred to lower sections.
+     This command puts the section on top of the stack. If the section was already on the stack, it is implicitly removed beforehand.
+     (A section cannot be on the stack more than once.)
+
+     The flags parameter can be a combination (separated by +) of the following flags:
+     * `exclusive` (MP_INPUT_EXCLUSIVE):
+       All sections enabled before the newly enabled section are disabled. They will be re-enabled as soon as all exclusive sections
+       above them are removed. In other words, the new section shadows all previous sections.
+     * `allow-hide-cursor` (MP_INPUT_ALLOW_HIDE_CURSOR): Don't force mouse pointer visible, even if inside the mouse area.
+     * `allow-vo-dragging` (MP_INPUT_ALLOW_VO_DRAGGING): Let mp_input_test_dragging() return true, even if inside the mouse area.
+
+   */
+  func enableSection(_ sectionName: String, _ flags: [String]) {
+    dq.sync {
+      enableSection_Unsafe(sectionName, flags)
+    }
+  }
+
+ private func enableSection_Unsafe(_ sectionName: String, _ flags: [String]) {
+   var isExclusive = false
+   for flag in flags {
+     switch flag {
+       case "allow-hide-cursor", "allow-vo-dragging":
+         // Ignore
+         break
+       case "exclusive":
+         isExclusive = true
+         log("Enabling exclusive section: \"\(sectionName)\"")
+         break
+       default:
+         log("Found unexpected flag \"\(flag)\" when enabling input section \"\(sectionName)\"", level: .error)
+     }
+   }
+
+   guard let section = sectionsDefined[sectionName] else {
+     log("Cannot enable section \"\(sectionName)\": it was never defined!", level: .error)
+     return
+   }
+
+   disableSection_Unsafe(sectionName)
+
+   sectionsDefined[sectionName] = section
+   if isExclusive {
+     sectionsEnabledExclusive.prepend(sectionName)
+   } else {
+     sectionsEnabled.prepend(sectionName)
+   }
+   log("After enable_section(\"\(sectionName)\") Sections: {Exclusive = \(sectionsEnabledExclusive); Enabled=\(sectionsEnabled); Defined=\(sectionsDefined.keys)}")
+   rebuildCurrentBindings()
+ }
+
+  /*
+   Disable the named input section. Undoes enable-section.
+   */
+  func disableSection(_ sectionName: String) {
+    dq.sync {
+      disableSection_Unsafe(sectionName)
+      rebuildCurrentBindings()
+    }
+  }
+
+  private func disableSection_Unsafe(_ sectionName: String) {
+    if sectionsDefined[sectionName] != nil {
+      sectionsEnabled.remove({ (x: String) -> Bool in x == sectionName })
+      sectionsEnabledExclusive.remove({ (x: String) -> Bool in x == sectionName })
+      sectionsDefined.removeValue(forKey: sectionName)
+    }
+  }
+
+  private func extractScriptNames(inputSection: MPVInputSection) -> Set<String> {
+    var scriptNameSet = Set<String>()
+    for kb in inputSection.keyBindings {
+      if kb.action.count == 2 && kb.action[0] == MPVCommand.scriptBinding.rawValue {
+        let scriptBindingName = kb.action[1]
+        if let scriptName = parseScriptName(from: scriptBindingName) {
+          scriptNameSet.insert(scriptName)
+        }
+      } else {
+        // indicates our code is wrong
+        log("Unexpected action for parsed key binding from 'define-section': \(kb.action)", level: .error)
+      }
+    }
+    return scriptNameSet
+  }
+
+  private func parseScriptName(from scriptBindingName: String) -> String? {
+    let splitName = scriptBindingName.split(separator: "/")
+    if splitName.count == 2 {
+      return String(splitName[0])
+    } else if splitName.count != 1 {
+      log("Unexpected script binding name from 'define-section': \(scriptBindingName)", level: .error)
+    }
+    return nil
+  }
+
+}

--- a/iina/KeyMapping.swift
+++ b/iina/KeyMapping.swift
@@ -8,25 +8,29 @@
 
 import Foundation
 
+/// - Tag: KeyMapping
 class KeyMapping: NSObject {
 
-  static private let modifierOrder: [String: Int] = [
-    "Ctrl": 0,
-    "Alt": 1,
-    "Shift": 2,
-    "Meta": 3
-  ]
-
+  // TODO: this is UI logic. Move it out of here.
   @objc var keyForDisplay: String {
     get {
-      return Preference.bool(for: .displayKeyBindingRawValues) ? key : prettyKey
+      if Preference.bool(for: .displayKeyBindingRawValues) {
+        return rawKey
+      } else {
+        if let (keyChar, modifiers) = KeyCodeHelper.macOSKeyEquivalent(from: normalizedMpvKey, usePrintableKeyName: true) {
+          return KeyCodeHelper.readableString(fromKey: keyChar, modifiers: modifiers)
+        } else {
+          return normalizedMpvKey
+        }
+      }
     }
     set {
-      key = newValue
+      rawKey = newValue
       NotificationCenter.default.post(Notification(name: .iinaKeyBindingChanged))
     }
   }
-  
+
+  // TODO: this is UI logic. Move it out of here.
   @objc var actionForDisplay: String {
     get {
       return Preference.bool(for: .displayKeyBindingRawValues) ? readableAction : prettyCommand
@@ -39,9 +43,29 @@ class KeyMapping: NSObject {
 
   var isIINACommand: Bool
 
-  var key: String
+  var rawKey: String {
+    didSet {
+      self.normalizedMpvKey = KeyCodeHelper.normalizeMpv(rawKey)
+    }
+  }
 
-  var action: [String]
+  private(set) var normalizedMpvKey: String
+
+  // This is a rare occurrence. The section, if it exists, will be the first element in `action` and will be surrounded by curly braces.
+  // Leave it inside `rawAction` and `action` so that it will be easy to edit in the UI.
+  var section: String? {
+    get {
+      if action.count > 1 && action[0].count > 0 && action[0][action[0].startIndex] == "{" {
+        if let endIndex = action[0].firstIndex(of: "}") {
+          let inner = action[0][action[0].index(after: action[0].startIndex)..<endIndex]
+          return inner.trimmingCharacters(in: .whitespaces)
+        }
+      }
+      return nil
+    }
+  }
+
+  private(set) var action: [String]
 
   private var privateRawAction: String
 
@@ -49,13 +73,12 @@ class KeyMapping: NSObject {
     set {
       if newValue.hasPrefix("@iina") {
         privateRawAction = newValue[newValue.index(newValue.startIndex, offsetBy: "@iina".count)...].trimmingCharacters(in: .whitespaces)
-        action = rawAction.components(separatedBy: .whitespaces).filter { !$0.isEmpty }
         isIINACommand = true
       } else {
         privateRawAction = newValue
-        action = rawAction.components(separatedBy: .whitespaces).filter { !$0.isEmpty }
         isIINACommand = false
       }
+      action = privateRawAction.components(separatedBy: .whitespaces).filter { !$0.isEmpty }
     }
     get {
       return privateRawAction
@@ -71,60 +94,60 @@ class KeyMapping: NSObject {
     }
   }
 
-  var prettyKey: String {
-    get {
-      if let (keyChar, modifiers) = KeyCodeHelper.macOSKeyEquivalent(from: self.key, usePrintableKeyName: true) {
-        return KeyCodeHelper.readableString(fromKey: keyChar, modifiers: modifiers)
-      } else {
-        return key
-      }
-    }
+  var isIgnored: Bool {
+    return privateRawAction == MPVCommand.ignore.rawValue
   }
 
   @objc var prettyCommand: String {
     return KeyBindingTranslator.readableCommand(fromAction: action, isIINACommand: isIINACommand)
   }
 
-  init(key: String, rawAction: String, isIINACommand: Bool = false, comment: String? = nil) {
-    // normalize different letter cases for modifier keys
-    var normalizedKey = key
-    ["Ctrl", "Meta", "Alt", "Shift"].forEach { keyword in
-      normalizedKey = normalizedKey.replacingOccurrences(of: keyword, with: keyword, options: .caseInsensitive)
+  var confFileFormat: String {
+    get {
+      let iinaCommandString = isIINACommand ? "#@iina " : ""
+      let commentString = (comment == nil || comment!.isEmpty) ? "" : "   #\(comment!)"
+      return "\(iinaCommandString)\(rawKey) \(action.joined(separator: " "))\(commentString)"
     }
-    var keyIsPlus = false
-    if normalizedKey.hasSuffix("+") {
-      keyIsPlus = true
-      normalizedKey = String(normalizedKey.dropLast())
-    }
-    normalizedKey = normalizedKey.components(separatedBy: "+")
-      .sorted { KeyMapping.modifierOrder[$0, default: 9] < KeyMapping.modifierOrder[$1, default: 9] }
-      .joined(separator: "+")
-    if keyIsPlus {
-      normalizedKey += "+"
-    }
-    self.key = normalizedKey
-    self.privateRawAction = rawAction
-    self.action = rawAction.components(separatedBy: .whitespaces).filter { !$0.isEmpty }
-    self.isIINACommand = isIINACommand
-    self.comment = comment
   }
 
+  init(rawKey: String, rawAction: String, isIINACommand: Bool = false, comment: String? = nil) {
+    self.rawKey = rawKey
+    self.normalizedMpvKey = KeyCodeHelper.normalizeMpv(rawKey)
+    self.isIINACommand = isIINACommand
+    self.comment = comment
+    self.privateRawAction = rawAction
+    self.action = rawAction.components(separatedBy: .whitespaces).filter { !$0.isEmpty }
+  }
+
+  public override var description: String {
+    return "KeyMapping(\"\(rawKey)\"->\"\(action.joined(separator: " "))\" iina=\(isIINACommand))"
+  }
+
+  // MARK: Static functions
+
+  // Returns nil if cannot read file
   static func parseInputConf(at path: String) -> [KeyMapping]? {
-    let reader = StreamReader(path: path)
+    guard let reader = StreamReader(path: path) else {
+      return nil
+    }
     var mapping: [KeyMapping] = []
-    while var line: String = reader?.nextLine() {      // ignore empty lines
+    while var line: String = reader.nextLine() {      // ignore empty lines
       var isIINACommand = false
-      if line.isEmpty { continue }
-      if line.hasPrefix("#@iina") {
-        // extended syntax
-        isIINACommand = true
-        line = String(line[line.index(line.startIndex, offsetBy: "#@iina".count)...])
-      } else if line.hasPrefix("#") {
-        // ignore comment
+      if line.trimmingCharacters(in: .whitespaces).isEmpty {
         continue
+      } else if line.hasPrefix("#") {
+        if line.hasPrefix("#@iina") {
+          // extended syntax
+          isIINACommand = true
+          line = String(line[line.index(line.startIndex, offsetBy: "#@iina".count)...])
+        } else {
+          // ignore comment line
+          continue
+        }
       }
-      // remove inline comment
+      var comment: String? = nil
       if let sharpIndex = line.firstIndex(of: "#") {
+        comment = String(line[line.index(after: sharpIndex)...])
         line = String(line[...line.index(before: sharpIndex)])
       }
       // split
@@ -136,20 +159,12 @@ class KeyMapping: NSObject {
       let key = String(splitted[0]).trimmingCharacters(in: .whitespaces)
       let action = String(splitted[1]).trimmingCharacters(in: .whitespaces)
 
-      mapping.append(KeyMapping(key: key, rawAction: action, isIINACommand: isIINACommand, comment: nil))
+      mapping.append(KeyMapping(rawKey: key, rawAction: action, isIINACommand: isIINACommand, comment: comment))
     }
     return mapping
   }
 
-  static func generateConfData(from mappings: [KeyMapping]) -> String {
-    var result = "# Generated by IINA\n\n"
-    mappings.forEach { km in
-      if km.isIINACommand {
-        result += "#@iina \(km.key) \(km.action.joined(separator: " "))\n"
-      } else {
-        result += "\(km.key) \(km.action.joined(separator: " "))\n"
-      }
-    }
-    return result
+  static func generateInputConf(from mappings: [KeyMapping]) -> String {
+    return mappings.reduce("# Generated by IINA\n\n", { prevLines, km in prevLines + "\(km.confFileFormat)\n" })
   }
 }

--- a/iina/LinkedList.swift
+++ b/iina/LinkedList.swift
@@ -1,0 +1,466 @@
+/*
+ Copyright (c) 2016 Matthijs Hollemans and contributors
+
+ Permission is hereby granted, free of charge, to any person obtaining a copy
+ of this software and associated documentation files (the "Software"), to deal
+ in the Software without restriction, including without limitation the rights
+ to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ copies of the Software, and to permit persons to whom the Software is
+ furnished to do so, subject to the following conditions:
+
+ The above copyright notice and this permission notice shall be included in
+ all copies or substantial portions of the Software.
+
+ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ THE SOFTWARE.
+
+ From Swift Algorithm Club (https://github.com/raywenderlich/swift-algorithm-club)
+ (modified heavily for better efficiency & usability)
+ */
+public final class LinkedList<T> {
+  public enum LinkedListError: Error {
+    case listIsEmpty
+    case indexInvalid(_ msg: String)
+    case indexOutOfBounds(_ msg: String)
+  }
+
+  public class LinkedListNode<T> {
+    var value: T
+    var next: LinkedListNode?
+    weak var previous: LinkedListNode?
+
+    public init(value: T) {
+      self.value = value
+    }
+  }
+
+  /// Typealiasing the node class to increase readability of code
+  public typealias Node = LinkedListNode<T>
+
+  /// The first element of the LinkedList
+  public private(set) var firstNode: Node?
+
+  // The last element of the LinkedList
+  public private(set) var lastNode: Node?
+
+  /// Computed property to check if the linked list is empty
+  public var isEmpty: Bool {
+    return count == 0
+  }
+
+  public var first: T? {
+    get {
+      firstNode?.value
+    }
+  }
+
+  public var last: T? {
+    get {
+      lastNode?.value
+    }
+  }
+
+  public private(set) var count: Int = 0
+
+  /// Default initializer
+  public init() {}
+
+
+  /// Subscript function to return the node at a specific index
+  ///
+  /// - Parameter index: Integer value of the requested value's index
+  public subscript(index: Int) -> T?  {
+    do {
+      return try self.item(at: index)
+    } catch {
+      return nil
+    }
+  }
+
+  /// Function to return the item at a specific index. Throws exception if index is out of bounds (0...self.count)
+  ///
+  /// - Parameter index: Integer value of the node's index to be returned
+  /// - Returns: LinkedListNode
+  public func item(at index: Int) throws -> T {
+    return try node(at: index).value
+  }
+
+  private func node(at index: Int) throws -> Node {
+    if firstNode == nil {
+      throw LinkedListError.listIsEmpty
+    } else if index < 0 {
+      throw LinkedListError.indexInvalid("index must be greater or equal to 0; got \(index)")
+    } else if index >= count {
+      throw LinkedListError.indexInvalid("index (\(index)) is larger than size of list!")
+    }
+
+    if index == 0 {
+      return firstNode!
+    } else if index == count - 1 {
+      return lastNode!
+    } else {
+      var node = firstNode!.next
+      for _ in 1..<index {
+        node = node?.next
+        assert (node != nil)
+      }
+
+      return node!
+    }
+  }
+
+  /// Function to return the node at a specific index. Throws exception if index is out of bounds (0...self.count)
+  ///
+  /// - Parameter whereCondition: Closure
+  /// - Returns: T
+  public func item(_ whereCondition: (T) -> Bool) -> T? {
+    var node = firstNode
+
+    while node != nil {
+      if whereCondition(node!.value) {
+        return node!.value
+      } else {
+        node = node!.next
+      }
+    }
+    return nil
+  }
+
+  /// Insert a value to the beginning of the list
+  ///
+  /// - Parameter value: The data value to be pre-pended
+  public func prepend(_ value: T) {
+    let newNode = Node(value: value)
+    try! insert(newNode, at: 0)
+  }
+
+  /// Append a value to the end of the list
+  ///
+  /// - Parameter value: The data value to be appended
+  public func append(_ value: T) {
+    let newNode = Node(value: value)
+    append(newNode)
+  }
+
+  /// Append a copy of a LinkedListNode to the end of the list.
+  ///
+  /// - Parameter node: The node containing the value to be appended
+  private func append(_ node: Node) {
+    let newNode = node
+    try! insert(newNode, at: count)
+  }
+
+  /// Append a copy of a LinkedList to the end of the list.
+  ///
+  /// - Parameter list: The list to be copied and appended.
+  public func append(_ list: LinkedList) {
+    var nodeToCopy = list.firstNode
+    while let node = nodeToCopy {
+      append(node.value)
+      nodeToCopy = node.next
+    }
+  }
+
+  /// Insert a value at a specific index. Crashes if index is out of bounds (0...self.count)
+  ///
+  /// - Parameters:
+  ///   - value: The data value to be inserted
+  ///   - index: Integer value of the index to be insterted at
+  public func insert(_ value: T, at index: Int) throws {
+    let newNode = Node(value: value)
+    try insert(newNode, at: index)
+  }
+
+  /// Insert a copy of a node at a specific index. Crashes if index is out of bounds (0...self.count)
+  ///
+  /// - Parameters:
+  ///   - node: The node containing the value to be inserted
+  ///   - index: Integer value of the index to be inserted at
+  private func insert(_ newNode: Node, at index: Int) throws {
+    if index == 0 {
+      if let firstNode = firstNode {
+        newNode.next = firstNode
+        firstNode.previous = newNode
+      } else {
+        lastNode = newNode
+      }
+      firstNode = newNode
+    } else {
+      let prev = try node(at: index - 1)
+      let next = prev.next
+      newNode.previous = prev
+      if let next = next {
+        newNode.next = next
+        next.previous = newNode
+      } else {
+        lastNode = newNode
+      }
+      prev.next = newNode
+    }
+
+    count += 1
+  }
+
+  /// Insert a copy of a LinkedList at a specific index. Crashes if index is out of bounds (0...self.count)
+  ///
+  /// - Parameters:
+  ///   - list: The LinkedList to be copied and inserted
+  ///   - index: Integer value of the index to be inserted at
+  public func insert(_ list: LinkedList, at index: Int) throws {
+    guard !list.isEmpty else { return }
+
+    let insertCount = list.count
+
+    if index == 0 {
+      list.lastNode?.next = firstNode
+      firstNode = list.firstNode
+    } else {
+      let prev = try node(at: index - 1)
+      let next = prev.next
+
+      prev.next = list.firstNode
+      list.firstNode?.previous = prev
+
+      if let next = next {
+        list.lastNode?.next = next
+        next.previous = list.lastNode
+      } else {
+        if list.lastNode != nil {
+          lastNode = list.lastNode
+        }
+      }
+    }
+
+    count += insertCount
+  }
+
+  /*
+   Removes all nodes/values from this list.
+   This is an O(n) operation because all links are set to nil in each node.
+   */
+  public func removeAll() {
+    var node = lastNode
+    while let nodeToRemove = node {
+      node = nodeToRemove.previous
+      nodeToRemove.previous = nil
+      nodeToRemove.next = nil
+      count -= 1
+    }
+
+    lastNode = nil
+    firstNode = nil
+  }
+
+  /*
+   Removes all nodes/values from this list.
+   This is an O(n) operation because all links are set to nil in each node.
+   */
+  public func clear() {
+    removeAll()
+  }
+
+  @discardableResult
+  public func remove(_ whereCondition: (T) -> Bool) -> T? {
+    var node = firstNode
+
+    while node != nil {
+      if whereCondition(node!.value) {
+        return remove(node: node!)
+      } else {
+        node = node!.next
+      }
+    }
+    return nil
+  }
+
+
+  /// Function to remove a specific node.
+  ///
+  /// - Parameter node: The node to be deleted
+  /// - Returns: The data value contained in the deleted node.
+  @discardableResult
+  private func remove(node: Node) -> T {
+    let prev = node.previous
+    let next = node.next
+
+    if let prev = prev {
+      prev.next = next
+    } else {
+      firstNode = next
+    }
+    if let next = next {
+      next.previous = prev
+    } else {
+      lastNode = prev
+    }
+
+    node.previous = nil
+    node.next = nil
+
+    count -= 1
+    return node.value
+  }
+
+  /// Function to remove the last node/value in the list. Crashes if the list is empty
+  ///
+  /// - Returns: The data value contained in the deleted node.
+  @discardableResult
+  public func removeLast() throws -> T {
+    guard !isEmpty else {
+      throw LinkedListError.listIsEmpty
+    }
+    return remove(node: lastNode!)
+  }
+
+  /// Function to remove a node/value at a specific index. Crashes if index is out of bounds (0...self.count)
+  ///
+  /// - Parameter index: Integer value of the index of the node to be removed
+  /// - Returns: The data value contained in the deleted node
+  @discardableResult
+  public func remove(at index: Int) throws -> T {
+    let node = try self.node(at: index)
+    return remove(node: node)
+  }
+
+ public func makeIterator() -> AnyIterator<T> {
+   var node = firstNode
+   return AnyIterator {
+     if let thisExistingNode = node {
+       node = thisExistingNode.next
+       return thisExistingNode.value
+     }
+     return nil
+   }
+ }
+}
+
+//: End of the base class declarations & beginning of extensions' declarations:
+
+// MARK: - Extension to enable the standard conversion of a list to String
+extension LinkedList: CustomStringConvertible {
+  public var description: String {
+    var s = "["
+    var node = firstNode
+    while let nd = node {
+      s += "\(nd.value)"
+      node = nd.next
+      if node != nil { s += ", " }
+    }
+    return s + "]"
+  }
+}
+
+// MARK: - Extension to add a 'reverse' function to the list
+extension LinkedList {
+  public func reverse() {
+    var node = firstNode
+    while let currentNode = node {
+      node = currentNode.next
+      swap(&currentNode.next, &currentNode.previous)
+      firstNode = currentNode
+    }
+  }
+}
+
+// MARK: - An extension with an implementation of 'map' & 'filter' functions
+extension LinkedList {
+  public func map<U>(transform: (T) -> U) -> LinkedList<U> {
+    let result = LinkedList<U>()
+    var node = firstNode
+    while let nd = node {
+      result.append(transform(nd.value))
+      node = nd.next
+    }
+    return result
+  }
+
+  public func filter(predicate: (T) -> Bool) -> LinkedList<T> {
+    let result = LinkedList<T>()
+    var node = firstNode
+    while let nd = node {
+      if predicate(nd.value) {
+        result.append(nd.value)
+      }
+      node = nd.next
+    }
+    return result
+  }
+}
+
+// MARK: - Extension to enable initialization from an Array
+extension LinkedList {
+  convenience init(array: Array<T>) {
+    self.init()
+
+    array.forEach { append($0) }
+  }
+}
+
+// MARK: - Extension to enable initialization from an Array Literal
+extension LinkedList: ExpressibleByArrayLiteral {
+  public convenience init(arrayLiteral elements: T...) {
+    self.init()
+
+    elements.forEach { append($0) }
+  }
+}
+
+// MARK: - Collection
+extension LinkedList: Collection {
+
+  public typealias Index = LinkedListIndex<T>
+
+  /// The position of the first element in a nonempty collection.
+  ///
+  /// If the collection is empty, `startIndex` is equal to `endIndex`.
+  /// - Complexity: O(1)
+  public var startIndex: Index {
+    get {
+      return LinkedListIndex<T>(node: firstNode, tag: 0)
+    }
+  }
+
+  /// The collection's "past the end" position---that is, the position one
+  /// greater than the last valid subscript argument.
+  /// - Complexity: O(n), where n is the number of elements in the list. This can be improved by keeping a reference
+  ///   to the last node in the collection.
+  public var endIndex: Index {
+    get {
+      if let h = self.firstNode {
+        return LinkedListIndex<T>(node: h, tag: count)
+      } else {
+        return LinkedListIndex<T>(node: nil, tag: startIndex.tag)
+      }
+    }
+  }
+
+  public subscript(position: Index) -> T {
+    get {
+      return position.node!.value
+    }
+  }
+
+  public func index(after idx: Index) -> Index {
+    return LinkedListIndex<T>(node: idx.node?.next, tag: idx.tag + 1)
+  }
+}
+
+// MARK: - Collection Index
+/// Custom index type that contains a reference to the node at index 'tag'
+public struct LinkedListIndex<T>: Comparable {
+  fileprivate let node: LinkedList<T>.LinkedListNode<T>?
+  fileprivate let tag: Int
+
+  public static func==<T>(lhs: LinkedListIndex<T>, rhs: LinkedListIndex<T>) -> Bool {
+    return (lhs.tag == rhs.tag)
+  }
+
+  public static func< <T>(lhs: LinkedListIndex<T>, rhs: LinkedListIndex<T>) -> Bool {
+    return (lhs.tag < rhs.tag)
+  }
+}

--- a/iina/MPVInputSection.swift
+++ b/iina/MPVInputSection.swift
@@ -1,0 +1,37 @@
+//
+//  MPVInputSection.swift
+//  iina
+//
+//  Created by Matt Svoboda on 2022.06.10.
+//  Copyright © 2022 lhc. All rights reserved.
+//
+
+import Foundation
+
+class MPVInputSection: CustomStringConvertible {
+  static let FLAG_DEFAULT = "default"
+  static let FLAG_FORCE = "force"
+  static let FLAG_EXCLUSIVE = "exclusive"
+
+  let name: String
+  let keyBindings: [KeyMapping]
+  let isForce: Bool
+
+  init(name: String, _ keyBindingsDict: [String: KeyMapping], isForce: Bool) {
+    self.name = name
+    self.keyBindings = Array(keyBindingsDict.values)
+    self.isForce = isForce
+  }
+
+  init(name: String, _ keyBindingsArray: [KeyMapping], isForce: Bool) {
+    self.name = name
+    self.keyBindings = keyBindingsArray
+    self.isForce = isForce
+  }
+
+  var description: String {
+    get {
+      "InputSection(\"\(name)\", \(isForce ? "force" : "weak"), \(keyBindings.count) bindings)"
+    }
+  }
+}

--- a/iina/MPVLogHandler.swift
+++ b/iina/MPVLogHandler.swift
@@ -1,0 +1,210 @@
+//
+//  MPVLogHandler.swift
+//  iina
+//
+//  Created by Matt Svoboda on 2022.06.09.
+//  Copyright © 2022 lhc. All rights reserved.
+//
+
+import Foundation
+
+private let DEFINE_SECTION_REGEX = try! NSRegularExpression(
+  pattern: #"args=\[name=\"(.*)\", contents=\"(.*)\", flags=\"(.*)\"\]"#, options: []
+)
+private let ENABLE_SECTION_REGEX = try! NSRegularExpression(
+  pattern: #"args=\[name=\"(.*)\", flags=\"(.*)\"\]"#, options: []
+)
+private let DISABLE_SECTION_REGEX = try! NSRegularExpression(
+  pattern: #"args=\[name=\"(.*)\"\]"#, options: []
+)
+private let FLAGS_REGEX = try! NSRegularExpression(
+  pattern: #"[^\+]+"#, options: []
+)
+
+private func all(_ string: String) -> NSRange {
+  return NSRange(location: 0, length: string.count)
+}
+
+class MPVLogHandler {
+  /*
+   * Change this variable to adjust threshold for *receiving* MPV_EVENT_LOG_MESSAGE messages.
+   * NOTE: Lua keybindings require at *least* level "debug", so don't set threshold to be stricter than this level
+   */
+  static let mpvLogSubscriptionLevel: MPVLogLevel = .debug
+
+  /*
+   * Change this variable to adjust threshold for writing MPV_EVENT_LOG_MESSAGE messages in IINA's log.
+   * This is unrelated to any log files mpv writes to directly.
+   */
+  static let iinaMpvLogLevel = MPVLogLevel(rawValue: Preference.integer(for: .iinaMpvLogLevel))!
+
+  private unowned let player: PlayerCore
+
+  /*
+   Only used for messages coming directly from the mpv log event stream
+   */
+  let mpvLogSubsystem: Logger.Subsystem
+
+  init(player: PlayerCore) {
+    self.player = player
+    mpvLogSubsystem = Logger.Subsystem(rawValue: "mpv\(player.label)")
+  }
+
+  func handleLogMessage(prefix: String, level: String, msg: String) {
+    // Reproduce the log line to IINA log only if within the configured mpv logging threshold
+    // (and of course only if IINA logging threshold is .debug or above)
+    if MPVLogHandler.iinaMpvLogLevel.shouldLog(severity: level) {
+      // try to match IINA's log format
+      let lev = level[level.index(level.startIndex, offsetBy: 0)]  // Some log levels are spelled out. Others are only 1 char. Shorten all to 1 char
+      Logger.log("[\(prefix)][\(lev)] \(msg)", level: .debug, subsystem: mpvLogSubsystem, appendNewlineAtTheEnd: false)
+    }
+    extractSectionInfo(prefix: prefix, severity: level, msg: msg)
+  }
+
+  /**
+   Looks for key binding sections set in scripts; extracts them if found & sends them to relevant key input controller.
+   Expected to return `true` if parsed & handled, `false` otherwise
+   */
+  @discardableResult
+  private func extractSectionInfo(prefix: String, severity: String, msg: String) -> Bool {
+    guard prefix == "cplayer", severity == MPVLogLevel.debug.description else {
+      return false
+    }
+
+    if msg.starts(with: "Run command: define-section") {
+      // Contains key binding definitions
+      return handleDefineSection(msg)
+    } else if msg.starts(with: "Run command: enable-section") {
+      // Enable key binding
+      return handleEnableSection(msg)
+    } else if msg.starts(with: "Run command: disable-section") {
+      // Disable key binding
+      return handleDisableSection(msg)
+    }
+    return false
+  }
+
+  private func matchRegex(_ regex: NSRegularExpression, _ msg: String) -> NSTextCheckingResult? {
+    return regex.firstMatch(in: msg, options: [], range: all(msg))
+  }
+
+  private func parseFlags(_ flagsUnparsed: String) -> [String] {
+    let matches = FLAGS_REGEX.matches(in: flagsUnparsed, range: all(flagsUnparsed))
+    if matches.isEmpty {
+      return [MPVInputSection.FLAG_DEFAULT]
+    }
+    return matches.map { match in
+      return String(flagsUnparsed[Range(match.range, in: flagsUnparsed)!])
+    }
+  }
+
+  private func parseBindingsFromDefineSectionContents(_ contentsUnparsed: String) -> [KeyMapping] {
+    var mappings: [KeyMapping] = []
+    if contentsUnparsed.isEmpty {
+      return mappings
+    }
+
+    for line in contentsUnparsed.components(separatedBy: "\\n") {
+      if !line.isEmpty {
+        let tokens = line.split(separator: " ")
+        if tokens.count == 3 && tokens[1] == MPVCommand.scriptBinding.rawValue {
+          mappings.append(KeyMapping(rawKey: String(tokens[0]), rawAction: "\(tokens[1]) \(tokens[2])"))
+        } else {
+          // "This command can be used to dispatch arbitrary keys to a script or a client API user".
+          // Need to figure out whether to add support for these as well.
+          Logger.log("Unrecognized mpv command in `define-section`; skipping line: \"\(line)\"", level: .warning, subsystem: player.subsystem)
+        }
+      }
+    }
+    return mappings
+  }
+
+  /*
+   "define-section"
+
+   Example log line:
+   [cplayer] debug: Run command: define-section, flags=64, args=[name="input_forced_webm",
+      contents="e script-binding webm/e\nESC script-binding webm/ESC\n", flags="force"]
+   */
+  private func handleDefineSection(_ msg: String) -> Bool {
+    guard let match = matchRegex(DEFINE_SECTION_REGEX, msg) else {
+      Logger.log("Found 'define-section' but failed to parse it: \(msg)", level: .error, subsystem: player.subsystem)
+      return false
+    }
+
+    guard let nameRange = Range(match.range(at: 1), in: msg),
+          let contentsRange = Range(match.range(at: 2), in: msg),
+          let flagsRange = Range(match.range(at: 3), in: msg) else {
+      Logger.log("Parsed 'define-section' but failed to find capture groups in it: \(msg)", level: .error, subsystem: player.subsystem)
+      return false
+    }
+
+    let name = String(msg[nameRange])
+    let content = String(msg[contentsRange])
+    let flags = parseFlags(String(msg[flagsRange]))
+    var isForce = false  // defaults to false
+    for flag in flags {
+      switch flag {
+        case MPVInputSection.FLAG_FORCE:
+          isForce = true
+        case MPVInputSection.FLAG_DEFAULT:
+          isForce = false
+        default:
+          Logger.log("Unrecognized flag in 'define-section': \(flag)", level: .error, subsystem: player.subsystem)
+          Logger.log("Offending log line: `\(msg)`", level: .error, subsystem: player.subsystem)
+      }
+    }
+
+    let section = MPVInputSection(name: name, parseBindingsFromDefineSectionContents(content), isForce: isForce)
+    Logger.log("define-section: \"\(section.name)\", mappings=\(section.keyBindings.count), force=\(section.isForce) ", subsystem: player.subsystem)
+    if Logger.enabled && Logger.Level.preferred >= .verbose {
+      let bindingList = section.keyBindings.map { ("\t<\(section.name)> \($0.normalizedMpvKey) -> \($0.rawAction)") }
+      Logger.log("Bindings:\n\(bindingList.joined(separator: "\n"))", level: .verbose, subsystem: player.subsystem)
+    }
+    player.keyInputController.defineSection(section)
+    return true
+  }
+
+  /*
+   "enable-section"
+   */
+  private func handleEnableSection(_ msg: String) -> Bool {
+    guard let match = matchRegex(ENABLE_SECTION_REGEX, msg) else {
+      Logger.log("Found 'enable-section' but failed to parse it: \(msg)", level: .error, subsystem: player.subsystem)
+      return false
+    }
+
+    guard let nameRange = Range(match.range(at: 1), in: msg),
+          let flagsRange = Range(match.range(at: 2), in: msg) else {
+      Logger.log("Parsed 'enable-section' but failed to find capture groups in it: \(msg)", level: .error, subsystem: player.subsystem)
+      return false
+    }
+
+    let name = String(msg[nameRange])
+    let flags = parseFlags(String(msg[flagsRange]))
+
+    Logger.log("enable-section: \"\(name)\", flags=\(flags) ", subsystem: player.subsystem)
+    player.keyInputController.enableSection(name, flags)
+    return true
+  }
+
+  /*
+   "disable-section"
+   */
+  private func handleDisableSection(_ msg: String) -> Bool {
+    guard let match = matchRegex(DISABLE_SECTION_REGEX, msg) else {
+      Logger.log("Found 'disable-section' but failed to parse it: \(msg)", level: .error, subsystem: player.subsystem)
+      return false
+    }
+
+    guard let nameRange = Range(match.range(at: 1), in: msg) else {
+      Logger.log("Parsed 'disable-section' but failed to find capture groups in it: \(msg)", level: .error, subsystem: player.subsystem)
+      return false
+    }
+
+    let name = String(msg[nameRange])
+    Logger.log("disable-section: \"\(name)\"", subsystem: player.subsystem)
+    player.keyInputController.disableSection(name)
+    return true
+  }
+}

--- a/iina/MPVLogLevel.swift
+++ b/iina/MPVLogLevel.swift
@@ -1,0 +1,114 @@
+//
+//  MPVLogLevel.swift
+//  iina
+//
+//  Created by Matt Svoboda on 2022.06.09.
+//  Copyright © 2022 lhc. All rights reserved.
+//
+
+import Foundation
+
+enum MPVLogLevel: Int, CustomStringConvertible {
+  case no = 0  // - disable absolutely all messages
+  case fatal   // - critical/aborting errors
+  case error   // - simple errors
+  case warn    // - possible problems
+  case info    // - informational message
+  case verbose // - noisy informational message
+  case debug   // - very noisy technical information
+  case trace   // - extremely noisy
+
+  static func fromString(_ name: String) -> MPVLogLevel? {
+    if name.count == 1 {
+      switch name {
+        case "n":
+          return .no
+        case "f":
+          return .fatal
+        case "e":
+          return .error
+        case "w":
+          return .warn
+        case "i":
+          return .info
+        case "v":
+          return .verbose
+        case "d":
+          return .debug
+        case "t":
+          return .trace
+        default:
+          return nil
+      }
+    }
+
+    switch name {
+      case "no":
+        return .no
+      case "fatal":
+        return .fatal
+      case "error":
+        return .error
+      case "warn":
+        return .warn
+      case "info":
+        return .info
+      case "verbose":
+        return .verbose
+      case "debug":
+        return .debug
+      case "trace":
+        return .trace
+      default:
+        return nil
+    }
+  }
+
+  public var description: String {
+    get {
+      switch self {
+        case .no:
+          return "no"
+        case .fatal:
+          return "fatal"
+        case .error:
+          return "error"
+        case .warn:
+          return "warn"
+        case .info:
+          return "info"
+        case .verbose:
+          return "verbose"
+        case .debug:
+          return "debug"
+        case .trace:
+          return "trace"
+      }
+    }
+  }
+
+  /*
+   Assumes that `self` represents a logging threshold.
+   Returns  true if the given level falls within this logging threshold.
+   Example: MPVLogLevel.debug.shouldLog(5) -> true
+   */
+  public func shouldLog(severity: Int) -> Bool {
+    return rawValue >= severity
+  }
+
+  /*
+   Assumes that `self` represents a logging threshold.
+   Returns  true if the given level falls within this logging threshold.
+   Examples:
+   1. MPVLogLevel.info.shouldLog("debug") -> false
+   2. MPVLogLevel.debug.shouldLog("verbose") -> false
+   */
+ public func shouldLog(severity: String) -> Bool {
+   if let severityParsed = MPVLogLevel.fromString(severity) {
+     return shouldLog(severity: severityParsed.rawValue)
+   } else {
+     Logger.log("Failed to parse logging level: '\(severity)'", level: .error)
+     return false
+   }
+ }
+}

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -8,19 +8,7 @@
 
 import Cocoa
 
-
-class MainMenuActionHandler: NSResponder {
-
-  unowned var player: PlayerCore
-
-  init(playerCore: PlayerCore) {
-    self.player = playerCore
-    super.init()
-  }
-
-  required init?(coder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
+extension PlayerWindowController {
 
   @objc func menuShowInspector(_ sender: AnyObject) {
     let inspector = (NSApp.delegate as! AppDelegate).inspector
@@ -69,11 +57,8 @@ class MainMenuActionHandler: NSResponder {
     }
   }
 
-}
-
 // MARK: - Control
 
-extension MainMenuActionHandler {
   @objc func menuTogglePause(_ sender: NSMenuItem) {
     player.togglePause()
     // set speed to 0 if is fastforwarding
@@ -182,11 +167,9 @@ extension MainMenuActionHandler {
   @objc func menuPreviousChapter(_ sender: NSMenuItem) {
     player.mpv.command(.add, args: ["chapter", "-1"], checkError: false)
   }
-}
 
 // MARK: - Video
 
-extension MainMenuActionHandler {
   @objc func menuChangeAspect(_ sender: NSMenuItem) {
     if let aspectStr = sender.representedObject as? String {
       player.setVideoAspect(aspectStr)
@@ -235,11 +218,9 @@ extension MainMenuActionHandler {
   @objc func menuToggleDeinterlace(_ sender: NSMenuItem) {
     player.toggleDeinterlace(sender.state != .on)
   }
-}
 
 // MARK: - Audio
 
-extension MainMenuActionHandler {
   @objc func menuChangeVolume(_ sender: NSMenuItem) {
     if let volumeDelta = sender.representedObject as? Int {
       let newVolume = Double(volumeDelta) + player.info.volume
@@ -265,11 +246,9 @@ extension MainMenuActionHandler {
   @objc func menuResetAudioDelay(_ sender: NSMenuItem) {
     player.setAudioDelay(0)
   }
-}
 
 // MARK: - Sub
 
-extension MainMenuActionHandler {
   @objc func menuLoadExternalSub(_ sender: NSMenuItem) {
     Utility.quickOpenPanel(title: "Load external subtitle file", chooseDir: false) { url in
       self.player.loadExternalSubFile(url, delay: true)

--- a/iina/MainWindow.swift
+++ b/iina/MainWindow.swift
@@ -11,12 +11,12 @@ import Cocoa
 class MainWindow: NSWindow {
   var forceKeyAndMain = false
 
-  override func cancelOperation(_ sender: Any?) {
-    let controller = windowController as! MainWindowController
-    if let kb = PlayerCore.keyBindings["ESC"] {
-      controller.handleKeyBinding(kb)
-    } else {
-      super.cancelOperation(sender)
+  override func keyDown(with event: NSEvent) {
+    // Forward all key events which the window receives to controller. This fixes:
+    // (a) ESC key not otherwise sent to window
+    // (b) window was not getting a chance to respond before main menu
+    if let controller = windowController as? MainWindowController {
+      controller.keyDown(with: event)
     }
   }
 

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -119,6 +119,10 @@ class MainWindowController: PlayerWindowController {
     }
   }
 
+  var hasKeyboardFocus: Bool {
+    window?.isKeyWindow ?? false
+  }
+
   /** For mpv's `geometry` option. We cache the parsed structure
    so never need to parse it every time. */
   var cachedGeometry: GeometryDef?
@@ -1093,6 +1097,7 @@ class MainWindowController: PlayerWindowController {
   }
 
   func windowWillClose(_ notification: Notification) {
+    Logger.log("Window closing", subsystem: player.subsystem)
     shouldApplyInitialWindowSize = true
     // Close PIP
     if pipStatus == .inPIP {
@@ -2623,7 +2628,7 @@ class MainWindowController: PlayerWindowController {
     case .toggleMusicMode:
       menuSwitchToMiniPlayer(.dummy)
     case .deleteCurrentFileHard:
-      menuActionHandler.menuDeleteCurrentFileHard(.dummy)
+      menuDeleteCurrentFileHard(.dummy)
     case .biggerWindow:
       let item = NSMenuItem()
       item.tag = 11

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -169,7 +169,7 @@ class MenuController: NSObject, NSMenuDelegate {
   func bindMenuItems() {
 
     [cycleSubtitles, cycleAudioTracks, cycleVideoTracks].forEach { item in
-      item?.action = #selector(MainMenuActionHandler.menuCycleTrack(_:))
+      item?.action = #selector(PlayerWindowController.menuCycleTrack(_:))
     }
 
     // File menu
@@ -181,8 +181,8 @@ class MenuController: NSObject, NSMenuDelegate {
     stringForOpenAlternative = openAlternative.title
     stringForOpenURLAlternative = openURLAlternative.title
 
-    savePlaylist.action = #selector(MainMenuActionHandler.menuSavePlaylist(_:))
-    deleteCurrentFile.action = #selector(MainMenuActionHandler.menuDeleteCurrentFile(_:))
+    savePlaylist.action = #selector(PlayerWindowController.menuSavePlaylist(_:))
+    deleteCurrentFile.action = #selector(PlayerWindowController.menuDeleteCurrentFile(_:))
 
     if Preference.bool(for: .enableCmdN) {
       newWindowSeparator.isHidden = false
@@ -193,16 +193,16 @@ class MenuController: NSObject, NSMenuDelegate {
 
     playbackMenu.delegate = self
 
-    pause.action = #selector(MainMenuActionHandler.menuTogglePause(_:))
-    stop.action = #selector(MainMenuActionHandler.menuStop(_:))
+    pause.action = #selector(PlayerWindowController.menuTogglePause(_:))
+    stop.action = #selector(PlayerWindowController.menuStop(_:))
 
     // -- seeking
-    forward.action = #selector(MainMenuActionHandler.menuStep(_:))
-    nextFrame.action = #selector(MainMenuActionHandler.menuStepFrame(_:))
-    backward.action = #selector(MainMenuActionHandler.menuStep(_:))
-    previousFrame.action = #selector(MainMenuActionHandler.menuStepFrame(_:))
-    jumpToBegin.action = #selector(MainMenuActionHandler.menuJumpToBegin(_:))
-    jumpTo.action = #selector(MainMenuActionHandler.menuJumpTo(_:))
+    forward.action = #selector(PlayerWindowController.menuStep(_:))
+    nextFrame.action = #selector(PlayerWindowController.menuStepFrame(_:))
+    backward.action = #selector(PlayerWindowController.menuStep(_:))
+    previousFrame.action = #selector(PlayerWindowController.menuStepFrame(_:))
+    jumpToBegin.action = #selector(PlayerWindowController.menuJumpToBegin(_:))
+    jumpTo.action = #selector(PlayerWindowController.menuJumpTo(_:))
 
     // -- speed
     (speedUp.representedObject,
@@ -210,28 +210,28 @@ class MenuController: NSObject, NSMenuDelegate {
      speedDown.representedObject,
      speedDownSlightly.representedObject) = (2.0, 1.1, 0.5, 0.9)
     [speedUp, speedDown, speedUpSlightly, speedDownSlightly, speedReset].forEach { item in
-      item?.action = #selector(MainMenuActionHandler.menuChangeSpeed(_:))
+      item?.action = #selector(PlayerWindowController.menuChangeSpeed(_:))
     }
 
     // -- screenshot
-    screenshot.action = #selector(MainMenuActionHandler.menuSnapshot(_:))
+    screenshot.action = #selector(PlayerWindowController.menuSnapshot(_:))
     gotoScreenshotFolder.action = #selector(AppDelegate.menuOpenScreenshotFolder(_:))
     // advancedScreenShot
 
     // -- list and chapter
-    abLoop.action = #selector(MainMenuActionHandler.menuABLoop(_:))
-    fileLoop.action = #selector(MainMenuActionHandler.menuFileLoop(_:))
+    abLoop.action = #selector(PlayerWindowController.menuABLoop(_:))
+    fileLoop.action = #selector(PlayerWindowController.menuFileLoop(_:))
     playlistMenu.delegate = self
     chapterMenu.delegate = self
-    playlistLoop.action = #selector(MainMenuActionHandler.menuPlaylistLoop(_:))
+    playlistLoop.action = #selector(PlayerWindowController.menuPlaylistLoop(_:))
     playlistPanel.action = #selector(MainWindowController.menuShowPlaylistPanel(_:))
     chapterPanel.action = #selector(MainWindowController.menuShowChaptersPanel(_:))
 
-    nextMedia.action = #selector(MainMenuActionHandler.menuNextMedia(_:))
-    previousMedia.action = #selector(MainMenuActionHandler.menuPreviousMedia(_:))
+    nextMedia.action = #selector(PlayerWindowController.menuNextMedia(_:))
+    previousMedia.action = #selector(PlayerWindowController.menuPreviousMedia(_:))
 
-    nextChapter.action = #selector(MainMenuActionHandler.menuNextChapter(_:))
-    previousChapter.action = #selector(MainMenuActionHandler.menuPreviousChapter(_:))
+    nextChapter.action = #selector(PlayerWindowController.menuNextChapter(_:))
+    previousChapter.action = #selector(PlayerWindowController.menuPreviousChapter(_:))
 
     // Video menu
 
@@ -261,7 +261,7 @@ class MenuController: NSObject, NSMenuDelegate {
     var aspectListObject = AppData.aspects
     aspectList.insert(Constants.String.default, at: 0)
     aspectListObject.insert("Default", at: 0)
-    bind(menu: aspectMenu, withOptions: aspectList, objects: aspectListObject, objectMap: nil, action: #selector(MainMenuActionHandler.menuChangeAspect(_:))) {
+    bind(menu: aspectMenu, withOptions: aspectList, objects: aspectListObject, objectMap: nil, action: #selector(PlayerWindowController.menuChangeAspect(_:))) {
       PlayerCore.active.info.unsureAspect == $0.representedObject as? String
     }
 
@@ -274,7 +274,7 @@ class MenuController: NSObject, NSMenuDelegate {
     // Allow custom crop size.
     cropList.append(Constants.String.custom)
     cropListForObject.append("Custom")
-    bind(menu: cropMenu, withOptions: cropList, objects: cropListForObject, objectMap: nil, action: #selector(MainMenuActionHandler.menuChangeCrop(_:))) {
+    bind(menu: cropMenu, withOptions: cropList, objects: cropListForObject, objectMap: nil, action: #selector(PlayerWindowController.menuChangeCrop(_:))) {
       return PlayerCore.active.info.unsureCrop == $0.representedObject as? String
     }
     // Separate "Custom..." from other crop sizes.
@@ -282,17 +282,17 @@ class MenuController: NSObject, NSMenuDelegate {
 
     // -- rotation
     let rotationTitles = AppData.rotations.map { "\($0)\(Constants.String.degree)" }
-    bind(menu: rotationMenu, withOptions: rotationTitles, objects: AppData.rotations, objectMap: nil, action: #selector(MainMenuActionHandler.menuChangeRotation(_:))) {
+    bind(menu: rotationMenu, withOptions: rotationTitles, objects: AppData.rotations, objectMap: nil, action: #selector(PlayerWindowController.menuChangeRotation(_:))) {
       PlayerCore.active.info.rotation == $0.representedObject as? Int
     }
 
     // -- flip and mirror
     flipMenu.delegate = self
-    flip.action = #selector(MainMenuActionHandler.menuToggleFlip(_:))
-    mirror.action = #selector(MainMenuActionHandler.menuToggleMirror(_:))
+    flip.action = #selector(PlayerWindowController.menuToggleFlip(_:))
+    mirror.action = #selector(PlayerWindowController.menuToggleMirror(_:))
 
     // -- deinterlace
-    deinterlace.action = #selector(MainMenuActionHandler.menuToggleDeinterlace(_:))
+    deinterlace.action = #selector(PlayerWindowController.menuToggleDeinterlace(_:))
 
     // -- delogo
     delogo.action = #selector(MainWindowController.menuSetDelogo(_:))
@@ -316,9 +316,9 @@ class MenuController: NSObject, NSMenuDelegate {
      increaseVolumeSlightly.representedObject,
      decreaseVolumeSlightly.representedObject) = (5, -5, 1, -1)
     [increaseVolume, decreaseVolume, increaseVolumeSlightly, decreaseVolumeSlightly].forEach { item in
-      item?.action = #selector(MainMenuActionHandler.menuChangeVolume(_:))
+      item?.action = #selector(PlayerWindowController.menuChangeVolume(_:))
     }
-    mute.action = #selector(MainMenuActionHandler.menuToggleMute(_:))
+    mute.action = #selector(PlayerWindowController.menuToggleMute(_:))
 
     // - audio delay
     (increaseAudioDelay.representedObject,
@@ -326,9 +326,9 @@ class MenuController: NSObject, NSMenuDelegate {
      decreaseAudioDelay.representedObject,
      decreaseAudioDelaySlightly.representedObject) = (0.5, 0.1, -0.5, -0.1)
     [increaseAudioDelay, decreaseAudioDelay, increaseAudioDelaySlightly, decreaseAudioDelaySlightly].forEach { item in
-      item?.action = #selector(MainMenuActionHandler.menuChangeAudioDelay(_:))
+      item?.action = #selector(PlayerWindowController.menuChangeAudioDelay(_:))
     }
-    resetAudioDelay.action = #selector(MainMenuActionHandler.menuResetAudioDelay(_:))
+    resetAudioDelay.action = #selector(PlayerWindowController.menuResetAudioDelay(_:))
 
     // - audio device
     audioDeviceMenu.delegate = self
@@ -344,16 +344,16 @@ class MenuController: NSObject, NSMenuDelegate {
 
     subMenu.delegate = self
     quickSettingsSub.action = #selector(MainWindowController.menuShowSubQuickSettings(_:))
-    loadExternalSub.action = #selector(MainMenuActionHandler.menuLoadExternalSub(_:))
+    loadExternalSub.action = #selector(PlayerWindowController.menuLoadExternalSub(_:))
     subTrackMenu.delegate = self
     secondSubTrackMenu.delegate = self
 
-    findOnlineSub.action = #selector(MainMenuActionHandler.menuFindOnlineSub(_:))
-    saveDownloadedSub.action = #selector(MainMenuActionHandler.saveDownloadedSub(_:))
+    findOnlineSub.action = #selector(PlayerWindowController.menuFindOnlineSub(_:))
+    saveDownloadedSub.action = #selector(PlayerWindowController.saveDownloadedSub(_:))
 
     // - text size
     [increaseTextSize, decreaseTextSize, resetTextSize].forEach {
-      $0.action = #selector(MainMenuActionHandler.menuChangeSubScale(_:))
+      $0.action = #selector(PlayerWindowController.menuChangeSubScale(_:))
     }
 
     // - delay
@@ -362,17 +362,17 @@ class MenuController: NSObject, NSMenuDelegate {
      decreaseSubDelay.representedObject,
      decreaseSubDelaySlightly.representedObject) = (0.5, 0.1, -0.5, -0.1)
     [increaseSubDelay, decreaseSubDelay, increaseSubDelaySlightly, decreaseSubDelaySlightly].forEach { item in
-      item?.action = #selector(MainMenuActionHandler.menuChangeSubDelay(_:))
+      item?.action = #selector(PlayerWindowController.menuChangeSubDelay(_:))
     }
-    resetSubDelay.action = #selector(MainMenuActionHandler.menuResetSubDelay(_:))
+    resetSubDelay.action = #selector(PlayerWindowController.menuResetSubDelay(_:))
 
     // encoding
     let encodingTitles = AppData.encodings.map { $0.title }
     let encodingObjects = AppData.encodings.map { $0.code }
-    bind(menu: encodingMenu, withOptions: encodingTitles, objects: encodingObjects, objectMap: nil, action: #selector(MainMenuActionHandler.menuSetSubEncoding(_:))) {
+    bind(menu: encodingMenu, withOptions: encodingTitles, objects: encodingObjects, objectMap: nil, action: #selector(PlayerWindowController.menuSetSubEncoding(_:))) {
       PlayerCore.active.info.subEncoding == $0.representedObject as? String
     }
-    subFont.action = #selector(MainMenuActionHandler.menuSubFont(_:))
+    subFont.action = #selector(PlayerWindowController.menuSubFont(_:))
     // Separate Auto from other encoding types
     encodingMenu.insertItem(NSMenuItem.separator(), at: 1)
 
@@ -384,7 +384,7 @@ class MenuController: NSObject, NSMenuDelegate {
       customTouchBar.isHidden = true
     }
 
-    inspector.action = #selector(MainMenuActionHandler.menuShowInspector(_:))
+    inspector.action = #selector(PlayerWindowController.menuShowInspector(_:))
     miniPlayer.action = #selector(MainWindowController.menuSwitchToMiniPlayer(_:))
   }
 
@@ -393,7 +393,7 @@ class MenuController: NSObject, NSMenuDelegate {
   private func updatePlaylist() {
     playlistMenu.removeAllItems()
     for (index, item) in PlayerCore.active.info.playlist.enumerated() {
-      playlistMenu.addItem(withTitle: item.filenameForDisplay, action: #selector(MainMenuActionHandler.menuPlaylistItem(_:)),
+      playlistMenu.addItem(withTitle: item.filenameForDisplay, action: #selector(PlayerWindowController.menuPlaylistItem(_:)),
                            tag: index, obj: nil, stateOn: item.isCurrent)
     }
   }
@@ -411,7 +411,7 @@ class MenuController: NSObject, NSMenuDelegate {
       let menuTitle = "\(padder(chapter.time.stringRepresentation)) – \(chapter.title)"
       let nextChapterTime = info.chapters[at: index+1]?.time ?? Constants.Time.infinite
       let isPlaying = info.videoPosition?.between(chapter.time, nextChapterTime) ?? false
-      let menuItem = NSMenuItem(title: menuTitle, action: #selector(MainMenuActionHandler.menuChapterSwitch(_:)), keyEquivalent: "")
+      let menuItem = NSMenuItem(title: menuTitle, action: #selector(PlayerWindowController.menuChapterSwitch(_:)), keyEquivalent: "")
       menuItem.tag = index
       menuItem.state = isPlaying ? .on : .off
       menuItem.attributedTitle = NSAttributedString(string: menuTitle, attributes: [.font: NSFont.monospacedDigitSystemFont(ofSize: 0, weight: .regular)])
@@ -422,14 +422,14 @@ class MenuController: NSObject, NSMenuDelegate {
   private func updateTracks(forMenu menu: NSMenu, type: MPVTrack.TrackType) {
     let info = PlayerCore.active.info
     menu.removeAllItems()
-    let noTrackMenuItem = NSMenuItem(title: Constants.String.trackNone, action: #selector(MainMenuActionHandler.menuChangeTrack(_:)), keyEquivalent: "")
+    let noTrackMenuItem = NSMenuItem(title: Constants.String.trackNone, action: #selector(PlayerWindowController.menuChangeTrack(_:)), keyEquivalent: "")
     noTrackMenuItem.representedObject = MPVTrack.emptyTrack(for: type)
     if info.trackId(type) == 0 {  // no track
       noTrackMenuItem.state = .on
     }
     menu.addItem(noTrackMenuItem)
     for track in info.trackList(type) {
-      menu.addItem(withTitle: track.readableTitle, action: #selector(MainMenuActionHandler.menuChangeTrack(_:)),
+      menu.addItem(withTitle: track.readableTitle, action: #selector(PlayerWindowController.menuChangeTrack(_:)),
                              tag: nil, obj: (track, type), stateOn: track.id == info.trackId(type))
     }
   }
@@ -700,7 +700,7 @@ class MenuController: NSObject, NSMenuDelegate {
       for kb in keyBindings {
         guard kb.isIINACommand == isIINACmd else { continue }
         let (sameAction, value) = sameKeyAction(kb.action, actions, normalizeLastNum, numRange)
-        if sameAction, let (kEqv, kMdf) = KeyCodeHelper.macOSKeyEquivalent(from: kb.key) {
+        if sameAction, let (kEqv, kMdf) = KeyCodeHelper.macOSKeyEquivalent(from: kb.normalizedMpvKey) {
           menuItem.keyEquivalent = kEqv
           menuItem.keyEquivalentModifierMask = kMdf
           if let value = value, let l10nKey = l10nKey {

--- a/iina/PrefKeyBindingViewController.swift
+++ b/iina/PrefKeyBindingViewController.swift
@@ -139,11 +139,11 @@ class PrefKeyBindingViewController: NSViewController, PreferenceWindowEmbeddable
       guard !key.isEmpty && !action.isEmpty else { return }
       if action.hasPrefix("@iina") {
         let trimmedAction = action[action.index(action.startIndex, offsetBy: "@iina".count)...].trimmingCharacters(in: .whitespaces)
-        self.mappingController.addObject(KeyMapping(key: key,
+        self.mappingController.addObject(KeyMapping(rawKey: key,
                                         rawAction: trimmedAction,
                                         isIINACommand: true))
       } else {
-        self.mappingController.addObject(KeyMapping(key: key, rawAction: action))
+        self.mappingController.addObject(KeyMapping(rawKey: key, rawAction: action))
       }
 
       self.kbTableView.scrollRowToVisible((self.mappingController.arrangedObjects as! [AnyObject]).count - 1)
@@ -329,7 +329,7 @@ class PrefKeyBindingViewController: NSViewController, PreferenceWindowEmbeddable
     setKeybindingsForPlayerCore()
     mappingController.filterPredicate = predicate
     do {
-      try KeyMapping.generateConfData(from: keyMapping).write(toFile: currentConfFilePath, atomically: true, encoding: .utf8)
+      try KeyMapping.generateInputConf(from: keyMapping).write(toFile: currentConfFilePath, atomically: true, encoding: .utf8)
     } catch {
       Utility.showAlert("config.cannot_write", sheetWindow: view.window)
     }
@@ -421,9 +421,9 @@ extension PrefKeyBindingViewController: NSTableViewDelegate, NSTableViewDataSour
     }
     guard kbTableView.selectedRow != -1 else { return }
     let selectedData = mappingController.selectedObjects[0] as! KeyMapping
-    showKeyBindingPanel(key: selectedData.key, action: selectedData.readableAction) { key, action in
+    showKeyBindingPanel(key: selectedData.rawKey, action: selectedData.readableAction) { key, action in
       guard !key.isEmpty && !action.isEmpty else { return }
-      selectedData.key = key
+      selectedData.rawKey = key
       selectedData.rawAction = action
       self.kbTableView.reloadData()
       NotificationCenter.default.post(Notification(name: .iinaKeyBindingChanged))

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -264,6 +264,9 @@ struct Preference {
     static let enableLogging = Key("enableLogging")
     static let logLevel = Key("logLevel")
 
+    /* The highest mpv log level which IINA will include mpv log events in its own logfile (mutually exclusive of mpv's logfile) */
+    static let iinaMpvLogLevel = Key("iinaMpvLogLevel")
+
     static let displayKeyBindingRawValues = Key("displayKeyBindingRawValues")
 
     /** unused */
@@ -786,6 +789,7 @@ struct Preference {
     .useMpvOsd: false,
     .enableLogging: false,
     .logLevel: Logger.Level.debug.rawValue,
+    .iinaMpvLogLevel: MPVLogLevel.warn.rawValue,
     .displayKeyBindingRawValues: false,
     .userOptions: [],
     .useUserDefinedConfDir: false,

--- a/iina/QuickSettingViewController.swift
+++ b/iina/QuickSettingViewController.swift
@@ -695,7 +695,7 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
   }
 
   @IBAction func searchOnlineAction(_ sender: AnyObject) {
-    mainWindow.menuActionHandler.menuFindOnlineSub(.dummy)
+    mainWindow.menuFindOnlineSub(.dummy)
   }
 
   @IBAction func subDelayChangedAction(_ sender: NSSlider) {

--- a/iina/RingBuffer.swift
+++ b/iina/RingBuffer.swift
@@ -1,0 +1,179 @@
+//
+//  RingBuffer.swift
+//  iina
+//
+//  Created by Matt Svoboda on 2022.05.17.
+//  Copyright © 2022 lhc. All rights reserved.
+//
+
+/*
+ Fixed-capacity ring buffer, backed by an data, which can append and pop from both the head and the tail.
+ If already at full capacity:
+ - Appending an element to the head will overwrite the element at the tail
+ - Appending elements to the tail will overwrite the elements at the head
+ */
+public struct RingBuffer<T>: CustomStringConvertible, Sequence {
+  private var data: [T?]
+  private var tailIndex = 0
+  private var headIndex = 0
+  private var elementCount = 0
+
+  public var count: Int {
+    get {
+      return elementCount
+    }
+  }
+
+  public init(capacity: Int) {
+    data = [T?](repeating: nil, count: capacity)
+    resetCounters()
+  }
+
+  /*
+   Gets the element at the head, without removing it or changing state in any way.
+   */
+  public var head: T? {
+    get {
+      return data[headIndex]
+    }
+  }
+
+  /*
+   Gets the element at the tail, without removing it or changing state in any way.
+   */
+  public var tail: T? {
+    get {
+      return data[tailIndex]
+    }
+  }
+
+  public var isEmpty: Bool {
+    return elementCount == 0
+  }
+
+  public var isFull: Bool {
+    return elementCount == data.count
+  }
+
+  /*
+   Sets all elements to zero & clears all internal variables to their initial state, except for `capacity`
+   */
+  public mutating func clear() {
+    for i in 0..<data.count {
+      data[i] = nil
+    }
+    resetCounters()
+  }
+
+  private mutating func resetCounters() {
+    headIndex = 0
+    tailIndex = 0
+    elementCount = 0
+  }
+
+  /*
+   Adds the given element to the head and increments the pointer. If already full, then the tail is overwritten.
+   Returns true if the tail was overwritten; false if not.
+   */
+  @discardableResult
+  public mutating func insertHead(_ element: T) -> Bool {
+    let overwrite = isFull
+    if overwrite {
+      headIndex = (headIndex + 1) %% data.count
+      tailIndex = (tailIndex + 1) %% data.count  // also advance tail since it is being overwritten
+    } else {
+      if data[headIndex] != nil {
+        // was empty, but then insertTail happened. move over and use the next available space:
+        headIndex = (headIndex + 1) %% data.count
+      }
+      elementCount = elementCount + 1
+    }
+    data[headIndex] = element
+    return overwrite
+  }
+
+  /*
+   Adds the given element to the tail and advances the tail pointer.
+   If already full, then the head is overwritten and the head pointer retreats.
+   Returns true if the head was overwritten; false if not.
+   */
+  @discardableResult
+  public mutating func insertTail(_ element: T) -> Bool {
+    let overwrite = isFull
+    if overwrite {
+      tailIndex = (tailIndex - 1) %% data.count
+      headIndex = (headIndex - 1) %% data.count  // also retreat tail since it is being overwritten
+    } else {
+      if data[tailIndex] != nil {
+        // was empty, but then insertHead happened. move over and use the next available space:
+        tailIndex = (tailIndex - 1) %% data.count
+      }
+      elementCount = elementCount + 1
+    }
+    data[tailIndex] = element
+    return overwrite
+  }
+
+  /*
+   Pops and returns the element at the head, retreating the pointer to the head.
+   Returns nil if already empty.
+   */
+  @discardableResult
+  public mutating func removeHead() -> T? {
+    guard !isEmpty else {
+      return nil
+    }
+    defer {
+      data[headIndex] = nil
+      headIndex = (headIndex - 1) %% data.count
+      elementCount = elementCount - 1
+    }
+    return data[headIndex]
+  }
+
+  /*
+   Pops and returns the element at the tail, advancing the pointer to the tail.
+   Returns nil if already empty.
+   */
+  @discardableResult
+  public mutating func removeTail() -> T? {
+    guard !isEmpty else {
+      return nil
+    }
+    defer {
+      data[tailIndex] = nil
+      tailIndex = (tailIndex + 1) %% data.count
+      elementCount = elementCount - 1
+    }
+    return data[tailIndex]
+  }
+
+  public var description: String {
+    get {
+      var string = ""
+      for elem in self {
+        if string.isEmpty {
+          string = "\(elem)"
+        } else {
+          string.append(", \(elem)")
+        }
+      }
+      return "[\(string)]"
+    }
+  }
+
+  /*
+   Returns an iterator which yields elements one at a time, in order of tail -> head
+   */
+  public func makeIterator() -> AnyIterator<T> {
+    var index = tailIndex
+    let endIndex = index + elementCount
+    return AnyIterator {
+      guard index < endIndex else { return nil }
+      defer {
+        index = index + 1
+      }
+      return data[index %% data.count]
+    }
+  }
+}


### PR DESCRIPTION
I've successfully reverse-engineered mpv's key input handling and reproduced the important parts so that Lua scripts can set/unset bindings in IINA as they would in mpv, following the priorities which they expect. Substantial changes had to be made to IINA's existing key handling mechanism to accomplish this. At the same time, this directly builds on the work I did to add support for key sequences (#3716) and also adds some critical fixes, rendering it obsolete, so in the interest of time I'd like to focus testing and address concerns with this issue going forward. I realize this probably won't make it into IINA all that soon, but I'd like to get the ball rolling in that direction (hopefully) and will try to keep it up to date in the meantime.

- [ ] This change has been discussed with the author.
- [X] It implements / fixes issues
  - #2140 
  - #3716 
  - #3846
  - #3831
  - #3881
  - #3851

---

**Description:**

To determine what and when bindings are being set by scripts, I initially tried subscribing to `MPV_EVENT_PROPERTY_CHANGE`, and also tried polling the `input-bindings` property via `mpv_get_property`, but these proved to be inadequate. I filed a feature request with the mpv project which goes into complete detail (see: https://github.com/mpv-player/mpv/issues/10275), and based on the discussion there it seems unlikely that such event support will be added in the near future, but I did get confirmation that, in fact, all the needed information can be gathered by parsing the `MPV_EVENT_LOG_MESSAGE` event stream.

Quick summary of design:

- Adds a new class, `KeyInputController`, which encapsulates all the key binding state for a single `PlayerCore`.
- Organizes key bindings into "input sections" as mpv does (see comments at the top of `KeyInputController.swift`), with all the bindings set by IINA into the "default" section.
- `MPVController` was already subscribed to `MPV_EVENT_LOG_MESSAGE` events at the `warning` level. This increases the threshold to the `debug` level so that input section data can be extracted. The amount of log data received from mpv is still quite small and performance impact is expected to be negligible.
  - Note: by default only `warning` level events are output to the IINA log, which preserves the previous behavior.
  - Yes, there is a small risk that future updates to mpv may change the format of the logs which may break this feature, but this not super likely given its current stable state, and it shouldn't be hard to cope.
- Adds a new class, `MPVLogHandler`, to parse the log messages for the 3 relevant input section event types and send them to `KeyInputController`.
- `KeyInputController` keeps track of which input sections are defined and enabled, in what order they were enabled, and whether they are "weak" or strong. Each time there is a change to an input section or to the global key bindings set via IINA, the list of key bindings is rebuilt for the given player. It retains information about which section they originated from, which also includes the script name. It may be useful to display this info to the user at some point.
- Also made many parsing & normalization fixes as detailed in #3887: this PR is a superset of that one. These fixes were needed to get the bindings from the built-in console & stats scripts to work properly since they are using unusual (mostly lowercase) names of some keys.