### PR TITLE
Fix quit triggers "invalid context state" error, #3593

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -435,6 +435,8 @@ class MPVController: NSObject {
 
   func mpvUninitRendering() {
     guard let mpvRenderContext = mpvRenderContext else { return }
+    lockAndSetOpenGLContext()
+    defer { unlockOpenGLContext() }
     mpv_render_context_set_update_callback(mpvRenderContext, nil, nil)
     mpv_render_context_free(mpvRenderContext)
   }


### PR DESCRIPTION
This commit will change MPVController.mpvUninitRendering to lock and set the OpenGL context before calling the mpv render methods.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #3593.

---

**Description:**
