### PR TITLE
Fix toggle menus to adhere to HIG, #3116

### DIFF
--- a/iina/AppData.swift
+++ b/iina/AppData.swift
@@ -89,8 +89,12 @@ struct Constants {
     static let hideChaptersPanel = NSLocalizedString("menu.hide_chapters", comment: "Hide Chapters Panel")
     static let playlistPanel = NSLocalizedString("menu.playlist", comment: "Show Playlist Panel")
     static let hidePlaylistPanel = NSLocalizedString("menu.hide_playlist", comment: "Hide Playlist Panel")
-    static let quickSettingsPanel = NSLocalizedString("menu.quicksettings", comment: "Show Quick Settings Panel")
-    static let hideQuickSettingsPanel = NSLocalizedString("menu.hide_quicksettings", comment: "Hide Quick Settings Panel")
+    static let videoPanel = NSLocalizedString("menu.video", comment: "Show Video Panel")
+    static let hideVideoPanel = NSLocalizedString("menu.hide_video", comment: "Hide Video Panel")
+    static let audioPanel = NSLocalizedString("menu.audio", comment: "Show Audio Panel")
+    static let hideAudioPanel = NSLocalizedString("menu.hide_audio", comment: "Hide Audio Panel")
+    static let subtitlesPanel = NSLocalizedString("menu.subtitles", comment: "Show Subtitles Panel")
+    static let hideSubtitlesPanel = NSLocalizedString("menu.hide_subtitles", comment: "Hide Subtitles Panel")
   }
   struct Time {
     static let infinite = VideoTime(999, 0, 0)

--- a/iina/AppData.swift
+++ b/iina/AppData.swift
@@ -85,6 +85,12 @@ struct Constants {
     static let exitPIP = NSLocalizedString("menu.exit_pip", comment: "Exit Picture-in-Picture")
     static let custom = NSLocalizedString("menu.crop_custom", comment: "Custom crop size")
     static let findOnlineSubtitles = NSLocalizedString("menu.find_online_sub", comment: "Find Online Subtitles")
+    static let chaptersPanel = NSLocalizedString("menu.chapters", comment: "Show Chapters Panel")
+    static let hideChaptersPanel = NSLocalizedString("menu.hide_chapters", comment: "Hide Chapters Panel")
+    static let playlistPanel = NSLocalizedString("menu.playlist", comment: "Show Playlist Panel")
+    static let hidePlaylistPanel = NSLocalizedString("menu.hide_playlist", comment: "Hide Playlist Panel")
+    static let quickSettingsPanel = NSLocalizedString("menu.quicksettings", comment: "Show Quick Settings Panel")
+    static let hideQuickSettingsPanel = NSLocalizedString("menu.hide_quicksettings", comment: "Hide Quick Settings Panel")
   }
   struct Time {
     static let infinite = VideoTime(999, 0, 0)

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -122,8 +122,12 @@
 "menu.hide_chapters" = "Hide Chapters Panel";
 "menu.playlist" = "Show Playlist Panel";
 "menu.hide_playlist" = "Hide Playlist Panel";
-"menu.quicksettings" = "Show Quick Settings Panel";
-"menu.hide_quicksettings" = "Hide Quick Settings Panel";
+"menu.video" = "Show Video Panel";
+"menu.hide_video" = "Hide Video Panel";
+"menu.audio" = "Show Audio Panel";
+"menu.hide_audio" = "Hide Audio Panel";
+"menu.subtitles" = "Show Subtitles Panel";
+"menu.hide_subtitles" = "Hide Subtitles Panel";
 
 "menu.seek_forward" = "Step Forward %.0fs";
 "menu.seek_backward" = "Step Backward %.0fs";

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -118,6 +118,12 @@
 "menu.pause" = "Pause";
 "menu.resume" = "Resume";
 "menu.speed" = "Speed: %.2fx";
+"menu.chapters" = "Show Chapters Panel";
+"menu.hide_chapters" = "Hide Chapters Panel";
+"menu.playlist" = "Show Playlist Panel";
+"menu.hide_playlist" = "Hide Playlist Panel";
+"menu.quicksettings" = "Show Quick Settings Panel";
+"menu.hide_quicksettings" = "Hide Quick Settings Panel";
 
 "menu.seek_forward" = "Step Forward %.0fs";
 "menu.seek_backward" = "Step Backward %.0fs";

--- a/iina/Base.lproj/MainMenu.xib
+++ b/iina/Base.lproj/MainMenu.xib
@@ -343,7 +343,7 @@ CA
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <menu key="submenu" title="Video" id="HyV-fh-RgO">
                         <items>
-                            <menuItem title="Show Quick Settings Panel" id="2t8-Ot-yoO">
+                            <menuItem title="Show Video Panel" id="2t8-Ot-yoO">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="HGF-Qh-LZk"/>
@@ -438,7 +438,7 @@ CA
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <menu key="submenu" title="Audio" id="sW8-ri-eA5">
                         <items>
-                            <menuItem title="Show Quick Settings Panel" id="43n-Ed-5kT">
+                            <menuItem title="Show Audio Panel" id="43n-Ed-5kT">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="Fs0-R8-rnS"/>
@@ -507,7 +507,7 @@ CA
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <menu key="submenu" title="Subtitles" id="EKp-Qx-4Mn">
                         <items>
-                            <menuItem title="Show Quick Settings Panel" id="8y7-Cy-lKT">
+                            <menuItem title="Show Subtitles Panel" id="8y7-Cy-lKT">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="EvW-J9-wqJ"/>

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2598,15 +2598,15 @@ class MainWindowController: PlayerWindowController {
       if let tab = tab {
         view.pleaseSwitchToTab(tab)
       }
-      showSideBar(viewController: view, type: .settings)
-    case .playlist:
+      showSideBar(viewController: view, type: .playlist)
+    case .settings:
       if let tab = tab {
         view.pleaseSwitchToTab(tab)
       }
       hideSideBar {
-        self.showSideBar(viewController: view, type: .settings)
+        self.showSideBar(viewController: view, type: .playlist)
       }
-    case .settings:
+    case .playlist:
       if view.currentTab == tab {
         if hideIfAlreadyShown {
           hideSideBar()

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -453,6 +453,12 @@ class MenuController: NSObject, NSMenuDelegate {
 
   private func updatePlaybackMenu() {
     let player = PlayerCore.active
+    let isDisplayingPlaylist = player.mainWindow.sideBarStatus == .playlist &&
+          player.mainWindow.playlistView.currentTab == .playlist
+    playlistPanel?.title = isDisplayingPlaylist ? Constants.String.hidePlaylistPanel : Constants.String.playlistPanel
+    let isDisplayingChapters = player.mainWindow.sideBarStatus == .playlist &&
+          player.mainWindow.playlistView.currentTab == .chapters
+    chapterPanel?.title = isDisplayingChapters ? Constants.String.hideChaptersPanel : Constants.String.chaptersPanel
     pause.title = player.info.isPaused ? Constants.String.resume : Constants.String.pause
     let isLoop = player.mpv.getString(MPVOption.PlaybackControl.loopFile) == "inf"
     fileLoop.state = isLoop ? .on : .off
@@ -462,12 +468,17 @@ class MenuController: NSObject, NSMenuDelegate {
   }
 
   private func updateVideoMenu() {
-    let isInFullScreen = PlayerCore.active.mainWindow.fsState.isFullscreen
-    let isInPIP = PlayerCore.active.mainWindow.pipStatus == .inPIP
-    let isOntop = PlayerCore.active.isInMiniPlayer ? PlayerCore.active.miniPlayer.isOntop : PlayerCore.active.mainWindow.isOntop
-    let isDelogo = PlayerCore.active.info.delogoFilter != nil
+    let player = PlayerCore.active
+    let isDisplayingSettings = player.mainWindow.sideBarStatus == .settings &&
+          player.mainWindow.quickSettingView.currentTab == .video
+    quickSettingsVideo?.title = isDisplayingSettings ? Constants.String.hideQuickSettingsPanel :
+        Constants.String.quickSettingsPanel
+    let isInFullScreen = player.mainWindow.fsState.isFullscreen
+    let isInPIP = player.mainWindow.pipStatus == .inPIP
+    let isOntop = player.isInMiniPlayer ? player.miniPlayer.isOntop : player.mainWindow.isOntop
+    let isDelogo = player.info.delogoFilter != nil
     alwaysOnTop.state = isOntop ? .on : .off
-    deinterlace.state = PlayerCore.active.info.deinterlace ? .on : .off
+    deinterlace.state = player.info.deinterlace ? .on : .off
     fullScreen.title = isInFullScreen ? Constants.String.exitFullScreen : Constants.String.fullScreen
     pictureInPicture?.title = isInPIP ? Constants.String.exitPIP : Constants.String.pip
     delogo.state = isDelogo ? .on : .off
@@ -475,6 +486,10 @@ class MenuController: NSObject, NSMenuDelegate {
 
   private func updateAudioMenu() {
     let player = PlayerCore.active
+    let isDisplayingSettings = player.mainWindow.sideBarStatus == .settings &&
+          player.mainWindow.quickSettingView.currentTab == .audio
+    quickSettingsAudio?.title = isDisplayingSettings ? Constants.String.hideQuickSettingsPanel :
+        Constants.String.quickSettingsPanel
     volumeIndicator.title = String(format: NSLocalizedString("menu.volume", comment: "Volume:"), Int(player.info.volume))
     audioDelayIndicator.title = String(format: NSLocalizedString("menu.audio_delay", comment: "Audio Delay:"), player.info.audioDelay)
   }
@@ -498,6 +513,9 @@ class MenuController: NSObject, NSMenuDelegate {
 
   private func updateSubMenu() {
     let player = PlayerCore.active
+    let isDisplayingSettings = player.mainWindow.sideBarStatus == .settings &&
+          player.mainWindow.quickSettingView.currentTab == .sub
+    quickSettingsSub?.title = isDisplayingSettings ? Constants.String.hideQuickSettingsPanel : Constants.String.quickSettingsPanel
     subDelayIndicator.title = String(format: NSLocalizedString("menu.sub_delay", comment: "Subtitle Delay:"), player.info.subDelay)
 
     let encodingCode = player.info.subEncoding ?? "auto"

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -471,8 +471,8 @@ class MenuController: NSObject, NSMenuDelegate {
     let player = PlayerCore.active
     let isDisplayingSettings = player.mainWindow.sideBarStatus == .settings &&
           player.mainWindow.quickSettingView.currentTab == .video
-    quickSettingsVideo?.title = isDisplayingSettings ? Constants.String.hideQuickSettingsPanel :
-        Constants.String.quickSettingsPanel
+    quickSettingsVideo?.title = isDisplayingSettings ? Constants.String.hideVideoPanel :
+        Constants.String.videoPanel
     let isInFullScreen = player.mainWindow.fsState.isFullscreen
     let isInPIP = player.mainWindow.pipStatus == .inPIP
     let isOntop = player.isInMiniPlayer ? player.miniPlayer.isOntop : player.mainWindow.isOntop
@@ -488,8 +488,8 @@ class MenuController: NSObject, NSMenuDelegate {
     let player = PlayerCore.active
     let isDisplayingSettings = player.mainWindow.sideBarStatus == .settings &&
           player.mainWindow.quickSettingView.currentTab == .audio
-    quickSettingsAudio?.title = isDisplayingSettings ? Constants.String.hideQuickSettingsPanel :
-        Constants.String.quickSettingsPanel
+    quickSettingsAudio?.title = isDisplayingSettings ? Constants.String.hideAudioPanel :
+        Constants.String.audioPanel
     volumeIndicator.title = String(format: NSLocalizedString("menu.volume", comment: "Volume:"), Int(player.info.volume))
     audioDelayIndicator.title = String(format: NSLocalizedString("menu.audio_delay", comment: "Audio Delay:"), player.info.audioDelay)
   }
@@ -515,7 +515,8 @@ class MenuController: NSObject, NSMenuDelegate {
     let player = PlayerCore.active
     let isDisplayingSettings = player.mainWindow.sideBarStatus == .settings &&
           player.mainWindow.quickSettingView.currentTab == .sub
-    quickSettingsSub?.title = isDisplayingSettings ? Constants.String.hideQuickSettingsPanel : Constants.String.quickSettingsPanel
+    quickSettingsSub?.title = isDisplayingSettings ? Constants.String.hideSubtitlesPanel :
+        Constants.String.subtitlesPanel
     subDelayIndicator.title = String(format: NSLocalizedString("menu.sub_delay", comment: "Subtitle Delay:"), player.info.subDelay)
 
     let encodingCode = player.info.subEncoding ?? "auto"

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -116,6 +116,16 @@
 "menu.pause" = "Pause";
 "menu.resume" = "Resume";
 "menu.speed" = "Speed: %.2fx";
+"menu.chapters" = "Show Chapters Panel";
+"menu.hide_chapters" = "Hide Chapters Panel";
+"menu.playlist" = "Show Playlist Panel";
+"menu.hide_playlist" = "Hide Playlist Panel";
+"menu.video" = "Show Video Panel";
+"menu.hide_video" = "Hide Video Panel";
+"menu.audio" = "Show Audio Panel";
+"menu.hide_audio" = "Hide Audio Panel";
+"menu.subtitles" = "Show Subtitles Panel";
+"menu.hide_subtitles" = "Hide Subtitles Panel";
 
 "menu.seek_forward" = "Step Forward %.0fs";
 "menu.seek_backward" = "Step Backward %.0fs";

--- a/iina/en.lproj/MainMenu.strings
+++ b/iina/en.lproj/MainMenu.strings
@@ -25,14 +25,14 @@
 /* Class = "NSMenuItem"; title = "Jump to…"; ObjectID = "2id-wn-xsC"; */
 "2id-wn-xsC.title" = "Jump to…";
 
-/* Class = "NSMenuItem"; title = "Show Quick Settings Panel"; ObjectID = "2t8-Ot-yoO"; */
-"2t8-Ot-yoO.title" = "Show Quick Settings Panel";
+/* Class = "NSMenuItem"; title = "Show Video Panel"; ObjectID = "2t8-Ot-yoO"; */
+"2t8-Ot-yoO.title" = "Show Video Panel";
 
 /* Class = "NSMenuItem"; title = "Select All"; ObjectID = "3Ax-P3-QQu"; */
 "3Ax-P3-QQu.title" = "Select All";
 
-/* Class = "NSMenuItem"; title = "Show Quick Settings Panel"; ObjectID = "43n-Ed-5kT"; */
-"43n-Ed-5kT.title" = "Show Quick Settings Panel";
+/* Class = "NSMenuItem"; title = "Show Audio Panel"; ObjectID = "43n-Ed-5kT"; */
+"43n-Ed-5kT.title" = "Show Audio Panel";
 
 /* Class = "NSMenuItem"; title = "Audio Delay + 0.5s"; ObjectID = "4ae-MT-2L1"; */
 "4ae-MT-2L1.title" = "Audio Delay + 0.5s";
@@ -70,8 +70,8 @@
 /* Class = "NSMenuItem"; title = "Speed:"; ObjectID = "8pV-XQ-AvB"; */
 "8pV-XQ-AvB.title" = "Speed:";
 
-/* Class = "NSMenuItem"; title = "Show Quick Settings Panel"; ObjectID = "8y7-Cy-lKT"; */
-"8y7-Cy-lKT.title" = "Show Quick Settings Panel";
+/* Class = "NSMenuItem"; title = "Show Subtitles Panel"; ObjectID = "8y7-Cy-lKT"; */
+"8y7-Cy-lKT.title" = "Show Subtitles Panel";
 
 /* Class = "NSMenuItem"; title = "Speed Up to 1.1x"; ObjectID = "91n-xW-L37"; */
 "91n-xW-L37.title" = "Speed Up to 1.1x";


### PR DESCRIPTION
This commit will change these toggle menus to use "Hide" in their title instead of "Show" when selecting the menu item hides the panel:
- Show Chapters Panel
- Show Playlist Panel
- Show Quick Settings Panel

This commit adds text that will require localization.

This fix only corrects one part of the reported issue. The behavior of buttons still needs to be updated to adhere to the HIG.

- [ ] This change has been discussed with the author.
- [x] It implements / fixes issue #3116.

---

**Description:**
This PR replaces the original PR, removing localization files.