### PR TITLE
Update the seek OSD with the actual position of the video

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -884,6 +884,10 @@ class MPVController: NSObject {
       }
       player.playbackRestarted()
       player.syncUI(.time)
+      let osdText = (player.info.videoPosition?.stringRepresentation ?? Constants.String.videoTimePlaceholder) + " / " +
+        (player.info.videoDuration?.stringRepresentation ?? Constants.String.videoTimePlaceholder)
+      let percentage = (player.info.videoPosition / player.info.videoDuration) ?? 1
+      player.sendOSD(.seek(osdText, percentage))
 
     case MPV_EVENT_END_FILE:
       // if receive end-file when loading file, might be error


### PR DESCRIPTION
- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**

When seeking the video by steps, the seek OSD displays the requested position but does not update with the actual position.