### PR TITLE
Workaround for dimmed HDR content in full screen on macOS 13

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1621,8 +1621,16 @@ class MainWindowController: PlayerWindowController {
     NSCursor.setHiddenUntilMouseMoves(true)
   }
   
-  // Workaround for macOS 13 where HDR content becomes dimmed when overlaying views are fully hidden.
-  private let almostInvisibleAlpha: CGFloat = 0.01
+  // Workaround for macOS 13 where HDR content becomes dimmed when overlaying views are fully hidden. (#3844)
+  private var almostInvisibleAlpha: CGFloat {
+    if #available(macOS 13, *) {
+      if fsState.isFullscreen && player.info.hdrEnabled {
+        return 0.01
+      }
+    }
+    // This issue does not occur when running in non HDR / non full screen or a macOS version lower than 13.
+    return 0
+  }
 
   private func hideUI() {
     // Don't hide UI when in PIP

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1621,7 +1621,7 @@ class MainWindowController: PlayerWindowController {
     NSCursor.setHiddenUntilMouseMoves(true)
   }
   
-  // Fixes a bug in macOS 13 where HDR content becomes dimmed overlaying views are fully hidden.
+  // Workaround for macOS 13 where HDR content becomes dimmed when overlaying views are fully hidden.
   private let almostInvisibleAlpha: CGFloat = 0.01
 
   private func hideUI() {

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1620,6 +1620,9 @@ class MainWindowController: PlayerWindowController {
     hideUI()
     NSCursor.setHiddenUntilMouseMoves(true)
   }
+  
+  // Fixes a bug in macOS 13 where HDR content becomes dimmed overlaying views are fully hidden.
+  private let almostInvisibleAlpha: CGFloat = 0.01
 
   private func hideUI() {
     // Don't hide UI when in PIP
@@ -1631,15 +1634,15 @@ class MainWindowController: PlayerWindowController {
     player.invalidateTimer()
     animationState = .willHide
     fadeableViews.forEach { (v) in
-      v.isHidden = false
+      v.alphaValue = almostInvisibleAlpha
     }
     NSAnimationContext.runAnimationGroup({ (context) in
       context.duration = UIAnimationDuration
       fadeableViews.forEach { (v) in
-        v.animator().alphaValue = 0
+        v.animator().alphaValue = almostInvisibleAlpha
       }
       if !self.fsState.isFullscreen {
-        titleTextField?.animator().alphaValue = 0
+        titleTextField?.animator().alphaValue = almostInvisibleAlpha
       }
     }) {
       // if no interrupt then hide animation
@@ -1648,7 +1651,7 @@ class MainWindowController: PlayerWindowController {
           if let btn = v as? NSButton, self.standardWindowButtons.contains(btn) {
             v.alphaValue = 1e-100
           } else {
-            v.isHidden = true
+            v.alphaValue = self.almostInvisibleAlpha
           }
         }
         self.animationState = .hidden


### PR DESCRIPTION

- [X] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #3844, #3880, #3906 and #4014

---

**Description:**

Starting with macOS 13, some strange behavior can be seen when viewing videos in full screen in HDR mode. The screen will be dimmed when the player controls disapear. It looks like it might be a bug on Apple's side, although I'm not sure. From what I've found was if the views do not set the property `isHidden`, but rather an almost invisible alpha level, the video displays normally in its full HDR glory. The end result for the user is the same, setting the player controls to such a low alpha is invisible to the human eye.
