### PR TITLE
Fix #3857: Enter Full Screen exists under 2 different menu items

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -128,6 +128,9 @@ class AppDelegate: NSObject, NSApplicationDelegate {
       guideWindow.show(pages: [.highlights])
     }
 
+    // Hide Window > "Enter Full Screen" menu item, because this is already present in the Video menu
+    UserDefaults.standard.set(false, forKey: "NSFullScreenMenuItemEverywhere")
+
     SUUpdater.shared().feedURL = URL(string: Preference.bool(for: .receiveBetaUpdate) ? AppData.appcastBetaLink : AppData.appcastLink)!
 
     // handle arguments


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3857.

---

**Description:**
Since the "Enter Fullscreen" option already exists under the Video menu, this patch hides the instance under the Window menu, to conform with Apple HIG. Note:
- This change has no effect on the built-in `fn-F` shortcut, which still works.
- This is set as a preference value which MacOS recognizes, which means:
  - Although it's set when IINA starts, it will not take effect until the app is closed & reopened.
  - After being set, even old versions of IINA will hide the full-screen option in the Window menu (unless IINA's prefs are manually deleted or edited to remove this key)