### PR TITLE
Fix subtitles won't show, any source, #3431

### DIFF
--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -80,6 +80,8 @@
 "osd.file_error" = "Error reading file";
 "osd.cannot_login" = "Cannot login";
 "osd.canceled" = "Canceled";
+"osd.cannot_connect" = "Cannot connect";
+"osd.timed_out" = "Timed Out";
 "osd.filter_added" = "Added Filter: %@";
 "osd.filter_removed" = "Removed Filter";
 "osd.file_loop" = "File Loop: %@";
@@ -186,6 +188,7 @@
 "alert.sub_lang_not_set" = "Please set preferred subtitle languages in preferences before using OpenSubtitles. English(eng) will be used this time.";
 "alert.sub.cannot_save_passwd" = "Cannot save your password to Keychain: %@";
 "alert.sub.cannot_login" = "Cannot login. Please check your username, password and network status.\n\n%@";
+"alert.sub.save_downloaded.title" = "Save Downloaded Subtitle";
 
 "alert.set_default.title" = "Setting IINA as Default App";
 "alert.set_default.message" = "IINA will be set as the default app for all file types it supports.";

--- a/iina/Base.lproj/MainMenu.xib
+++ b/iina/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21225" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21225"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -551,7 +551,7 @@ CA
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Find Online Subtitles from" id="i0H-bE-bH8"/>
                             </menuItem>
-                            <menuItem title="Save Downloaded Subtitle" id="9zk-co-roT">
+                            <menuItem title="Save Downloaded Subtitle…" id="9zk-co-roT">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="58S-lP-UEY"/>

--- a/iina/JustXMLRPC.swift
+++ b/iina/JustXMLRPC.swift
@@ -21,6 +21,7 @@ class JustXMLRPC {
     var readableDescription: String {
       return "\(method): [\(httpCode)] \(reason)"
     }
+    var underlyingError: Error?
   }
 
   enum Result {
@@ -74,7 +75,8 @@ class JustXMLRPC {
         }
       } else {
         // http error
-        callback(.error(XMLRPCError(method: method, httpCode: response.statusCode ?? 0, reason: response.reason)))
+        callback(.error(XMLRPCError(method: method, httpCode: response.statusCode ?? 0,
+                                    reason: response.reason, underlyingError: response.error)))
       }
     })
   }

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -342,7 +342,6 @@ extension MainMenuActionHandler {
 
   @objc func saveDownloadedSub(_ sender: NSMenuItem) {
     let selected = player.info.subTracks.filter { $0.id == player.info.sid }
-    guard let currURL = player.info.currentURL else { return }
     guard selected.count > 0 else {
       Utility.showAlert("sub.no_selected")
 
@@ -356,13 +355,27 @@ extension MainMenuActionHandler {
     }
     let subURL = URL(fileURLWithPath: path)
     let subFileName = subURL.lastPathComponent
-    let destURL = currURL.deletingLastPathComponent().appendingPathComponent(subFileName, isDirectory: false)
-    do {
-      try FileManager.default.copyItem(at: subURL, to: destURL)
-      player.sendOSD(.savedSub)
-    } catch let error as NSError {
-      Utility.showAlert("error_saving_file", arguments: ["subtitle",
-                                                         error.localizedDescription])
+    Utility.quickSavePanel(title: NSLocalizedString("alert.sub.save_downloaded.title",
+         comment: "Save Downloaded Subtitle"), filename: subFileName) { (destURL) in
+      do {
+        // The Save panel checks to see if a file already exists and if so asks if it should be
+        // replaced. The quickSavePanel would not have called this code if the user canceled, so if
+        // the destination file already exists move it to the trash.
+        do {
+          try FileManager.default.trashItem(at: destURL, resultingItemURL: nil)
+            Logger.log("Trashed existing subtitle file \(destURL)")
+          } catch CocoaError.fileNoSuchFile {
+            // Expected, ignore error. The Apple Secure Coding Guide in the section Race Conditions
+            // and Secure File Operations recommends attempting an operation and handling errors
+            // gracefully instead of trying to figure out ahead of time whether the operation will
+            // succeed.
+          }
+          try FileManager.default.copyItem(at: subURL, to: destURL)
+          Logger.log("Saved downloaded subtitle to \(destURL.path)")
+          self.player.sendOSD(.savedSub)
+      } catch let error as NSError {
+        Utility.showAlert("error_saving_file", arguments: ["subtitle", error.localizedDescription])
+      }
     }
   }
 

--- a/iina/OSDMessage.swift
+++ b/iina/OSDMessage.swift
@@ -72,6 +72,9 @@ enum OSDMessage {
   case fileError
   case networkError
   case canceled
+  case cannotConnect
+  case timedOut
+
   case fileLoop(Bool)
   case playlistLoop(Bool)
 
@@ -307,6 +310,18 @@ enum OSDMessage {
     case .canceled:
       return (
         NSLocalizedString("osd.canceled", comment: "Canceled"),
+        .normal
+      )
+
+    case .cannotConnect:
+      return (
+        NSLocalizedString("osd.cannot_connect", comment: "Cannot connect"),
+        .normal
+      )
+
+    case .timedOut:
+      return (
+        NSLocalizedString("osd.timed_out", comment: "Timed out"),
         .normal
       )
 

--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -194,11 +194,15 @@ class Utility {
   /**
    Pop up a save panel.
    */
-  static func quickSavePanel(title: String, types: [String], sheetWindow: NSWindow? = nil, callback: @escaping (URL) -> Void) {
+  static func quickSavePanel(title: String, filename: String? = nil, types: [String]? = nil,
+                             sheetWindow: NSWindow? = nil, callback: @escaping (URL) -> Void) {
     let panel = NSSavePanel()
     panel.title = title
     panel.canCreateDirectories = true
     panel.allowedFileTypes = types
+    if filename != nil {
+      panel.nameFieldStringValue = filename!
+    }
     let handler: (NSApplication.ModalResponse) -> Void = { result in
       if result == .OK, let url = panel.url {
         callback(url)


### PR DESCRIPTION
This commit will:

- Change OpenSubSubtitle.hash to throw noResult if the video is being streamed
- Change OpenSubSubtitle.requestIMDB to use the media title as the text for the lookup if the video is being streamed
- Change OpenSubSubtitle.hash and ShooterSubtitle.hash to ensure file is closed
- Improve logging when obtaining subtitles
- Change MainMenuActions.saveDownloadedSub to bring up a Save panel to ask the user where to save the downloaded subtitle file
- Change the "Save Downloaded Subtitle" menu item to end with an ellipsis to indicate the user will be prompted for additional information
- Change Utility.quickSavePanel to accept an optional filename parameter
- Add "Cannot connect" OSD message
- Add "Timed out" OSD message
- Change subtitle classes to use an extension when defining the logger subsystem
- Add parameter labels to trailing closures in AssrtSubtitle methods

With these changes subtitles can be downloaded and viewed for movies streamed from YouTube and from Dailymotion when using OpenSubtitles.org.

This is a reimplementation of the fix in PR #3499 that was applied only to the 1.3.0 branch to avoid merge conflicts with the plugin system. The fix has been adapted to be compatible with the changes made to the subtitle modules to support the plugin system.

The reimplementation also adds two new OSD messages for common failures when connecting to opensubtitles.org and improves some of the logging.

This commit also eliminates Swift compiler build warnings due to backward matching of unlabeled trailing closure being deprecated. These warnings had been eliminated but were reintroduced during the large merge of the plugin system.

- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3431.

---

**Description:**
This is a replacement for the commit in PR #3944. This commit removes the language translation files that were inappropriately included in that PR. This commit only includes changes to the base translation files. I am posting a new PR with this commit that replaces PR  #3944. PR #3944 will be closed.