### PR TITLE
Fix white window after entering PIP when pausing

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2737,7 +2737,9 @@ extension MainWindowController: PIPViewControllerDelegate {
     // Therefore we should wait until the view is moved to the PIP superview.
     let currentTrackIsAlbumArt = player.info.currentTrack(.video)?.isAlbumart ?? false
     if player.info.isPaused || currentTrackIsAlbumArt {
-      videoView.pendingRedrawAfterEnteringPIP = true
+      // It takes two `layout` before finishing entering PIP (tested on macOS 12, but
+      // could be earlier). Force redraw for the first two `layout`s.
+      videoView.pendingRedrawAfterEnteringPIPCount = 2
     }
 
     if let window = self.window {

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2739,7 +2739,7 @@ extension MainWindowController: PIPViewControllerDelegate {
     if player.info.isPaused || currentTrackIsAlbumArt {
       // It takes two `layout` before finishing entering PIP (tested on macOS 12, but
       // could be earlier). Force redraw for the first two `layout`s.
-      videoView.pendingRedrawAfterEnteringPIPCount = 2
+      videoView.pendingRedrawsAfterEnteringPIP = 2
     }
 
     if let window = self.window {

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -37,7 +37,7 @@ class VideoView: NSView {
   // cached indicator to prevent unnecessary updates of DisplayLink
   var currentDisplay: UInt32?
 
-  var pendingRedrawAfterEnteringPIP = false;
+  var pendingRedrawAfterEnteringPIPCount = 0;
 
   lazy var hdrSubsystem = Logger.Subsystem(rawValue: "hdr")
 
@@ -95,9 +95,9 @@ class VideoView: NSView {
 
   override func layout() {
     super.layout()
-    if pendingRedrawAfterEnteringPIP && superview != nil {
+    if pendingRedrawAfterEnteringPIPCount != 0 && superview != nil {
+      pendingRedrawAfterEnteringPIPCount -= 1
       videoLayer.draw(forced: true)
-      pendingRedrawAfterEnteringPIP = false
     }
   }
 

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -37,7 +37,7 @@ class VideoView: NSView {
   // cached indicator to prevent unnecessary updates of DisplayLink
   var currentDisplay: UInt32?
 
-  var pendingRedrawAfterEnteringPIPCount = 0;
+  var pendingRedrawsAfterEnteringPIP = 0;
 
   lazy var hdrSubsystem = Logger.Subsystem(rawValue: "hdr")
 
@@ -95,8 +95,8 @@ class VideoView: NSView {
 
   override func layout() {
     super.layout()
-    if pendingRedrawAfterEnteringPIPCount != 0 && superview != nil {
-      pendingRedrawAfterEnteringPIPCount -= 1
+    if pendingRedrawsAfterEnteringPIP != 0 && superview != nil {
+      pendingRedrawsAfterEnteringPIP -= 1
       videoLayer.draw(forced: true)
     }
   }


### PR DESCRIPTION
We need to redraw a frame after entering PIP when pausing, and previously we perform such redraw in the next `layout`. However, it now takes two `layout`s before finishing entering PIP. This was tested on macOS 13 beta and macOS 12.6.

Changing the pending flag into a counter and redrawing twice solve the problem.