### PR TITLE
Add useful logging for HDR

### DIFF
--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -631,7 +631,9 @@ extension NSScreen {
     }
     // Unfortunately localizedName is not available until macOS Catalina.
     if #available(macOS 10.15, *) {
-      Logger.log("\(label): \(screen.localizedName) visible frame \(screen.visibleFrame)")
+      let maxPossibleEDR = screen.maximumPotentialExtendedDynamicRangeColorComponentValue
+      let canEnableEDR = maxPossibleEDR > 1.0
+      Logger.log("\(label): \"\(screen.localizedName)\" visible frame \(screen.visibleFrame) EDR: {supports=\(canEnableEDR) maxPotential=\(maxPossibleEDR) maxCurrent=\(screen.maximumExtendedDynamicRangeColorComponentValue)}")
     } else {
       Logger.log("\(label): visible frame \(screen.visibleFrame)")
     }

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -213,9 +213,12 @@ class VideoView: NSView {
     CVDisplayLinkStop(link)
   }
 
+  // This should only be called if the window has changed displays
   func updateDisplayLink() {
     guard let window = window, let link = link, let screen = window.screen else { return }
     let displayId = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as! UInt32
+
+    // Do nothing if on the same display
     if (currentDisplay == displayId) { return }
     currentDisplay = displayId
 
@@ -250,8 +253,10 @@ class VideoView: NSView {
 
   func setICCProfile(_ displayId: UInt32) {
     if !Preference.bool(for: .loadIccProfile) {
+      Logger.log("Not using ICC due to user preference", subsystem: hdrSubsystem)
       player.mpv.setString(MPVOption.GPURendererOptions.iccProfile, "")
     } else {
+      Logger.log("Loading ICC profile", subsystem: hdrSubsystem)
       typealias ProfileData = (uuid: CFUUID, profileUrl: URL?)
       guard let uuid = CGDisplayCreateUUIDFromDisplayID(displayId)?.takeRetainedValue() else { return }
 
@@ -279,6 +284,7 @@ class VideoView: NSView {
     }
 
     if videoLayer.colorspace != nil {
+      Logger.log("Nilling out colorspace", subsystem: hdrSubsystem)
       videoLayer.colorspace = nil;
       videoLayer.wantsExtendedDynamicRangeContent = false
       player.mpv.setString(MPVOption.GPURendererOptions.targetTrc, "auto")
@@ -295,6 +301,9 @@ extension VideoView {
     guard player.mainWindow.loaded else { return }
     guard player.mpv.fileLoaded else { return }
     guard let displayId = currentDisplay else { return };
+    if let screen = self.window?.screen {
+      NSScreen.log("Refreshing HDR for \(player.subsystem.rawValue) @ display\(displayId)", screen)
+    }
     let edrEnabled = requestEdrMode()
     let edrAvailable = edrEnabled != false
     if player.info.hdrAvailable != edrAvailable {
@@ -365,7 +374,7 @@ extension VideoView {
     guard player.info.hdrEnabled else { return nil }
 
     if videoLayer.colorspace?.name == name {
-      Logger.log("HDR mode has been enabled, skipping", level: .debug, subsystem: hdrSubsystem);
+      Logger.log("HDR mode already enabled, skipping", level: .debug, subsystem: hdrSubsystem);
       return true;
     }
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
Adds some extra logging which I found very useful for debugging HDR, in particular `maximumExtendedDynamicRangeColorComponentValue` and `maximumPotentialExtendedDynamicRangeColorComponentValue` from `NSScreen`.