### PR TITLE
Fix does not respond to additionalInfoTitle, #3811

### DIFF
--- a/iina/Base.lproj/MainWindowController.xib
+++ b/iina/Base.lproj/MainWindowController.xib
@@ -155,9 +155,6 @@
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
-                                <connections>
-                                    <action selector="additionalInfoTitle:" target="-2" id="wG0-5O-SnW"/>
-                                </connections>
                             </textField>
                         </subviews>
                         <constraints>


### PR DESCRIPTION
The commit in the pull request will remove an extraneous and unneeded
action connection between the XIB and MainWindowController for the
additionalInfoTitle label.

- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3811.

---

**Description:**
