### PR TITLE
Fix audio continues after window closed, #3995

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1290,7 +1290,6 @@ class PlayerCore: NSObject {
 
   func fileStarted(path: String) {
     Logger.log("File started", subsystem: subsystem)
-    isStopped = false
     info.justStartedFile = true
     info.disableOSDForFileLoading = true
     currentMediaIsAudio = .unknown
@@ -1356,6 +1355,7 @@ class PlayerCore: NSObject {
     triedUsingExactSeekForCurrentFile = false
     info.fileLoading = false
     info.haveDownloadedSub = false
+    isStopped = false
     checkUnsyncedWindowOptions()
     // generate thumbnails if window has loaded video
     if mainWindow.isVideoLoaded {


### PR DESCRIPTION
The fix in the commit moves the resetting of the isStopped flag from the fileStarted method in PlayerCore to the fileLoaded method.

The method fileStarted was the wrong place to reset this flag because mpv will start loading the next file in the playlist while still stopping playback of the previous file.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #3995.

---

**Description:**
This fixes a regression recently added to the develop branch.