### PR TITLE
Improve the file api performance for plugin system

### DIFF
--- a/iina/JavascriptAPIFile.swift
+++ b/iina/JavascriptAPIFile.swift
@@ -248,7 +248,7 @@ class JavascriptFileHandle: NSObject, JavascriptFileHandleExportable {
         ptr?.deallocate()
     }
     let arrayBufferRef = JSObjectMakeTypedArrayWithBytesNoCopy(context.jsGlobalContextRef,
-                                                                kJSTypedArrayTypeInt8Array,
+                                                                kJSTypedArrayTypeUint8Array,
                                                                 rawPtr.baseAddress,
                                                                 length,
                                                                 deallocator,

--- a/iina/JavascriptAPIFile.swift
+++ b/iina/JavascriptAPIFile.swift
@@ -240,20 +240,20 @@ class JavascriptFileHandle: NSObject, JavascriptFileHandleExportable {
   private func createUInt8Array(fromData data: Data) -> JSValue? {
     let context = JSContext.current()!
     let length = data.count
-    let getter: @convention(block) (Int) -> UInt8 = { offset in
-      return data[offset]
+    let rawPtr = UnsafeMutableBufferPointer<UInt8>.allocate(capacity: length)
+    _ = data.withUnsafeBytes { (dataPtr: UnsafeRawBufferPointer) in
+      rawPtr.initialize(from: dataPtr)
     }
-    context.setObject(getter, forKeyedSubscript: "__iina_data_getter" as NSString)
-
-    let array = context.evaluateScript("""
-    Uint8Array.from(function* () {
-      for (let i = 0; i < \(length); i++) {
-        yield __iina_data_getter(i);
-      }
-    }())
-    """)
-
-    context.setObject(nil, forKeyedSubscript: "__iina_data_getter" as NSString)
-    return array
+    let deallocator: JSTypedArrayBytesDeallocator = { ptr, _ in
+        ptr?.deallocate()
+    }
+    let arrayBufferRef = JSObjectMakeTypedArrayWithBytesNoCopy(context.jsGlobalContextRef,
+                                                                kJSTypedArrayTypeInt8Array,
+                                                                rawPtr.baseAddress,
+                                                                length,
+                                                                deallocator,
+                                                                nil,
+                                                                nil)
+    return JSValue(jsValueRef: arrayBufferRef, in: context)
   }
 }


### PR DESCRIPTION

- [ ] This change has been discussed with the author.
- [ ] It implements / fixes issue #.

---

**Description:**

The current plugin file system read api is very slow, it takes ~8s to read 16MB file. The bottleneck is createUInt8Array which are copying in JavaScript.

In this PR we can directly use JavaScriptCore API JSObjectMakeTypedArrayWithBytesNoCopy to create type array directly in Swift, which is much faster

Test on Mac Studio (M1 Max), read 16 MB File to javascript
Before Change: 7338ms
After Change: 3.94 ms
