### PR TITLE
Fix NSFileHandleOperationException crash in logger, #3590

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		49542986216C34950058F680 /* OpenInIINA.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 49542973216C34950058F680 /* OpenInIINA.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		496B19921E2968530035AF10 /* PIP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 496B19911E2968530035AF10 /* PIP.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
 		519872FF26879B9B00F84BCC /* AccessibilityPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519872FE26879B9B00F84BCC /* AccessibilityPreferences.swift */; };
+		51F7974728C7E00200812D0D /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F7974628C7E00200812D0D /* Lock.swift */; };
 		6100FF2B1EDF9806002CF0FB /* dsa_pub.pem in Resources */ = {isa = PBXBuildFile; fileRef = 6100FF2A1EDF9806002CF0FB /* dsa_pub.pem */; };
 		8400D5C41E17C6D2006785F5 /* AboutWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8400D5C21E17C6D2006785F5 /* AboutWindowController.swift */; };
 		8400D5C61E1AB2F1006785F5 /* MainWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8400D5C81E1AB2F1006785F5 /* MainWindowController.xib */; };
@@ -495,6 +496,7 @@
 		49542983216C34950058F680 /* OpenInIINA.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = OpenInIINA.entitlements; sourceTree = "<group>"; };
 		496B19911E2968530035AF10 /* PIP.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PIP.framework; path = ../../../../System/Library/PrivateFrameworks/PIP.framework; sourceTree = "<group>"; };
 		519872FE26879B9B00F84BCC /* AccessibilityPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPreferences.swift; sourceTree = "<group>"; };
+		51F7974628C7E00200812D0D /* Lock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
 		5879479521A87DD700757A6F /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/MiniPlayerWindowController.strings; sourceTree = "<group>"; };
 		5879479621A87E6100757A6F /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/PreferenceWindowController.strings; sourceTree = "<group>"; };
 		5EF9F7E521FB42E900748374 /* pt-BR */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "pt-BR"; path = "pt-BR.lproj/MainMenu.strings"; sourceTree = "<group>"; };
@@ -1765,6 +1767,7 @@
 				E3ECC89D1FE9A6D900BED8C7 /* GeometryDef.swift */,
 				E3C12F6A201F281F00297964 /* FirstRunManager.swift */,
 				E342832E20B7149800139865 /* Logger.swift */,
+				51F7974628C7E00200812D0D /* Lock.swift */,
 				E3F698862120D878005792C9 /* ExtendedColors.swift */,
 				E301EFD921312AB300BC8588 /* KeychainAccess.swift */,
 			);
@@ -2476,6 +2479,7 @@
 				8407D1401E3A684C0043895D /* ViewLayer.swift in Sources */,
 				84A0BA9B1D2FAB4100BC8DA1 /* Parameter.swift in Sources */,
 				84EB1F051D2F5C5B004FA5A1 /* AppData.swift in Sources */,
+				51F7974728C7E00200812D0D /* Lock.swift in Sources */,
 				84C8D58F1D794CE600D98A0E /* MPVFilter.swift in Sources */,
 				845404AA1E4396F500B02B12 /* ScriptLoader.swift in Sources */,
 				84A0BAA11D2FAE7600BC8DA1 /* VideoView.swift in Sources */,

--- a/iina/Lock.swift
+++ b/iina/Lock.swift
@@ -1,0 +1,83 @@
+//
+//  Lock.swift
+//  iina
+//
+//  Created by low-batt on 9/5/22.
+//  Copyright © 2022 lhc. All rights reserved.
+//
+
+import Foundation
+
+/// An object that coordinates the operation of multiple threads of execution.
+///
+/// This class hides the need for different implementations depending upon the macOS version.
+/// An [os_unfair_lock](https://developer.apple.com/documentation/os/os_unfair_lock) is preferred for its efficiency,
+/// however it was introduced in macOS 10.12, so an
+/// [NSLock](https://developer.apple.com/documentation/foundation/nslock) is used when running under earlier
+/// macOS versions.
+///
+/// The interface exposed is patterned after
+/// [OSAllocatedUnfairLock](https://developer.apple.com/documentation/os/osallocatedunfairlock)
+/// which is expected to be included in macOS 13.
+///
+///- Warning: This isn’t a recursive lock. Attempting to lock an object more than once from the same thread without unlocking in
+///    between will either trigger a runtime exception (macOS 10.12+) or will block your thread permanently (macOS 10.11).
+class Lock {
+
+  private let lock: LockImpl
+
+  init() {
+    if #available(macOS 10.12, *) {
+      lock = OSUnfairLockImpl()
+    } else {
+      lock = NSLockImpl()
+    }
+  }
+
+  /// Executes a closure while holding a lock.
+  /// - Parameter body: A closure that contains the code to execute using the lock.
+  /// - Returns: The value that body returns.
+  /// - Throws: The exception that body throws.
+  func withLock<R>(_ body: () throws -> R) rethrows -> R {
+    return try lock.withLock(body)
+  }
+}
+
+// MARK: - Implementation
+
+private protocol LockImpl {
+  func withLock<R>(_ body: () throws -> R) rethrows -> R
+}
+
+@available(macOS 10.12, *)
+private class OSUnfairLockImpl: LockImpl {
+
+  // Use a pointer to insure the lock, which is a struct, is not copied.
+  private let lock = os_unfair_lock_t.allocate(capacity: 1)
+
+  init() {
+    lock.initialize(to: .init())
+  }
+
+  deinit {
+    lock.deinitialize(count: 1)
+    lock.deallocate()
+  }
+
+  func withLock<R>(_ body: () throws -> R) rethrows -> R {
+    os_unfair_lock_lock(lock)
+    defer { os_unfair_lock_unlock(lock) }
+    return try body()
+  }
+}
+
+private class NSLockImpl: LockImpl {
+
+  private let lock = NSLock()
+
+  func withLock<R>(_ body: () throws -> R) rethrows -> R {
+    lock.lock()
+    defer { lock.unlock() }
+    return try body()
+  }
+}

--- a/iina/Lock.swift
+++ b/iina/Lock.swift
@@ -52,7 +52,7 @@ private protocol LockImpl {
 @available(macOS 10.12, *)
 private class OSUnfairLockImpl: LockImpl {
 
-  // Use a pointer to insure the lock, which is a struct, is not copied.
+  // Use a pointer to ensure the lock, which is a struct, is not copied.
   private let lock = os_unfair_lock_t.allocate(capacity: 1)
 
   init() {
@@ -71,7 +71,7 @@ private class OSUnfairLockImpl: LockImpl {
   }
 }
 
-private class NSLockImpl: LockImpl {
+private struct NSLockImpl: LockImpl {
 
   private let lock = NSLock()
 

--- a/iina/Logger.swift
+++ b/iina/Logger.swift
@@ -8,6 +8,17 @@
 
 import Foundation
 
+/// The IINA Logger.
+///
+/// Logging to a file is controlled by a preference in `Advanced` preferences and by default is disabled.
+///
+/// The logger takes a two phase approach to handling errors. During initialization of the logger any failure while creating the log directory,
+/// creating the log file and opening the file for writing, is treated as a fatal error. The user will be shown an alert and when the user
+/// dismisses the alert the application will terminate. Once the logger is successfully initialized errors involving the file are only printed to
+/// the console to avoid disrupting playback.
+/// - Important: The `createDirIfNotExist` method in `Utilities` **must not** be used by the logger. If an error occurs
+///     that method will attempt to report it using the logger. If the logger is still being initialized this will result in a crash. For that reason
+///     the logger uses its own similar method.
 struct Logger {
 
   struct Subsystem: RawRepresentable {
@@ -45,31 +56,97 @@ struct Logger {
   static let enabled = Preference.bool(for: .enableAdvancedSettings) && Preference.bool(for: .enableLogging)
 
   static let logDirectory: URL = {
+    // get path
+    let libraryPath = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)
+    guard libraryPath.count >= 1 else {
+      fatalDuringInit("Cannot get path to Logs directory: \(libraryPath)")
+    }
+    let logsUrl = libraryPath.first!.appendingPathComponent("Logs", isDirectory: true)
+    let bundleID = Bundle.main.bundleIdentifier!
+    let appLogsUrl = logsUrl.appendingPathComponent(bundleID, isDirectory: true)
+
+    // MUST NOT use the similar method in Utilities as that method uses Logger methods. Logger
+    // methods must not ever be called while the logger is still initializing.
+    createDirIfNotExist(url: logsUrl)
+
     let formatter = DateFormatter()
     formatter.dateFormat = "yyyy-MM-dd-HH-mm-ss"
     let timeString  = formatter.string(from: Date())
     let token = Utility.ShortCodeGenerator.getCode(length: 6)
     let sessionDirName = "\(timeString)_\(token)"
-    let sessionDir = Utility.logDirURL.appendingPathComponent(sessionDirName, isDirectory: true)
-    Utility.createDirIfNotExist(url: sessionDir)
+    let sessionDir = appLogsUrl.appendingPathComponent(sessionDirName, isDirectory: true)
+
+    // MUST NOT use the similar method in Utilities. See above for reason.
+    createDirIfNotExist(url: sessionDir)
     return sessionDir
   }()
 
-  private static var logFileHandle: FileHandle = {
-    let logFileURL = logDirectory.appendingPathComponent("iina.log")
-    FileManager.default.createFile(atPath: logFileURL.path, contents: nil, attributes: nil)
-    return try! FileHandle(forWritingTo: logFileURL)
+  private static let logFile: URL = logDirectory.appendingPathComponent("iina.log")
+
+  private static let loggerSubsystem = Logger.Subsystem(rawValue: "logger")
+
+  private static var logFileHandle: FileHandle? = {
+    FileManager.default.createFile(atPath: logFile.path, contents: nil, attributes: nil)
+    do {
+      return try FileHandle(forWritingTo: logFile)
+    } catch  {
+      fatalDuringInit("Cannot open log file \(logFile.path) for writing: \(error.localizedDescription)")
+    }
   }()
 
-  private static var dateFormatter: DateFormatter = {
+  private static let dateFormatter: DateFormatter = {
     let formatter = DateFormatter()
     formatter.dateFormat = "HH:mm:ss.SSS"
     return formatter
   }()
 
+  // Must coordinate closing of the log file to avoid writing to a closed file handle.
+  private static let lock = Lock()
+
+  /// Closes the log file, if logging is enabled,
+  /// - Important: Currently IINA does not coordinate threads during termination. This results in a race condition as to whether
+  ///     a thread will attempt to log a message after the log file has been closed or not.  Previously this was triggering crashes due
+  ///     to writing to a closed file handle. The logger now uses a lock to coordinate closing of the log file. If a log message is logged
+  ///     after the log file is closed it will only be logged to the console.
   static func closeLogFile() {
     guard enabled else { return }
-    logFileHandle.closeFile()
+    // Lock to avoid closing the log file while another thread is writing to it.
+    lock.withLock {
+      guard let fileHandle = logFileHandle else { return }
+      do {
+        // The deprecated method is used instead of the new close method that throws swift exceptions
+        // because testing with the new write method found it failed to convert all objective-c
+        // exceptions to swift exceptions.
+        try ObjcUtils.catchException { fileHandle.closeFile() }
+      } catch {
+        // Unusual, but could happen if closing causes a buffer to be flushed to a full disk.
+        print(formatMessage("Cannot close log file \(logFile.path): \(error.localizedDescription)",
+                            .error, Logger.loggerSubsystem, true))
+      }
+      logFileHandle = nil
+    }
+  }
+
+  /// Creates a directory at the specified URL along with any nonexistent parent directories.
+  ///
+  /// If the directory cannot be created then this method will treat the failure as a fatal error. The user will be shown an alert and when
+  /// the user dismisses the alert the application will terminate.
+  /// - Parameter url: A file URL that specifies the directory to create.
+  /// - Important: This method is designed to be usable during logger initialization. The similar method found in `Utilities`
+  ///     **must not** be used. If an error occurs that method will attempt to report it using the logger. As the logger is still being
+  ///     initialized this will result in a crash.
+  private static func createDirIfNotExist(url: URL) {
+    do {
+      try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true, attributes: nil)
+    } catch {
+      fatalDuringInit("Cannot create directory \(url): \(error.localizedDescription)")
+    }
+  }
+
+  private static func formatMessage(_ message: String, _ level: Level, _ subsystem: Subsystem,
+                                    _ appendNewlineAtTheEnd: Bool) -> String {
+    let time = dateFormatter.string(from: Date())
+    return "\(time) [\(subsystem.rawValue)][\(level.description)] \(message)\(appendNewlineAtTheEnd ? "\n" : "")"
   }
 
   static func log(_ message: String, level: Level = .debug, subsystem: Subsystem = .general, appendNewlineAtTheEnd: Bool = true) {
@@ -78,33 +155,60 @@ struct Logger {
     #endif
 
     guard level >= .preferred else { return }
-    let time = dateFormatter.string(from: Date())
-    let string = "\(time) [\(subsystem.rawValue)][\(level.description)] \(message)\(appendNewlineAtTheEnd ? "\n" : "")"
+    let string = formatMessage(message, level, subsystem, appendNewlineAtTheEnd)
     print(string, terminator: "")
 
     #if DEBUG
     guard enabled else { return }
     #endif
 
-    if let data = string.data(using: .utf8) {
-      logFileHandle.write(data)
-    } else {
-      NSLog("Cannot encode log string!")
+    guard let data = string.data(using: .utf8) else {
+      print(formatMessage("Cannot encode log string!", .error, Logger.loggerSubsystem, false))
+      return
+    }
+    // Lock to prevent the log file from being closed by another thread while writing to it.
+    lock.withLock() {
+      // The logger may be called after it has been closed.
+      guard let logFileHandle = logFileHandle else { return }
+      do {
+        // The deprecated write method is used instead of the replacement method that throws swift
+        // exceptions because testing the new method with macOS 12.5.1 showed that method failed to
+        // turn all objective-c exceptions into swift exceptions. The exception thrown for writing
+        // to a closed channel was not picked up by the catch block.
+        try ObjcUtils.catchException { logFileHandle.write(data) }
+      } catch {
+        print(formatMessage("Cannot write to log file: \(error.localizedDescription)", .error,
+                            Logger.loggerSubsystem, false))
+      }
     }
   }
 
   static func ensure(_ condition: @autoclosure () -> Bool, _ errorMessage: String = "Assertion failed in \(#line):\(#file)", _ cleanup: () -> Void = {}) {
     guard condition() else {
       log(errorMessage, level: .error)
-      Utility.showAlert("fatal_error", arguments: [errorMessage])
-      cleanup()
-      exit(1)
+      showAlertAndExit(errorMessage, cleanup)
     }
   }
 
   static func fatal(_ message: String, _ cleanup: () -> Void = {}) -> Never {
     log(message, level: .error)
     log(Thread.callStackSymbols.joined(separator: "\n"))
+    showAlertAndExit(message, cleanup)
+  }
+
+  /// Reports a fatal error during logger initialization and stops execution.
+  ///
+  /// This method will print the given error message to the console and then show an alert to the user. When the user dismisses the
+  /// alert this method will terminate the process with an exit code of one.
+  /// - Parameter message: The fatal error to report.
+  /// - Important: This method differs from the method `fatal` in that it is designed to be safe to call during logger initialization
+  ///     and therefore intentionally avoids attempting to log the fatal error message.
+  private static func fatalDuringInit(_ message: String) -> Never {
+    print(formatMessage(message, .error, Logger.loggerSubsystem, true))
+    showAlertAndExit(message)
+  }
+
+  private static func showAlertAndExit(_ message: String, _ cleanup: () -> Void = {}) -> Never {
     Utility.showAlert("fatal_error", arguments: [message])
     cleanup()
     exit(1)

--- a/iina/Logger.swift
+++ b/iina/Logger.swift
@@ -57,11 +57,11 @@ struct Logger {
 
   static let logDirectory: URL = {
     // get path
-    let libraryPath = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)
-    guard libraryPath.count >= 1 else {
-      fatalDuringInit("Cannot get path to Logs directory: \(libraryPath)")
+    let libraryPaths = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)
+    guard let libraryPath = libraryPaths.first else {
+      fatalDuringInit("Cannot get path to Logs directory: \(libraryPaths)")
     }
-    let logsUrl = libraryPath.first!.appendingPathComponent("Logs", isDirectory: true)
+    let logsUrl = libraryPath.appendingPathComponent("Logs", isDirectory: true)
     let bundleID = Bundle.main.bundleIdentifier!
     let appLogsUrl = logsUrl.appendingPathComponent(bundleID, isDirectory: true)
 

--- a/iina/PrefAdvancedViewController.swift
+++ b/iina/PrefAdvancedViewController.swift
@@ -70,7 +70,7 @@ class PrefAdvancedViewController: PreferenceViewController, PreferenceWindowEmbe
   // MARK: - IBAction
 
   @IBAction func revealLogDir(_ sender: AnyObject) {
-    NSWorkspace.shared.open(Utility.logDirURL)
+    NSWorkspace.shared.open(Logger.logDirectory)
   }
 
   @IBAction func addOptionBtnAction(_ sender: AnyObject) {

--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -356,17 +356,6 @@ class Utility {
     return url
   }()
 
-  static let logDirURL: URL = {
-    // get path
-    let libraryPath = FileManager.default.urls(for: .libraryDirectory, in: .userDomainMask)
-    Logger.ensure(libraryPath.count >= 1, "Cannot get path to Logs directory")
-    let logsUrl = libraryPath.first!.appendingPathComponent("Logs", isDirectory: true)
-    let bundleID = Bundle.main.bundleIdentifier!
-    let appLogsUrl = logsUrl.appendingPathComponent(bundleID, isDirectory: true)
-    createDirIfNotExist(url: appLogsUrl)
-    return appLogsUrl
-  }()
-
   static let watchLaterURL: URL = {
     let url = Utility.appSupportDirUrl.appendingPathComponent(AppData.watchLaterFolder, isDirectory: true)
     createDirIfNotExist(url: url)


### PR DESCRIPTION
The commit in the pull request will:
- Add a new Lock class
- Change Logger to use a lock to coordinate closing of the log file
- Change Logger to not use `Utilities` methods that call back into the logger
- Change Logger to catch and handle exceptions thrown by file operations
- Remove logDirURL from Utilities
- Change PrefAdvancedViewController to use Logger.logDirectory instead of Utilities.logDirURL

These changes address multiple ways in which the logger can cause IINA to crash.

- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3590.

---

**Description:**
A new proposed fix for this issue that directly addresses the logger crash.