### PR TITLE
Multiple fixes to key binding parsing

### DIFF
--- a/iina/AppData.swift
+++ b/iina/AppData.swift
@@ -105,9 +105,12 @@ extension Notification.Name {
   static let iinaMediaTitleChanged = Notification.Name("IINAMediaTitleChanged")
   static let iinaVFChanged = Notification.Name("IINAVfChanged")
   static let iinaAFChanged = Notification.Name("IINAAfChanged")
-  static let iinaKeyBindingInputChanged = Notification.Name("IINAkeyBindingInputChanged")
+  static let iinaInputConfListChanged = Notification.Name("IINAInputConfListChanged")
+  static let iinaCurrentInputConfChanged = Notification.Name("IINACurrentInputConfChanged")
+  static let iinaKeyBindingInputChanged = Notification.Name("IINAKeyBindingInputChanged")
   static let iinaFileLoaded = Notification.Name("IINAFileLoaded")
   static let iinaHistoryUpdated = Notification.Name("IINAHistoryUpdated")
   static let iinaLegacyFullScreen = Notification.Name("IINALegacyFullScreen")
+  static let iinaGlobalKeyBindingsChanged = Notification.Name("iinaGlobalKeyBindingsChanged")
   static let iinaKeyBindingChanged = Notification.Name("iinaKeyBindingChanged")
 }

--- a/iina/AppData.swift
+++ b/iina/AppData.swift
@@ -105,8 +105,6 @@ extension Notification.Name {
   static let iinaMediaTitleChanged = Notification.Name("IINAMediaTitleChanged")
   static let iinaVFChanged = Notification.Name("IINAVfChanged")
   static let iinaAFChanged = Notification.Name("IINAAfChanged")
-  static let iinaInputConfListChanged = Notification.Name("IINAInputConfListChanged")
-  static let iinaCurrentInputConfChanged = Notification.Name("IINACurrentInputConfChanged")
   static let iinaKeyBindingInputChanged = Notification.Name("IINAKeyBindingInputChanged")
   static let iinaFileLoaded = Notification.Name("IINAFileLoaded")
   static let iinaHistoryUpdated = Notification.Name("IINAHistoryUpdated")

--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -416,6 +416,10 @@ extension String {
     return "%\(count)%\(self)"
   }
 
+  func equalsIgnoreCase(_ other: String) -> Bool {
+    return localizedCompare(other) == .orderedSame
+  }
+
   mutating func deleteLast(_ num: Int) {
     removeLast(Swift.min(num, count))
   }

--- a/iina/KeyCodeHelper.swift
+++ b/iina/KeyCodeHelper.swift
@@ -9,9 +9,22 @@
 import Foundation
 import Carbon
 
-fileprivate let modifierSymbols: [(NSEvent.ModifierFlags, String)] = [(.control, "⌃"), (.option, "⌥"), (.shift, "⇧"), (.command, "⌘")]
-
 class KeyCodeHelper {
+
+  // mpv modifiers in normal form:
+  static let CTRL_KEY = "Ctrl"
+  static let ALT_KEY = "Alt"
+  static let SHIFT_KEY = "Shift"
+  static let META_KEY = "Meta"
+
+  fileprivate static let modifierOrder: [String: Int] = [
+    CTRL_KEY: 0,
+    ALT_KEY: 1,
+    SHIFT_KEY: 2,
+    META_KEY: 3
+  ]
+
+  fileprivate static let modifierSymbols: [(NSEvent.ModifierFlags, String)] = [(.control, "⌃"), (.option, "⌥"), (.shift, "⇧"), (.command, "⌘")]
 
   static let keyMap: [UInt16 : (String, String?)] = [
     0x00: ("a", "A"),
@@ -185,10 +198,10 @@ class KeyCodeHelper {
   }()
 
   static let mpvSymbolToKeyName: [String: String] = [
-    "META": "⌘",
-    "SHIFT": "⇧",
-    "ALT": "⌥",
-    "CTRL":"⌃",
+    META_KEY: "⌘",
+    SHIFT_KEY: "⇧",
+    ALT_KEY: "⌥",
+    CTRL_KEY:"⌃",
     "SHARP": "#",
     "ENTER": "↩︎",
     "KP_ENTER": "↩︎",
@@ -263,39 +276,169 @@ class KeyCodeHelper {
       keyChar = keyName.0
     }
     // modifiers
-    // the same order as `KeyMapping.modifierOrder`
+    // the same order as `KeyCodeHelper.modifierOrder`
     if modifiers.contains(.control) {
-      keyString += "Ctrl+"
+      keyString += "\(CTRL_KEY)+"
     }
     if modifiers.contains(.option) {
-      keyString += "Alt+"
+      keyString += "\(ALT_KEY)+"
     }
     if modifiers.contains(.shift) {
-      keyString += "Shift+"
+      keyString += "\(SHIFT_KEY)+"
     }
     if modifiers.contains(.command) {
-      keyString += "Meta+"
+      keyString += "\(META_KEY)+"
     }
     // char
     keyString += keyChar
     return keyString
   }
 
-  static func macOSKeyEquivalent(from mpvKeyCode: String, usePrintableKeyName: Bool = false) -> (key: String, modifiers: NSEvent.ModifierFlags)? {
-    if mpvKeyCode == "+" {
-      return ("+", [])
+  // Finds and returns the end index of the next key in the string
+  private static func getNextEndIndex(_ unparsedRemainder: Substring) -> String.Index? {
+    if let dashIndex = unparsedRemainder.firstIndex(of: "-"),
+     let indexBeyondDash = unparsedRemainder.index(dashIndex, offsetBy: 1, limitedBy: unparsedRemainder.index(before: unparsedRemainder.endIndex)) { // There is a '-' somewhere, and there is at least 1 char after it
+      if dashIndex == unparsedRemainder.startIndex {
+        guard unparsedRemainder[indexBeyondDash] == "-" else {
+          return nil
+        }
+        // Next char is '-' and should be treated like a key, but needs to be terminated
+        return indexBeyondDash
+      } else {
+        // The '-' should be treated like a separator char
+        return dashIndex
+      }
     }
-    let splitted = mpvKeyCode.replacingOccurrences(of: "++", with: "+PLUS").components(separatedBy: "+")
+    // No '-' in string, or it is the only char in the string: use whole string as the next key
+    return unparsedRemainder.endIndex
+  }
+
+  // See mpv/input/keycodes.c: mp_input_get_keys_from_string()
+  public static func splitKeystrokes(_ keystrokes: String) -> [String] {
+    var unparsedRemainder = Substring(keystrokes)
+    var splitKeystrokeList: [String] = []
+
+    while !unparsedRemainder.isEmpty && splitKeystrokeList.count < 4 {
+      guard let endIndex = getNextEndIndex(unparsedRemainder) else {
+        Logger.log("Could not split keystrokes; not a valid sequence: \"\(keystrokes)\"", level: .warning)
+        return [keystrokes]
+      }
+
+      let ks = String(unparsedRemainder[unparsedRemainder.startIndex..<endIndex])
+      guard !ks.isEmpty else {
+          Logger.log("While splitting keystrokes: Last keystroke is empty! Returning list: \(splitKeystrokeList)", level: .error)
+          return splitKeystrokeList
+      }
+      splitKeystrokeList.append(ks)
+
+      guard let indexBeyondEnd = unparsedRemainder.index(endIndex, offsetBy: 1, limitedBy: unparsedRemainder.endIndex) else {
+        break
+      }
+
+      unparsedRemainder = unparsedRemainder[indexBeyondEnd...]
+    }
+    return splitKeystrokeList
+  }
+
+  // Normalizes a single "press" of possibly multiple keys (as joined with '+')
+  private static func normalizeSingleMpvKeystroke(_ mpvKeystroke: String) -> String {
+    if mpvKeystroke == "+" {
+      return mpvKeystroke
+    }
+    var normalizedList: [String] = []
+    let splitted = mpvKeystroke.replacingOccurrences(of: "++", with: "+PLUS").components(separatedBy: "+")
+    var key = splitted.last!
+    splitted.dropLast().forEach { k in
+      // Modifiers have first letter capitalized. All other special chars are capitalized
+      if k.equalsIgnoreCase(SHIFT_KEY) {
+        // For alphabetic chars, remove the "Shift+" and replace with actual uppercase char
+        if key.count == 1, key.lowercased() != key.uppercased() {
+          key = key.uppercased()
+        } else {
+          normalizedList.append(SHIFT_KEY)
+        }
+      } else if k.equalsIgnoreCase(META_KEY) {
+        normalizedList.append(META_KEY)
+      } else if k.equalsIgnoreCase(CTRL_KEY) {
+        normalizedList.append(CTRL_KEY)
+      } else if k.equalsIgnoreCase(ALT_KEY) {
+        normalizedList.append(ALT_KEY)
+      } else {
+        normalizedList.append(k.uppercased())
+      }
+    }
+    if key.count > 1 {
+      // assume it's a special char
+      key = key.uppercased()
+    }
+    normalizedList.append(key)
+
+    normalizedList = normalizedList.sorted { modifierOrder[$0, default: 9] < modifierOrder[$1, default: 9] }
+    return normalizedList.joined(separator: "+")
+  }
+
+  public static func splitAndNormalizeMpvString(_ mpvKeystrokes: String) -> [String] {
+    // this is a hard-coded special case in mpv
+    if mpvKeystrokes == "default-bindings" {
+      return [mpvKeystrokes]
+    }
+    let keystrokesList = splitKeystrokes(mpvKeystrokes)
+
+    var normalizedList: [String] = []
+    for keystroke in keystrokesList {
+      normalizedList.append(normalizeSingleMpvKeystroke(keystroke))
+    }
+    return normalizedList
+  }
+
+  /*
+   MPV accepts several forms for the same keystroke. This ensures that it is reduced to a single standardized form
+   (such that it can be used in a set or map, and which matches what `mpvKeyCode()` returns).
+
+   Definitions used here:
+   - A "key" is just any individual key on a keyboard (including keyboards from different locales around the world).
+   - A "keystroke" for our purposes is any combination of up to 4 different keys which are held down simultaneously, of which only one is a
+     "regular" (non-modifier) key, and the rest are "modifier keys". Note that currently we don't enforce the restriction on only one regular key.
+   - The 4 "modifier keys" include: "Meta" (aka Command), "Ctrl", "Alt" (aka Option), "Shift"
+   - A "key sequence" is an ordered list of up to 4 keystrokes. Whereas a "keystroke" is a set of keys typed in parallel, a "key sequence" is a set
+     of keystrokes typed serially.
+
+   Normal Form Rules:
+   1. If the key is matches the exact string "default-bindings", assume it is part of the special line "default-bindings start",
+      and return it as-is.
+   2. The input string is parsed as a sequence of up to 4 keystrokes, each of which is separated by the character "-".
+      Note that "-" is itself a valid keystroke, so that e.g. this is a valid 4-key sequence: "-------"
+   3. Each resulting keystroke shall be parsed into up to 4 keys, each of which is separated by the character "+".
+      Note that the "+" character is accepted as a valid key, but it is normalized to "PLUS".
+   4. Each of the 4 modifiers shall be written with the first letter in uppercase and the remaining letters in lowercase.
+   5. There always shall be exactly 1 "regular" key in each keystroke, and it is always the last key in the keystroke.
+   6. A keystroke can contain between 0 and 3 modifiers (up to 1 of each kind).
+   7. The modifiers, if present, shall respect the following order from left to right: "Ctrl", "Alt", "Shift", "Meta"
+      (e.g., "Meta+Ctrl+J" is invalid, but "Ctrl+Alt+DEL" is valid)
+   8. If the regular key in the keystroke is of the set of characters which have separate and distinct uppercase and lowercase versions, then
+      the keystroke shall never contain an explicit "Shift" modifier but instead shall use the uppercase character.
+   9. Any remaining special keys not previously mentioned and which have more than one character in their name shall be written in all uppercase.
+      (examples: SHARP, SPACE, PGDOWN)
+   */
+  public static func normalizeMpv(_ mpvKeystrokes: String) -> String {
+    let normalizedList = splitAndNormalizeMpvString(mpvKeystrokes)
+    return normalizedList.joined(separator: "-")
+  }
+
+  // Converts an mpv-formatted key string to a (key, modifiers) pair suitable for assignment to a MacOS menu item.
+  // IMPORTANT: `mpvKeyCode` must be normalized first! Use `KeyCodeHelper.normalizeMpv()`.
+  static func macOSKeyEquivalent(from mpvKeyCode: String, usePrintableKeyName: Bool = false) -> (key: String, modifiers: NSEvent.ModifierFlags)? {
+    let splitted = mpvKeyCode.components(separatedBy: "+")
     var key: String
     var modifiers: NSEvent.ModifierFlags = []
     guard !splitted.isEmpty else { return nil }
     key = splitted.last!
     splitted.dropLast().forEach { k in
       switch k {
-      case "Meta": modifiers.insert(.command)
-      case "Ctrl": modifiers.insert(.control)
-      case "Alt": modifiers.insert(.option)
-      case "Shift": modifiers.insert(.shift)
+      case META_KEY: modifiers.insert(.command)
+      case CTRL_KEY: modifiers.insert(.control)
+      case ALT_KEY: modifiers.insert(.option)
+      case SHIFT_KEY: modifiers.insert(.shift)
       default: break
       }
     }
@@ -306,6 +449,7 @@ class KeyCodeHelper {
     return (key, modifiers)
   }
 
+  // Formats a MacOS (key, modifiers) pair into a MacOS-formatted display string.
   static func readableString(fromKey key: String, modifiers: NSEvent.ModifierFlags) -> String {
     var key = key
     var modifiers = modifiers

--- a/iina/KeyMapping.swift
+++ b/iina/KeyMapping.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 
+fileprivate let IINA_PREFIX = "#@iina"
+
 class KeyMapping: NSObject {
 
   // TODO: this is UI logic. Move it out of here.
@@ -70,8 +72,9 @@ class KeyMapping: NSObject {
 
   var rawAction: String {
     set {
-      if newValue.hasPrefix("@iina") {
-        privateRawAction = newValue[newValue.index(newValue.startIndex, offsetBy: "@iina".count)...].trimmingCharacters(in: .whitespaces)
+      if newValue.hasPrefix(IINA_PREFIX) {
+        privateRawAction = newValue[newValue.index(newValue.startIndex,
+                                                   offsetBy: IINA_PREFIX.count)...].trimmingCharacters(in: .whitespaces)
         isIINACommand = true
       } else {
         privateRawAction = newValue
@@ -89,7 +92,7 @@ class KeyMapping: NSObject {
   @objc var readableAction: String {
     get {
       let joined = action.joined(separator: " ")
-      return isIINACommand ? ("@iina " + joined) : joined
+      return isIINACommand ? ("\(IINA_PREFIX) " + joined) : joined
     }
   }
 
@@ -103,7 +106,7 @@ class KeyMapping: NSObject {
 
   var confFileFormat: String {
     get {
-      let iinaCommandString = isIINACommand ? "#@iina " : ""
+      let iinaCommandString = isIINACommand ? "\(IINA_PREFIX) " : ""
       let commentString = (comment == nil || comment!.isEmpty) ? "" : "   #\(comment!)"
       return "\(iinaCommandString)\(rawKey) \(action.joined(separator: " "))\(commentString)"
     }
@@ -135,10 +138,10 @@ class KeyMapping: NSObject {
       if line.trimmingCharacters(in: .whitespaces).isEmpty {
         continue
       } else if line.hasPrefix("#") {
-        if line.hasPrefix("#@iina") {
+        if line.hasPrefix(IINA_PREFIX) {
           // extended syntax
           isIINACommand = true
-          line = String(line[line.index(line.startIndex, offsetBy: "#@iina".count)...])
+          line = String(line[line.index(line.startIndex, offsetBy: IINA_PREFIX.count)...])
         } else {
           // ignore comment line
           continue

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -700,7 +700,7 @@ class MenuController: NSObject, NSMenuDelegate {
       for kb in keyBindings {
         guard kb.isIINACommand == isIINACmd else { continue }
         let (sameAction, value) = sameKeyAction(kb.action, actions, normalizeLastNum, numRange)
-        if sameAction, let (kEqv, kMdf) = KeyCodeHelper.macOSKeyEquivalent(from: kb.key) {
+        if sameAction, let (kEqv, kMdf) = KeyCodeHelper.macOSKeyEquivalent(from: kb.rawKey) {
           menuItem.keyEquivalent = kEqv
           menuItem.keyEquivalentModifierMask = kMdf
           if let value = value, let l10nKey = l10nKey {

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -282,11 +282,49 @@ class PlayerCore: NSObject {
   }
 
   static func setKeyBindings(_ keyMappings: [KeyMapping]) {
-    Logger.log("Set key bindings")
-    var keyBindings: [String: KeyMapping] = [:]
-    keyMappings.forEach { keyBindings[$0.key] = $0 }
-    PlayerCore.keyBindings = keyBindings
-    (NSApp.delegate as? AppDelegate)?.menuController.updateKeyEquivalentsFrom(Array(keyBindings.values))
+    Logger.log("Set key bindings (\(keyMappings.count) mappings)")
+    // If multiple bindings map to the same key, choose the last one
+    var keyBindingsDict: [String: KeyMapping] = [:]
+    var orderedKeyList: [String] = []
+    keyMappings.forEach {
+      if $0.rawKey == "default-bindings" && $0.action.count == 1 && $0.action[0] == "start" {
+        Logger.log("Skipping line: \"default-bindings start\"", level: .verbose)
+      } else {
+        if let kb = filterSectionBindings($0) {
+          let key = kb.normalizedMpvKey
+          if keyBindingsDict[key] == nil {
+            orderedKeyList.append(key)
+          }
+          keyBindingsDict[key] = kb
+        }
+      }
+    }
+    PlayerCore.keyBindings = keyBindingsDict
+
+    // For menu item bindings, filter duplicate keys as above, but preserve order
+    var kbUniqueOrderedList: [KeyMapping] = []
+    for key in orderedKeyList {
+      kbUniqueOrderedList.append(keyBindingsDict[key]!)
+    }
+
+    (NSApp.delegate as? AppDelegate)?.menuController.updateKeyEquivalentsFrom(kbUniqueOrderedList)
+
+    NotificationCenter.default.post(Notification(name: .iinaGlobalKeyBindingsChanged, object: kbUniqueOrderedList))
+  }
+
+  static private func filterSectionBindings(_ kb: KeyMapping) -> KeyMapping? {
+    guard let section = kb.section else {
+      return kb
+    }
+
+    if section == "default" {
+      // Drop "{default}" because it is unnecessary and will get in the way of libmpv command execution
+      let newRawAction = Array(kb.action.dropFirst()).joined(separator: " ")
+      return KeyMapping(rawKey: kb.rawKey, rawAction: newRawAction, isIINACommand: kb.isIINACommand, comment: kb.comment)
+    } else {
+      Logger.log("Skipping binding from section \"\(section)\": \(kb.rawKey)", level: .verbose)
+      return nil
+    }
   }
 
   func startMPV() {

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -289,14 +289,12 @@ class PlayerCore: NSObject {
     keyMappings.forEach {
       if $0.rawKey == "default-bindings" && $0.action.count == 1 && $0.action[0] == "start" {
         Logger.log("Skipping line: \"default-bindings start\"", level: .verbose)
-      } else {
-        if let kb = filterSectionBindings($0) {
-          let key = kb.normalizedMpvKey
-          if keyBindingsDict[key] == nil {
-            orderedKeyList.append(key)
-          }
-          keyBindingsDict[key] = kb
+      } else if let kb = filterSectionBindings($0) {
+        let key = kb.normalizedMpvKey
+        if keyBindingsDict[key] == nil {
+          orderedKeyList.append(key)
         }
+        keyBindingsDict[key] = kb
       }
     }
     PlayerCore.keyBindings = keyBindingsDict

--- a/iina/PrefKeyBindingViewController.swift
+++ b/iina/PrefKeyBindingViewController.swift
@@ -139,11 +139,11 @@ class PrefKeyBindingViewController: NSViewController, PreferenceWindowEmbeddable
       guard !key.isEmpty && !action.isEmpty else { return }
       if action.hasPrefix("@iina") {
         let trimmedAction = action[action.index(action.startIndex, offsetBy: "@iina".count)...].trimmingCharacters(in: .whitespaces)
-        self.mappingController.addObject(KeyMapping(key: key,
+        self.mappingController.addObject(KeyMapping(rawKey: key,
                                         rawAction: trimmedAction,
                                         isIINACommand: true))
       } else {
-        self.mappingController.addObject(KeyMapping(key: key, rawAction: action))
+        self.mappingController.addObject(KeyMapping(rawKey: key, rawAction: action))
       }
 
       self.kbTableView.scrollRowToVisible((self.mappingController.arrangedObjects as! [AnyObject]).count - 1)
@@ -329,7 +329,7 @@ class PrefKeyBindingViewController: NSViewController, PreferenceWindowEmbeddable
     setKeybindingsForPlayerCore()
     mappingController.filterPredicate = predicate
     do {
-      try KeyMapping.generateConfData(from: keyMapping).write(toFile: currentConfFilePath, atomically: true, encoding: .utf8)
+      try KeyMapping.generateInputConf(from: keyMapping).write(toFile: currentConfFilePath, atomically: true, encoding: .utf8)
     } catch {
       Utility.showAlert("config.cannot_write", sheetWindow: view.window)
     }
@@ -421,9 +421,9 @@ extension PrefKeyBindingViewController: NSTableViewDelegate, NSTableViewDataSour
     }
     guard kbTableView.selectedRow != -1 else { return }
     let selectedData = mappingController.selectedObjects[0] as! KeyMapping
-    showKeyBindingPanel(key: selectedData.key, action: selectedData.readableAction) { key, action in
+    showKeyBindingPanel(key: selectedData.rawKey, action: selectedData.readableAction) { key, action in
       guard !key.isEmpty && !action.isEmpty else { return }
-      selectedData.key = key
+      selectedData.rawKey = key
       selectedData.rawAction = action
       self.kbTableView.reloadData()
       NotificationCenter.default.post(Notification(name: .iinaKeyBindingChanged))


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [x] It implements / fixes issues:
   #3831 
   #3881 
   #3851

---

**Description:**
This patch is a subset of (and is actually back-ported from) #3847, and contains only the changes to parsing and mapping key bindings. It is the successor to #3833: it fixes a loophole in that logic which result in unused duplicate entries being stored, while also adding other fixes which couldn't be merged separately.

It does the following
- Splits `KeyMapping`'s `key` field into rawKey and `normalizedMpvKey`, similar to how its `action` field has raw & parsed version.
- Moves the existing mpv normalization logic out of the `KeyMapping` constructor and into `KeyCodeHelper`.
- Expands the mpv normalization logic to ensure that in normal form (fixes #3851):
  - Special key symbols are capitalized
  - A key's uppercase symbol is used if it is available, instead of containing "Shift+"
  - Key sequences containing the `-` (minus) key are properly parsed
- Use normal form always when identifying key bindings; use raw form when editing in the UI, to ensure consistent functionality while keeping a smooth user experience
- Add check for ignoring the line `default-bindings begin`, rather than binding it to a ke
- Add check for `{section_name}` (section name in curly braces): if it is "default" then strip the section and include the binding; for other section names do not include the binding (fixes #3881)
