### PR TITLE
Fix a bug where music mode doesn't show time info

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -431,6 +431,7 @@ class PlayerCore: NSObject {
     miniPlayer.showWindow(self)
 
     miniPlayer.updateTitle()
+    syncUITime()
     let playlistView = mainWindow.playlistView.view
     let videoView = mainWindow.videoView
     // reset down shift for playlistView


### PR DESCRIPTION
**Description:**
Steps to reproduce:
- Pause a video
- Enter Music Mode
- The time information is not available on the UI

Calling `syncUITime` when entering music mode solves the issue.