### PR TITLE
Fix random failure to resume playback position, #3939

### DIFF
--- a/iina/AppData.swift
+++ b/iina/AppData.swift
@@ -114,4 +114,6 @@ extension Notification.Name {
   static let iinaLegacyFullScreen = Notification.Name("IINALegacyFullScreen")
   static let iinaKeyBindingChanged = Notification.Name("iinaKeyBindingChanged")
   static let iinaPluginChanged = Notification.Name("IINAPluginChanged")
+  static let iinaPlayerStopped = Notification.Name("iinaPlayerStopped")
+  static let iinaPlayerShutdown = Notification.Name("iinaPlayerShutdown")
 }

--- a/iina/JavascriptAPIGlobal.swift
+++ b/iina/JavascriptAPIGlobal.swift
@@ -30,7 +30,7 @@ class JavascriptAPIGlobalController: JavascriptAPI, JavascriptAPIGlobalControlle
   override func cleanUp(_ instance: JavascriptPluginInstance) {
     instances.values.forEach {
       $0.mainWindow.close()
-      $0.terminateMPV()
+      $0.shutdown()
     }
     instances.removeAll()
     childAPIs.removeAll()

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1115,16 +1115,10 @@ class MainWindowController: PlayerWindowController {
       }
     }
     // stop playing
-    if !player.isMpvTerminated {
-      if case .fullscreen(legacy: true, priorWindowedFrame: _) = fsState {
-        restoreDockSettings()
-      }
-      player.savePlaybackPosition()
-      player.stop()
-      videoView.stopDisplayLink()
+    if case .fullscreen(legacy: true, priorWindowedFrame: _) = fsState {
+      restoreDockSettings()
     }
-    player.info.currentFolder = nil
-    player.info.matchedSubs.removeAll()
+    player.stop()
     // stop tracking mouse event
     guard let w = self.window, let cv = w.contentView else { return }
     cv.trackingAreas.forEach(cv.removeTrackingArea)

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -168,6 +168,8 @@ class MenuController: NSObject, NSMenuDelegate {
   @IBOutlet weak var inspector: NSMenuItem!
   @IBOutlet weak var miniPlayer: NSMenuItem!
 
+  /// If `true` then all menu items are disabled.
+  private var isDisabled = false
 
   // MARK: - Construct Menus
 
@@ -677,6 +679,8 @@ class MenuController: NSObject, NSMenuDelegate {
   // MARK: - Menu delegate
 
   func menuWillOpen(_ menu: NSMenu) {
+    // If all menu items are disabled do not update the menus.
+    guard !isDisabled else { return }
     switch menu {
     case fileMenu:
       updateOpenMenuItems()
@@ -826,6 +830,27 @@ class MenuController: NSObject, NSMenuDelegate {
         menuItem.keyEquivalent = ""
         menuItem.keyEquivalentModifierMask = []
       }
+    }
+  }
+
+  /// Disable all menu items.
+  ///
+  /// This method is used during application termination to stop any further input from the user.
+  func disableAllMenus() {
+    isDisabled = true
+    disableAllMenuItems(NSApp.mainMenu!)
+  }
+
+  /// Disable all menu items in the given menu and any submenus.
+  ///
+  /// This method recursively descends through the entire tree of menu items disabling all items.
+  /// - Parameter menu: Menu to disable
+  private func disableAllMenuItems(_ menu: NSMenu) {
+    for item in menu.items {
+      if item.hasSubmenu {
+        disableAllMenuItems(item.submenu!)
+      }
+      item.isEnabled = false
     }
   }
 }

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -186,7 +186,7 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
   func windowWillClose(_ notification: Notification) {
     player.switchedToMiniPlayerManually = false
     player.switchedBackFromMiniPlayerManually = false
-    if !player.isMpvTerminated {
+    if !player.isShuttingDown {
       // not needed if called when terminating the whole app
       player.switchBackFromMiniPlayer(automatically: true, showMainWindow: false)
     }

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -2039,7 +2039,7 @@ class NowPlayingInfoManager {
     var info = center.nowPlayingInfo ?? [String: Any]()
 
     let activePlayer = PlayerCore.lastActive
-    guard !activePlayer.isMpvTerminated else { return }
+    guard !activePlayer.isShuttingDown else { return }
 
     if withTitle {
       if activePlayer.currentMediaIsAudio == .isAudio {

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -115,6 +115,7 @@ class PlayerCore: NSObject {
   var miniPlayer: MiniPlayerWindowController!
 
   var mpv: MPVController!
+
   var plugins: [JavascriptPluginInstance] = []
   private var pluginMap: [String: JavascriptPluginInstance] = [:]
   var pluginMenuNeedsUpdate = false
@@ -132,7 +133,14 @@ class PlayerCore: NSObject {
 
   var displayOSD: Bool = true
 
-  var isMpvTerminated: Bool = false
+  /// Whether shutdown of this player has been initiated.
+  var isShuttingDown = false
+
+  /// Whether shutdown of this player has completed (mpv has shutdown).
+  var isShutdown = false
+
+  /// Whether mpv playback has stopped and the media has been unloaded.
+  var isStopped = true
 
   var isInMiniPlayer = false
   var switchedToMiniPlayerManually = false
@@ -373,16 +381,38 @@ class PlayerCore: NSObject {
     mainWindow.videoView.uninit()
   }
 
-  // Terminate mpv
-  func terminateMPV(sendQuit: Bool = true) {
-    guard !isMpvTerminated else { return }
+  private func savePlayerState() {
     savePlaybackPosition()
     invalidateTimer()
     uninitVideo()
-    if sendQuit {
-      mpv.mpvQuit()
+  }
+
+  /// Initiate shutdown of this player.
+  ///
+  /// This method is intended to only be used during application termination. Once shutdown has been initiated player methods
+  /// **must not** be called.
+  /// - Important: As a part of shutting down the player this method sends a quit command to mpv. Even though the command is
+  ///     sent to mpv using the synchronous API mpv executes the quit command asynchronously. The player is not fully shutdown
+  ///     until mpv finishes executing the quit command and shuts down.
+  func shutdown() {
+    guard !isShuttingDown else { return }
+    isShuttingDown = true
+    Logger.log("Shutting down", subsystem: subsystem)
+    savePlayerState()
+    mpv.mpvQuit()
+  }
+
+  func mpvHasShutdown(isMPVInitiated: Bool = false) {
+    let suffix = isMPVInitiated ? " (initiated by mpv)" : ""
+    Logger.log("Player has shutdown\(suffix)", subsystem: subsystem)
+    isStopped = true
+    isShutdown = true
+    // If mpv shutdown was initiated by mpv then the player state has not been saved.
+    if isMPVInitiated {
+      isShuttingDown = true
+      savePlayerState()
     }
-    isMpvTerminated = true
+    postNotification(.iinaPlayerShutdown)
   }
 
   // invalidate timer
@@ -509,9 +539,31 @@ class PlayerCore: NSObject {
     mpv.setFlag(MPVOption.PlaybackControl.pause, false)
   }
 
+  /// Stop playback and unload the media.
   func stop() {
-    mpv.command(.stop)
+    savePlaybackPosition()
+
+    mainWindow.videoView.stopDisplayLink()
     invalidateTimer()
+
+    info.currentFolder = nil
+    info.matchedSubs.removeAll()
+
+    // Do not send a stop command to mpv if it is already stopped. This happens when quitting is
+    // initiated directly through mpv.
+    guard !isStopped else { return }
+    Logger.log("Stopping playback", subsystem: subsystem)
+    mpv.command(.stop)
+  }
+
+  /// Playback has stopped and the media has been unloaded.
+  ///
+  /// This method is called by `MPVController` when mpv emits an event indicating the asynchronous mpv `stop` command
+  /// has completed executing.
+  func playbackStopped() {
+    Logger.log("Playback has stopped", subsystem: subsystem)
+    isStopped = true
+    postNotification(.iinaPlayerStopped)
   }
 
   func toggleMute(_ set: Bool? = nil) {
@@ -1210,8 +1262,13 @@ class PlayerCore: NSObject {
 
   func savePlaybackPosition() {
     guard Preference.bool(for: .resumeLastPosition) else { return }
-    Logger.log("Write watch later config", subsystem: subsystem)
-    mpv.command(.writeWatchLaterConfig)
+
+    // If the player is stopped then the file has been unloaded and it is too late to save the
+    // watch later configuration.
+    if !isStopped {
+      Logger.log("Write watch later config", subsystem: subsystem)
+      mpv.command(.writeWatchLaterConfig)
+    }
     if let url = info.currentURL {
       Preference.set(url, for: .iinaLastPlayedFilePath)
       // Write to cache directly (rather than calling `refreshCachedVideoProgress`).
@@ -1233,6 +1290,7 @@ class PlayerCore: NSObject {
 
   func fileStarted(path: String) {
     Logger.log("File started", subsystem: subsystem)
+    isStopped = false
     info.justStartedFile = true
     info.disableOSDForFileLoading = true
     currentMediaIsAudio = .unknown
@@ -1366,6 +1424,8 @@ class PlayerCore: NSObject {
   }
 
   func trackListChanged() {
+    // Must not process track list changes if mpv is terminating.
+    guard !isShuttingDown else { return }
     Logger.log("Track list changed", subsystem: subsystem)
     getTrackInfo()
     getSelectedTracks()
@@ -1396,6 +1456,7 @@ class PlayerCore: NSObject {
   func refreshEdrMode() {
     guard mainWindow.loaded else { return }
     DispatchQueue.main.async {
+      guard !self.isStopped else { return }
       self.mainWindow.videoView.refreshEdrMode()
     }
   }


### PR DESCRIPTION
This commit will:
- Add isStopped and isShutdown properties to PlayerCore
- Rename PlayerCore property isMpvTerminated to isShuttingDown
- Add playbackStopped and mpvHasShutdown methods to PlayerCore
- Add savePlayerState method to PlayerCore
- Add iinaPlayerStopped and iinaPlayerShutdown notifications
- Change PlayerCore to post the new notifications
- Change savePlaybackPosition to not send a command to write the watch later file if playback has been stopped
- Move code in MainWindowController method windowWillClose related to stopping playback to the PlayerCore stop method
- Change MPVController to inform PlayerCore when the stop command finishes and when mpv shuts down
- Change MPVController to remove IINA preference observers before sending a quit command to mpv
- Change MPVController to not use the main dispatch queue when calling NSApp.terminate to avoid blocking the queue
- Add an isDisabled property to MenuController
- Add disableAllMenus and disableAllMenuItems methods to MenuController
- Change menuWillOpen to not update menus if menus are disabled
- Add a disableAllCommands method to RemoteCommandController
- Add isTerminated property to AppDelegate
- Add a removeAllMenuItems method to AppDelegate
- Change AppDelegate method applicationShouldHandleReopen to not permit reopening during termination
- Change AppDelegate method applicationShouldTerminate to return terminateLater to Cocoa to delay termination until mpv has finished shutting down
- Change applicationShouldTerminate to shutdown further user input and coordinate application shutdown using observers for the new iinaPlayerStopped and iinaPlayerShutdown notifications

From a high level perspective these changes:
- Stop further input from the user once application termination starts
- Disallow reopening during termination
- Wait for the asynchronous mpv stop command to complete before sending the mpv quit command
- Wait for the asynchronous quit command to complete before allowing Cocoa to proceed with termination

These changes are needed because mpv may decide to write to the watch later file and then fail to store the playback position if the quit command is sent to mpv while a stop command is still executing. This breaks the "Resume last playback position" IINA feature. To correct this IINA must move to a controlled clean shutdown.

- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3939.

---

**Description:**
This proposed fix replaces the original thread based fix with one that is event driven.