### PR TITLE
Fix: PlayerWindowController.windowDidChangeScreen not getting called (issue 4025)

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1536,6 +1536,8 @@ class MainWindowController: PlayerWindowController {
   }
   
   override func windowDidChangeScreen(_ notification: Notification) {
+    super.windowDidChangeScreen(notification)
+
     player.events.emit(.windowScreenChanged)
   }
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4025.

---

**Description:**
Looks like this slipped through the cracks somehow.