### PR TITLE
Change `reveal` to `show` in UI & codebase

### DIFF
--- a/iina/Base.lproj/HistoryWindowController.xib
+++ b/iina/Base.lproj/HistoryWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21225" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21225"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -280,10 +280,10 @@
                     </connections>
                 </menuItem>
                 <menuItem isSeparatorItem="YES" id="Ray-7t-D5u"/>
-                <menuItem title="Reveal in Finder" tag="100" id="FPK-nx-hvF">
+                <menuItem title="Show in Finder" tag="100" id="FPK-nx-hvF">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
-                        <action selector="revealInFinderAction:" target="-2" id="Yq5-aR-1EY"/>
+                        <action selector="showInFinderAction:" target="-2" id="5eT-Zi-DEq"/>
                     </connections>
                 </menuItem>
                 <menuItem isSeparatorItem="YES" id="beT-X0-8gP"/>

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -167,7 +167,7 @@
 "alert.config.empty_name" = "The name cannot be empty.";
 "alert.config.name_existing" = "The name already exists.";
 "alert.config.file_existing.title" = "File Already Exists";
-"alert.config.file_existing.message" = "This should not happen. Choose OK to overwrite, Cancel to reveal the file in Finder.";
+"alert.config.file_existing.message" = "This should not happen. Choose OK to overwrite, Cancel to show the file in Finder.";
 "alert.config.cannot_create" = "Cannot create config file!\n%@";
 "alert.config.cannot_write" = "Cannot write to config file!";
 
@@ -263,7 +263,7 @@
 "pl_menu.delete_multi" = "Move Selected Files to Trash";
 "pl_menu.delete_after_play" = "Move to Trash After Playback";
 "pl_menu.delete_after_play_multi" = "Move Selected Files to Trash After Playback";
-"pl_menu.reveal_in_finder" = "Reveal in Finder";
+"pl_menu.show_in_finder" = "Show in Finder";
 "pl_menu.add_file" = "Add File…";
 "pl_menu.add_url" = "Add URL…";
 "pl_menu.clear_playlist" = "Clear Playlist";

--- a/iina/Base.lproj/PrefAdvancedViewController.xib
+++ b/iina/Base.lproj/PrefAdvancedViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21225" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21225"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -60,7 +60,7 @@
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                     <connections>
-                        <action selector="revealLogDir:" target="-2" id="VoU-0Y-IN8"/>
+                        <action selector="openLogDir:" target="-2" id="dfR-Jf-uSQ"/>
                         <binding destination="nyg-fH-Pug" name="enabled" keyPath="values.enableAdvancedSettings" id="CH7-kE-1sm"/>
                     </connections>
                 </button>

--- a/iina/Base.lproj/PrefKeyBindingViewController.xib
+++ b/iina/Base.lproj/PrefKeyBindingViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15705" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21225" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15705"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21225"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -18,7 +18,7 @@
                 <outlet property="mappingController" destination="xGz-Vh-hMb" id="hDG-Z5-OmL"/>
                 <outlet property="newConfigBtn" destination="iCp-ho-SlQ" id="LI0-TX-tNs"/>
                 <outlet property="removeKmBtn" destination="uFG-OF-DJ5" id="XWN-Lt-tmc"/>
-                <outlet property="revealConfFileBtn" destination="KZA-hu-vhZ" id="lVg-3j-Qgp"/>
+                <outlet property="showConfFileBtn" destination="KZA-hu-vhZ" id="lVg-3j-Qgp"/>
                 <outlet property="useMediaKeysButton" destination="LU9-QU-BFL" id="b9B-LC-pyM"/>
                 <outlet property="view" destination="Hz6-mo-xeY" id="0bl-1N-x8E"/>
             </connections>
@@ -122,13 +122,13 @@
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KZA-hu-vhZ">
-                    <rect key="frame" x="2" y="1" width="200" height="32"/>
-                    <buttonCell key="cell" type="push" title="Reveal config file in Finder" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="gDo-JL-a9k">
+                    <rect key="frame" x="1" y="1" width="210" height="32"/>
+                    <buttonCell key="cell" type="push" title="Show the config file in Finder" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="gDo-JL-a9k">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                     <connections>
-                        <action selector="revealConfFileAction:" target="-2" id="NK4-Mj-IlB"/>
+                        <action selector="showConfFileAction:" target="-2" id="IMG-HR-TWq"/>
                     </connections>
                 </button>
                 <box boxType="custom" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="mLe-eI-lIk">

--- a/iina/HistoryWindowController.swift
+++ b/iina/HistoryWindowController.swift
@@ -8,7 +8,7 @@
 
 import Cocoa
 
-fileprivate let MenuItemTagRevealInFinder = 100
+fileprivate let MenuItemTagShowInFinder = 100
 fileprivate let MenuItemTagDelete = 101
 fileprivate let MenuItemTagSearchFilename = 200
 fileprivate let MenuItemTagSearchFullPath = 201
@@ -230,7 +230,7 @@ class HistoryWindowController: NSWindowController, NSOutlineViewDelegate, NSOutl
 
   func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
     switch menuItem.tag {
-    case MenuItemTagRevealInFinder:
+    case MenuItemTagShowInFinder:
       if selectedEntries.isEmpty { return false }
       return selectedEntries.contains { FileManager.default.fileExists(atPath: $0.url.path) }
     case MenuItemTagDelete, MenuItemTagPlay, MenuItemTagPlayInNewWindow:
@@ -262,7 +262,7 @@ class HistoryWindowController: NSWindowController, NSOutlineViewDelegate, NSOutl
     reloadData()
   }
 
-  @IBAction func revealInFinderAction(_ sender: AnyObject) {
+  @IBAction func showInFinderAction(_ sender: AnyObject) {
     let urls = selectedEntries.compactMap { FileManager.default.fileExists(atPath: $0.url.path) ? $0.url: nil }
     NSWorkspace.shared.activateFileViewerSelecting(urls)
   }

--- a/iina/JavascriptAPIFile.swift
+++ b/iina/JavascriptAPIFile.swift
@@ -16,7 +16,7 @@ import JavaScriptCore
   func read(_ path: String, _ options: [String: Any]) -> Any?
   func trash(_ path: String)
   func delete(_ path: String)
-  func revealInFinder(_ path: String)
+  func showInFinder(_ path: String)
   func handle(_ path: String, _ mode: String) -> JavascriptFileHandle?
 }
 
@@ -126,7 +126,7 @@ class JavascriptAPIFile: JavascriptAPI, JavascriptAPIFileExportable {
     }
   }
 
-  func revealInFinder(_ path: String) {
+  func showInFinder(_ path: String) {
     guard let filePath = parsePath(path).path else { return }
 
     NSWorkspace.shared.activateFileViewerSelecting([URL(fileURLWithPath: filePath)])

--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -657,7 +657,7 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
     // WIP
   }
 
-  @IBAction func contextMenuRevealInFinder(_ sender: NSMenuItem) {
+  @IBAction func contextMenuShowInFinder(_ sender: NSMenuItem) {
     guard let selectedRows = selectedRows else { return }
     var urls: [URL] = []
     for index in selectedRows {
@@ -756,7 +756,7 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
         result.addItem(withTitle: NSLocalizedString(localCount == 1 ? "pl_menu.delete" : "pl_menu.delete_multi", comment: "Delete"), action: #selector(self.contextMenuDeleteFile(_:)))
         // result.addItem(withTitle: NSLocalizedString(isSingleItem ? "pl_menu.delete_after_play" : "pl_menu.delete_after_play_multi", comment: "Delete After Playback"), action: #selector(self.contextMenuDeleteFileAfterPlayback(_:)))
 
-        result.addItem(withTitle: NSLocalizedString("pl_menu.reveal_in_finder", comment: "Reveal in Finder"), action: #selector(self.contextMenuRevealInFinder(_:)))
+        result.addItem(withTitle: NSLocalizedString("pl_menu.show_in_finder", comment: "Show in Finder"), action: #selector(self.contextMenuShowInFinder(_:)))
         result.addItem(NSMenuItem.separator())
       }
     }

--- a/iina/PrefAdvancedViewController.swift
+++ b/iina/PrefAdvancedViewController.swift
@@ -69,7 +69,7 @@ class PrefAdvancedViewController: PreferenceViewController, PreferenceWindowEmbe
 
   // MARK: - IBAction
 
-  @IBAction func revealLogDir(_ sender: AnyObject) {
+  @IBAction func openLogDir(_ sender: AnyObject) {
     NSWorkspace.shared.open(Logger.logDirectory)
   }
 

--- a/iina/PrefKeyBindingViewController.swift
+++ b/iina/PrefKeyBindingViewController.swift
@@ -49,7 +49,7 @@ class PrefKeyBindingViewController: NSViewController, PreferenceWindowEmbeddable
   @IBOutlet weak var configHintLabel: NSTextField!
   @IBOutlet weak var addKmBtn: NSButton!
   @IBOutlet weak var removeKmBtn: NSButton!
-  @IBOutlet weak var revealConfFileBtn: NSButton!
+  @IBOutlet weak var showConfFileBtn: NSButton!
   @IBOutlet weak var deleteConfFileBtn: NSButton!
   @IBOutlet weak var newConfigBtn: NSButton!
   @IBOutlet weak var duplicateConfigBtn: NSButton!
@@ -253,7 +253,7 @@ class PrefKeyBindingViewController: NSViewController, PreferenceWindowEmbeddable
     }
   }
 
-  @IBAction func revealConfFileAction(_ sender: AnyObject) {
+  @IBAction func showConfFileAction(_ sender: AnyObject) {
     let url = URL(fileURLWithPath: currentConfFilePath)
     NSWorkspace.shared.activateFileViewerSelecting([url])
   }
@@ -315,7 +315,7 @@ class PrefKeyBindingViewController: NSViewController, PreferenceWindowEmbeddable
 
   private func changeButtonEnabledStatus() {
     shouldEnableEdit = !isDefaultConfig(currentConfName)
-    [revealConfFileBtn, deleteConfFileBtn, addKmBtn].forEach { btn in
+    [showConfFileBtn, deleteConfFileBtn, addKmBtn].forEach { btn in
       btn.isEnabled = shouldEnableEdit
     }
     kbTableView.tableColumns.forEach { $0.isEditable = shouldEnableEdit }

--- a/iina/PrefPluginViewController.swift
+++ b/iina/PrefPluginViewController.swift
@@ -428,7 +428,7 @@ class PrefPluginViewController: NSViewController, PreferenceWindowEmbeddable {
     }
   }
 
-  @IBAction func revealPlugin(_ sender: Any) {
+  @IBAction func showPlugin(_ sender: Any) {
     guard let currentPlugin = currentPlugin else { return }
     NSWorkspace.shared.activateFileViewerSelecting([currentPlugin.root])
   }

--- a/iina/PrefPluginViewController.xib
+++ b/iina/PrefPluginViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21225" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21225"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -455,13 +455,13 @@
                                         </connections>
                                     </segmentedControl>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sl8-zI-7f5">
-                                        <rect key="frame" x="361" y="368" width="98" height="17"/>
-                                        <buttonCell key="cell" type="roundRect" title="Reveal in Finder" bezelStyle="roundedRect" alignment="center" controlSize="small" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="drh-6w-3z1">
+                                        <rect key="frame" x="367" y="368" width="92" height="17"/>
+                                        <buttonCell key="cell" type="roundRect" title="Show in Finder" bezelStyle="roundedRect" alignment="center" controlSize="small" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="drh-6w-3z1">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="controlContent" size="11"/>
                                         </buttonCell>
                                         <connections>
-                                            <action selector="revealPlugin:" target="-2" id="qhh-x5-Xcs"/>
+                                            <action selector="showPlugin:" target="-2" id="idx-f9-Qaq"/>
                                         </connections>
                                     </button>
                                 </subviews>

--- a/iina/af.lproj/HistoryWindowController.strings
+++ b/iina/af.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Afspeelgeskiedenis";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "Toon in Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/af.lproj/Localizable.strings
+++ b/iina/af.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Skuif gekose lêers na asblik";
 "pl_menu.delete_after_play" = "Skuif na asblik na afspeel";
 "pl_menu.delete_after_play_multi" = "Skuif gekose lêers na Asblik na afspeel";
-"pl_menu.reveal_in_finder" = "Toon in Finder";
+"pl_menu.show_in_finder" = "Toon in Finder";
 "pl_menu.add_file" = "Voeg lêer toe…";
 "pl_menu.add_url" = "Voeg bronadres toe…";
 "pl_menu.clear_playlist" = "Wis afspeellys";

--- a/iina/af.lproj/PrefKeyBindingViewController.strings
+++ b/iina/af.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Opstelling:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show the config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "Toon konfigurasielêer in Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */

--- a/iina/ar.lproj/HistoryWindowController.strings
+++ b/iina/ar.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "تاريخ التشغيل";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "كشف في Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/ar.lproj/Localizable.strings
+++ b/iina/ar.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "نقل الملفات المحددة إلى سلة المهملات";
 "pl_menu.delete_after_play" = "النقل إلى سلة المهملات بعد التشغيل";
 "pl_menu.delete_after_play_multi" = "نقل الملفات المحددة إلى سلة المهملات بعد تشغيلها";
-"pl_menu.reveal_in_finder" = "كشف في Finder";
+"pl_menu.show_in_finder" = "كشف في Finder";
 "pl_menu.add_file" = "إضافة ملف…";
 "pl_menu.add_url" = "إضافة عنوان URL…";
 "pl_menu.clear_playlist" = "مسح قائمة التشغيل";

--- a/iina/ar.lproj/PrefKeyBindingViewController.strings
+++ b/iina/ar.lproj/PrefKeyBindingViewController.strings
@@ -16,10 +16,10 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "التكوين:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "عرض ملف التكوين في Finder";
 
-/* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */
+/* Class = "NSButtgonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */
 "gpZ-Rh-DMn.title" = "استنساخ…";
 
 /* Class = "NSButton"; ibShadowedToolTip = "Show the raw mpv key code and command."; ObjectID = "l2M-TH-eCt"; */

--- a/iina/be.lproj/HistoryWindowController.strings
+++ b/iina/be.lproj/HistoryWindowController.strings
@@ -13,8 +13,8 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Playback History";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
-"FPK-nx-hvF.title" = "Reveal in Finder";
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
+"FPK-nx-hvF.title" = "Show in Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */
 "Gx5-gP-rzr.title" = "Search in";

--- a/iina/be.lproj/Localizable.strings
+++ b/iina/be.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Move Selected Files to Trash";
 "pl_menu.delete_after_play" = "Move to Trash After Playback";
 "pl_menu.delete_after_play_multi" = "Move Selected Files to Trash After Playback";
-"pl_menu.reveal_in_finder" = "Reveal in Finder";
+"pl_menu.show_in_finder" = "Show in Finder";
 "pl_menu.add_file" = "Add File…";
 "pl_menu.add_url" = "Add URL…";
 "pl_menu.clear_playlist" = "Clear Playlist";

--- a/iina/be.lproj/PrefKeyBindingViewController.strings
+++ b/iina/be.lproj/PrefKeyBindingViewController.strings
@@ -16,8 +16,8 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configuration:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
-"gDo-JL-a9k.title" = "Reveal config file in Finder";
+/* Class = "NSButtonCell"; title = "Show config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+"gDo-JL-a9k.title" = "Show config file in Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */
 "gpZ-Rh-DMn.title" = "Duplicate…";

--- a/iina/bg.lproj/HistoryWindowController.strings
+++ b/iina/bg.lproj/HistoryWindowController.strings
@@ -13,8 +13,8 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Playback History";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
-"FPK-nx-hvF.title" = "Reveal in Finder";
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
+"FPK-nx-hvF.title" = "Show in Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */
 "Gx5-gP-rzr.title" = "Search in";

--- a/iina/bg.lproj/Localizable.strings
+++ b/iina/bg.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Move Selected Files to Trash";
 "pl_menu.delete_after_play" = "Move to Trash After Playback";
 "pl_menu.delete_after_play_multi" = "Move Selected Files to Trash After Playback";
-"pl_menu.reveal_in_finder" = "Reveal in Finder";
+"pl_menu.show_in_finder" = "Show in Finder";
 "pl_menu.add_file" = "Add File…";
 "pl_menu.add_url" = "Add URL…";
 "pl_menu.clear_playlist" = "Clear Playlist";

--- a/iina/bg.lproj/PrefKeyBindingViewController.strings
+++ b/iina/bg.lproj/PrefKeyBindingViewController.strings
@@ -16,8 +16,8 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configuration:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
-"gDo-JL-a9k.title" = "Reveal config file in Finder";
+/* Class = "NSButtonCell"; title = "Show config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+"gDo-JL-a9k.title" = "Show config file in Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */
 "gpZ-Rh-DMn.title" = "Duplicate…";

--- a/iina/bn.lproj/HistoryWindowController.strings
+++ b/iina/bn.lproj/HistoryWindowController.strings
@@ -13,8 +13,8 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Playback History";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
-"FPK-nx-hvF.title" = "Reveal in Finder";
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
+"FPK-nx-hvF.title" = "Show in Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */
 "Gx5-gP-rzr.title" = "Search in";

--- a/iina/bn.lproj/Localizable.strings
+++ b/iina/bn.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Move Selected Files to Trash";
 "pl_menu.delete_after_play" = "Move to Trash After Playback";
 "pl_menu.delete_after_play_multi" = "Move Selected Files to Trash After Playback";
-"pl_menu.reveal_in_finder" = "Reveal in Finder";
+"pl_menu.show_in_finder" = "Show in Finder";
 "pl_menu.add_file" = "Add File…";
 "pl_menu.add_url" = "Add URL…";
 "pl_menu.clear_playlist" = "Clear Playlist";

--- a/iina/bn.lproj/PrefKeyBindingViewController.strings
+++ b/iina/bn.lproj/PrefKeyBindingViewController.strings
@@ -16,8 +16,8 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configuration:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
-"gDo-JL-a9k.title" = "Reveal config file in Finder";
+/* Class = "NSButtonCell"; title = "Show config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+"gDo-JL-a9k.title" = "Show config file in Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */
 "gpZ-Rh-DMn.title" = "Duplicate…";

--- a/iina/ca.lproj/HistoryWindowController.strings
+++ b/iina/ca.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Historial de reproducció";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "Mostra al Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/ca.lproj/Localizable.strings
+++ b/iina/ca.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Mou els fitxer seleccionats a la papepera";
 "pl_menu.delete_after_play" = "Mou a la paperera després de la seva reproducció";
 "pl_menu.delete_after_play_multi" = "Mou els fitxer seleccionats a la paperera després de la seva reproducció";
-"pl_menu.reveal_in_finder" = "Mostra al Finder";
+"pl_menu.show_in_finder" = "Mostra al Finder";
 "pl_menu.add_file" = "Afegeix fitxer…";
 "pl_menu.add_url" = "Afegeix enllaç…";
 "pl_menu.clear_playlist" = "Neteja llista de reproducció";

--- a/iina/ca.lproj/PrefKeyBindingViewController.strings
+++ b/iina/ca.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configuració:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show the config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "Mostra fitxer de configuració al Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */

--- a/iina/cs.lproj/HistoryWindowController.strings
+++ b/iina/cs.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Historie přehrávání";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "Zobrazit ve Finderu";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/cs.lproj/Localizable.strings
+++ b/iina/cs.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Přesunout vybrané soubory do koše";
 "pl_menu.delete_after_play" = "Po přehrání přesunout do koše";
 "pl_menu.delete_after_play_multi" = "Po přehrání přesunout vybrané soubory do koše";
-"pl_menu.reveal_in_finder" = "Zobrazit ve Finderu";
+"pl_menu.show_in_finder" = "Zobrazit ve Finderu";
 "pl_menu.add_file" = "Přidat soubor…";
 "pl_menu.add_url" = "Přidat URL…";
 "pl_menu.clear_playlist" = "Smazat playlist";

--- a/iina/cs.lproj/PrefKeyBindingViewController.strings
+++ b/iina/cs.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Konfigurace:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show the config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "Zobrazit konfigurační soubor ve Finderu";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */

--- a/iina/da.lproj/HistoryWindowController.strings
+++ b/iina/da.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Playback Historik";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "Vis i Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/da.lproj/Localizable.strings
+++ b/iina/da.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Flyt valgte filer til papirkurven";
 "pl_menu.delete_after_play" = "Flyt til papirkurven efter afspilning";
 "pl_menu.delete_after_play_multi" = "Flyt valgte filer til papirkurven efter afspilning";
-"pl_menu.reveal_in_finder" = "Vis i finder";
+"pl_menu.show_in_finder" = "Vis i finder";
 "pl_menu.add_file" = "Tilføj Arkiv…";
 "pl_menu.add_url" = "Tilføj URL…";
 "pl_menu.clear_playlist" = "Tøm Playlist";

--- a/iina/da.lproj/PrefKeyBindingViewController.strings
+++ b/iina/da.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Konfiguration:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show the config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "Vis config fil i Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */

--- a/iina/de.lproj/HistoryWindowController.strings
+++ b/iina/de.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Wiedergabeverlauf";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "In Finder anzeigen";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/de.lproj/Localizable.strings
+++ b/iina/de.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Auswahl in den Papierkorb legen";
 "pl_menu.delete_after_play" = "Nach Wiedergabe in den Papierkorb legen";
 "pl_menu.delete_after_play_multi" = "Auswahl nach Wiedergabe in den Papierkorb legen";
-"pl_menu.reveal_in_finder" = "Im Finder anzeigen";
+"pl_menu.show_in_finder" = "Im Finder anzeigen";
 "pl_menu.add_file" = "Datei hinzufügen …";
 "pl_menu.add_url" = "Adresse hinzufügen …";
 "pl_menu.clear_playlist" = "Wiedergabeliste leeren";

--- a/iina/de.lproj/PrefKeyBindingViewController.strings
+++ b/iina/de.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Konfiguration:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show the config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "Im Finder anzeigen";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */

--- a/iina/el.lproj/HistoryWindowController.strings
+++ b/iina/el.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Ιστορικό Αναπαραγωγής";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "Εμφάνιση στον Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/el.lproj/Localizable.strings
+++ b/iina/el.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Move Selected Files to Trash";
 "pl_menu.delete_after_play" = "Move to Trash After Playback";
 "pl_menu.delete_after_play_multi" = "Move Selected Files to Trash After Playback";
-"pl_menu.reveal_in_finder" = "Reveal in Finder";
+"pl_menu.show_in_finder" = "Show in Finder";
 "pl_menu.add_file" = "Add File…";
 "pl_menu.add_url" = "Add URL…";
 "pl_menu.clear_playlist" = "Clear Playlist";

--- a/iina/el.lproj/PrefKeyBindingViewController.strings
+++ b/iina/el.lproj/PrefKeyBindingViewController.strings
@@ -16,8 +16,8 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configuration:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
-"gDo-JL-a9k.title" = "Reveal config file in Finder";
+/* Class = "NSButtonCell"; title = "Show config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+"gDo-JL-a9k.title" = "Show config file in Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */
 "gpZ-Rh-DMn.title" = "Duplicate…";

--- a/iina/en-GB.lproj/HistoryWindowController.strings
+++ b/iina/en-GB.lproj/HistoryWindowController.strings
@@ -13,8 +13,8 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Playback History";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
-"FPK-nx-hvF.title" = "Reveal in Finder";
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
+"FPK-nx-hvF.title" = "Show in Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */
 "Gx5-gP-rzr.title" = "Search in";

--- a/iina/en-GB.lproj/Localizable.strings
+++ b/iina/en-GB.lproj/Localizable.strings
@@ -165,7 +165,7 @@
 "alert.config.empty_name" = "The name cannot be empty.";
 "alert.config.name_existing" = "The name already exists.";
 "alert.config.file_existing.title" = "File Already Exists";
-"alert.config.file_existing.message" = "This should not happen. Choose OK to overwrite, Cancel to reveal the file in Finder.";
+"alert.config.file_existing.message" = "This should not happen. Choose OK to overwrite, Cancel to show the file in Finder.";
 "alert.config.cannot_create" = "Cannot create config file!\n%@";
 "alert.config.cannot_write" = "Cannot write to config file!";
 
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Move Selected Files to Trash";
 "pl_menu.delete_after_play" = "Move to Trash After Playback";
 "pl_menu.delete_after_play_multi" = "Move Selected Files to Trash After Playback";
-"pl_menu.reveal_in_finder" = "Reveal in Finder";
+"pl_menu.show_in_finder" = "Show in Finder";
 "pl_menu.add_file" = "Add File…";
 "pl_menu.add_url" = "Add URL…";
 "pl_menu.clear_playlist" = "Clear Playlist";

--- a/iina/en-GB.lproj/PrefKeyBindingViewController.strings
+++ b/iina/en-GB.lproj/PrefKeyBindingViewController.strings
@@ -16,8 +16,8 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configuration:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
-"gDo-JL-a9k.title" = "Reveal config file in Finder";
+/* Class = "NSButtonCell"; title = "Show the config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+"gDo-JL-a9k.title" = "Show the config file in Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */
 "gpZ-Rh-DMn.title" = "Duplicate…";

--- a/iina/en.lproj/HistoryWindowController.strings
+++ b/iina/en.lproj/HistoryWindowController.strings
@@ -13,8 +13,8 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Playback History";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
-"FPK-nx-hvF.title" = "Reveal in Finder";
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
+"FPK-nx-hvF.title" = "Show in Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */
 "Gx5-gP-rzr.title" = "Search in";

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -165,7 +165,7 @@
 "alert.config.empty_name" = "The name cannot be empty.";
 "alert.config.name_existing" = "The name already exists.";
 "alert.config.file_existing.title" = "File Already Exists";
-"alert.config.file_existing.message" = "This should not happen. Choose OK to overwrite, Cancel to reveal the file in Finder.";
+"alert.config.file_existing.message" = "This should not happen. Choose OK to overwrite, Cancel to show the file in Finder.";
 "alert.config.cannot_create" = "Cannot create config file!\n%@";
 "alert.config.cannot_write" = "Cannot write to config file!";
 
@@ -260,7 +260,7 @@
 "pl_menu.delete_multi" = "Move Selected Files to Trash";
 "pl_menu.delete_after_play" = "Move to Trash After Playback";
 "pl_menu.delete_after_play_multi" = "Move Selected Files to Trash After Playback";
-"pl_menu.reveal_in_finder" = "Reveal in Finder";
+"pl_menu.show_in_finder" = "Show in Finder";
 "pl_menu.add_file" = "Add File…";
 "pl_menu.add_url" = "Add URL…";
 "pl_menu.clear_playlist" = "Clear Playlist";

--- a/iina/en.lproj/PrefKeyBindingViewController.strings
+++ b/iina/en.lproj/PrefKeyBindingViewController.strings
@@ -16,8 +16,8 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configuration:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
-"gDo-JL-a9k.title" = "Reveal config file in Finder";
+/* Class = "NSButtonCell"; title = "Show the config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+"gDo-JL-a9k.title" = "Show the config file in Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */
 "gpZ-Rh-DMn.title" = "Duplicate…";

--- a/iina/es.lproj/HistoryWindowController.strings
+++ b/iina/es.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Historial de reproducción";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "Mostrar en el Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/es.lproj/Localizable.strings
+++ b/iina/es.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Mover los archivos seleccionados a la Papelera";
 "pl_menu.delete_after_play" = "Mover a la Papelera después de reproducir";
 "pl_menu.delete_after_play_multi" = "Mover los archivos seleccionados a la Papelera después de reproducir";
-"pl_menu.reveal_in_finder" = "Mostrar en el Finder";
+"pl_menu.show_in_finder" = "Mostrar en el Finder";
 "pl_menu.add_file" = "Añadir archivo…";
 "pl_menu.add_url" = "Añadir URL…";
 "pl_menu.clear_playlist" = "Borrar la lista de reproducción";

--- a/iina/es.lproj/PrefKeyBindingViewController.strings
+++ b/iina/es.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configuración:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show the config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "Mostrar archivo de configuración en el Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */

--- a/iina/eu.lproj/HistoryWindowController.strings
+++ b/iina/eu.lproj/HistoryWindowController.strings
@@ -13,8 +13,8 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Playback History";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
-"FPK-nx-hvF.title" = "Reveal in Finder";
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
+"FPK-nx-hvF.title" = "Show in Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */
 "Gx5-gP-rzr.title" = "Search in";

--- a/iina/eu.lproj/Localizable.strings
+++ b/iina/eu.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Move Selected Files to Trash";
 "pl_menu.delete_after_play" = "Move to Trash After Playback";
 "pl_menu.delete_after_play_multi" = "Move Selected Files to Trash After Playback";
-"pl_menu.reveal_in_finder" = "Reveal in Finder";
+"pl_menu.show_in_finder" = "Show in Finder";
 "pl_menu.add_file" = "Add File…";
 "pl_menu.add_url" = "Add URL…";
 "pl_menu.clear_playlist" = "Clear Playlist";

--- a/iina/eu.lproj/PrefKeyBindingViewController.strings
+++ b/iina/eu.lproj/PrefKeyBindingViewController.strings
@@ -16,8 +16,8 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configuration:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
-"gDo-JL-a9k.title" = "Reveal config file in Finder";
+/* Class = "NSButtonCell"; title = "Show config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+"gDo-JL-a9k.title" = "Show config file in Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */
 "gpZ-Rh-DMn.title" = "Duplicate…";

--- a/iina/fa.lproj/HistoryWindowController.strings
+++ b/iina/fa.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "سابقه پخش";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "نشان دادن در Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/fa.lproj/Localizable.strings
+++ b/iina/fa.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Move Selected Files to Trash";
 "pl_menu.delete_after_play" = "Move to Trash After Playback";
 "pl_menu.delete_after_play_multi" = "Move Selected Files to Trash After Playback";
-"pl_menu.reveal_in_finder" = "Reveal in Finder";
+"pl_menu.show_in_finder" = "Show in Finder";
 "pl_menu.add_file" = "Add File…";
 "pl_menu.add_url" = "Add URL…";
 "pl_menu.clear_playlist" = "Clear Playlist";

--- a/iina/fa.lproj/PrefKeyBindingViewController.strings
+++ b/iina/fa.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "پیکربندی:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "نمایش فایل تنظیمات در فایندر";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */

--- a/iina/fi.lproj/HistoryWindowController.strings
+++ b/iina/fi.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Toistohistoria";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "Näytä Finderissa";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/fi.lproj/Localizable.strings
+++ b/iina/fi.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Siirrä valitut tiedostot roskakoriin";
 "pl_menu.delete_after_play" = "Siirrä roskakoriin toiston jälkeen";
 "pl_menu.delete_after_play_multi" = "Siirrä valitut tiedostot roskakoriin toiston jälkeen";
-"pl_menu.reveal_in_finder" = "Näytä Finderissa";
+"pl_menu.show_in_finder" = "Näytä Finderissa";
 "pl_menu.add_file" = "Lisää tiedosto…";
 "pl_menu.add_url" = "Lisää URL-osoite…";
 "pl_menu.clear_playlist" = "Tyhjennä soittolista";

--- a/iina/fi.lproj/PrefKeyBindingViewController.strings
+++ b/iina/fi.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Asetukset:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show the config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "Näytä asetustiedosto Finderissa";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */

--- a/iina/fr.lproj/HistoryWindowController.strings
+++ b/iina/fr.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Historique de lecture";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "Afficher dans le Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/fr.lproj/Localizable.strings
+++ b/iina/fr.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Supprimer";
 "pl_menu.delete_after_play" = "Supprimer après lecture";
 "pl_menu.delete_after_play_multi" = "Supprimer après lecture";
-"pl_menu.reveal_in_finder" = "Afficher dans le Finder";
+"pl_menu.show_in_finder" = "Afficher dans le Finder";
 "pl_menu.add_file" = "Ajouter un fichier…";
 "pl_menu.add_url" = "Ajouter une URL…";
 "pl_menu.clear_playlist" = "Vider la playlist";

--- a/iina/fr.lproj/PrefKeyBindingViewController.strings
+++ b/iina/fr.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configuration :";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show the config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "Afficher le fichier de configuration dans le Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */

--- a/iina/he.lproj/HistoryWindowController.strings
+++ b/iina/he.lproj/HistoryWindowController.strings
@@ -13,8 +13,8 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Playback History";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
-"FPK-nx-hvF.title" = "Reveal in Finder";
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
+"FPK-nx-hvF.title" = "Show in Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */
 "Gx5-gP-rzr.title" = "Search in";

--- a/iina/he.lproj/Localizable.strings
+++ b/iina/he.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Move Selected Files to Trash";
 "pl_menu.delete_after_play" = "Move to Trash After Playback";
 "pl_menu.delete_after_play_multi" = "Move Selected Files to Trash After Playback";
-"pl_menu.reveal_in_finder" = "Reveal in Finder";
+"pl_menu.show_in_finder" = "Show in Finder";
 "pl_menu.add_file" = "Add File…";
 "pl_menu.add_url" = "Add URL…";
 "pl_menu.clear_playlist" = "Clear Playlist";

--- a/iina/he.lproj/PrefKeyBindingViewController.strings
+++ b/iina/he.lproj/PrefKeyBindingViewController.strings
@@ -16,8 +16,8 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configuration:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
-"gDo-JL-a9k.title" = "Reveal config file in Finder";
+/* Class = "NSButtonCell"; title = "Show config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+"gDo-JL-a9k.title" = "Show config file in Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */
 "gpZ-Rh-DMn.title" = "Duplicate…";

--- a/iina/hi.lproj/HistoryWindowController.strings
+++ b/iina/hi.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "प्लेबैक इतिहास";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "खोजक में पता चलता है";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/hi.lproj/Localizable.strings
+++ b/iina/hi.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "चयनित फ़ाइलों को ट्रैश में ले जाएं";
 "pl_menu.delete_after_play" = "प्लेबैक के बाद ट्रैश में जाएं";
 "pl_menu.delete_after_play_multi" = "प्लेबैक के बाद ट्रैश में चयनित फ़ाइलों को स्थानांतरित करें";
-"pl_menu.reveal_in_finder" = "खोजक में पता चलता है";
+"pl_menu.show_in_finder" = "खोजक में पता चलता है";
 "pl_menu.add_file" = "फाइल जोडें…";
 "pl_menu.add_url" = "यू आर एल जोड़िये…";
 "pl_menu.clear_playlist" = "क्लियर प्लेलिस्ट";

--- a/iina/hi.lproj/PrefKeyBindingViewController.strings
+++ b/iina/hi.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "विन्यास:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show the config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "फाइंडर में कॉन्फिगर फाइल का खुलासा करें";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */

--- a/iina/hr.lproj/HistoryWindowController.strings
+++ b/iina/hr.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Povijest reprodukcija";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "Prikaži u Finderu";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/hr.lproj/Localizable.strings
+++ b/iina/hr.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Premjesti odabrane datoteke u smeće";
 "pl_menu.delete_after_play" = "Premjesti u smeće nakon reprodukcije";
 "pl_menu.delete_after_play_multi" = "Premjesti odabrane datoteke u smeće nakon reprodukcije";
-"pl_menu.reveal_in_finder" = "Prikaži u Finderu";
+"pl_menu.show_in_finder" = "Prikaži u Finderu";
 "pl_menu.add_file" = "Dodaj datoteku…";
 "pl_menu.add_url" = "Dodaj URL adresu…";
 "pl_menu.clear_playlist" = "Očisti popis naslova";

--- a/iina/hr.lproj/PrefKeyBindingViewController.strings
+++ b/iina/hr.lproj/PrefKeyBindingViewController.strings
@@ -16,8 +16,8 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Konfiguracija:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
-"gDo-JL-a9k.title" = "Reveal config file in Finder";
+/* Class = "NSButtonCell"; title = "Show config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+"gDo-JL-a9k.title" = "Show config file in Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */
 "gpZ-Rh-DMn.title" = "Dupliciraj…";

--- a/iina/hu.lproj/HistoryWindowController.strings
+++ b/iina/hu.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Lejátszási előzmények";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "Megjelenítés a Finder-ben";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/hu.lproj/Localizable.strings
+++ b/iina/hu.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "A kiválasztott fájlok áthelyezése a kukába";
 "pl_menu.delete_after_play" = "Áthelyezés a kukába lejátszás után";
 "pl_menu.delete_after_play_multi" = "Kiválasztott fájlok áthelyezése a kukába lejátszás után";
-"pl_menu.reveal_in_finder" = "Megjelenítés a Finder-ben";
+"pl_menu.show_in_finder" = "Megjelenítés a Finder-ben";
 "pl_menu.add_file" = "Fájl hozzáadása…";
 "pl_menu.add_url" = "URL hozzáadása…";
 "pl_menu.clear_playlist" = "Lejátszási lista ürítése";

--- a/iina/hu.lproj/PrefKeyBindingViewController.strings
+++ b/iina/hu.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Konfiguráció:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show the config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "Konfigurációs fájl megjelenítése Finderben";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */

--- a/iina/hy.lproj/HistoryWindowController.strings
+++ b/iina/hy.lproj/HistoryWindowController.strings
@@ -13,8 +13,8 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Playback History";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
-"FPK-nx-hvF.title" = "Reveal in Finder";
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
+"FPK-nx-hvF.title" = "Show in Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */
 "Gx5-gP-rzr.title" = "Search in";

--- a/iina/hy.lproj/Localizable.strings
+++ b/iina/hy.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Move Selected Files to Trash";
 "pl_menu.delete_after_play" = "Move to Trash After Playback";
 "pl_menu.delete_after_play_multi" = "Move Selected Files to Trash After Playback";
-"pl_menu.reveal_in_finder" = "Reveal in Finder";
+"pl_menu.show_in_finder" = "Show in Finder";
 "pl_menu.add_file" = "Add File…";
 "pl_menu.add_url" = "Add URL…";
 "pl_menu.clear_playlist" = "Clear Playlist";

--- a/iina/hy.lproj/PrefKeyBindingViewController.strings
+++ b/iina/hy.lproj/PrefKeyBindingViewController.strings
@@ -16,8 +16,8 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configuration:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
-"gDo-JL-a9k.title" = "Reveal config file in Finder";
+/* Class = "NSButtonCell"; title = "Show config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+"gDo-JL-a9k.title" = "Show config file in Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */
 "gpZ-Rh-DMn.title" = "Duplicate…";

--- a/iina/id.lproj/HistoryWindowController.strings
+++ b/iina/id.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Riwayat Pemutaran";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "Tampilkan dalam Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/id.lproj/Localizable.strings
+++ b/iina/id.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Move Selected Files to Trash";
 "pl_menu.delete_after_play" = "Move to Trash After Playback";
 "pl_menu.delete_after_play_multi" = "Move Selected Files to Trash After Playback";
-"pl_menu.reveal_in_finder" = "Reveal in Finder";
+"pl_menu.show_in_finder" = "Show in Finder";
 "pl_menu.add_file" = "Add File…";
 "pl_menu.add_url" = "Add URL…";
 "pl_menu.clear_playlist" = "Clear Playlist";

--- a/iina/id.lproj/PrefKeyBindingViewController.strings
+++ b/iina/id.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Konfigurasi:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "Tampilkan file konfig di Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */

--- a/iina/is.lproj/HistoryWindowController.strings
+++ b/iina/is.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Spilunarferill";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "Sýna í Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/is.lproj/Localizable.strings
+++ b/iina/is.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Move Selected Files to Trash";
 "pl_menu.delete_after_play" = "Move to Trash After Playback";
 "pl_menu.delete_after_play_multi" = "Move Selected Files to Trash After Playback";
-"pl_menu.reveal_in_finder" = "Reveal in Finder";
+"pl_menu.show_in_finder" = "Show in Finder";
 "pl_menu.add_file" = "Add File…";
 "pl_menu.add_url" = "Add URL…";
 "pl_menu.clear_playlist" = "Clear Playlist";

--- a/iina/is.lproj/PrefKeyBindingViewController.strings
+++ b/iina/is.lproj/PrefKeyBindingViewController.strings
@@ -16,8 +16,8 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configuration:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
-"gDo-JL-a9k.title" = "Reveal config file in Finder";
+/* Class = "NSButtonCell"; title = "Show config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+"gDo-JL-a9k.title" = "Show config file in Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */
 "gpZ-Rh-DMn.title" = "Duplicate…";

--- a/iina/it.lproj/HistoryWindowController.strings
+++ b/iina/it.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Cronologia riproduzioni";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "Mostra nel Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/it.lproj/Localizable.strings
+++ b/iina/it.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Sposta i file selezionati nel cestino";
 "pl_menu.delete_after_play" = "Sposta nel cestino dopo la riporoduzione";
 "pl_menu.delete_after_play_multi" = "Muovi i file selezionati nel cestiono dopo la riproduzione";
-"pl_menu.reveal_in_finder" = "Mostra nel Finder";
+"pl_menu.show_in_finder" = "Mostra nel Finder";
 "pl_menu.add_file" = "Aggiungi file…";
 "pl_menu.add_url" = "Aggiungi URL…";
 "pl_menu.clear_playlist" = "Cancella la playlist";

--- a/iina/it.lproj/PrefKeyBindingViewController.strings
+++ b/iina/it.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configurazione:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show the config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "Mostra il file di configurazione nel Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */

--- a/iina/ja.lproj/HistoryWindowController.strings
+++ b/iina/ja.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "再生履歴";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "Finderで表示";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/ja.lproj/Localizable.strings
+++ b/iina/ja.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "選択したファイルをゴミ箱へ移動";
 "pl_menu.delete_after_play" = "再生した後にゴミ箱へ移動";
 "pl_menu.delete_after_play_multi" = "再生した後に選択したファイルをゴミ箱へ移動";
-"pl_menu.reveal_in_finder" = "Finderで表示";
+"pl_menu.show_in_finder" = "Finderで表示";
 "pl_menu.add_file" = "ファイルの追加…";
 "pl_menu.add_url" = "URLの追加…";
 "pl_menu.clear_playlist" = "プレイリストを消去する";

--- a/iina/ja.lproj/PrefKeyBindingViewController.strings
+++ b/iina/ja.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "設定:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show the config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "設定ファイルをFinderで表示";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */

--- a/iina/kn.lproj/HistoryWindowController.strings
+++ b/iina/kn.lproj/HistoryWindowController.strings
@@ -13,8 +13,8 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Playback History";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
-"FPK-nx-hvF.title" = "Reveal in Finder";
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
+"FPK-nx-hvF.title" = "Show in Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */
 "Gx5-gP-rzr.title" = "Search in";

--- a/iina/kn.lproj/Localizable.strings
+++ b/iina/kn.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Move Selected Files to Trash";
 "pl_menu.delete_after_play" = "Move to Trash After Playback";
 "pl_menu.delete_after_play_multi" = "Move Selected Files to Trash After Playback";
-"pl_menu.reveal_in_finder" = "Reveal in Finder";
+"pl_menu.show_in_finder" = "Show in Finder";
 "pl_menu.add_file" = "Add File…";
 "pl_menu.add_url" = "Add URL…";
 "pl_menu.clear_playlist" = "Clear Playlist";

--- a/iina/kn.lproj/PrefKeyBindingViewController.strings
+++ b/iina/kn.lproj/PrefKeyBindingViewController.strings
@@ -16,8 +16,8 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configuration:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
-"gDo-JL-a9k.title" = "Reveal config file in Finder";
+/* Class = "NSButtonCell"; title = "Show config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+"gDo-JL-a9k.title" = "Show config file in Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */
 "gpZ-Rh-DMn.title" = "Duplicate…";

--- a/iina/ko.lproj/HistoryWindowController.strings
+++ b/iina/ko.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "재생 기록";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "파인더에서 보기";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/ko.lproj/Localizable.strings
+++ b/iina/ko.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "선택한 파일을 휴지통에 버리기";
 "pl_menu.delete_after_play" = "재생 후 휴지통에 버리기";
 "pl_menu.delete_after_play_multi" = "선택항목 재생 후 휴지통에 버리기";
-"pl_menu.reveal_in_finder" = "파인더에서 보기";
+"pl_menu.show_in_finder" = "파인더에서 보기";
 "pl_menu.add_file" = "파일 추가…";
 "pl_menu.add_url" = "URL 추가…";
 "pl_menu.clear_playlist" = "재생목록 지움";

--- a/iina/ko.lproj/PrefKeyBindingViewController.strings
+++ b/iina/ko.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "설정";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show the config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "설정 파일 폴더 보기";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */

--- a/iina/lv.lproj/HistoryWindowController.strings
+++ b/iina/lv.lproj/HistoryWindowController.strings
@@ -13,8 +13,8 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Playback History";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
-"FPK-nx-hvF.title" = "Reveal in Finder";
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
+"FPK-nx-hvF.title" = "Show in Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */
 "Gx5-gP-rzr.title" = "Search in";

--- a/iina/lv.lproj/Localizable.strings
+++ b/iina/lv.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Move Selected Files to Trash";
 "pl_menu.delete_after_play" = "Move to Trash After Playback";
 "pl_menu.delete_after_play_multi" = "Move Selected Files to Trash After Playback";
-"pl_menu.reveal_in_finder" = "Reveal in Finder";
+"pl_menu.show_in_finder" = "Show in Finder";
 "pl_menu.add_file" = "Add File…";
 "pl_menu.add_url" = "Add URL…";
 "pl_menu.clear_playlist" = "Clear Playlist";

--- a/iina/lv.lproj/PrefKeyBindingViewController.strings
+++ b/iina/lv.lproj/PrefKeyBindingViewController.strings
@@ -16,8 +16,8 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configuration:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
-"gDo-JL-a9k.title" = "Reveal config file in Finder";
+/* Class = "NSButtonCell"; title = "Show config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+"gDo-JL-a9k.title" = "Show config file in Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */
 "gpZ-Rh-DMn.title" = "Duplicate…";

--- a/iina/mk.lproj/HistoryWindowController.strings
+++ b/iina/mk.lproj/HistoryWindowController.strings
@@ -13,8 +13,8 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Playback History";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
-"FPK-nx-hvF.title" = "Reveal in Finder";
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
+"FPK-nx-hvF.title" = "Show in Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */
 "Gx5-gP-rzr.title" = "Search in";

--- a/iina/mk.lproj/Localizable.strings
+++ b/iina/mk.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Move Selected Files to Trash";
 "pl_menu.delete_after_play" = "Move to Trash After Playback";
 "pl_menu.delete_after_play_multi" = "Move Selected Files to Trash After Playback";
-"pl_menu.reveal_in_finder" = "Reveal in Finder";
+"pl_menu.show_in_finder" = "Show in Finder";
 "pl_menu.add_file" = "Add File…";
 "pl_menu.add_url" = "Add URL…";
 "pl_menu.clear_playlist" = "Clear Playlist";

--- a/iina/mk.lproj/PrefKeyBindingViewController.strings
+++ b/iina/mk.lproj/PrefKeyBindingViewController.strings
@@ -16,8 +16,8 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configuration:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
-"gDo-JL-a9k.title" = "Reveal config file in Finder";
+/* Class = "NSButtonCell"; title = "Show config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+"gDo-JL-a9k.title" = "Show config file in Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */
 "gpZ-Rh-DMn.title" = "Duplicate…";

--- a/iina/ml.lproj/HistoryWindowController.strings
+++ b/iina/ml.lproj/HistoryWindowController.strings
@@ -13,8 +13,8 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Playback History";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
-"FPK-nx-hvF.title" = "Reveal in Finder";
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
+"FPK-nx-hvF.title" = "Show in Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */
 "Gx5-gP-rzr.title" = "Search in";

--- a/iina/ml.lproj/Localizable.strings
+++ b/iina/ml.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Move Selected Files to Trash";
 "pl_menu.delete_after_play" = "Move to Trash After Playback";
 "pl_menu.delete_after_play_multi" = "Move Selected Files to Trash After Playback";
-"pl_menu.reveal_in_finder" = "Reveal in Finder";
+"pl_menu.show_in_finder" = "Show in Finder";
 "pl_menu.add_file" = "Add File…";
 "pl_menu.add_url" = "Add URL…";
 "pl_menu.clear_playlist" = "Clear Playlist";

--- a/iina/ml.lproj/PrefKeyBindingViewController.strings
+++ b/iina/ml.lproj/PrefKeyBindingViewController.strings
@@ -16,8 +16,8 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configuration:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
-"gDo-JL-a9k.title" = "Reveal config file in Finder";
+/* Class = "NSButtonCell"; title = "Show config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+"gDo-JL-a9k.title" = "Show config file in Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */
 "gpZ-Rh-DMn.title" = "Duplicate…";

--- a/iina/nl.lproj/HistoryWindowController.strings
+++ b/iina/nl.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Afspeelgeschiedenis";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "Toon in Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/nl.lproj/Localizable.strings
+++ b/iina/nl.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Verplaats selectie naar prullenmand";
 "pl_menu.delete_after_play" = "Verplaats naar prullenmand na afspelen";
 "pl_menu.delete_after_play_multi" = "Verplaats selectie naar prullenmand na afspelen";
-"pl_menu.reveal_in_finder" = "Toon in Finder";
+"pl_menu.show_in_finder" = "Toon in Finder";
 "pl_menu.add_file" = "Voeg bestand toe…";
 "pl_menu.add_url" = "Voeg URL toe…";
 "pl_menu.clear_playlist" = "Wis afspeellijst";

--- a/iina/nl.lproj/PrefKeyBindingViewController.strings
+++ b/iina/nl.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configuratie:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show the config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "Toon configuratiebestand in Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */

--- a/iina/no.lproj/HistoryWindowController.strings
+++ b/iina/no.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Avspillingshistorikk";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "Vis i Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/no.lproj/Localizable.strings
+++ b/iina/no.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Flytt valgte til papirkurv";
 "pl_menu.delete_after_play" = "Flytt til papirkurv etter avspilling";
 "pl_menu.delete_after_play_multi" = "Flytt valgte til papirkurv etter avspilling";
-"pl_menu.reveal_in_finder" = "Vis i Finder";
+"pl_menu.show_in_finder" = "Vis i Finder";
 "pl_menu.add_file" = "Legg til fil…";
 "pl_menu.add_url" = "Legg til URL…";
 "pl_menu.clear_playlist" = "Tøm spilleliste";

--- a/iina/no.lproj/PrefKeyBindingViewController.strings
+++ b/iina/no.lproj/PrefKeyBindingViewController.strings
@@ -16,8 +16,8 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configuration:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
-"gDo-JL-a9k.title" = "Reveal config file in Finder";
+/* Class = "NSButtonCell"; title = "Show config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+"gDo-JL-a9k.title" = "Show config file in Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */
 "gpZ-Rh-DMn.title" = "Duplicate…";

--- a/iina/pl.lproj/HistoryWindowController.strings
+++ b/iina/pl.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Historia odtwarzania";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "Pokaż w Finderze";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/pl.lproj/Localizable.strings
+++ b/iina/pl.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Przenieś wybrane pliki do kosza";
 "pl_menu.delete_after_play" = "Przenieś plik do kosza po zakończeniu odtwarzania";
 "pl_menu.delete_after_play_multi" = "Przenieś po odtwarzaniu wybrane pliki do kosza";
-"pl_menu.reveal_in_finder" = "Pokaż w Finderze";
+"pl_menu.show_in_finder" = "Pokaż w Finderze";
 "pl_menu.add_file" = "Dodaj plik…";
 "pl_menu.add_url" = "Dodaj adres URL…";
 "pl_menu.clear_playlist" = "Wyczyść playlistę";

--- a/iina/pl.lproj/PrefKeyBindingViewController.strings
+++ b/iina/pl.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Konfiguracja:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show the config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "Pokaż plik konfiguracyjny w Finderze";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */

--- a/iina/pt-BR.lproj/HistoryWindowController.strings
+++ b/iina/pt-BR.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Histórico de Reprodução";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "Mostrar no Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/pt-BR.lproj/Localizable.strings
+++ b/iina/pt-BR.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Mover arquivos selecionados pro Lixo";
 "pl_menu.delete_after_play" = "Mover pro Lixo depois de tocar";
 "pl_menu.delete_after_play_multi" = "Mover arquivos selecionados pro Lixo depois de tocar";
-"pl_menu.reveal_in_finder" = "Mostrar no Finder";
+"pl_menu.show_in_finder" = "Mostrar no Finder";
 "pl_menu.add_file" = "Adicionar Arquivo…";
 "pl_menu.add_url" = "Adicionar URL…";
 "pl_menu.clear_playlist" = "Limpar Lista de Reprodução";

--- a/iina/pt-BR.lproj/PrefKeyBindingViewController.strings
+++ b/iina/pt-BR.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configuração:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show the config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "Mostrar arquivo de configuração no Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */

--- a/iina/pt.lproj/HistoryWindowController.strings
+++ b/iina/pt.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Histórico de Reprodução";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "Mostrar no Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/pt.lproj/Localizable.strings
+++ b/iina/pt.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Mover Ficheiros Selecionados para o Lixo";
 "pl_menu.delete_after_play" = "Mover para o Lixo depois da Reprodução";
 "pl_menu.delete_after_play_multi" = "Mover Ficheiros Selecionados para o Lixo depois da Reprodução";
-"pl_menu.reveal_in_finder" = "Mostrar no Finder";
+"pl_menu.show_in_finder" = "Mostrar no Finder";
 "pl_menu.add_file" = "Adicionar Ficheiro…";
 "pl_menu.add_url" = "Adicionar URL…";
 "pl_menu.clear_playlist" = "Limpar Lista de Reprodução";

--- a/iina/pt.lproj/PrefKeyBindingViewController.strings
+++ b/iina/pt.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configuração:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show the config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "Mostrar ficheiro de configuração no Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */

--- a/iina/ro.lproj/HistoryWindowController.strings
+++ b/iina/ro.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Istoric de redare";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "Arată în Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/ro.lproj/Localizable.strings
+++ b/iina/ro.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Mută fișierele selectate la Coș";
 "pl_menu.delete_after_play" = "Mută la Coș după redare";
 "pl_menu.delete_after_play_multi" = "Mută elementele selectare la Coș după ce au fost redate";
-"pl_menu.reveal_in_finder" = "Arată în Finder";
+"pl_menu.show_in_finder" = "Arată în Finder";
 "pl_menu.add_file" = "Adaugă Fișier…";
 "pl_menu.add_url" = "Adaugă URL…";
 "pl_menu.clear_playlist" = "Șterge lista de redare";

--- a/iina/ro.lproj/PrefKeyBindingViewController.strings
+++ b/iina/ro.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configurație:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show the config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "Afișează fișierul de configurație în Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */

--- a/iina/ru.lproj/HistoryWindowController.strings
+++ b/iina/ru.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "История воспроизведения";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "Показать в Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/ru.lproj/Localizable.strings
+++ b/iina/ru.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Переместить выбранные в Корзину";
 "pl_menu.delete_after_play" = "Переместить в Корзину после воспроизведения";
 "pl_menu.delete_after_play_multi" = "Переместить выбранные в Корзину после воспроизведения";
-"pl_menu.reveal_in_finder" = "Показать в Finder";
+"pl_menu.show_in_finder" = "Показать в Finder";
 "pl_menu.add_file" = "Добавить файл…";
 "pl_menu.add_url" = "Добавить URL…";
 "pl_menu.clear_playlist" = "Очистить плейлист";

--- a/iina/ru.lproj/PrefKeyBindingViewController.strings
+++ b/iina/ru.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Конфигурация:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show the config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "Показать файл конфигурации в Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */

--- a/iina/sk.lproj/HistoryWindowController.strings
+++ b/iina/sk.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "História prehrávania";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "Zobraziť vo Finderi";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/sk.lproj/Localizable.strings
+++ b/iina/sk.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Presunúť Vybrané Súbory do Koša";
 "pl_menu.delete_after_play" = "Presunúť do Koša po Prehraní";
 "pl_menu.delete_after_play_multi" = "Presunúť Vybrané Súbory do Koša po Prehraní";
-"pl_menu.reveal_in_finder" = "Zobraziť vo Finderi";
+"pl_menu.show_in_finder" = "Zobraziť vo Finderi";
 "pl_menu.add_file" = "Pridať Súbor…";
 "pl_menu.add_url" = "Pridať URL…";
 "pl_menu.clear_playlist" = "Vyčistiť Playlist";

--- a/iina/sk.lproj/PrefKeyBindingViewController.strings
+++ b/iina/sk.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Konfigurácia:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show the config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "Zobraziť konfiguračný súbor vo Finderi";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */

--- a/iina/sl.lproj/HistoryWindowController.strings
+++ b/iina/sl.lproj/HistoryWindowController.strings
@@ -13,8 +13,8 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Playback History";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
-"FPK-nx-hvF.title" = "Reveal in Finder";
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
+"FPK-nx-hvF.title" = "Show in Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */
 "Gx5-gP-rzr.title" = "Search in";

--- a/iina/sl.lproj/Localizable.strings
+++ b/iina/sl.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Move Selected Files to Trash";
 "pl_menu.delete_after_play" = "Move to Trash After Playback";
 "pl_menu.delete_after_play_multi" = "Move Selected Files to Trash After Playback";
-"pl_menu.reveal_in_finder" = "Reveal in Finder";
+"pl_menu.show_in_finder" = "Show in Finder";
 "pl_menu.add_file" = "Add File…";
 "pl_menu.add_url" = "Add URL…";
 "pl_menu.clear_playlist" = "Clear Playlist";

--- a/iina/sl.lproj/PrefKeyBindingViewController.strings
+++ b/iina/sl.lproj/PrefKeyBindingViewController.strings
@@ -16,8 +16,8 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configuration:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
-"gDo-JL-a9k.title" = "Reveal config file in Finder";
+/* Class = "NSButtonCell"; title = "Show config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+"gDo-JL-a9k.title" = "Show config file in Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */
 "gpZ-Rh-DMn.title" = "Duplicate…";

--- a/iina/sr-CS.lproj/HistoryWindowController.strings
+++ b/iina/sr-CS.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Istorija reprodukcije";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "Prikaži u Finderu";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/sr-CS.lproj/Localizable.strings
+++ b/iina/sr-CS.lproj/Localizable.strings
@@ -244,7 +244,7 @@
 "pl_menu.delete_multi" = "Premesti izabrane datoteke u smeće";
 "pl_menu.delete_after_play" = "Premesti u smeće nakon reprodukcije";
 "pl_menu.delete_after_play_multi" = "Premesti izabrane datoteke u smeće nakon reprodukcije";
-"pl_menu.reveal_in_finder" = "Prikaži u Finderu";
+"pl_menu.show_in_finder" = "Prikaži u Finderu";
 "pl_menu.add_file" = "Dodaj datoteku…";
 "pl_menu.add_url" = "Dodaj URL…";
 "pl_menu.clear_playlist" = "Obriši plejlistu";

--- a/iina/sr-CS.lproj/PrefKeyBindingViewController.strings
+++ b/iina/sr-CS.lproj/PrefKeyBindingViewController.strings
@@ -16,8 +16,8 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configuration:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
-"gDo-JL-a9k.title" = "Reveal config file in Finder";
+/* Class = "NSButtonCell"; title = "Show config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+"gDo-JL-a9k.title" = "Show config file in Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */
 "gpZ-Rh-DMn.title" = "Duplicate…";

--- a/iina/sr-Cyrl.lproj/HistoryWindowController.strings
+++ b/iina/sr-Cyrl.lproj/HistoryWindowController.strings
@@ -13,8 +13,8 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Playback History";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
-"FPK-nx-hvF.title" = "Reveal in Finder";
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
+"FPK-nx-hvF.title" = "Show in Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */
 "Gx5-gP-rzr.title" = "Search in";

--- a/iina/sr-Cyrl.lproj/Localizable.strings
+++ b/iina/sr-Cyrl.lproj/Localizable.strings
@@ -227,7 +227,7 @@
 "pl_menu.delete_multi" = "Move Selected Files to Trash";
 "pl_menu.delete_after_play" = "Move to Trash After Playback";
 "pl_menu.delete_after_play_multi" = "Move Selected Files to Trash After Playback";
-"pl_menu.reveal_in_finder" = "Reveal in Finder";
+"pl_menu.show_in_finder" = "Show in Finder";
 "pl_menu.add_file" = "Add File…";
 "pl_menu.add_url" = "Add URL…";
 "pl_menu.clear_playlist" = "Clear Playlist";

--- a/iina/sr-Cyrl.lproj/PrefKeyBindingViewController.strings
+++ b/iina/sr-Cyrl.lproj/PrefKeyBindingViewController.strings
@@ -16,8 +16,8 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configuration:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
-"gDo-JL-a9k.title" = "Reveal config file in Finder";
+/* Class = "NSButtonCell"; title = "Show config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+"gDo-JL-a9k.title" = "Show config file in Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */
 "gpZ-Rh-DMn.title" = "Duplicate…";

--- a/iina/sr-Latn.lproj/HistoryWindowController.strings
+++ b/iina/sr-Latn.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Istorija reprodukcije";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "Prikaži u Finderu";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/sr-Latn.lproj/Localizable.strings
+++ b/iina/sr-Latn.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Premesti izabrane datoteke u smeće";
 "pl_menu.delete_after_play" = "Premesti u smeće nakon reprodukcije";
 "pl_menu.delete_after_play_multi" = "Premesti izabrane datoteke u smeće nakon reprodukcije";
-"pl_menu.reveal_in_finder" = "Prikaži u Finderu";
+"pl_menu.show_in_finder" = "Prikaži u Finderu";
 "pl_menu.add_file" = "Dodaj datoteku…";
 "pl_menu.add_url" = "Dodaj URL…";
 "pl_menu.clear_playlist" = "Obriši plejlistu";

--- a/iina/sr-Latn.lproj/PrefKeyBindingViewController.strings
+++ b/iina/sr-Latn.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Konfiguracija:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show the config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "Prikaži konfiguracionu datoteku u Finderu";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */

--- a/iina/sr.lproj/HistoryWindowController.strings
+++ b/iina/sr.lproj/HistoryWindowController.strings
@@ -13,8 +13,8 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Playback History";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
-"FPK-nx-hvF.title" = "Reveal in Finder";
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
+"FPK-nx-hvF.title" = "Show in Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */
 "Gx5-gP-rzr.title" = "Search in";

--- a/iina/sr.lproj/Localizable.strings
+++ b/iina/sr.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Move Selected Files to Trash";
 "pl_menu.delete_after_play" = "Move to Trash After Playback";
 "pl_menu.delete_after_play_multi" = "Move Selected Files to Trash After Playback";
-"pl_menu.reveal_in_finder" = "Reveal in Finder";
+"pl_menu.show_in_finder" = "Show in Finder";
 "pl_menu.add_file" = "Add File…";
 "pl_menu.add_url" = "Add URL…";
 "pl_menu.clear_playlist" = "Clear Playlist";

--- a/iina/sr.lproj/PrefKeyBindingViewController.strings
+++ b/iina/sr.lproj/PrefKeyBindingViewController.strings
@@ -16,8 +16,8 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configuration:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
-"gDo-JL-a9k.title" = "Reveal config file in Finder";
+/* Class = "NSButtonCell"; title = "Show config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+"gDo-JL-a9k.title" = "Show config file in Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */
 "gpZ-Rh-DMn.title" = "Duplicate…";

--- a/iina/sv.lproj/HistoryWindowController.strings
+++ b/iina/sv.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Uppspelningshistorik";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "Visa i Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/sv.lproj/Localizable.strings
+++ b/iina/sv.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Flytta markerade filer till papperskorgen";
 "pl_menu.delete_after_play" = "Flytta till papperskorgen efter uppspelning";
 "pl_menu.delete_after_play_multi" = "Flytta markerade filer till papperskorgen efter uppspelning";
-"pl_menu.reveal_in_finder" = "Visa i Finder";
+"pl_menu.show_in_finder" = "Visa i Finder";
 "pl_menu.add_file" = "Lägg till fil…";
 "pl_menu.add_url" = "Lägg till URL…";
 "pl_menu.clear_playlist" = "Rensa spellista";

--- a/iina/sv.lproj/PrefKeyBindingViewController.strings
+++ b/iina/sv.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Konfiguration:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show the config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "Visa konfigurationsfil i Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */

--- a/iina/ta.lproj/HistoryWindowController.strings
+++ b/iina/ta.lproj/HistoryWindowController.strings
@@ -13,8 +13,8 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Playback History";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
-"FPK-nx-hvF.title" = "Reveal in Finder";
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
+"FPK-nx-hvF.title" = "Show in Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */
 "Gx5-gP-rzr.title" = "Search in";

--- a/iina/ta.lproj/Localizable.strings
+++ b/iina/ta.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Move Selected Files to Trash";
 "pl_menu.delete_after_play" = "Move to Trash After Playback";
 "pl_menu.delete_after_play_multi" = "Move Selected Files to Trash After Playback";
-"pl_menu.reveal_in_finder" = "Reveal in Finder";
+"pl_menu.show_in_finder" = "Show in Finder";
 "pl_menu.add_file" = "கோப்பைச் சேர்…";
 "pl_menu.add_url" = "URLஐ சேர்…";
 "pl_menu.clear_playlist" = "Clear Playlist";

--- a/iina/ta.lproj/PrefKeyBindingViewController.strings
+++ b/iina/ta.lproj/PrefKeyBindingViewController.strings
@@ -16,8 +16,8 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "அமைப்பு:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
-"gDo-JL-a9k.title" = "Reveal config file in Finder";
+/* Class = "NSButtonCell"; title = "Show config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+"gDo-JL-a9k.title" = "Show config file in Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */
 "gpZ-Rh-DMn.title" = "Duplicate…";

--- a/iina/th.lproj/HistoryWindowController.strings
+++ b/iina/th.lproj/HistoryWindowController.strings
@@ -13,8 +13,8 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Playback History";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
-"FPK-nx-hvF.title" = "Reveal in Finder";
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
+"FPK-nx-hvF.title" = "Show in Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */
 "Gx5-gP-rzr.title" = "Search in";

--- a/iina/th.lproj/Localizable.strings
+++ b/iina/th.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Move Selected Files to Trash";
 "pl_menu.delete_after_play" = "Move to Trash After Playback";
 "pl_menu.delete_after_play_multi" = "Move Selected Files to Trash After Playback";
-"pl_menu.reveal_in_finder" = "Reveal in Finder";
+"pl_menu.show_in_finder" = "Show in Finder";
 "pl_menu.add_file" = "Add File…";
 "pl_menu.add_url" = "Add URL…";
 "pl_menu.clear_playlist" = "Clear Playlist";

--- a/iina/th.lproj/PrefKeyBindingViewController.strings
+++ b/iina/th.lproj/PrefKeyBindingViewController.strings
@@ -16,8 +16,8 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configuration:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
-"gDo-JL-a9k.title" = "Reveal config file in Finder";
+/* Class = "NSButtonCell"; title = "Show config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+"gDo-JL-a9k.title" = "Show config file in Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */
 "gpZ-Rh-DMn.title" = "Duplicate…";

--- a/iina/tr.lproj/HistoryWindowController.strings
+++ b/iina/tr.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Oynatma Geçmişi";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "Finder'da Göster";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/tr.lproj/Localizable.strings
+++ b/iina/tr.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Seçili Dosyaları Çöp Kutusuna Taşı";
 "pl_menu.delete_after_play" = "Oynatma İşleminden Sonra Çöp Kutusuna Taşı";
 "pl_menu.delete_after_play_multi" = "Seçilen Dosyaları Oynatma İşleminden Sonra Çöp Kutusuna Taşı";
-"pl_menu.reveal_in_finder" = "Finder'da göster";
+"pl_menu.show_in_finder" = "Finder'da göster";
 "pl_menu.add_file" = "Dosya Ekle";
 "pl_menu.add_url" = "Internet Adresi (URL) Ekle...";
 "pl_menu.clear_playlist" = "Oynatma Listesini Temizle";

--- a/iina/tr.lproj/PrefKeyBindingViewController.strings
+++ b/iina/tr.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Yapılandırma:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show the config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "Yapılandırma dosyasını Finder'da göster";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */

--- a/iina/ug.lproj/HistoryWindowController.strings
+++ b/iina/ug.lproj/HistoryWindowController.strings
@@ -13,8 +13,8 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Playback History";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
-"FPK-nx-hvF.title" = "Reveal in Finder";
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
+"FPK-nx-hvF.title" = "Show in Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */
 "Gx5-gP-rzr.title" = "Search in";

--- a/iina/ug.lproj/Localizable.strings
+++ b/iina/ug.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Move Selected Files to Trash";
 "pl_menu.delete_after_play" = "Move to Trash After Playback";
 "pl_menu.delete_after_play_multi" = "Move Selected Files to Trash After Playback";
-"pl_menu.reveal_in_finder" = "Reveal in Finder";
+"pl_menu.show_in_finder" = "Show in Finder";
 "pl_menu.add_file" = "Add File…";
 "pl_menu.add_url" = "Add URL…";
 "pl_menu.clear_playlist" = "Clear Playlist";

--- a/iina/ug.lproj/PrefKeyBindingViewController.strings
+++ b/iina/ug.lproj/PrefKeyBindingViewController.strings
@@ -16,8 +16,8 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configuration:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
-"gDo-JL-a9k.title" = "Reveal config file in Finder";
+/* Class = "NSButtonCell"; title = "Show config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+"gDo-JL-a9k.title" = "Show config file in Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */
 "gpZ-Rh-DMn.title" = "Duplicate…";

--- a/iina/uk.lproj/HistoryWindowController.strings
+++ b/iina/uk.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Історія перегляду";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "Показати у Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/uk.lproj/Localizable.strings
+++ b/iina/uk.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Перемістити вибрані файли у Смітник";
 "pl_menu.delete_after_play" = "Перемістити у Смітник після перегляду";
 "pl_menu.delete_after_play_multi" = "Перемістити вибрані файли у Смітник після перегляду";
-"pl_menu.reveal_in_finder" = "Показати у Finder";
+"pl_menu.show_in_finder" = "Показати у Finder";
 "pl_menu.add_file" = "Додати файл…";
 "pl_menu.add_url" = "Додати URL…";
 "pl_menu.clear_playlist" = "Очистити плейліст";

--- a/iina/uk.lproj/PrefKeyBindingViewController.strings
+++ b/iina/uk.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Конфігурація:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show the config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "Показати файл конфігурації у Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */

--- a/iina/ur.lproj/HistoryWindowController.strings
+++ b/iina/ur.lproj/HistoryWindowController.strings
@@ -13,8 +13,8 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Playback History";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
-"FPK-nx-hvF.title" = "Reveal in Finder";
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
+"FPK-nx-hvF.title" = "Show in Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */
 "Gx5-gP-rzr.title" = "Search in";

--- a/iina/ur.lproj/Localizable.strings
+++ b/iina/ur.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Move Selected Files to Trash";
 "pl_menu.delete_after_play" = "Move to Trash After Playback";
 "pl_menu.delete_after_play_multi" = "Move Selected Files to Trash After Playback";
-"pl_menu.reveal_in_finder" = "Reveal in Finder";
+"pl_menu.show_in_finder" = "Show in Finder";
 "pl_menu.add_file" = "Add File…";
 "pl_menu.add_url" = "Add URL…";
 "pl_menu.clear_playlist" = "Clear Playlist";

--- a/iina/ur.lproj/PrefKeyBindingViewController.strings
+++ b/iina/ur.lproj/PrefKeyBindingViewController.strings
@@ -16,8 +16,8 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Configuration:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
-"gDo-JL-a9k.title" = "Reveal config file in Finder";
+/* Class = "NSButtonCell"; title = "Show config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+"gDo-JL-a9k.title" = "Show config file in Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */
 "gpZ-Rh-DMn.title" = "Duplicate…";

--- a/iina/vi.lproj/HistoryWindowController.strings
+++ b/iina/vi.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "Lịch sử xem lại";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "Xem trong Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/vi.lproj/Localizable.strings
+++ b/iina/vi.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "Move Selected Files to Trash";
 "pl_menu.delete_after_play" = "Move to Trash After Playback";
 "pl_menu.delete_after_play_multi" = "Move Selected Files to Trash After Playback";
-"pl_menu.reveal_in_finder" = "Reveal in Finder";
+"pl_menu.show_in_finder" = "Show in Finder";
 "pl_menu.add_file" = "Add File…";
 "pl_menu.add_url" = "Add URL…";
 "pl_menu.clear_playlist" = "Clear Playlist";

--- a/iina/vi.lproj/PrefKeyBindingViewController.strings
+++ b/iina/vi.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "Cấu hình:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "Xem tệp cấu hình trong Finder";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */

--- a/iina/zh-Hans.lproj/HistoryWindowController.strings
+++ b/iina/zh-Hans.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "播放历史";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "在“访达”中显示";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/zh-Hans.lproj/Localizable.strings
+++ b/iina/zh-Hans.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "将选中项移到废纸篓";
 "pl_menu.delete_after_play" = "播放后移到废纸篓";
 "pl_menu.delete_after_play_multi" = "播放后将选中项移到废纸篓";
-"pl_menu.reveal_in_finder" = "在“访达”中显示";
+"pl_menu.show_in_finder" = "在“访达”中显示";
 "pl_menu.add_file" = "添加文件…";
 "pl_menu.add_url" = "添加 URL…";
 "pl_menu.clear_playlist" = "清除播放列表";

--- a/iina/zh-Hans.lproj/PrefKeyBindingViewController.strings
+++ b/iina/zh-Hans.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "配置文件:";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show the config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "在 Finder 中查看配置文件";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */

--- a/iina/zh-Hant.lproj/HistoryWindowController.strings
+++ b/iina/zh-Hant.lproj/HistoryWindowController.strings
@@ -13,7 +13,7 @@
 /* Class = "NSWindow"; title = "Playback History"; ObjectID = "F0z-JX-Cv5"; */
 "F0z-JX-Cv5.title" = "播放記錄";
 
-/* Class = "NSMenuItem"; title = "Reveal in Finder"; ObjectID = "FPK-nx-hvF"; */
+/* Class = "NSMenuItem"; title = "Show in Finder"; ObjectID = "FPK-nx-hvF"; */
 "FPK-nx-hvF.title" = "顯示於 Finder";
 
 /* Class = "NSMenuItem"; title = "Search in"; ObjectID = "Gx5-gP-rzr"; */

--- a/iina/zh-Hant.lproj/Localizable.strings
+++ b/iina/zh-Hant.lproj/Localizable.strings
@@ -257,7 +257,7 @@
 "pl_menu.delete_multi" = "將所選檔案丟到垃圾桶";
 "pl_menu.delete_after_play" = "播放完畢後丟到垃圾桶";
 "pl_menu.delete_after_play_multi" = "播放完畢後，將已所選的檔案丟到垃圾桶";
-"pl_menu.reveal_in_finder" = "顯示於 Finder";
+"pl_menu.show_in_finder" = "顯示於 Finder";
 "pl_menu.add_file" = "加入檔案⋯";
 "pl_menu.add_url" = "加入 URL⋯";
 "pl_menu.clear_playlist" = "清除播放列表";

--- a/iina/zh-Hant.lproj/PrefKeyBindingViewController.strings
+++ b/iina/zh-Hant.lproj/PrefKeyBindingViewController.strings
@@ -16,7 +16,7 @@
 /* Class = "NSTextFieldCell"; title = "Configuration:"; ObjectID = "au5-6f-s55"; */
 "au5-6f-s55.title" = "設定：";
 
-/* Class = "NSButtonCell"; title = "Reveal config file in Finder"; ObjectID = "gDo-JL-a9k"; */
+/* Class = "NSButtonCell"; title = "Show the config file in Finder"; ObjectID = "gDo-JL-a9k"; */
 "gDo-JL-a9k.title" = "在 Finder 中顯示設定檔";
 
 /* Class = "NSButtonCell"; title = "Duplicate…"; ObjectID = "gpZ-Rh-DMn"; */


### PR DESCRIPTION
- [x] This PR fixes #3976.

Changes in UI:
- Preferences > Key Bindings > "Reveal config file in Finder" -> "Show the config file in Finder"
- Preferences > Plugin > "Reveal in Finder" -> "Show in Finder"
- Playback History > (context menu) > "Reveal in Finder" -> "Show in Finder"
- Config file existing error message: "This should not happen. Choose OK to overwrite, Cancel to reveal the file in Finder." -> "This should not happen. Choose OK to overwrite, Cancel to show the file in Finder.";

Other changes:
- In `Localizables.strings`, the key name "pl_menu.reveal_in_finder" has been renamed to "pl_menu.show_in_finder"
- Many function has been renamed from "reveal" to "show"

The only "reveal" I didn't change is the button in the OSD after a screenshot is taken. I can't come up with a good word for that.

Since it contains changes to xib files, some changes may seem messy, but I've tried to make it as clean as possible.