### PR TITLE
Refresh Plugin menu (fix for issue #3994)

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -261,7 +261,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     NSApplication.shared.servicesProvider = self
 
-    menuController?.pluginMenuNeedsUpdate = true
+    (NSApp.delegate as? AppDelegate)?.menuController?.updatePluginMenu()
   }
 
   /** Show welcome window if `application(_:openFile:)` wasn't called, i.e. launched normally. */

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -162,7 +162,6 @@ class MenuController: NSObject, NSMenuDelegate {
   // Plugin
   @IBOutlet weak var pluginMenu: NSMenu!
   @IBOutlet weak var pluginMenuItem: NSMenuItem!
-  var pluginMenuNeedsUpdate = false
   // Window
   @IBOutlet weak var customTouchBar: NSMenuItem!
   @IBOutlet weak var inspector: NSMenuItem!
@@ -584,8 +583,6 @@ class MenuController: NSObject, NSMenuDelegate {
         NSMenuItem(title: "⚠︎ Conflicting key shortcuts…", action: nil, keyEquivalent: ""),
         at: 0)
     }
-
-    pluginMenuNeedsUpdate = false
   }
 
   @discardableResult

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -118,7 +118,6 @@ class PlayerCore: NSObject {
 
   var plugins: [JavascriptPluginInstance] = []
   private var pluginMap: [String: JavascriptPluginInstance] = [:]
-  var pluginMenuNeedsUpdate = false
   var events = EventController()
 
   lazy var ffmpegController: FFmpegController = {
@@ -173,7 +172,7 @@ class PlayerCore: NSObject {
 
   static func reloadPluginForAll(_ plugin: JavascriptPlugin) {
     playerCores.forEach { $0.reloadPlugin(plugin) }
-    (NSApp.delegate as? AppDelegate)?.menuController?.pluginMenuNeedsUpdate = true
+    (NSApp.delegate as? AppDelegate)?.menuController?.updatePluginMenu()
   }
 
   func loadPlugins() {

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -415,6 +415,8 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
     if #available(macOS 10.13, *), RemoteCommandController.useSystemMediaControl {
       NowPlayingInfoManager.updateInfo(withTitle: true)
     }
+    (NSApp.delegate as? AppDelegate)?.menuController?.updatePluginMenu()
+
     NotificationCenter.default.post(name: .iinaMainWindowChanged, object: true)
   }
   


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #3994.

---

**Description:**

Took a crack at this. It looks like everything is fixed if lines like this
```Swift
menuController?.pluginMenuNeedsUpdate = true
```
are replaced with this:

```Swift
(NSApp.delegate as? AppDelegate)?.menuController?.updatePluginMenu()
```


But also I added a line in `PlayerWindowController`, when focus changes, if I am reading the code correctly and it is possible for players to have separate plugin instances and those plugin instances have different menu items