### PR TITLE
Close option to start iina-cli in music-mode, #3651

### DIFF
--- a/iina-cli/main.swift
+++ b/iina-cli/main.swift
@@ -54,6 +54,8 @@ if userArgs.contains(where: { $0 == "--help" || $0 == "-h" }) {
     --keep-running:
             Normally iina-cli launches IINA and quits immediately. Supply this option
             if you would like to keep it running until the main application exits.
+    --music-mode:
+            Enter music mode after opening the media.
     --pip:
             Enter Picture-in-Picture after opening the media.
     --help | -h:

--- a/iina-cli/main.swift
+++ b/iina-cli/main.swift
@@ -57,7 +57,8 @@ if userArgs.contains(where: { $0 == "--help" || $0 == "-h" }) {
     --music-mode:
             Enter music mode after opening the media.
     --pip:
-            Enter Picture-in-Picture after opening the media.
+            Enter Picture-in-Picture after opening the media. Music mode does not
+            support Picture-in-Picture.
     --help | -h:
             Print this message.
 
@@ -66,6 +67,13 @@ if userArgs.contains(where: { $0 == "--help" || $0 == "-h" }) {
     Example: --volume=20 --no-resume-playback
     """)
   exit(0)
+}
+
+if userArgs.contains("--music-mode"), userArgs.contains("--pip") {
+  // Music mode does not support Picture-in-Picture. Combining these options is not permitted.
+  print("Cannot specify both --music-mode and --pip")
+  // Command line usage error.
+  exit(EX_USAGE)
 }
 
 var isStdin = false

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -315,9 +315,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         }
       }
 
-      // enter PIP
-      if #available(macOS 10.12, *), let pc = lastPlayerCore, commandLineStatus.enterPIP {
-        pc.mainWindow.enterPIP()
+      if let pc = lastPlayerCore {
+        // PiP is not supported in music mode. Ignore the PiP option if music mode was specified.
+        if commandLineStatus.enterMusicMode {
+          pc.switchToMiniPlayer()
+        } else if #available(macOS 10.12, *), commandLineStatus.enterPIP {
+          pc.mainWindow.enterPIP()
+        }
       }
     }
 
@@ -846,6 +850,7 @@ struct CommandLineStatus {
   var isCommandLine = false
   var isStdin = false
   var openSeparateWindows = false
+  var enterMusicMode = false
   var enterPIP = false
   var mpvArguments: [(String, String)] = []
   var iinaArguments: [(String, String)] = []
@@ -879,6 +884,9 @@ struct CommandLineStatus {
         }
         if name == "separate-windows" {
           openSeparateWindows = true
+        }
+        if name == "music-mode" {
+          enterMusicMode = true
         }
         if name == "pip" {
           enterPIP = true

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -316,8 +316,15 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
       }
 
       if let pc = lastPlayerCore {
-        // PiP is not supported in music mode. Ignore the PiP option if music mode was specified.
         if commandLineStatus.enterMusicMode {
+          if commandLineStatus.enterPIP {
+            // PiP is not supported in music mode. Combining these options is not permitted and is
+            // rejected by iina-cli. The IINA executable must have been invoked directly with
+            // arguments.
+            Logger.log("Cannot specify both --music-mode and --pip", level: .error)
+            // Command line usage error.
+            exit(EX_USAGE)
+          }
           pc.switchToMiniPlayer()
         } else if #available(macOS 10.12, *), commandLineStatus.enterPIP {
           pc.mainWindow.enterPIP()


### PR DESCRIPTION
The commit in the pull request will:
- Add a new enterMusicMode property to the CommandLineStatus struct
- Add support for a new --music-mode option to the
  AppDelegate.parseArguments method
- Add code to applicationDidFinishLaunching to switch to the mini player
  if the music-mode option is specified
- Add the new --music-mode option to the output of the --help option

- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3651.

---

**Description:**
