### PR TITLE
Fix TSan: data race ViewLayer.forceRender, #3827

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -1404,8 +1404,5 @@ fileprivate func mpvGetOpenGLFunc(_ ctx: UnsafeMutableRawPointer?, _ name: Unsaf
 fileprivate func mpvUpdateCallback(_ ctx: UnsafeMutableRawPointer?) {
   let layer = bridge(ptr: ctx!) as ViewLayer
   guard !layer.blocked else { return }
-
-  layer.mpvGLQueue.async {
-    layer.draw()
-  }
+  layer.draw()
 }

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1992,11 +1992,7 @@ class MainWindowController: PlayerWindowController {
       videoView.needsLayout = true
       videoView.layoutSubtreeIfNeeded()
       // force rerender a frame
-      videoView.videoLayer.mpvGLQueue.async {
-        DispatchQueue.main.sync {
-          self.videoView.videoLayer.draw()
-        }
-      }
+      videoView.videoLayer.draw(forced: true)
     }
 
     let controlView = mode.viewController()

--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -14,7 +14,7 @@ class ViewLayer: CAOpenGLLayer {
 
   weak var videoView: VideoView!
 
-  lazy var mpvGLQueue = DispatchQueue(label: "com.colliderli.iina.mpvgl", qos: .userInteractive)
+  private let mpvGLQueue = DispatchQueue(label: "com.colliderli.iina.mpvgl", qos: .userInteractive)
   var blocked = false
 
   private var fbo: GLint = 1
@@ -143,28 +143,30 @@ class ViewLayer: CAOpenGLLayer {
   }
 
   func draw(forced: Bool = false) {
-    needsMPVRender = true
-    if forced { forceRender = true }
-    display()
-    if forced {
-      forceRender = false
-      return
-    }
-    if needsMPVRender {
-      videoView.player.mpv.lockAndSetOpenGLContext()
-      defer { videoView.player.mpv.unlockOpenGLContext() }
-      // draw(inCGLContext:) is not called, needs a skip render
-      if !videoView.isUninited, let renderContext = videoView.player.mpv.mpvRenderContext {
-        var skip: CInt = 1
-        withUnsafeMutablePointer(to: &skip) { skip in
-          var params: [mpv_render_param] = [
-            mpv_render_param(type: MPV_RENDER_PARAM_SKIP_RENDERING, data: .init(skip)),
-            mpv_render_param()
-          ]
-          mpv_render_context_render(renderContext, &params);
-        }
+    mpvGLQueue.async { [self] in
+      needsMPVRender = true
+      if forced { forceRender = true }
+      display()
+      if forced {
+        forceRender = false
+        return
       }
-      needsMPVRender = false
+      if needsMPVRender {
+        videoView.player.mpv.lockAndSetOpenGLContext()
+        defer { videoView.player.mpv.unlockOpenGLContext() }
+        // draw(inCGLContext:) is not called, needs a skip render
+        if !videoView.isUninited, let renderContext = videoView.player.mpv.mpvRenderContext {
+          var skip: CInt = 1
+          withUnsafeMutablePointer(to: &skip) { skip in
+            var params: [mpv_render_param] = [
+              mpv_render_param(type: MPV_RENDER_PARAM_SKIP_RENDERING, data: .init(skip)),
+              mpv_render_param()
+            ]
+            mpv_render_context_render(renderContext, &params);
+          }
+        }
+        needsMPVRender = false
+      }
     }
   }
 


### PR DESCRIPTION
This commit will:

- Change VideoLaye.draw to queue a task to the mpvGLQueue queue
- Change MPVController.mpvUpdateCallback to call draw directly
- Change MainWindowController.enterInteractiveMode  to call draw directly
- Change mpvGLQueue to be a private constant

These changes cause all drawing to occur from tasks submitted to mpvGLQueue . Restricting all drawing to a single serial dispatch queue eliminates the data race with these two properties.

- [x] This change has been discussed with the author.
- [x] It implements / fixes issue #3827.

---

**Description:**
