### PR TITLE
Fix top of progress bar not behaving as such, #3911

### DIFF
--- a/iina/Base.lproj/MainWindowController.xib
+++ b/iina/Base.lproj/MainWindowController.xib
@@ -495,12 +495,12 @@
             </subviews>
             <constraints>
                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="150" id="E6z-SF-UDn"/>
-                <constraint firstAttribute="bottom" secondItem="eBP-6g-bAT" secondAttribute="bottom" constant="4.5" id="GNu-nJ-qPy"/>
+                <constraint firstAttribute="bottom" secondItem="eBP-6g-bAT" secondAttribute="bottom" constant="6" id="GNu-nJ-qPy"/>
                 <constraint firstItem="GgV-Cc-sk0" firstAttribute="centerY" secondItem="NBD-MV-OuG" secondAttribute="centerY" id="N3P-Qk-arP"/>
                 <constraint firstItem="eBP-6g-bAT" firstAttribute="centerX" secondItem="BE1-yC-oJL" secondAttribute="centerX" id="VDD-aU-mmP"/>
                 <constraint firstItem="eBP-6g-bAT" firstAttribute="centerY" secondItem="NBD-MV-OuG" secondAttribute="centerY" id="dX4-4l-aJM"/>
                 <constraint firstItem="NBD-MV-OuG" firstAttribute="leading" secondItem="BE1-yC-oJL" secondAttribute="leading" constant="2" id="fcm-ao-T7h"/>
-                <constraint firstItem="eBP-6g-bAT" firstAttribute="top" secondItem="BE1-yC-oJL" secondAttribute="top" constant="4.5" id="oEb-w7-DDS"/>
+                <constraint firstItem="eBP-6g-bAT" firstAttribute="top" secondItem="BE1-yC-oJL" secondAttribute="top" constant="6" id="oEb-w7-DDS"/>
                 <constraint firstAttribute="trailing" secondItem="GgV-Cc-sk0" secondAttribute="trailing" constant="2" id="plE-qU-XZt"/>
                 <constraint firstItem="eBP-6g-bAT" firstAttribute="leading" secondItem="NBD-MV-OuG" secondAttribute="trailing" constant="2" id="uHE-D2-HgP"/>
                 <constraint firstItem="GgV-Cc-sk0" firstAttribute="leading" secondItem="eBP-6g-bAT" secondAttribute="trailing" constant="2" id="vzW-0s-yR6"/>

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2059,11 +2059,35 @@ class MainWindowController: PlayerWindowController {
     }
   }
 
+  /// Determine if the thumbnail preview can be shown above the progress bar in the on screen controller..
+  ///
+  /// Normally the OSC's thumbnail preview is shown above the time preview. This is the preferred location. However the
+  /// thumbnail preview extends beyond the frame of the OSC. If the OSC is near the top of the window this could result
+  /// in the thumbnail extending outside of the window resulting in clipping. This method checks if there is room for the
+  /// thumbnail to fully fit in the window. Otherwise the thumbnail must be displayed below the OSC's progress bar.
+  /// - Parameters:
+  ///   - timnePreviewYPos: The y-coordinate of the time preview `TextField`.
+  ///   - thumbnailHeight: The height of the thumbnail.
+  /// - Returns: `true` if the thumbnail can be shown above the slider, `false` otherwise.
+  private func canShowThumbnailAbove(timnePreviewYPos: Double, thumbnailHeight: Double) -> Bool {
+    guard oscPosition != .bottom else { return true }
+    guard oscPosition != .top else { return false }
+    // The layout preference for the on screen controller is set to the default floating layout.
+    // Must insure the top of the thumbnail would be below the top of the window.
+    let topOfThumbnail = timnePreviewYPos + timePreviewWhenSeek.frame.height + thumbnailHeight
+    // Normally the height of the usable area of the window can be obtained from the content
+    // layout. But when the legacy full screen preference is enabled the layout height may be
+    // larger than the content view if the display contains a camera housing. Use the lower of
+    // the two heights.
+    let windowContentHeight = min(window!.contentLayoutRect.height, window!.contentView!.frame.height)
+    return topOfThumbnail <= windowContentHeight
+  }
+
   /** Display time label when mouse over slider */
   private func updateTimeLabel(_ mouseXPos: CGFloat, originalPos: NSPoint) {
-    let timeLabelXPos = playSlider.frame.origin.y + 15
-    timePreviewWhenSeek.frame.origin = NSPoint(x: round(mouseXPos + playSlider.frame.origin.x - timePreviewWhenSeek.frame.width / 2),
-                                               y: timeLabelXPos + 1)
+    let timeLabelXPos = round(mouseXPos + playSlider.frame.origin.x - timePreviewWhenSeek.frame.width / 2)
+    let timeLabelYPos = playSlider.frame.origin.y + playSlider.frame.height
+    timePreviewWhenSeek.frame.origin = NSPoint(x: timeLabelXPos, y: timeLabelYPos)
     let sliderFrame = playSlider.bounds
     let sliderFrameInWindow = playSlider.superview!.convert(playSlider.frame.origin, to: nil)
     var percentage = Double((mouseXPos - 3) / (sliderFrame.width - 6))
@@ -2079,8 +2103,9 @@ class MainWindowController: PlayerWindowController {
         thumbnailPeekView.imageView.image = image.rotate(rotation)
         thumbnailPeekView.isHidden = false
         let height = round(120 / thumbnailPeekView.imageView.image!.size.aspect)
-        let yPos = (oscPosition == .top || (oscPosition == .floating && sliderFrameInWindow.y + 52 + height >= window!.frame.height)) ?
-          sliderFrameInWindow.y - height : sliderFrameInWindow.y + 32
+        let timePreviewFrameInWindow = timePreviewWhenSeek.superview!.convert(timePreviewWhenSeek.frame.origin, to: nil)
+        let showAbove = canShowThumbnailAbove(timnePreviewYPos: timePreviewFrameInWindow.y, thumbnailHeight: height)
+        let yPos = showAbove ? timePreviewFrameInWindow.y + timePreviewWhenSeek.frame.height : sliderFrameInWindow.y - height
         thumbnailPeekView.frame.size = NSSize(width: 120, height: height)
         thumbnailPeekView.frame.origin = NSPoint(x: round(originalPos.x - thumbnailPeekView.frame.width / 2), y: yPos)
       } else {
@@ -2573,7 +2598,7 @@ class MainWindowController: PlayerWindowController {
     // label
     timePreviewWhenSeek.frame.origin = CGPoint(
       x: round(sender.knobPointPosition() - timePreviewWhenSeek.frame.width / 2),
-      y: playSlider.frame.origin.y + 16)
+      y: playSlider.frame.origin.y + playSlider.frame.height)
     timePreviewWhenSeek.stringValue = (player.info.videoDuration! * percentage * 0.01).stringRepresentation
   }
 

--- a/iina/PlaySliderCell.swift
+++ b/iina/PlaySliderCell.swift
@@ -95,6 +95,13 @@ class PlaySliderCell: NSSliderCell {
   override func awakeFromNib() {
     minValue = 0
     maxValue = 100
+    if #available(macOS 11, *) {
+      let slider = self.controlView as! NSSlider
+      // Apple increased the height of sliders in Big Sur. Until we have time to restructure the
+      // on screen controller to accommodate a larger slider reduce the size of the slider from
+      // regular to small. This makes the slider match the behavior seen under Catalina.
+      slider.controlSize = .small
+    }
   }
 
   override func drawKnob(_ knobRect: NSRect) {


### PR DESCRIPTION
The commit in the pull request will:
- Change MainWindowController methods playSliderChanges and
  updateTimeLabel to position the time preview relative to the progress
  bar
- Add method canShowThumbnailAbove to MainWindowController
- Change updateTimeLabel to use canShowThumbnailAbove
- Change PlaySliderCell.awakeFromNib to set slider control size to small
  for macOS 11+
- Increase bottom and top constraints around progress bar from 4.5 to 6

These changes stop the time preview from intruding into the progress bar
in the on screen controller.

- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3911.

---

**Description:**
Correct regression introduced by Big Sur.