### PR TITLE
Fix bug: Shift modifier incorrectly added to filter shortcuts

### DIFF
--- a/iina/FilterWindowController.swift
+++ b/iina/FilterWindowController.swift
@@ -249,7 +249,7 @@ class FilterWindowController: NSWindowController, NSWindowDelegate {
     currentSavedFilter = savedFilters[row]
     editFilterNameTextField.stringValue = currentSavedFilter!.name
     editFilterStringTextField.stringValue = currentSavedFilter!.filterString
-    editFilterKeyRecordView.currentRawKey = currentSavedFilter!.shortcutKey
+    editFilterKeyRecordView.currentKey = currentSavedFilter!.shortcutKey
     editFilterKeyRecordView.currentKeyModifiers = currentSavedFilter!.shortcutKeyModifiers
     editFilterKeyRecordViewLabel.stringValue = currentSavedFilter!.readableShortCutKey
     window!.beginSheet(editFilterSheet)
@@ -322,7 +322,7 @@ extension FilterWindowController {
     if let currentFilter = currentFilter {
       let filter = SavedFilter(name: saveFilterNameTextField.stringValue,
                                filterString: currentFilter.stringFormat,
-                               shortcutKey: keyRecordView.currentRawKey,
+                               shortcutKey: keyRecordView.currentKey,
                                modifiers: keyRecordView.currentKeyModifiers)
       savedFilters.append(filter)
       reloadTable()
@@ -339,8 +339,7 @@ extension FilterWindowController {
     if let currentFilter = currentSavedFilter {
       currentFilter.name = editFilterNameTextField.stringValue
       currentFilter.filterString = editFilterStringTextField.stringValue
-      // FIXME: shouldn't be shift-modified; should examine this carefully
-      currentFilter.shortcutKey = editFilterKeyRecordView.currentRawKey.lowercased()
+      currentFilter.shortcutKey = editFilterKeyRecordView.currentKey
       currentFilter.shortcutKeyModifiers = editFilterKeyRecordView.currentKeyModifiers
       reloadTable()
       syncSavedFilter()

--- a/iina/KeyRecordView.swift
+++ b/iina/KeyRecordView.swift
@@ -33,8 +33,6 @@ class KeyRecordView: NSView {
 
   var delegate: KeyRecordViewDelegate!
 
-  var currentRawKey: String = ""
-  var currentKeyInReadableFormat: String = ""
   var currentKey: String = ""
   var currentKeyModifiers: NSEvent.ModifierFlags = []
 
@@ -55,7 +53,6 @@ class KeyRecordView: NSView {
   override func keyDown(with event: NSEvent) {
     currentKey = event.charactersIgnoringModifiers ?? ""
     currentKeyModifiers = event.modifierFlags
-    (currentKeyInReadableFormat, currentRawKey) = event.readableKeyDescription
     delegate.keyRecordView(self, recordedKeyDownWith: event)
   }
 

--- a/iina/SavedFilter.swift
+++ b/iina/SavedFilter.swift
@@ -22,10 +22,7 @@ class SavedFilter: NSObject {
   @objc var filterString: String
   @objc var readableShortCutKey: String {
     get {
-      return ([(.control, "⌃"), (.option, "⌥"), (.shift, "⇧"), (.command, "⌘")] as [(NSEvent.ModifierFlags, String)])
-        .map { shortcutKeyModifiers.contains($0.0) ? $0.1 : "" }
-        .joined()
-        .appending(shortcutKey.uppercased())
+      return KeyCodeHelper.readableString(fromKey: shortcutKey, modifiers: shortcutKeyModifiers)
     }
   }
   @objc var isEnabled = false


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #3998.

---

**Description:**
See above issue for problem description.

**Summary / conclusions**
This terrifying block of code appears to be the culprit:
```Swift
extension NSEvent {
  var readableKeyDescription: (String, String) {
    get {

      let rawKeyCharacter: String
      if let char = NSEventKeyCodeMapping[Int(self.keyCode)] {
        rawKeyCharacter = char
      } else {
        let inputSource = TISCopyCurrentASCIICapableKeyboardLayoutInputSource().takeUnretainedValue()
        if let layoutData = TISGetInputSourceProperty(inputSource, kTISPropertyUnicodeKeyLayoutData) {
          let dataRef = unsafeBitCast(layoutData, to: CFData.self)
          let keyLayout = unsafeBitCast(CFDataGetBytePtr(dataRef), to: UnsafePointer<UCKeyboardLayout>.self)
          var deadKeyState = UInt32(0)
          let maxLength = 4
          var actualLength = 0
          var actualString = [UniChar](repeating: 0, count: maxLength)
          let error = UCKeyTranslate(keyLayout,
                                     UInt16(self.keyCode),
                                     UInt16(kUCKeyActionDisplay),
                                     UInt32((0 >> 8) & 0xFF),
                                     UInt32(LMGetKbdType()),
                                     OptionBits(kUCKeyTranslateNoDeadKeysBit),
                                     &deadKeyState,
                                     maxLength,
                                     &actualLength,
                                     &actualString)
          if error == 0 {
            rawKeyCharacter = String(utf16CodeUnits: &actualString, count: maxLength).uppercased()

          } else {
            rawKeyCharacter = KeyCodeHelper.keyMap[self.keyCode]?.0 ?? ""
          }
        } else {
          rawKeyCharacter = KeyCodeHelper.keyMap[self.keyCode]?.0 ?? ""
        }
      }

      return (([(.control, "⌃"), (.option, "⌥"), (.shift, "⇧"), (.command, "⌘")] as [(NSEvent.ModifierFlags, String)])
        .map { self.modifierFlags.contains($0.0) ? $0.1 : "" }
        .joined()
        .appending(rawKeyCharacter), rawKeyCharacter)
    }
  }
}
```

The value it returns will always be in uppercase, which is fine for display purposes, but it shouldn't have been using it to store the "raw" key value (The code was already grabbing the raw value from the user and putting it in `currentKey`, and it was far simpler to just use that). It has another problem: it seems to add 3 null characters to the string it returns. The debugger shows that `t` is stored as `T\0\0\0`.

This is not good, but I'm going to punt and declare it to be outside the scope of this defect. 

After this fix, `readableKeyDescription` is only used in two places:
1. In `FilterWindowController` for display. At least this doesn't seem to be breaking anything.
2. In `KeyCodeHelper.mpvKeyCode()`, where it is checked for inequality against another string, causing a block of code to always evaluate to `true` - which is ok because that block should always be executed.

This should be cleaned up at some point. Rather than try to debug that block, a more prudent solution would be to remove all use of it and find a simpler substitute if needed. At least this PR makes strides in that direction. 