### PR TITLE
Fix postMessage type not valid JSON object will crash

### DIFF
--- a/iina/JavascriptMessageHub.swift
+++ b/iina/JavascriptMessageHub.swift
@@ -21,7 +21,8 @@ class JavascriptMessageHub {
   func postMessage(to webView: WKWebView, name: String, data: JSValue) {
     guard let object = data.toObject() else { return }
     DispatchQueue.main.async {
-      guard let data = try? JSONSerialization.data(withJSONObject: object),
+      guard JSONSerialization.isValidJSONObject(object),
+        let data = try? JSONSerialization.data(withJSONObject: object),
          let dataString = String(data: data, encoding: .utf8) else {
           webView.evaluateJavaScript("window.iina._emit(`\(name)`)")
           return


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**

`postMessage` only support valid JSON object, not test before convert.