### PR TITLE
HDR: Observe `MPVProperty.videoParams*` directly to avoid possible ra…

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -132,6 +132,8 @@ class MPVController: NSObject {
     MPVOption.Window.windowScale: MPV_FORMAT_DOUBLE,
     MPVProperty.mediaTitle: MPV_FORMAT_STRING,
     MPVProperty.videoParamsRotate: MPV_FORMAT_INT64,
+    MPVProperty.videoParamsPrimaries: MPV_FORMAT_STRING,
+    MPVProperty.videoParamsGamma: MPV_FORMAT_STRING,
     MPVProperty.idleActive: MPV_FORMAT_FLAG
   ]
 
@@ -989,14 +991,18 @@ class MPVController: NSObject {
         player.mainWindow.rotation = rotation
       }
 
+    case MPVProperty.videoParamsPrimaries:
+      fallthrough;
+
+    case MPVProperty.videoParamsGamma:
+      if #available(macOS 10.15, *) {
+        player.refreshEdrMode()
+      }
+
     case MPVOption.TrackSelection.vid:
       player.info.vid = Int(getInt(MPVOption.TrackSelection.vid))
       player.postNotification(.iinaVIDChanged)
       player.sendOSD(.track(player.info.currentTrack(.video) ?? .noneVideoTrack))
-
-      if #available(macOS 10.15, *) {
-        player.refreshEdrMode()
-      }
 
     case MPVOption.TrackSelection.aid:
       player.info.aid = Int(getInt(MPVOption.TrackSelection.aid))

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -306,7 +306,10 @@ extension VideoView {
   func requestEdrMode() -> Bool? {
     guard let mpv = player.mpv else { return false }
 
-    guard let primaries = mpv.getString(MPVProperty.videoParamsPrimaries), let gamma = mpv.getString(MPVProperty.videoParamsGamma) else { return false }
+    guard let primaries = mpv.getString(MPVProperty.videoParamsPrimaries), let gamma = mpv.getString(MPVProperty.videoParamsGamma) else {
+      Logger.log("HDR primaries and gamma not available", level: .debug, subsystem: hdrSubsystem);
+      return false;
+    }
 
     var name: CFString? = nil;
     switch primaries {
@@ -360,6 +363,11 @@ extension VideoView {
     }
 
     guard player.info.hdrEnabled else { return nil }
+
+    if videoLayer.colorspace?.name == name {
+      Logger.log("HDR mode has been enabled, skipping", level: .debug, subsystem: hdrSubsystem);
+      return true;
+    }
 
     Logger.log("Will activate HDR color space instead of using ICC profile", level: .debug, subsystem: hdrSubsystem);
 


### PR DESCRIPTION
This commit will change `MPVController`, adding observers for:
- `MPVProperty.videoParamsPrimaries`
- `MPVProperty.videoParamsGamma`

And re-evaluate whether HDR should be enabled upon changes to these properties.

Ref: https://github.com/iina/iina/issues/3806#issuecomment-1154518956

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #3806

---

**Description:**
