### PR TITLE
fix: postMessage type not valid JSON object will crash

### DIFF
--- a/iina/JavascriptMessageHub.swift
+++ b/iina/JavascriptMessageHub.swift
@@ -24,7 +24,11 @@ class JavascriptMessageHub {
       guard JSONSerialization.isValidJSONObject(object),
         let data = try? JSONSerialization.data(withJSONObject: object),
          let dataString = String(data: data, encoding: .utf8) else {
-          webView.evaluateJavaScript("window.iina._emit(`\(name)`)")
+          if let dataString = data.toString() {
+            webView.evaluateJavaScript("window.iina._emit(`\(name)`, `\(dataString)`)")
+          } else {
+            webView.evaluateJavaScript("window.iina._emit(`\(name)`)")
+          }
           return
       }
       webView.evaluateJavaScript("window.iina._emit(`\(name)`, `\(dataString)`)")

--- a/iina/JavascriptMessageHub.swift
+++ b/iina/JavascriptMessageHub.swift
@@ -50,11 +50,13 @@ class JavascriptMessageHub {
 
   func callListener(forEvent name: String, withDataString dataString: String?) {
     guard let callback = listeners[name] else { return }
-
-    guard let dataString = dataString,
-      let data = dataString.data(using: .utf8),
-      let decoded = try? JSONSerialization.jsonObject(with: data) else {
+    guard let dataString = dataString else {
       callback.value.call(withArguments: [])
+      return
+    }
+    guard let data = dataString.data(using: .utf8),
+      let decoded = try? JSONSerialization.jsonObject(with: data) else {
+      callback.value.call(withArguments: [JSValue(object: dataString, in: callback.value.context) ?? NSNull()])
       return
     }
 

--- a/iina/JavascriptMessageHub.swift
+++ b/iina/JavascriptMessageHub.swift
@@ -21,7 +21,8 @@ class JavascriptMessageHub {
   func postMessage(to webView: WKWebView, name: String, data: JSValue) {
     guard let object = data.toObject() else { return }
     DispatchQueue.main.async {
-      guard let data = try? JSONSerialization.data(withJSONObject: object),
+      guard JSONSerialization.isValidJSONObject(object),
+        let data = try? JSONSerialization.data(withJSONObject: object),
          let dataString = String(data: data, encoding: .utf8) else {
           webView.evaluateJavaScript("window.iina._emit(`\(name)`)")
           return


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**

`postMessage` only support valid JSON object, not test before convert.