### PR TITLE
Fix layout errors & warnings in Quick Settings panels, fix clipping due to H scroll, optimize layout

### DIFF
--- a/iina/Base.lproj/QuickSettingViewController.xib
+++ b/iina/Base.lproj/QuickSettingViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -10,9 +10,9 @@
         <customObject id="-2" userLabel="File's Owner" customClass="QuickSettingViewController" customModule="IINA" customModuleProvider="target">
             <connections>
                 <outlet property="aspectSegment" destination="Ljl-w6-gIf" id="X3Q-8g-q0e"/>
-                <outlet property="audioDelaySlider" destination="a7T-nr-ELY" id="enM-FA-bea"/>
-                <outlet property="audioDelaySliderConstraint" destination="Er7-gv-OMp" id="l5B-2g-Wk7"/>
-                <outlet property="audioDelaySliderIndicator" destination="gR7-cS-zmu" id="4Zq-bk-Nxd"/>
+                <outlet property="audioDelaySlider" destination="gJr-l6-WQ2" id="in4-Ig-0sm"/>
+                <outlet property="audioDelaySliderConstraint" destination="5oB-ve-G3c" id="0lC-5Q-tyI"/>
+                <outlet property="audioDelaySliderIndicator" destination="giU-Mo-tN9" id="ZWu-U8-86x"/>
                 <outlet property="audioEqSlider1" destination="pHR-ym-VeQ" id="Chq-ra-A3e"/>
                 <outlet property="audioEqSlider10" destination="w04-h5-qaz" id="hRO-UH-FuK"/>
                 <outlet property="audioEqSlider2" destination="Qhv-oC-xzP" id="Gye-bX-a4v"/>
@@ -25,29 +25,29 @@
                 <outlet property="audioEqSlider9" destination="gbd-xf-hGS" id="yjy-wE-LJd"/>
                 <outlet property="audioTabBtn" destination="3Fk-ey-FhK" id="I1P-Dg-gtv"/>
                 <outlet property="audioTableView" destination="FLg-2m-Zaq" id="rId-Io-Y2B"/>
-                <outlet property="brightnessSlider" destination="sBU-NZ-sp3" id="IWR-1I-CcR"/>
-                <outlet property="buttonTopConstraint" destination="fh9-0T-pEX" id="Jx2-9m-OZQ"/>
-                <outlet property="contrastSlider" destination="0Ww-YT-a8e" id="wNQ-VI-uMd"/>
-                <outlet property="cropSegment" destination="kUi-hW-BR6" id="fsg-We-n2K"/>
+                <outlet property="brightnessSlider" destination="eFW-a3-kWx" id="BTl-mg-ShV"/>
+                <outlet property="buttonTopConstraint" destination="qd3-0i-qbr" id="uh3-P6-1jm"/>
+                <outlet property="contrastSlider" destination="mTb-L6-55O" id="8A5-dO-dID"/>
+                <outlet property="cropSegment" destination="sPT-jd-T7a" id="WM1-4v-Pfm"/>
                 <outlet property="customAspectTextField" destination="XAI-y0-tcy" id="j96-rd-E5w"/>
-                <outlet property="customAudioDelayTextField" destination="0DM-CY-o8W" id="B2n-SJ-T4f"/>
+                <outlet property="customAudioDelayTextField" destination="Qiz-tS-aWT" id="QQg-ZP-uPz"/>
                 <outlet property="customSpeedTextField" destination="sIs-a1-rGR" id="kRd-3q-zab"/>
                 <outlet property="customSubDelayTextField" destination="eOz-bB-vzM" id="oqr-mw-c55"/>
-                <outlet property="deinterlaceSwitch" destination="2FQ-VQ-dTd" id="snK-5x-1Gh"/>
-                <outlet property="gammaSlider" destination="SL7-DZ-5ff" id="CFA-xb-DCH"/>
-                <outlet property="hardwareDecodingSwitch" destination="0pq-Hh-3hb" id="53n-xc-rxs"/>
-                <outlet property="hdrSwitch" destination="0RB-r2-J8C" id="Yov-nL-YFt"/>
-                <outlet property="hueSlider" destination="ntv-89-1iw" id="dQo-yf-zVI"/>
+                <outlet property="deinterlaceSwitch" destination="SMb-H5-j6h" id="PZ6-te-OHr"/>
+                <outlet property="gammaSlider" destination="fLl-8b-pj0" id="jEi-R0-6G0"/>
+                <outlet property="hardwareDecodingSwitch" destination="7z5-cT-Huj" id="lHA-DF-UM7"/>
+                <outlet property="hdrSwitch" destination="U8P-fW-N3q" id="VUC-bd-g4X"/>
+                <outlet property="hueSlider" destination="mKB-Mu-l5Y" id="vy8-lj-ko8"/>
                 <outlet property="pluginContentContainerView" destination="GeS-T1-vtB" id="a96-Mh-BMb"/>
                 <outlet property="pluginTabsScrollView" destination="dfw-cq-GHm" id="3z0-CB-HKn"/>
                 <outlet property="pluginTabsView" destination="iNg-R1-bXw" id="2HU-DJ-gyX"/>
-                <outlet property="pluginTabsViewHeightConstraint" destination="RHG-Ug-zyI" id="dxy-7A-57c"/>
+                <outlet property="pluginTabsViewHeightConstraint" destination="ZRN-u2-VBd" id="wWC-3x-wNe"/>
                 <outlet property="rotateSegment" destination="bza-SA-tXE" id="Sdw-vn-MUV"/>
-                <outlet property="saturationSlider" destination="qeO-tk-I0D" id="uDF-fx-afd"/>
+                <outlet property="saturationSlider" destination="VlS-Jo-4C0" id="rJV-p9-OVz"/>
                 <outlet property="secSubTableView" destination="Jve-qX-Agy" id="0ia-bh-sbu"/>
                 <outlet property="speedSlider" destination="UWh-M9-5Nw" id="UXr-dD-8K1"/>
-                <outlet property="speedSliderConstraint" destination="92J-9M-Lrn" id="6U0-Yu-KuK"/>
-                <outlet property="speedSliderIndicator" destination="3EN-WD-QNI" id="flo-Hs-pTQ"/>
+                <outlet property="speedSliderConstraint" destination="qTf-o6-Mef" id="mB3-5X-SOE"/>
+                <outlet property="speedSliderIndicator" destination="3EN-WD-QNI" id="vDD-eE-x6w"/>
                 <outlet property="subDelaySlider" destination="dXz-x4-sm5" id="VX5-8O-mf4"/>
                 <outlet property="subDelaySliderConstraint" destination="7t1-v0-J55" id="ypG-K0-i1x"/>
                 <outlet property="subDelaySliderIndicator" destination="VdJ-nq-zaM" id="0uy-Jw-eKf"/>
@@ -63,8 +63,8 @@
                 <outlet property="subTextColorWell" destination="9mo-uL-hfC" id="HEi-c0-WG6"/>
                 <outlet property="subTextFontBtn" destination="qGz-rB-dsV" id="Xkg-P1-vDv"/>
                 <outlet property="subTextSizePopUp" destination="xtF-tn-m9W" id="62h-S6-9gV"/>
-                <outlet property="switchHorizontalLine" destination="vFH-Zl-rQn" id="yiN-9D-Eqf"/>
-                <outlet property="switchHorizontalLine2" destination="taW-wc-jG7" id="Brp-gf-AMh"/>
+                <outlet property="switchHorizontalLine" destination="PyM-xa-vx9" id="LX2-Xa-lH4"/>
+                <outlet property="switchHorizontalLine2" destination="qYi-uQ-6qo" id="doE-zM-QU3"/>
                 <outlet property="tabView" destination="udA-m2-eJb" id="zL4-73-AVP"/>
                 <outlet property="videoTabBtn" destination="Ma8-6g-tVw" id="d0g-Fi-gzz"/>
                 <outlet property="videoTableView" destination="rsV-qL-l7b" id="A8k-AU-noQ"/>
@@ -74,20 +74,13 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY" customClass="QuickSettingView" customModule="IINA" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="360" height="823"/>
+            <rect key="frame" x="0.0" y="0.0" width="360" height="912"/>
             <subviews>
-                <stackView distribution="equalSpacing" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="250" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dNi-Ib-2vd">
-                    <rect key="frame" x="0.0" y="775" width="360" height="48"/>
+                <stackView distribution="fillEqually" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="200" verticalStackHuggingPriority="250" horizontalHuggingPriority="200" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dNi-Ib-2vd" userLabel="TabButtons Stack View">
+                    <rect key="frame" x="20" y="864" width="320" height="48"/>
                     <subviews>
-                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="129-cv-qAR">
-                            <rect key="frame" x="0.0" y="0.0" width="0.0" height="48"/>
-                            <constraints>
-                                <constraint firstAttribute="height" constant="48" id="EkR-fq-Y2z"/>
-                                <constraint firstAttribute="width" id="e8p-hm-lf2"/>
-                            </constraints>
-                        </customView>
-                        <button horizontalHuggingPriority="252" verticalHuggingPriority="750" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ma8-6g-tVw">
-                            <rect key="frame" x="34" y="15" width="64" height="18"/>
+                        <button horizontalHuggingPriority="252" verticalHuggingPriority="750" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ma8-6g-tVw" userLabel="VideoTab Button">
+                            <rect key="frame" x="0.0" y="0.0" width="101" height="48"/>
                             <buttonCell key="cell" type="square" title="VIDEO" bezelStyle="shadowlessSquare" image="tab_video" imagePosition="leading" alignment="center" imageScaling="proportionallyDown" inset="2" id="lQt-I0-jHO">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="systemBold"/>
@@ -96,8 +89,8 @@
                                 <action selector="tabBtnAction:" target="-2" id="T17-c3-4hp"/>
                             </connections>
                         </button>
-                        <button horizontalHuggingPriority="251" verticalHuggingPriority="750" tag="1" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3Fk-ey-FhK">
-                            <rect key="frame" x="132" y="15" width="65" height="18"/>
+                        <button horizontalHuggingPriority="251" verticalHuggingPriority="750" tag="1" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3Fk-ey-FhK" userLabel="AudioTab Buttom">
+                            <rect key="frame" x="109" y="0.0" width="102" height="48"/>
                             <buttonCell key="cell" type="square" title="AUDIO" bezelStyle="shadowlessSquare" image="tab_audio" imagePosition="leading" alignment="center" imageScaling="proportionallyDown" inset="2" id="cpm-5o-a2c">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="systemBold"/>
@@ -106,8 +99,8 @@
                                 <action selector="tabBtnAction:" target="-2" id="mLi-M9-gbN"/>
                             </connections>
                         </button>
-                        <button horizontalHuggingPriority="253" verticalHuggingPriority="750" tag="2" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rH3-pU-mFc">
-                            <rect key="frame" x="231" y="15" width="95" height="18"/>
+                        <button horizontalHuggingPriority="253" verticalHuggingPriority="750" tag="2" imageHugsTitle="YES" translatesAutoresizingMaskIntoConstraints="NO" id="rH3-pU-mFc" userLabel="SubtitlesTab Button">
+                            <rect key="frame" x="219" y="0.0" width="101" height="48"/>
                             <buttonCell key="cell" type="square" title="SUBTITLES" bezelStyle="shadowlessSquare" image="tab_sub" imagePosition="leading" alignment="center" imageScaling="proportionallyDown" inset="2" id="NxO-to-jcI">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="systemBold"/>
@@ -116,20 +109,17 @@
                                 <action selector="tabBtnAction:" target="-2" id="IEz-WA-p4g"/>
                             </connections>
                         </button>
-                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Bls-kU-Nau">
-                            <rect key="frame" x="360" y="0.0" width="0.0" height="48"/>
-                            <constraints>
-                                <constraint firstAttribute="width" id="9yd-MS-Ols"/>
-                                <constraint firstAttribute="height" constant="48" id="EA3-kz-2Pz"/>
-                            </constraints>
-                        </customView>
                     </subviews>
                     <constraints>
-                        <constraint firstAttribute="height" constant="48" id="Ogo-ym-5Mm"/>
+                        <constraint firstItem="3Fk-ey-FhK" firstAttribute="top" secondItem="dNi-Ib-2vd" secondAttribute="top" id="4LK-un-GWd"/>
+                        <constraint firstAttribute="bottom" secondItem="Ma8-6g-tVw" secondAttribute="bottom" id="HNL-01-U01"/>
+                        <constraint firstAttribute="height" constant="48" id="OsF-5u-ZcS"/>
+                        <constraint firstItem="rH3-pU-mFc" firstAttribute="top" secondItem="dNi-Ib-2vd" secondAttribute="top" id="YVm-dH-zWO"/>
+                        <constraint firstAttribute="bottom" secondItem="3Fk-ey-FhK" secondAttribute="bottom" id="dxx-Gz-ehl"/>
+                        <constraint firstItem="Ma8-6g-tVw" firstAttribute="top" secondItem="dNi-Ib-2vd" secondAttribute="top" id="meL-a5-YbR"/>
+                        <constraint firstAttribute="bottom" secondItem="rH3-pU-mFc" secondAttribute="bottom" id="s0t-hu-6rE"/>
                     </constraints>
                     <visibilityPriorities>
-                        <integer value="1000"/>
-                        <integer value="1000"/>
                         <integer value="1000"/>
                         <integer value="1000"/>
                         <integer value="1000"/>
@@ -138,24 +128,22 @@
                         <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>
                         <real value="3.4028234663852886e+38"/>
-                        <real value="3.4028234663852886e+38"/>
-                        <real value="3.4028234663852886e+38"/>
                     </customSpacing>
                 </stackView>
-                <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="L78-cf-BxB">
-                    <rect key="frame" x="0.0" y="772" width="360" height="5"/>
+                <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="L78-cf-BxB" userLabel="BelowTabButtons Horizontal Line">
+                    <rect key="frame" x="0.0" y="861" width="360" height="5"/>
                 </box>
-                <customView translatesAutoresizingMaskIntoConstraints="NO" id="iNg-R1-bXw">
-                    <rect key="frame" x="0.0" y="739" width="360" height="36"/>
+                <customView translatesAutoresizingMaskIntoConstraints="NO" id="iNg-R1-bXw" userLabel="PluginTabs View">
+                    <rect key="frame" x="0.0" y="827" width="360" height="36"/>
                     <subviews>
-                        <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="dfw-cq-GHm">
-                            <rect key="frame" x="0.0" y="0.0" width="360" height="36"/>
-                            <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="Q9c-dH-CRI">
-                                <rect key="frame" x="0.0" y="0.0" width="360" height="36"/>
+                        <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="dfw-cq-GHm" userLabel="PluginsTabs Scroll View">
+                            <rect key="frame" x="0.0" y="1" width="360" height="35"/>
+                            <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="Q9c-dH-CRI" userLabel="PluginsTabs Clip View">
+                                <rect key="frame" x="0.0" y="0.0" width="360" height="35"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <view id="PF8-CN-LtV">
-                                        <rect key="frame" x="0.0" y="0.0" width="345" height="21"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="345" height="20"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     </view>
                                 </subviews>
@@ -170,448 +158,370 @@
                                 <autoresizingMask key="autoresizingMask"/>
                             </scroller>
                         </scrollView>
-                        <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="Uvg-kn-ZiM">
+                        <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="Uvg-kn-ZiM" userLabel="BelowPluginsTabs Horizontal Line">
                             <rect key="frame" x="0.0" y="-2" width="360" height="5"/>
                         </box>
                     </subviews>
                     <constraints>
-                        <constraint firstItem="Uvg-kn-ZiM" firstAttribute="leading" secondItem="iNg-R1-bXw" secondAttribute="leading" id="5Bo-pQ-8wF"/>
-                        <constraint firstItem="dfw-cq-GHm" firstAttribute="top" secondItem="iNg-R1-bXw" secondAttribute="top" id="7ps-Be-eEG"/>
-                        <constraint firstItem="dfw-cq-GHm" firstAttribute="leading" secondItem="iNg-R1-bXw" secondAttribute="leading" id="F2h-TK-LUs"/>
-                        <constraint firstAttribute="bottom" secondItem="Uvg-kn-ZiM" secondAttribute="bottom" id="F8Z-Qr-FvK"/>
-                        <constraint firstAttribute="height" constant="36" id="RHG-Ug-zyI"/>
-                        <constraint firstAttribute="trailing" secondItem="Uvg-kn-ZiM" secondAttribute="trailing" id="ftU-01-8Uk"/>
-                        <constraint firstAttribute="trailing" secondItem="dfw-cq-GHm" secondAttribute="trailing" id="gkT-b0-syJ"/>
-                        <constraint firstAttribute="bottom" secondItem="dfw-cq-GHm" secondAttribute="bottom" id="tBp-Il-qYT"/>
+                        <constraint firstAttribute="top" secondItem="dfw-cq-GHm" secondAttribute="top" id="DBW-bI-ICl"/>
+                        <constraint firstItem="dfw-cq-GHm" firstAttribute="leading" secondItem="iNg-R1-bXw" secondAttribute="leading" id="Dfn-E4-5qj"/>
+                        <constraint firstItem="Uvg-kn-ZiM" firstAttribute="leading" secondItem="dfw-cq-GHm" secondAttribute="leading" id="HCD-Hu-Owm"/>
+                        <constraint firstAttribute="bottom" secondItem="Uvg-kn-ZiM" secondAttribute="bottom" id="KOj-Va-6Hm"/>
+                        <constraint firstItem="Uvg-kn-ZiM" firstAttribute="trailing" secondItem="dfw-cq-GHm" secondAttribute="trailing" id="MBU-DO-CWE"/>
+                        <constraint firstAttribute="height" constant="36" identifier="pluginTabsViewHeightConstraint" id="ZRN-u2-VBd"/>
+                        <constraint firstItem="Uvg-kn-ZiM" firstAttribute="top" secondItem="dfw-cq-GHm" secondAttribute="bottom" id="heN-C5-wgL"/>
+                        <constraint firstAttribute="trailing" secondItem="dfw-cq-GHm" secondAttribute="trailing" id="mqw-9f-ZMt"/>
                     </constraints>
                 </customView>
-                <tabView drawsBackground="NO" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="udA-m2-eJb">
-                    <rect key="frame" x="0.0" y="0.0" width="360" height="739"/>
+                <tabView drawsBackground="NO" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="udA-m2-eJb" userLabel="AllTabs Tab View">
+                    <rect key="frame" x="0.0" y="0.0" width="360" height="827"/>
                     <font key="font" metaFont="system"/>
                     <tabViewItems>
-                        <tabViewItem label="Video" identifier="1" id="CYP-el-A6A">
-                            <view key="view" id="NRI-ba-KMd">
-                                <rect key="frame" x="0.0" y="0.0" width="360" height="739"/>
+                        <tabViewItem label="Video" identifier="1" id="CYP-el-A6A" userLabel="VideoTab Tab View Item">
+                            <view key="view" id="NRI-ba-KMd" userLabel="VideoTab View">
+                                <rect key="frame" x="0.0" y="0.0" width="360" height="827"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
-                                    <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="SHU-hX-9MT">
-                                        <rect key="frame" x="0.0" y="0.0" width="360" height="739"/>
-                                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="8Es-YX-dNf">
-                                            <rect key="frame" x="0.0" y="0.0" width="360" height="739"/>
+                                    <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SHU-hX-9MT" userLabel="VideoTab Scroll View">
+                                        <rect key="frame" x="0.0" y="0.0" width="354" height="827"/>
+                                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="8Es-YX-dNf" userLabel="VideoTab Clip View">
+                                            <rect key="frame" x="0.0" y="0.0" width="354" height="827"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
-                                                <view translatesAutoresizingMaskIntoConstraints="NO" id="ZGz-La-n9c" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="-44" width="360" height="783"/>
+                                                <view translatesAutoresizingMaskIntoConstraints="NO" id="ZGz-La-n9c" userLabel="VideoTab Flipped CONTENT VIEW" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
+                                                    <rect key="frame" x="0.0" y="67" width="354" height="760"/>
                                                     <subviews>
-                                                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="5v4-Te-950">
-                                                            <rect key="frame" x="0.0" y="0.0" width="360" height="783"/>
+                                                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="seu-WU-cTV" userLabel="HORIZONTAL-INSETS">
+                                                            <rect key="frame" x="20" y="740" width="314" height="0.0"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" id="4UC-le-Tmg"/>
+                                                            </constraints>
+                                                        </customView>
+                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ng5-FC-tts" userLabel="Video track Label">
+                                                            <rect key="frame" x="18" y="724" width="318" height="16"/>
+                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Video track:" id="VzC-tM-KT7">
+                                                                <font key="font" metaFont="systemBold"/>
+                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                        </textField>
+                                                        <scrollView focusRingType="none" borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ykw-rb-M9D" userLabel="VideoTrackTable Scroll View">
+                                                            <rect key="frame" x="0.0" y="641" width="354" height="75"/>
+                                                            <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="jek-w4-LTf" userLabel="VideoTrackTable Clip View">
+                                                                <rect key="frame" x="0.0" y="0.0" width="354" height="75"/>
+                                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                <subviews>
+                                                                    <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="rsV-qL-l7b" userLabel="VideoTrackTable Table View">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="354" height="75"/>
+                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                        <size key="intercellSpacing" width="3" height="2"/>
+                                                                        <color key="backgroundColor" white="1" alpha="0.082057643580000006" colorSpace="deviceWhite"/>
+                                                                        <tableViewGridLines key="gridStyleMask" horizontal="YES"/>
+                                                                        <color key="gridColor" red="1" green="1" blue="1" alpha="0.10000000000000001" colorSpace="calibratedRGB"/>
+                                                                        <tableColumns>
+                                                                            <tableColumn identifier="IsChosen" editable="NO" width="22" minWidth="22" maxWidth="200" id="PPM-Xv-dec">
+                                                                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="right">
+                                                                                    <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                    <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                                                </tableHeaderCell>
+                                                                                <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" alignment="right" title="0" id="z4R-2L-mKS">
+                                                                                    <font key="font" metaFont="system"/>
+                                                                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                </textFieldCell>
+                                                                                <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                                                <prototypeCellViews>
+                                                                                    <tableCellView id="99i-8I-ANv">
+                                                                                        <rect key="frame" x="1" y="1" width="27" height="17"/>
+                                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                                        <subviews>
+                                                                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="kfS-xI-KPe">
+                                                                                                <rect key="frame" x="0.0" y="0.0" width="27" height="17"/>
+                                                                                                <constraints>
+                                                                                                    <constraint firstAttribute="height" constant="17" id="tAH-cB-Po2"/>
+                                                                                                </constraints>
+                                                                                                <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="dlX-H5-BCo">
+                                                                                                    <font key="font" metaFont="system"/>
+                                                                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                                </textFieldCell>
+                                                                                                <connections>
+                                                                                                    <binding destination="99i-8I-ANv" name="value" keyPath="objectValue" id="dU5-kW-VVa"/>
+                                                                                                </connections>
+                                                                                            </textField>
+                                                                                        </subviews>
+                                                                                        <constraints>
+                                                                                            <constraint firstItem="kfS-xI-KPe" firstAttribute="leading" secondItem="99i-8I-ANv" secondAttribute="leading" constant="2" id="R3c-qW-JBz"/>
+                                                                                            <constraint firstItem="kfS-xI-KPe" firstAttribute="centerX" secondItem="99i-8I-ANv" secondAttribute="centerX" id="hfL-Lc-0J5"/>
+                                                                                            <constraint firstItem="kfS-xI-KPe" firstAttribute="centerY" secondItem="99i-8I-ANv" secondAttribute="centerY" id="m0P-If-qLe"/>
+                                                                                        </constraints>
+                                                                                        <connections>
+                                                                                            <outlet property="textField" destination="kfS-xI-KPe" id="bhC-fw-C4F"/>
+                                                                                        </connections>
+                                                                                    </tableCellView>
+                                                                                </prototypeCellViews>
+                                                                            </tableColumn>
+                                                                            <tableColumn identifier="TrackId" width="22" minWidth="22" maxWidth="200" id="Rm0-nB-ZDI">
+                                                                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                                                    <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                                                                </tableHeaderCell>
+                                                                                <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="9ss-EF-bby">
+                                                                                    <font key="font" metaFont="system"/>
+                                                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                </textFieldCell>
+                                                                                <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                                                <prototypeCellViews>
+                                                                                    <tableCellView id="EOK-X6-h3U">
+                                                                                        <rect key="frame" x="31" y="1" width="22" height="17"/>
+                                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                                        <subviews>
+                                                                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="s0D-BR-Bfy">
+                                                                                                <rect key="frame" x="0.0" y="0.0" width="22" height="17"/>
+                                                                                                <constraints>
+                                                                                                    <constraint firstAttribute="height" constant="17" id="wbc-c0-LPM"/>
+                                                                                                </constraints>
+                                                                                                <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="Pf6-Fd-0mO">
+                                                                                                    <font key="font" metaFont="system"/>
+                                                                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                                </textFieldCell>
+                                                                                                <connections>
+                                                                                                    <binding destination="EOK-X6-h3U" name="value" keyPath="objectValue" id="JPW-KP-pJN"/>
+                                                                                                </connections>
+                                                                                            </textField>
+                                                                                        </subviews>
+                                                                                        <constraints>
+                                                                                            <constraint firstItem="s0D-BR-Bfy" firstAttribute="centerY" secondItem="EOK-X6-h3U" secondAttribute="centerY" id="Dar-xn-ZWQ"/>
+                                                                                            <constraint firstItem="s0D-BR-Bfy" firstAttribute="centerX" secondItem="EOK-X6-h3U" secondAttribute="centerX" id="EJ9-Zw-Nzl"/>
+                                                                                            <constraint firstItem="s0D-BR-Bfy" firstAttribute="leading" secondItem="EOK-X6-h3U" secondAttribute="leading" constant="2" id="aQ1-Zg-h8j"/>
+                                                                                        </constraints>
+                                                                                        <connections>
+                                                                                            <outlet property="textField" destination="s0D-BR-Bfy" id="Gdk-1b-JTF"/>
+                                                                                        </connections>
+                                                                                    </tableCellView>
+                                                                                </prototypeCellViews>
+                                                                            </tableColumn>
+                                                                            <tableColumn identifier="TrackName" editable="NO" width="292" minWidth="100" maxWidth="10000" id="DgA-Ly-Gb8">
+                                                                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                                                    <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                                                                </tableHeaderCell>
+                                                                                <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" allowsUndo="NO" alignment="left" title="Text Cell" id="qpa-hD-ImC">
+                                                                                    <font key="font" metaFont="system"/>
+                                                                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                </textFieldCell>
+                                                                                <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                                                <prototypeCellViews>
+                                                                                    <tableCellView id="QLv-Qp-hCf">
+                                                                                        <rect key="frame" x="56" y="1" width="296" height="17"/>
+                                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                                        <subviews>
+                                                                                            <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="r2o-di-dN5">
+                                                                                                <rect key="frame" x="0.0" y="0.0" width="296" height="17"/>
+                                                                                                <constraints>
+                                                                                                    <constraint firstAttribute="height" constant="17" id="Ai3-GM-1Yw"/>
+                                                                                                </constraints>
+                                                                                                <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="jWy-C5-Xu9">
+                                                                                                    <font key="font" metaFont="system"/>
+                                                                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                                                </textFieldCell>
+                                                                                                <connections>
+                                                                                                    <binding destination="QLv-Qp-hCf" name="value" keyPath="objectValue" id="RoD-Zm-RdC"/>
+                                                                                                </connections>
+                                                                                            </textField>
+                                                                                        </subviews>
+                                                                                        <constraints>
+                                                                                            <constraint firstItem="r2o-di-dN5" firstAttribute="leading" secondItem="QLv-Qp-hCf" secondAttribute="leading" constant="2" id="Lhx-nh-pQ4"/>
+                                                                                            <constraint firstItem="r2o-di-dN5" firstAttribute="centerX" secondItem="QLv-Qp-hCf" secondAttribute="centerX" id="ZHJ-3g-zVB"/>
+                                                                                            <constraint firstItem="r2o-di-dN5" firstAttribute="centerY" secondItem="QLv-Qp-hCf" secondAttribute="centerY" id="c5v-ES-heI"/>
+                                                                                        </constraints>
+                                                                                        <connections>
+                                                                                            <outlet property="textField" destination="r2o-di-dN5" id="wA6-wm-GAV"/>
+                                                                                        </connections>
+                                                                                    </tableCellView>
+                                                                                </prototypeCellViews>
+                                                                            </tableColumn>
+                                                                        </tableColumns>
+                                                                    </tableView>
+                                                                </subviews>
+                                                            </clipView>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="75" id="QlN-U3-ekO"/>
+                                                            </constraints>
+                                                            <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="XXI-Cy-jma">
+                                                                <rect key="frame" x="0.0" y="61" width="100" height="15"/>
+                                                                <autoresizingMask key="autoresizingMask"/>
+                                                            </scroller>
+                                                            <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="wog-uC-A3q">
+                                                                <rect key="frame" x="-16" y="0.0" width="16" height="0.0"/>
+                                                                <autoresizingMask key="autoresizingMask"/>
+                                                            </scroller>
+                                                        </scrollView>
+                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CUa-0e-DwY" userLabel="Aspect ratio Label">
+                                                            <rect key="frame" x="18" y="605" width="318" height="16"/>
+                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Aspect ratio:" id="AiH-PV-YHQ">
+                                                                <font key="font" metaFont="systemBold"/>
+                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                        </textField>
+                                                        <segmentedControl horizontalHuggingPriority="100" verticalHuggingPriority="750" horizontalCompressionResistancePriority="500" translatesAutoresizingMaskIntoConstraints="NO" id="Ljl-w6-gIf" userLabel="AspectRatio Segmented Control">
+                                                            <rect key="frame" x="18" y="574" width="250" height="24"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="240" id="43J-t3-UhR"/>
+                                                            </constraints>
+                                                            <segmentedCell key="cell" borderStyle="border" alignment="left" segmentDistribution="fillProportionally" style="rounded" trackingMode="selectOne" id="cMu-YF-riv">
+                                                                <font key="font" metaFont="system"/>
+                                                                <segments>
+                                                                    <segment label="Default" selected="YES"/>
+                                                                    <segment label="4:3" tag="1"/>
+                                                                    <segment label="16:9" tag="2"/>
+                                                                    <segment label="16:10" tag="3"/>
+                                                                    <segment label="21:9" tag="4"/>
+                                                                    <segment label="5:4"/>
+                                                                </segments>
+                                                            </segmentedCell>
+                                                            <connections>
+                                                                <action selector="aspectChangedAction:" target="-2" id="U7C-TJ-2UJ"/>
+                                                            </connections>
+                                                        </segmentedControl>
+                                                        <textField identifier="customAspectRatio" horizontalHuggingPriority="500" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XAI-y0-tcy" userLabel="CustomAspectRatio Text Field">
+                                                            <rect key="frame" x="274" y="576" width="60" height="21"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="width" priority="900" constant="60" id="JnW-kS-XvK"/>
+                                                            </constraints>
+                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="jR7-Mt-N0T" customClass="RoundedTextFieldCell" customModule="IINA" customModuleProvider="target">
+                                                                <font key="font" metaFont="system"/>
+                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                            <connections>
+                                                                <action selector="customAspectEditFinishedAction:" target="-2" id="8DL-tk-4rJ"/>
+                                                            </connections>
+                                                        </textField>
+                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oAm-jJ-3kE" userLabel="CropLabel Text Field">
+                                                            <rect key="frame" x="18" y="539" width="318" height="16"/>
+                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Crop:" id="m9e-IB-IDJ">
+                                                                <font key="font" metaFont="systemBold"/>
+                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                        </textField>
+                                                        <segmentedControl horizontalHuggingPriority="100" verticalHuggingPriority="750" horizontalCompressionResistancePriority="500" translatesAutoresizingMaskIntoConstraints="NO" id="sPT-jd-T7a" userLabel="CropChooser Segmented Control">
+                                                            <rect key="frame" x="18" y="508" width="318" height="24"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="230" id="tTp-B3-gF5"/>
+                                                            </constraints>
+                                                            <segmentedCell key="cell" borderStyle="border" alignment="left" segmentDistribution="fillProportionally" style="rounded" trackingMode="selectOne" id="SxB-cw-MYx" userLabel="CropChooser Segmented Cell">
+                                                                <font key="font" metaFont="system"/>
+                                                                <segments>
+                                                                    <segment label="None"/>
+                                                                    <segment label="4:3" selected="YES" tag="1"/>
+                                                                    <segment label="16:9" tag="2"/>
+                                                                    <segment label="16:10" tag="3"/>
+                                                                    <segment label="21:9" tag="4"/>
+                                                                    <segment label="5:4"/>
+                                                                    <segment label="Custom..."/>
+                                                                </segments>
+                                                            </segmentedCell>
+                                                            <connections>
+                                                                <action selector="cropChangedAction:" target="-2" id="94g-N6-rTB"/>
+                                                            </connections>
+                                                        </segmentedControl>
+                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7vv-En-VYY" userLabel="RotationLabel Text Field">
+                                                            <rect key="frame" x="18" y="473" width="318" height="16"/>
+                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Rotation:" id="to3-rc-Agv">
+                                                                <font key="font" metaFont="systemBold"/>
+                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                        </textField>
+                                                        <segmentedControl verticalHuggingPriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="bza-SA-tXE" userLabel="Rotation Segmented Control">
+                                                            <rect key="frame" x="18" y="442" width="172" height="24"/>
+                                                            <segmentedCell key="cell" borderStyle="border" alignment="left" segmentDistribution="fillEqually" style="rounded" trackingMode="selectOne" id="z1L-0N-dfK">
+                                                                <font key="font" metaFont="system"/>
+                                                                <segments>
+                                                                    <segment label="0°" selected="YES"/>
+                                                                    <segment label="90°" tag="1"/>
+                                                                    <segment label="180°" tag="2"/>
+                                                                    <segment label="270°" tag="3"/>
+                                                                </segments>
+                                                            </segmentedCell>
+                                                            <connections>
+                                                                <action selector="rotationChangedAction:" target="-2" id="aL1-XS-nLe"/>
+                                                            </connections>
+                                                        </segmentedControl>
+                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="d4r-sL-0Vo" userLabel="SpeedLabel Text Field">
+                                                            <rect key="frame" x="18" y="407" width="318" height="16"/>
+                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Speed:" id="1KQ-oZ-A2x">
+                                                                <font key="font" metaFont="systemBold"/>
+                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                        </textField>
+                                                        <customView autoresizesSubviews="NO" horizontalHuggingPriority="200" horizontalCompressionResistancePriority="700" translatesAutoresizingMaskIntoConstraints="NO" id="5v4-Te-950" userLabel="SpeedSlider Container View">
+                                                            <rect key="frame" x="20" y="361" width="314" height="42"/>
                                                             <subviews>
-                                                                <scrollView focusRingType="none" borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ykw-rb-M9D">
-                                                                    <rect key="frame" x="0.0" y="663" width="360" height="76"/>
-                                                                    <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="jek-w4-LTf">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="360" height="76"/>
-                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                        <subviews>
-                                                                            <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="rsV-qL-l7b">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="360" height="76"/>
-                                                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                                <size key="intercellSpacing" width="3" height="2"/>
-                                                                                <color key="backgroundColor" white="1" alpha="0.082057643580000006" colorSpace="deviceWhite"/>
-                                                                                <tableViewGridLines key="gridStyleMask" horizontal="YES"/>
-                                                                                <color key="gridColor" red="1" green="1" blue="1" alpha="0.10000000000000001" colorSpace="calibratedRGB"/>
-                                                                                <tableColumns>
-                                                                                    <tableColumn identifier="IsChosen" editable="NO" width="16" minWidth="16" maxWidth="1000" id="PPM-Xv-dec">
-                                                                                        <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="right">
-                                                                                            <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                            <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
-                                                                                        </tableHeaderCell>
-                                                                                        <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" alignment="right" title="0" id="z4R-2L-mKS">
-                                                                                            <font key="font" metaFont="system"/>
-                                                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                                        </textFieldCell>
-                                                                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                                                                        <prototypeCellViews>
-                                                                                            <tableCellView id="99i-8I-ANv">
-                                                                                                <rect key="frame" x="1" y="1" width="21" height="17"/>
-                                                                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                                                <subviews>
-                                                                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="kfS-xI-KPe">
-                                                                                                        <rect key="frame" x="0.0" y="0.0" width="21" height="17"/>
-                                                                                                        <constraints>
-                                                                                                            <constraint firstAttribute="height" constant="17" id="n4q-6o-nJA"/>
-                                                                                                        </constraints>
-                                                                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="dlX-H5-BCo">
-                                                                                                            <font key="font" metaFont="system"/>
-                                                                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                                                        </textFieldCell>
-                                                                                                        <connections>
-                                                                                                            <binding destination="99i-8I-ANv" name="value" keyPath="objectValue" id="dU5-kW-VVa"/>
-                                                                                                        </connections>
-                                                                                                    </textField>
-                                                                                                </subviews>
-                                                                                                <constraints>
-                                                                                                    <constraint firstItem="kfS-xI-KPe" firstAttribute="centerX" secondItem="99i-8I-ANv" secondAttribute="centerX" id="bVs-3O-cve"/>
-                                                                                                    <constraint firstItem="kfS-xI-KPe" firstAttribute="centerY" secondItem="99i-8I-ANv" secondAttribute="centerY" id="hsg-gb-1mY"/>
-                                                                                                    <constraint firstItem="kfS-xI-KPe" firstAttribute="leading" secondItem="99i-8I-ANv" secondAttribute="leading" constant="2" id="teA-7a-W8B"/>
-                                                                                                </constraints>
-                                                                                                <connections>
-                                                                                                    <outlet property="textField" destination="kfS-xI-KPe" id="bhC-fw-C4F"/>
-                                                                                                </connections>
-                                                                                            </tableCellView>
-                                                                                        </prototypeCellViews>
-                                                                                    </tableColumn>
-                                                                                    <tableColumn identifier="TrackId" width="22" minWidth="10" maxWidth="3.4028234663852886e+38" id="Rm0-nB-ZDI">
-                                                                                        <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                                                                            <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                                                                        </tableHeaderCell>
-                                                                                        <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="9ss-EF-bby">
-                                                                                            <font key="font" metaFont="system"/>
-                                                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                            <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                                        </textFieldCell>
-                                                                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                                                                        <prototypeCellViews>
-                                                                                            <tableCellView id="EOK-X6-h3U">
-                                                                                                <rect key="frame" x="25" y="1" width="22" height="17"/>
-                                                                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                                                <subviews>
-                                                                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="s0D-BR-Bfy">
-                                                                                                        <rect key="frame" x="0.0" y="0.0" width="22" height="17"/>
-                                                                                                        <constraints>
-                                                                                                            <constraint firstAttribute="height" constant="17" id="8dq-95-hrV"/>
-                                                                                                        </constraints>
-                                                                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="Pf6-Fd-0mO">
-                                                                                                            <font key="font" metaFont="systemBold"/>
-                                                                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                                                        </textFieldCell>
-                                                                                                        <connections>
-                                                                                                            <binding destination="EOK-X6-h3U" name="value" keyPath="objectValue" id="JPW-KP-pJN"/>
-                                                                                                        </connections>
-                                                                                                    </textField>
-                                                                                                </subviews>
-                                                                                                <constraints>
-                                                                                                    <constraint firstItem="s0D-BR-Bfy" firstAttribute="centerY" secondItem="EOK-X6-h3U" secondAttribute="centerY" id="bJJ-tz-D19"/>
-                                                                                                    <constraint firstItem="s0D-BR-Bfy" firstAttribute="leading" secondItem="EOK-X6-h3U" secondAttribute="leading" constant="2" id="gTn-e6-tMo"/>
-                                                                                                    <constraint firstItem="s0D-BR-Bfy" firstAttribute="centerX" secondItem="EOK-X6-h3U" secondAttribute="centerX" id="rs5-dj-vfK"/>
-                                                                                                </constraints>
-                                                                                                <connections>
-                                                                                                    <outlet property="textField" destination="s0D-BR-Bfy" id="Gdk-1b-JTF"/>
-                                                                                                </connections>
-                                                                                            </tableCellView>
-                                                                                        </prototypeCellViews>
-                                                                                    </tableColumn>
-                                                                                    <tableColumn identifier="TrackName" editable="NO" width="304" minWidth="40" maxWidth="3.4028234663852886e+38" id="DgA-Ly-Gb8">
-                                                                                        <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                                                                            <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                                                                        </tableHeaderCell>
-                                                                                        <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" allowsUndo="NO" alignment="left" title="Text Cell" id="qpa-hD-ImC">
-                                                                                            <font key="font" metaFont="system"/>
-                                                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                                        </textFieldCell>
-                                                                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                                                                        <prototypeCellViews>
-                                                                                            <tableCellView id="QLv-Qp-hCf">
-                                                                                                <rect key="frame" x="50" y="1" width="308" height="17"/>
-                                                                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                                                <subviews>
-                                                                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="r2o-di-dN5">
-                                                                                                        <rect key="frame" x="0.0" y="0.0" width="308" height="17"/>
-                                                                                                        <constraints>
-                                                                                                            <constraint firstAttribute="height" constant="17" id="103-BE-POM"/>
-                                                                                                        </constraints>
-                                                                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="jWy-C5-Xu9">
-                                                                                                            <font key="font" metaFont="system"/>
-                                                                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                                                        </textFieldCell>
-                                                                                                        <connections>
-                                                                                                            <binding destination="QLv-Qp-hCf" name="value" keyPath="objectValue" id="RoD-Zm-RdC"/>
-                                                                                                        </connections>
-                                                                                                    </textField>
-                                                                                                </subviews>
-                                                                                                <constraints>
-                                                                                                    <constraint firstItem="r2o-di-dN5" firstAttribute="centerX" secondItem="QLv-Qp-hCf" secondAttribute="centerX" id="Auo-az-e1w"/>
-                                                                                                    <constraint firstItem="r2o-di-dN5" firstAttribute="centerY" secondItem="QLv-Qp-hCf" secondAttribute="centerY" id="c2L-Zk-Us7"/>
-                                                                                                    <constraint firstItem="r2o-di-dN5" firstAttribute="leading" secondItem="QLv-Qp-hCf" secondAttribute="leading" constant="2" id="tF7-yO-AfY"/>
-                                                                                                </constraints>
-                                                                                                <connections>
-                                                                                                    <outlet property="textField" destination="r2o-di-dN5" id="wA6-wm-GAV"/>
-                                                                                                </connections>
-                                                                                            </tableCellView>
-                                                                                        </prototypeCellViews>
-                                                                                    </tableColumn>
-                                                                                </tableColumns>
-                                                                            </tableView>
-                                                                        </subviews>
-                                                                    </clipView>
+                                                                <slider horizontalHuggingPriority="1" verticalHuggingPriority="700" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="700" translatesAutoresizingMaskIntoConstraints="NO" id="UWh-M9-5Nw" userLabel="SpeedSlider Horizontal Tick Slider">
+                                                                    <rect key="frame" x="-2" y="10" width="240" height="20"/>
                                                                     <constraints>
-                                                                        <constraint firstAttribute="height" constant="76" id="fts-DH-Iho"/>
-                                                                    </constraints>
-                                                                    <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="XXI-Cy-jma">
-                                                                        <rect key="frame" x="0.0" y="60" width="360" height="16"/>
-                                                                        <autoresizingMask key="autoresizingMask"/>
-                                                                    </scroller>
-                                                                    <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="wog-uC-A3q">
-                                                                        <rect key="frame" x="-16" y="0.0" width="16" height="0.0"/>
-                                                                        <autoresizingMask key="autoresizingMask"/>
-                                                                    </scroller>
-                                                                </scrollView>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ng5-FC-tts">
-                                                                    <rect key="frame" x="17" y="747" width="83" height="16"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Video track:" id="VzC-tM-KT7">
-                                                                        <font key="font" metaFont="systemBold"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="g3A-4u-nNt">
-                                                                    <rect key="frame" x="20" y="596" width="254" height="24"/>
-                                                                    <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="qKQ-r0-Z3k">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="254" height="24"/>
-                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                        <subviews>
-                                                                            <view translatesAutoresizingMaskIntoConstraints="NO" id="ib3-bC-6aV">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="249" height="24"/>
-                                                                                <subviews>
-                                                                                    <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ljl-w6-gIf">
-                                                                                        <rect key="frame" x="-2" y="0.0" width="253" height="24"/>
-                                                                                        <segmentedCell key="cell" borderStyle="border" alignment="left" style="rounded" trackingMode="selectOne" id="cMu-YF-riv">
-                                                                                            <font key="font" metaFont="system"/>
-                                                                                            <segments>
-                                                                                                <segment label="Default" selected="YES"/>
-                                                                                                <segment label="4:3" tag="1"/>
-                                                                                                <segment label="16:9" tag="2"/>
-                                                                                                <segment label="16:10" tag="3"/>
-                                                                                                <segment label="21:9" tag="4"/>
-                                                                                                <segment label="5:4"/>
-                                                                                            </segments>
-                                                                                        </segmentedCell>
-                                                                                        <connections>
-                                                                                            <action selector="aspectChangedAction:" target="-2" id="U7C-TJ-2UJ"/>
-                                                                                        </connections>
-                                                                                    </segmentedControl>
-                                                                                </subviews>
-                                                                                <constraints>
-                                                                                    <constraint firstAttribute="trailing" secondItem="Ljl-w6-gIf" secondAttribute="trailing" id="fvw-en-E7d"/>
-                                                                                    <constraint firstItem="Ljl-w6-gIf" firstAttribute="leading" secondItem="ib3-bC-6aV" secondAttribute="leading" id="jcf-fy-12r"/>
-                                                                                    <constraint firstAttribute="bottom" secondItem="Ljl-w6-gIf" secondAttribute="bottom" constant="1" id="qQQ-hV-mJz"/>
-                                                                                    <constraint firstItem="Ljl-w6-gIf" firstAttribute="top" secondItem="ib3-bC-6aV" secondAttribute="top" constant="1" id="rU3-AY-WQh"/>
-                                                                                </constraints>
-                                                                            </view>
-                                                                        </subviews>
-                                                                        <constraints>
-                                                                            <constraint firstAttribute="bottom" secondItem="ib3-bC-6aV" secondAttribute="bottom" id="0Ji-70-NjL"/>
-                                                                            <constraint firstItem="ib3-bC-6aV" firstAttribute="top" secondItem="qKQ-r0-Z3k" secondAttribute="top" id="HXz-SC-t6o"/>
-                                                                            <constraint firstItem="ib3-bC-6aV" firstAttribute="leading" secondItem="qKQ-r0-Z3k" secondAttribute="leading" id="LMS-LQ-8F2"/>
-                                                                        </constraints>
-                                                                    </clipView>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="24" id="t6G-5y-4ke"/>
-                                                                    </constraints>
-                                                                    <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="U7n-SE-hGj">
-                                                                        <rect key="frame" x="-100" y="-100" width="254" height="16"/>
-                                                                        <autoresizingMask key="autoresizingMask"/>
-                                                                    </scroller>
-                                                                    <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="W1r-G9-KGn">
-                                                                        <rect key="frame" x="-100" y="-100" width="16" height="24"/>
-                                                                        <autoresizingMask key="autoresizingMask"/>
-                                                                    </scroller>
-                                                                </scrollView>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8ZJ-PD-t0R">
-                                                                    <rect key="frame" x="17" y="627" width="91" height="16"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Aspect Ratio:" id="YgL-iV-bca">
-                                                                        <font key="font" metaFont="systemBold"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XAI-y0-tcy">
-                                                                    <rect key="frame" x="282" y="598" width="58" height="21"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="width" constant="58" id="6bj-r1-RIj"/>
-                                                                    </constraints>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="jR7-Mt-N0T" customClass="RoundedTextFieldCell" customModule="IINA" customModuleProvider="target">
-                                                                        <font key="font" metaFont="system"/>
-                                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                    <connections>
-                                                                        <action selector="customAspectEditFinishedAction:" target="-2" id="8DL-tk-4rJ"/>
-                                                                    </connections>
-                                                                </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oAm-jJ-3kE">
-                                                                    <rect key="frame" x="17" y="559" width="40" height="16"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Crop:" id="m9e-IB-IDJ">
-                                                                        <font key="font" metaFont="systemBold"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <button verticalHuggingPriority="750" horizontalCompressionResistancePriority="720" translatesAutoresizingMaskIntoConstraints="NO" id="ItN-JT-puN">
-                                                                    <rect key="frame" x="253" y="523" width="94" height="32"/>
-                                                                    <buttonCell key="cell" type="push" title="Custom..." bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="vFD-HU-RVz">
-                                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                        <font key="font" metaFont="system"/>
-                                                                    </buttonCell>
-                                                                    <connections>
-                                                                        <action selector="cropBtnAction:" target="-2" id="5b5-dQ-OPB"/>
-                                                                    </connections>
-                                                                </button>
-                                                                <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="dsX-c1-BZP">
-                                                                    <rect key="frame" x="20" y="528" width="232" height="24"/>
-                                                                    <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="xML-5l-47G">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="232" height="24"/>
-                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                        <subviews>
-                                                                            <view translatesAutoresizingMaskIntoConstraints="NO" id="WPA-DO-5yW">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="265" height="24"/>
-                                                                                <subviews>
-                                                                                    <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kUi-hW-BR6">
-                                                                                        <rect key="frame" x="-2" y="0.0" width="269" height="24"/>
-                                                                                        <segmentedCell key="cell" borderStyle="border" alignment="left" style="rounded" trackingMode="selectOne" id="iuN-rN-jT7">
-                                                                                            <font key="font" metaFont="system"/>
-                                                                                            <segments>
-                                                                                                <segment label="None" width="46"/>
-                                                                                                <segment label="4:3" width="46" selected="YES" tag="1"/>
-                                                                                                <segment label="16:9" width="46" tag="2"/>
-                                                                                                <segment label="16:10" tag="3"/>
-                                                                                                <segment label="21:9" tag="4"/>
-                                                                                                <segment label="5:4"/>
-                                                                                            </segments>
-                                                                                        </segmentedCell>
-                                                                                        <connections>
-                                                                                            <action selector="cropChangedAction:" target="-2" id="1Go-JW-6R4"/>
-                                                                                        </connections>
-                                                                                    </segmentedControl>
-                                                                                </subviews>
-                                                                                <constraints>
-                                                                                    <constraint firstItem="kUi-hW-BR6" firstAttribute="top" secondItem="WPA-DO-5yW" secondAttribute="top" constant="1" id="dzF-m3-WAc"/>
-                                                                                    <constraint firstAttribute="bottom" secondItem="kUi-hW-BR6" secondAttribute="bottom" constant="1" id="iaS-Wl-hPP"/>
-                                                                                    <constraint firstAttribute="trailing" secondItem="kUi-hW-BR6" secondAttribute="trailing" id="on4-3g-owY"/>
-                                                                                    <constraint firstItem="kUi-hW-BR6" firstAttribute="leading" secondItem="WPA-DO-5yW" secondAttribute="leading" id="qH7-rY-3sY"/>
-                                                                                </constraints>
-                                                                            </view>
-                                                                        </subviews>
-                                                                        <constraints>
-                                                                            <constraint firstItem="WPA-DO-5yW" firstAttribute="top" secondItem="xML-5l-47G" secondAttribute="top" id="QtB-lq-Uqk"/>
-                                                                            <constraint firstItem="WPA-DO-5yW" firstAttribute="leading" secondItem="xML-5l-47G" secondAttribute="leading" id="ghe-Hk-Qeb"/>
-                                                                            <constraint firstAttribute="bottom" secondItem="WPA-DO-5yW" secondAttribute="bottom" id="jSO-Iy-B3w"/>
-                                                                        </constraints>
-                                                                    </clipView>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="24" id="gZP-yp-6VD"/>
-                                                                    </constraints>
-                                                                    <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="Ix6-jG-2wj">
-                                                                        <rect key="frame" x="-100" y="-100" width="183" height="16"/>
-                                                                        <autoresizingMask key="autoresizingMask"/>
-                                                                    </scroller>
-                                                                    <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="Waw-1N-X7w">
-                                                                        <rect key="frame" x="-100" y="-100" width="16" height="23"/>
-                                                                        <autoresizingMask key="autoresizingMask"/>
-                                                                    </scroller>
-                                                                </scrollView>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7vv-En-VYY">
-                                                                    <rect key="frame" x="17" y="491" width="64" height="16"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Rotation:" id="to3-rc-Agv">
-                                                                        <font key="font" metaFont="systemBold"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bza-SA-tXE">
-                                                                    <rect key="frame" x="18" y="460" width="151" height="24"/>
-                                                                    <segmentedCell key="cell" borderStyle="border" alignment="left" style="rounded" trackingMode="selectOne" id="z1L-0N-dfK">
-                                                                        <font key="font" metaFont="system"/>
-                                                                        <segments>
-                                                                            <segment label="0°" selected="YES"/>
-                                                                            <segment label="90°" tag="1"/>
-                                                                            <segment label="180°" tag="2"/>
-                                                                            <segment label="270°" tag="3"/>
-                                                                        </segments>
-                                                                    </segmentedCell>
-                                                                    <connections>
-                                                                        <action selector="rotationChangedAction:" target="-2" id="aL1-XS-nLe"/>
-                                                                    </connections>
-                                                                </segmentedControl>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wBg-Dk-cUX">
-                                                                    <rect key="frame" x="93" y="380" width="18" height="14"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="14" id="ScZ-Cn-Mii"/>
-                                                                    </constraints>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="1x" id="B0I-bX-HZS">
-                                                                        <font key="font" metaFont="label" size="9"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Njq-za-TIf">
-                                                                    <rect key="frame" x="167" y="383" width="19" height="11"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="4x" id="PLX-gY-e0h">
-                                                                        <font key="font" metaFont="label" size="9"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UWh-M9-5Nw">
-                                                                    <rect key="frame" x="19" y="393" width="240" height="20"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="width" constant="236" id="mhI-LR-I5w"/>
+                                                                        <constraint firstAttribute="width" constant="236" id="oce-0K-3Eq"/>
                                                                     </constraints>
                                                                     <sliderCell key="cell" controlSize="small" continuous="YES" alignment="left" maxValue="24" doubleValue="8" tickMarkPosition="below" numberOfTickMarks="25" sliderType="linear" id="qxp-Lt-D6o"/>
                                                                     <connections>
                                                                         <action selector="speedChangedAction:" target="-2" id="asr-iq-ZNJ"/>
                                                                     </connections>
                                                                 </slider>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3EN-WD-QNI" userLabel="Speed Slider Indicator">
-                                                                    <rect key="frame" x="92" y="411" width="19" height="13"/>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3EN-WD-QNI" userLabel="SpeedSliderIndicator Text Field">
+                                                                    <rect key="frame" x="63" y="29" width="34" height="13"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="30" id="TXe-gX-yCY"/>
+                                                                    </constraints>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="1x" usesSingleLineMode="YES" id="ldQ-YL-IEp">
                                                                         <font key="font" metaFont="system" size="10"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mjX-Jf-925">
-                                                                    <rect key="frame" x="239" y="380" width="20" height="14"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="14" id="Duh-ya-4aq"/>
-                                                                    </constraints>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="16x" id="p63-Nx-yJZ">
-                                                                        <font key="font" metaFont="label" size="9"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="d4r-sL-0Vo">
-                                                                    <rect key="frame" x="17" y="423" width="50" height="16"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Speed:" id="1KQ-oZ-A2x">
-                                                                        <font key="font" metaFont="systemBold"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nhb-Co-xbZ">
-                                                                    <rect key="frame" x="19" y="380" width="29" height="14"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="14" id="JVv-2s-ysw"/>
-                                                                    </constraints>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nhb-Co-xbZ" userLabel="0.25xLabel Text Field">
+                                                                    <rect key="frame" x="-2" y="0.0" width="29" height="11"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="0.25x" id="Ew1-N1-0Pi">
                                                                         <font key="font" metaFont="label" size="9"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sIs-a1-rGR">
-                                                                    <rect key="frame" x="267" y="393" width="57" height="21"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="57" id="Ood-Jd-gLJ"/>
-                                                                    </constraints>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" title="1" drawsBackground="YES" usesSingleLineMode="YES" id="Mav-NA-RfN" customClass="RoundedTextFieldCell" customModule="IINA" customModuleProvider="target">
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wBg-Dk-cUX" userLabel="1xLabel Text Field">
+                                                                    <rect key="frame" x="71" y="0.0" width="18" height="11"/>
+                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="1x" id="B0I-bX-HZS">
+                                                                        <font key="font" metaFont="label" size="9"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Njq-za-TIf" userLabel="4xLabel Text Field">
+                                                                    <rect key="frame" x="148" y="0.0" width="19" height="11"/>
+                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="4x" id="PLX-gY-e0h">
+                                                                        <font key="font" metaFont="label" size="9"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mjX-Jf-925" userLabel="16xLabel Text Field">
+                                                                    <rect key="frame" x="218" y="0.0" width="20" height="11"/>
+                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="16x" id="p63-Nx-yJZ">
+                                                                        <font key="font" metaFont="label" size="9"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <textField horizontalHuggingPriority="100" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sIs-a1-rGR" userLabel="SpeedEdit Text Field">
+                                                                    <rect key="frame" x="244" y="10" width="59" height="21"/>
+                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" title="1" drawsBackground="YES" usesSingleLineMode="YES" id="Mav-NA-RfN" userLabel="SpeedEdit Text Field Cell" customClass="RoundedTextFieldCell" customModule="IINA" customModuleProvider="target">
                                                                         <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="55S-dl-9lV">
                                                                             <real key="minimum" value="0.01"/>
                                                                         </numberFormatter>
@@ -623,417 +533,446 @@
                                                                         <action selector="customSpeedEditFinishedAction:" target="-2" id="f1u-Mu-w4S"/>
                                                                     </connections>
                                                                 </textField>
-                                                                <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="IWj-Dg-ZDI">
-                                                                    <rect key="frame" x="0.0" y="210" width="360" height="5"/>
-                                                                </box>
-                                                                <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sBU-NZ-sp3">
-                                                                    <rect key="frame" x="91" y="136" width="220" height="20"/>
-                                                                    <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="0Sg-Ca-QjC"/>
-                                                                    <connections>
-                                                                        <action selector="equalizerSliderAction:" target="-2" id="bF8-qZ-hks"/>
-                                                                    </connections>
-                                                                </slider>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="KVn-1o-Qzh">
-                                                                    <rect key="frame" x="18" y="136" width="76" height="17"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="72" id="TvH-N9-GfJ"/>
-                                                                        <constraint firstAttribute="height" constant="17" id="X61-kd-B4a"/>
-                                                                    </constraints>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Brightness:" id="cdR-uY-riN">
-                                                                        <font key="font" metaFont="message" size="11"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0Ww-YT-a8e">
-                                                                    <rect key="frame" x="91" y="108" width="220" height="20"/>
-                                                                    <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="d8Q-Fw-bbA"/>
-                                                                    <connections>
-                                                                        <action selector="equalizerSliderAction:" target="-2" id="Mtl-BL-VYs"/>
-                                                                    </connections>
-                                                                </slider>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8Uj-eX-hSm">
-                                                                    <rect key="frame" x="18" y="108" width="76" height="17"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="17" id="SUH-N6-OC2"/>
-                                                                    </constraints>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Contrast:" id="eDl-Si-LSa">
-                                                                        <font key="font" metaFont="message" size="11"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qeO-tk-I0D">
-                                                                    <rect key="frame" x="91" y="80" width="220" height="20"/>
-                                                                    <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="aEN-2P-ffr"/>
-                                                                    <connections>
-                                                                        <action selector="equalizerSliderAction:" target="-2" id="64F-Yg-BY8"/>
-                                                                    </connections>
-                                                                </slider>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2Zt-RU-LEK">
-                                                                    <rect key="frame" x="18" y="80" width="76" height="17"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="17" id="EAl-du-IHD"/>
-                                                                    </constraints>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Saturation:" id="Rky-lo-Buu">
-                                                                        <font key="font" metaFont="message" size="11"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SL7-DZ-5ff">
-                                                                    <rect key="frame" x="91" y="52" width="220" height="20"/>
-                                                                    <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="IEh-at-wdd"/>
-                                                                    <connections>
-                                                                        <action selector="equalizerSliderAction:" target="-2" id="h5f-VW-qGS"/>
-                                                                    </connections>
-                                                                </slider>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kYz-ZC-58W">
-                                                                    <rect key="frame" x="18" y="52" width="76" height="17"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="17" id="uQX-b9-7MG"/>
-                                                                    </constraints>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Gamma:" id="r6x-z0-oFC">
-                                                                        <font key="font" metaFont="message" size="11"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ntv-89-1iw">
-                                                                    <rect key="frame" x="91" y="24" width="220" height="20"/>
-                                                                    <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="MTr-Ze-dRm"/>
-                                                                    <connections>
-                                                                        <action selector="equalizerSliderAction:" target="-2" id="b6L-ZX-hlF"/>
-                                                                    </connections>
-                                                                </slider>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nEK-El-M50">
-                                                                    <rect key="frame" x="18" y="24" width="76" height="17"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="17" id="fmX-dE-dgH"/>
-                                                                    </constraints>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Hue:" id="eLh-fu-pMj">
-                                                                        <font key="font" metaFont="message" size="11"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="RVg-iv-SLo">
-                                                                    <rect key="frame" x="325" y="134" width="15" height="23"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="17" id="K2i-XQ-bmF"/>
-                                                                    </constraints>
-                                                                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRefreshFreestandingTemplate" imagePosition="overlaps" alignment="center" inset="2" id="uC7-Dj-MnT">
-                                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                                <textField horizontalHuggingPriority="999" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ftl-yD-3Pp">
+                                                                    <rect key="frame" x="301" y="13" width="15" height="16"/>
+                                                                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="x" id="dD9-6c-nPz">
                                                                         <font key="font" metaFont="system"/>
-                                                                    </buttonCell>
-                                                                    <connections>
-                                                                        <action selector="resetEqualizerBtnAction:" target="-2" id="7EI-ef-QfR"/>
-                                                                    </connections>
-                                                                </button>
-                                                                <button verticalHuggingPriority="750" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="g2t-lZ-AEy">
-                                                                    <rect key="frame" x="325" y="106" width="15" height="23"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="17" id="No4-dM-lef"/>
-                                                                    </constraints>
-                                                                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRefreshFreestandingTemplate" imagePosition="overlaps" alignment="center" inset="2" id="ya6-mv-WX1">
-                                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                        <font key="font" metaFont="system"/>
-                                                                    </buttonCell>
-                                                                    <connections>
-                                                                        <action selector="resetEqualizerBtnAction:" target="-2" id="WbP-Bb-JbW"/>
-                                                                    </connections>
-                                                                </button>
-                                                                <button verticalHuggingPriority="750" tag="2" translatesAutoresizingMaskIntoConstraints="NO" id="N1k-37-4OP">
-                                                                    <rect key="frame" x="325" y="78" width="15" height="23"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="17" id="BH7-Hv-t8g"/>
-                                                                    </constraints>
-                                                                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRefreshFreestandingTemplate" imagePosition="overlaps" alignment="center" inset="2" id="cxM-pl-voc">
-                                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                        <font key="font" metaFont="system"/>
-                                                                    </buttonCell>
-                                                                    <connections>
-                                                                        <action selector="resetEqualizerBtnAction:" target="-2" id="MF6-Fz-yqb"/>
-                                                                    </connections>
-                                                                </button>
-                                                                <button verticalHuggingPriority="750" tag="3" translatesAutoresizingMaskIntoConstraints="NO" id="Cec-wN-J62">
-                                                                    <rect key="frame" x="325" y="50" width="15" height="23"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="17" id="hEq-A3-uQc"/>
-                                                                    </constraints>
-                                                                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRefreshFreestandingTemplate" imagePosition="overlaps" alignment="center" inset="2" id="z7P-3I-fAn">
-                                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                        <font key="font" metaFont="system"/>
-                                                                    </buttonCell>
-                                                                    <connections>
-                                                                        <action selector="resetEqualizerBtnAction:" target="-2" id="wMC-t4-VKN"/>
-                                                                    </connections>
-                                                                </button>
-                                                                <button verticalHuggingPriority="750" tag="4" translatesAutoresizingMaskIntoConstraints="NO" id="Cs3-ib-x4Y">
-                                                                    <rect key="frame" x="325" y="22" width="15" height="23"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="17" id="HBL-aN-fWE"/>
-                                                                    </constraints>
-                                                                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRefreshFreestandingTemplate" imagePosition="overlaps" alignment="center" inset="2" id="rIE-LS-ghR">
-                                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                        <font key="font" metaFont="system"/>
-                                                                    </buttonCell>
-                                                                    <connections>
-                                                                        <action selector="resetEqualizerBtnAction:" target="-2" id="5MT-kZ-5Mh"/>
-                                                                    </connections>
-                                                                </button>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="C7W-xd-6OE">
-                                                                    <rect key="frame" x="327" y="396" width="11" height="16"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="x" id="W7H-mU-v3D">
-                                                                        <font key="font" metaFont="system"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <box boxType="custom" cornerRadius="6" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="H0J-Co-VYF">
-                                                                    <rect key="frame" x="20" y="229" width="320" height="134"/>
-                                                                    <view key="contentView" id="1d0-P6-ccO">
-                                                                        <rect key="frame" x="1" y="1" width="318" height="132"/>
-                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                        <subviews>
-                                                                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="2FQ-VQ-dTd" customClass="Switch" customModule="IINA" customModuleProvider="target">
-                                                                                <rect key="frame" x="12" y="48" width="294" height="36"/>
-                                                                                <constraints>
-                                                                                    <constraint firstAttribute="height" constant="36" id="ivE-Da-tar"/>
-                                                                                </constraints>
-                                                                                <userDefinedRuntimeAttributes>
-                                                                                    <userDefinedRuntimeAttribute type="string" keyPath="title" value="quicksetting.deinterlace"/>
-                                                                                </userDefinedRuntimeAttributes>
-                                                                            </customView>
-                                                                            <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="vFH-Zl-rQn">
-                                                                                <rect key="frame" x="12" y="85" width="306" height="5"/>
-                                                                            </box>
-                                                                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="0pq-Hh-3hb" customClass="Switch" customModule="IINA" customModuleProvider="target">
-                                                                                <rect key="frame" x="12" y="92" width="294" height="36"/>
-                                                                                <constraints>
-                                                                                    <constraint firstAttribute="height" constant="36" id="tE2-0l-lBC"/>
-                                                                                </constraints>
-                                                                                <userDefinedRuntimeAttributes>
-                                                                                    <userDefinedRuntimeAttribute type="string" keyPath="title" value="quicksetting.hwdec"/>
-                                                                                </userDefinedRuntimeAttributes>
-                                                                            </customView>
-                                                                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="0RB-r2-J8C" customClass="Switch" customModule="IINA" customModuleProvider="target">
-                                                                                <rect key="frame" x="12" y="4" width="294" height="36"/>
-                                                                                <constraints>
-                                                                                    <constraint firstAttribute="height" constant="36" id="PWq-Em-egl"/>
-                                                                                </constraints>
-                                                                                <userDefinedRuntimeAttributes>
-                                                                                    <userDefinedRuntimeAttribute type="string" keyPath="title" value="quicksetting.hdr"/>
-                                                                                </userDefinedRuntimeAttributes>
-                                                                            </customView>
-                                                                            <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="taW-wc-jG7">
-                                                                                <rect key="frame" x="12" y="41" width="306" height="5"/>
-                                                                            </box>
-                                                                        </subviews>
-                                                                        <constraints>
-                                                                            <constraint firstAttribute="trailing" secondItem="vFH-Zl-rQn" secondAttribute="trailing" id="4f2-sV-zHk"/>
-                                                                            <constraint firstItem="2FQ-VQ-dTd" firstAttribute="leading" secondItem="0RB-r2-J8C" secondAttribute="leading" id="7iy-KH-Ifw"/>
-                                                                            <constraint firstItem="vFH-Zl-rQn" firstAttribute="leading" secondItem="1d0-P6-ccO" secondAttribute="leading" constant="12" id="NqH-9C-Ctk"/>
-                                                                            <constraint firstItem="0RB-r2-J8C" firstAttribute="leading" secondItem="vFH-Zl-rQn" secondAttribute="leading" id="QSp-uh-Ycc"/>
-                                                                            <constraint firstItem="vFH-Zl-rQn" firstAttribute="top" secondItem="0pq-Hh-3hb" secondAttribute="bottom" constant="4" id="Qaj-Mu-Aep"/>
-                                                                            <constraint firstItem="0pq-Hh-3hb" firstAttribute="trailing" secondItem="2FQ-VQ-dTd" secondAttribute="trailing" id="SNJ-yp-hzm"/>
-                                                                            <constraint firstItem="0pq-Hh-3hb" firstAttribute="top" secondItem="1d0-P6-ccO" secondAttribute="top" constant="4" id="Wqk-vr-Pfx"/>
-                                                                            <constraint firstItem="0RB-r2-J8C" firstAttribute="top" secondItem="2FQ-VQ-dTd" secondAttribute="bottom" constant="8" id="Yn5-cl-zIx"/>
-                                                                            <constraint firstItem="2FQ-VQ-dTd" firstAttribute="top" secondItem="0pq-Hh-3hb" secondAttribute="bottom" constant="8" id="ZIY-VZ-Qx2"/>
-                                                                            <constraint firstItem="taW-wc-jG7" firstAttribute="leading" secondItem="1d0-P6-ccO" secondAttribute="leading" constant="12" id="cU3-iB-7tQ"/>
-                                                                            <constraint firstItem="taW-wc-jG7" firstAttribute="top" secondItem="2FQ-VQ-dTd" secondAttribute="bottom" constant="4" id="ej1-ck-adH"/>
-                                                                            <constraint firstItem="2FQ-VQ-dTd" firstAttribute="trailing" secondItem="0RB-r2-J8C" secondAttribute="trailing" id="gXe-MM-2V6"/>
-                                                                            <constraint firstItem="0pq-Hh-3hb" firstAttribute="leading" secondItem="2FQ-VQ-dTd" secondAttribute="leading" id="lr3-44-oTV"/>
-                                                                            <constraint firstItem="0pq-Hh-3hb" firstAttribute="centerX" secondItem="1d0-P6-ccO" secondAttribute="centerX" id="nJs-Oy-x1J"/>
-                                                                            <constraint firstAttribute="trailing" secondItem="taW-wc-jG7" secondAttribute="trailing" id="p2Z-9g-shk"/>
-                                                                            <constraint firstAttribute="bottom" secondItem="0RB-r2-J8C" secondAttribute="bottom" constant="4" id="tYP-h7-JWk"/>
-                                                                        </constraints>
-                                                                    </view>
-                                                                    <color key="borderColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                    <color key="fillColor" red="0.99999600649999998" green="1" blue="1" alpha="0.10000000000000001" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                </box>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dFy-zT-BqP">
-                                                                    <rect key="frame" x="17" y="172" width="64" height="16"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Equalizer" id="Xez-sb-mfB">
-                                                                        <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
                                                             </subviews>
                                                             <constraints>
-                                                                <constraint firstAttribute="trailing" secondItem="Cec-wN-J62" secondAttribute="trailing" constant="20" id="0VS-7a-ogO"/>
-                                                                <constraint firstItem="d4r-sL-0Vo" firstAttribute="top" secondItem="bza-SA-tXE" secondAttribute="bottom" constant="22" id="2dd-6U-5JF"/>
-                                                                <constraint firstItem="kYz-ZC-58W" firstAttribute="width" secondItem="KVn-1o-Qzh" secondAttribute="width" id="2el-E9-Qtg"/>
-                                                                <constraint firstItem="Njq-za-TIf" firstAttribute="top" secondItem="UWh-M9-5Nw" secondAttribute="bottom" constant="1" id="2fd-vu-drk"/>
-                                                                <constraint firstItem="7vv-En-VYY" firstAttribute="top" secondItem="dsX-c1-BZP" secondAttribute="bottom" constant="21" id="2tl-2k-7WD"/>
-                                                                <constraint firstItem="H0J-Co-VYF" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="20" id="39P-eZ-GAu"/>
-                                                                <constraint firstItem="g2t-lZ-AEy" firstAttribute="centerY" secondItem="0Ww-YT-a8e" secondAttribute="centerY" id="3Kh-dx-oIx"/>
-                                                                <constraint firstAttribute="trailing" secondItem="N1k-37-4OP" secondAttribute="trailing" constant="20" id="5br-Q9-w6g"/>
-                                                                <constraint firstItem="ykw-rb-M9D" firstAttribute="top" secondItem="Ng5-FC-tts" secondAttribute="bottom" constant="8" id="6Od-LZ-fNN"/>
-                                                                <constraint firstItem="Cs3-ib-x4Y" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="ntv-89-1iw" secondAttribute="trailing" constant="8" id="6PU-Zp-82g"/>
-                                                                <constraint firstAttribute="trailing" secondItem="H0J-Co-VYF" secondAttribute="trailing" constant="20" id="6Q9-XF-bOn"/>
-                                                                <constraint firstItem="Njq-za-TIf" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="wBg-Dk-cUX" secondAttribute="trailing" constant="8" symbolic="YES" id="7O2-4O-ehs"/>
-                                                                <constraint firstAttribute="trailing" secondItem="ntv-89-1iw" secondAttribute="trailing" constant="51" id="8GY-ka-LVa"/>
-                                                                <constraint firstItem="3EN-WD-QNI" firstAttribute="centerX" secondItem="UWh-M9-5Nw" secondAttribute="leading" constant="80" id="92J-9M-Lrn"/>
-                                                                <constraint firstItem="KVn-1o-Qzh" firstAttribute="top" secondItem="dFy-zT-BqP" secondAttribute="bottom" constant="19" id="970-TZ-ALY"/>
-                                                                <constraint firstItem="8ZJ-PD-t0R" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="19" id="9Sd-Mo-oNR"/>
-                                                                <constraint firstItem="0Ww-YT-a8e" firstAttribute="centerY" secondItem="8Uj-eX-hSm" secondAttribute="centerY" constant="-1" id="B0c-jl-1XQ"/>
-                                                                <constraint firstItem="kYz-ZC-58W" firstAttribute="top" secondItem="2Zt-RU-LEK" secondAttribute="bottom" constant="11" id="B7h-Eh-6Vi"/>
-                                                                <constraint firstItem="N1k-37-4OP" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="qeO-tk-I0D" secondAttribute="trailing" constant="8" id="C5u-TB-elV"/>
-                                                                <constraint firstItem="2Zt-RU-LEK" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="20" id="C61-e9-1jh"/>
-                                                                <constraint firstItem="SL7-DZ-5ff" firstAttribute="leading" secondItem="kYz-ZC-58W" secondAttribute="trailing" constant="1" id="DGv-8S-1cx"/>
-                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="8ZJ-PD-t0R" secondAttribute="trailing" constant="35" id="Dlg-Mc-874"/>
-                                                                <constraint firstItem="dsX-c1-BZP" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="20" id="DnK-YD-AUB"/>
-                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="d4r-sL-0Vo" secondAttribute="trailing" constant="35" id="ELU-P9-Djx"/>
-                                                                <constraint firstItem="Nhb-Co-xbZ" firstAttribute="top" secondItem="UWh-M9-5Nw" secondAttribute="bottom" constant="1" id="Emd-QP-HFC"/>
-                                                                <constraint firstItem="RVg-iv-SLo" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="sBU-NZ-sp3" secondAttribute="trailing" constant="8" id="Eyu-cm-Bhy"/>
-                                                                <constraint firstItem="KVn-1o-Qzh" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="20" id="F1e-4k-MuR"/>
-                                                                <constraint firstItem="2Zt-RU-LEK" firstAttribute="top" secondItem="8Uj-eX-hSm" secondAttribute="bottom" constant="11" id="FP3-ig-1Zr"/>
-                                                                <constraint firstItem="8Uj-eX-hSm" firstAttribute="width" secondItem="KVn-1o-Qzh" secondAttribute="width" id="FTg-hm-WPJ"/>
-                                                                <constraint firstItem="UWh-M9-5Nw" firstAttribute="top" secondItem="3EN-WD-QNI" secondAttribute="bottom" id="Flg-AY-ygf"/>
-                                                                <constraint firstItem="dFy-zT-BqP" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="19" id="G5S-Q8-ZeM"/>
-                                                                <constraint firstItem="nEK-El-M50" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="20" id="Grd-2Q-AeY"/>
-                                                                <constraint firstAttribute="trailing" secondItem="SL7-DZ-5ff" secondAttribute="trailing" constant="51" id="HbQ-Yd-1nd"/>
-                                                                <constraint firstItem="ykw-rb-M9D" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" id="IDV-m3-6MW"/>
-                                                                <constraint firstAttribute="trailing" secondItem="qeO-tk-I0D" secondAttribute="trailing" constant="51" id="Ike-sL-VNz"/>
-                                                                <constraint firstItem="mjX-Jf-925" firstAttribute="top" secondItem="UWh-M9-5Nw" secondAttribute="bottom" constant="1" id="In6-zL-WCc"/>
-                                                                <constraint firstAttribute="bottom" secondItem="nEK-El-M50" secondAttribute="bottom" constant="24" id="Ltn-af-ibl"/>
-                                                                <constraint firstItem="UWh-M9-5Nw" firstAttribute="leading" secondItem="Nhb-Co-xbZ" secondAttribute="leading" id="NGa-67-RQ3"/>
-                                                                <constraint firstItem="0Ww-YT-a8e" firstAttribute="leading" secondItem="8Uj-eX-hSm" secondAttribute="trailing" constant="1" id="NiE-Dm-ChB"/>
-                                                                <constraint firstAttribute="trailing" secondItem="RVg-iv-SLo" secondAttribute="trailing" constant="20" id="Nod-gk-WVf"/>
-                                                                <constraint firstItem="Ng5-FC-tts" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="19" id="Omp-b4-73b"/>
-                                                                <constraint firstItem="C7W-xd-6OE" firstAttribute="leading" secondItem="sIs-a1-rGR" secondAttribute="trailing" constant="5" id="OwJ-38-Pvv"/>
-                                                                <constraint firstItem="7vv-En-VYY" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="19" id="Pdo-MY-Ipv"/>
-                                                                <constraint firstItem="wBg-Dk-cUX" firstAttribute="top" secondItem="UWh-M9-5Nw" secondAttribute="bottom" constant="1" id="Q6G-Fz-CGT"/>
-                                                                <constraint firstItem="bza-SA-tXE" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="20" id="Qa8-ju-KHP"/>
-                                                                <constraint firstItem="wBg-Dk-cUX" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Nhb-Co-xbZ" secondAttribute="trailing" constant="8" symbolic="YES" id="Qht-rb-VcY"/>
-                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="dFy-zT-BqP" secondAttribute="trailing" id="RF3-m9-10f"/>
-                                                                <constraint firstItem="ItN-JT-puN" firstAttribute="centerY" secondItem="dsX-c1-BZP" secondAttribute="centerY" id="SAV-G5-5wL"/>
-                                                                <constraint firstItem="g3A-4u-nNt" firstAttribute="top" secondItem="8ZJ-PD-t0R" secondAttribute="bottom" constant="7" id="SKe-RW-aSJ"/>
-                                                                <constraint firstItem="Cec-wN-J62" firstAttribute="centerY" secondItem="SL7-DZ-5ff" secondAttribute="centerY" id="SbN-O3-hQF"/>
-                                                                <constraint firstItem="8ZJ-PD-t0R" firstAttribute="top" secondItem="ykw-rb-M9D" secondAttribute="bottom" constant="20" id="SsM-RU-d20"/>
-                                                                <constraint firstItem="8Uj-eX-hSm" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="20" id="T08-gr-bMl"/>
-                                                                <constraint firstItem="mjX-Jf-925" firstAttribute="trailing" secondItem="UWh-M9-5Nw" secondAttribute="trailing" id="Tfz-E0-gcH"/>
-                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="7vv-En-VYY" secondAttribute="trailing" constant="35" id="UG0-YC-mdd"/>
-                                                                <constraint firstItem="bza-SA-tXE" firstAttribute="top" secondItem="7vv-En-VYY" secondAttribute="bottom" constant="8" id="UNm-OF-IiO"/>
-                                                                <constraint firstItem="ItN-JT-puN" firstAttribute="leading" secondItem="dsX-c1-BZP" secondAttribute="trailing" constant="8" id="UtM-OV-im7"/>
-                                                                <constraint firstAttribute="trailing" secondItem="g2t-lZ-AEy" secondAttribute="trailing" constant="20" id="V20-xT-lvO"/>
-                                                                <constraint firstItem="SL7-DZ-5ff" firstAttribute="centerY" secondItem="kYz-ZC-58W" secondAttribute="centerY" constant="-1" id="V50-WA-XT5"/>
-                                                                <constraint firstItem="mjX-Jf-925" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Njq-za-TIf" secondAttribute="trailing" constant="8" symbolic="YES" id="VJx-BE-SW6"/>
-                                                                <constraint firstItem="kYz-ZC-58W" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="20" id="WaX-of-cel"/>
-                                                                <constraint firstAttribute="trailing" secondItem="Cs3-ib-x4Y" secondAttribute="trailing" constant="20" id="Ws1-7P-jpF"/>
-                                                                <constraint firstItem="N1k-37-4OP" firstAttribute="centerY" secondItem="qeO-tk-I0D" secondAttribute="centerY" id="XJ5-f1-XrE"/>
-                                                                <constraint firstItem="d4r-sL-0Vo" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="19" id="YXU-bO-7fz"/>
-                                                                <constraint firstAttribute="trailing" secondItem="ItN-JT-puN" secondAttribute="trailing" constant="20" id="axE-h4-tZb"/>
-                                                                <constraint firstItem="sIs-a1-rGR" firstAttribute="baseline" secondItem="C7W-xd-6OE" secondAttribute="baseline" id="axs-9b-6io"/>
-                                                                <constraint firstItem="dFy-zT-BqP" firstAttribute="top" secondItem="IWj-Dg-ZDI" secondAttribute="bottom" constant="24" id="bJi-Qb-mOl"/>
-                                                                <constraint firstItem="dsX-c1-BZP" firstAttribute="top" secondItem="oAm-jJ-3kE" secondAttribute="bottom" constant="7" id="eUv-sB-JtG"/>
-                                                                <constraint firstItem="sBU-NZ-sp3" firstAttribute="centerY" secondItem="KVn-1o-Qzh" secondAttribute="centerY" constant="-1" id="ekL-0l-eZn"/>
-                                                                <constraint firstAttribute="trailing" secondItem="C7W-xd-6OE" secondAttribute="trailing" constant="24" id="fIL-TV-0vr"/>
-                                                                <constraint firstItem="oAm-jJ-3kE" firstAttribute="top" secondItem="g3A-4u-nNt" secondAttribute="bottom" constant="21" id="fqG-6I-Z5N"/>
-                                                                <constraint firstItem="Cec-wN-J62" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="SL7-DZ-5ff" secondAttribute="trailing" constant="8" id="frf-kH-48f"/>
-                                                                <constraint firstAttribute="trailing" secondItem="0Ww-YT-a8e" secondAttribute="trailing" constant="51" id="guT-nx-Wk3"/>
-                                                                <constraint firstItem="8Uj-eX-hSm" firstAttribute="top" secondItem="KVn-1o-Qzh" secondAttribute="bottom" constant="11" id="h27-1N-oqq"/>
-                                                                <constraint firstItem="g3A-4u-nNt" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="20" id="hXU-o7-Se9"/>
-                                                                <constraint firstItem="XAI-y0-tcy" firstAttribute="leading" secondItem="g3A-4u-nNt" secondAttribute="trailing" constant="8" id="ihI-wW-bKO"/>
-                                                                <constraint firstItem="sIs-a1-rGR" firstAttribute="leading" secondItem="UWh-M9-5Nw" secondAttribute="trailing" constant="10" id="lZi-Gn-0wp"/>
-                                                                <constraint firstItem="UWh-M9-5Nw" firstAttribute="top" secondItem="d4r-sL-0Vo" secondAttribute="bottom" constant="12" id="lxM-no-JPt"/>
-                                                                <constraint firstItem="Ng5-FC-tts" firstAttribute="top" secondItem="5v4-Te-950" secondAttribute="top" constant="20" id="mnE-cz-hms"/>
-                                                                <constraint firstItem="sIs-a1-rGR" firstAttribute="centerY" secondItem="UWh-M9-5Nw" secondAttribute="centerY" id="msa-vu-iWm"/>
-                                                                <constraint firstItem="ntv-89-1iw" firstAttribute="centerY" secondItem="nEK-El-M50" secondAttribute="centerY" constant="-1" id="nlv-SX-hed"/>
-                                                                <constraint firstItem="Cs3-ib-x4Y" firstAttribute="centerY" secondItem="ntv-89-1iw" secondAttribute="centerY" id="oaP-Ea-Hxf"/>
-                                                                <constraint firstItem="sBU-NZ-sp3" firstAttribute="leading" secondItem="KVn-1o-Qzh" secondAttribute="trailing" constant="1" id="oi8-qd-gl7"/>
-                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Ng5-FC-tts" secondAttribute="trailing" constant="35" id="opt-ak-vjT"/>
-                                                                <constraint firstItem="RVg-iv-SLo" firstAttribute="centerY" secondItem="sBU-NZ-sp3" secondAttribute="centerY" id="p3g-be-o3f"/>
-                                                                <constraint firstItem="IWj-Dg-ZDI" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" id="qz4-0r-Wmb"/>
-                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="oAm-jJ-3kE" secondAttribute="trailing" id="rJP-h4-nmQ"/>
-                                                                <constraint firstAttribute="trailing" secondItem="XAI-y0-tcy" secondAttribute="trailing" constant="20" id="s3L-tw-1U3"/>
-                                                                <constraint firstItem="nEK-El-M50" firstAttribute="width" secondItem="KVn-1o-Qzh" secondAttribute="width" id="se1-Eo-JSd"/>
-                                                                <constraint firstItem="XAI-y0-tcy" firstAttribute="centerY" secondItem="g3A-4u-nNt" secondAttribute="centerY" id="sjZ-nV-Ju0"/>
-                                                                <constraint firstItem="nEK-El-M50" firstAttribute="top" secondItem="kYz-ZC-58W" secondAttribute="bottom" constant="11" id="tPs-tE-Vha"/>
-                                                                <constraint firstItem="g2t-lZ-AEy" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="0Ww-YT-a8e" secondAttribute="trailing" constant="8" id="tUf-eP-axV"/>
-                                                                <constraint firstItem="IWj-Dg-ZDI" firstAttribute="top" secondItem="H0J-Co-VYF" secondAttribute="bottom" constant="16" id="tUw-d7-2Lk"/>
-                                                                <constraint firstItem="UWh-M9-5Nw" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="21" id="tix-10-NM5"/>
-                                                                <constraint firstItem="qeO-tk-I0D" firstAttribute="centerY" secondItem="2Zt-RU-LEK" secondAttribute="centerY" constant="-1" id="uES-Tw-LyK"/>
-                                                                <constraint firstItem="2Zt-RU-LEK" firstAttribute="width" secondItem="KVn-1o-Qzh" secondAttribute="width" id="ujz-0j-0bK"/>
-                                                                <constraint firstItem="ntv-89-1iw" firstAttribute="leading" secondItem="nEK-El-M50" secondAttribute="trailing" constant="1" id="vwz-ag-OXf"/>
-                                                                <constraint firstItem="oAm-jJ-3kE" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="19" id="xGc-cc-diR"/>
-                                                                <constraint firstAttribute="trailing" secondItem="ykw-rb-M9D" secondAttribute="trailing" id="y2x-tm-gpt"/>
-                                                                <constraint firstItem="qeO-tk-I0D" firstAttribute="leading" secondItem="2Zt-RU-LEK" secondAttribute="trailing" constant="1" id="y60-T3-dbz"/>
-                                                                <constraint firstItem="Njq-za-TIf" firstAttribute="centerX" secondItem="UWh-M9-5Nw" secondAttribute="trailing" constant="-81" id="ye2-KO-sgF"/>
-                                                                <constraint firstAttribute="trailing" secondItem="sBU-NZ-sp3" secondAttribute="trailing" constant="51" id="yjg-bb-MWl"/>
-                                                                <constraint firstAttribute="trailing" secondItem="IWj-Dg-ZDI" secondAttribute="trailing" id="zbB-sz-CoS"/>
-                                                                <constraint firstItem="UWh-M9-5Nw" firstAttribute="leading" secondItem="wBg-Dk-cUX" secondAttribute="centerX" constant="-81" id="zd4-0W-06H"/>
-                                                                <constraint firstItem="H0J-Co-VYF" firstAttribute="top" secondItem="UWh-M9-5Nw" secondAttribute="bottom" constant="32" id="zdQ-uF-4Of"/>
+                                                                <constraint firstItem="Njq-za-TIf" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="wBg-Dk-cUX" secondAttribute="leading" id="0og-bi-e6K"/>
+                                                                <constraint firstItem="Njq-za-TIf" firstAttribute="firstBaseline" secondItem="Nhb-Co-xbZ" secondAttribute="firstBaseline" id="3b5-3Q-r9W"/>
+                                                                <constraint firstItem="sIs-a1-rGR" firstAttribute="leading" secondItem="UWh-M9-5Nw" secondAttribute="trailing" constant="8" id="45f-oW-eLi"/>
+                                                                <constraint firstItem="wBg-Dk-cUX" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Nhb-Co-xbZ" secondAttribute="trailing" id="85g-vN-0eC"/>
+                                                                <constraint firstAttribute="trailing" secondItem="ftl-yD-3Pp" secondAttribute="trailing" id="96C-Yr-KHl"/>
+                                                                <constraint firstItem="mjX-Jf-925" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Njq-za-TIf" secondAttribute="trailing" id="Aep-cH-5hZ"/>
+                                                                <constraint firstItem="UWh-M9-5Nw" firstAttribute="top" secondItem="3EN-WD-QNI" secondAttribute="bottom" constant="1" id="Ew9-hh-DuD"/>
+                                                                <constraint firstItem="Njq-za-TIf" firstAttribute="centerX" secondItem="UWh-M9-5Nw" secondAttribute="trailing" multiplier="0.667" id="H0i-c4-qHi"/>
+                                                                <constraint firstItem="sIs-a1-rGR" firstAttribute="trailing" secondItem="ftl-yD-3Pp" secondAttribute="leading" id="NH7-04-aU7"/>
+                                                                <constraint firstItem="3EN-WD-QNI" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="UWh-M9-5Nw" secondAttribute="leading" id="VCK-Xl-WI5"/>
+                                                                <constraint firstItem="ftl-yD-3Pp" firstAttribute="firstBaseline" secondItem="sIs-a1-rGR" secondAttribute="firstBaseline" id="ZAk-oK-iEc"/>
+                                                                <constraint firstItem="mjX-Jf-925" firstAttribute="trailing" secondItem="UWh-M9-5Nw" secondAttribute="trailing" id="a9v-VN-b9b"/>
+                                                                <constraint firstItem="UWh-M9-5Nw" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" id="b9h-cf-WWr"/>
+                                                                <constraint firstItem="Nhb-Co-xbZ" firstAttribute="leading" secondItem="UWh-M9-5Nw" secondAttribute="leading" id="bpH-bS-WjS"/>
+                                                                <constraint firstItem="3EN-WD-QNI" firstAttribute="top" secondItem="5v4-Te-950" secondAttribute="top" id="cOT-x8-ZcW"/>
+                                                                <constraint firstItem="wBg-Dk-cUX" firstAttribute="centerX" secondItem="UWh-M9-5Nw" secondAttribute="leading" multiplier="0.3333" constant="80" id="hlk-KQ-DJ7"/>
+                                                                <constraint firstItem="wBg-Dk-cUX" firstAttribute="firstBaseline" secondItem="Nhb-Co-xbZ" secondAttribute="firstBaseline" id="ime-8Z-RkU"/>
+                                                                <constraint firstAttribute="bottom" secondItem="Nhb-Co-xbZ" secondAttribute="bottom" id="iwc-ox-8MG"/>
+                                                                <constraint firstItem="mjX-Jf-925" firstAttribute="firstBaseline" secondItem="Nhb-Co-xbZ" secondAttribute="firstBaseline" id="pcC-I5-fWK"/>
+                                                                <constraint firstItem="3EN-WD-QNI" firstAttribute="centerX" secondItem="UWh-M9-5Nw" secondAttribute="leading" priority="800" constant="80" id="qTf-o6-Mef"/>
+                                                                <constraint firstItem="Nhb-Co-xbZ" firstAttribute="top" secondItem="UWh-M9-5Nw" secondAttribute="bottom" constant="1" id="vt5-Yi-wDm"/>
+                                                                <constraint firstItem="sIs-a1-rGR" firstAttribute="centerY" secondItem="UWh-M9-5Nw" secondAttribute="centerY" id="xKa-An-0CC"/>
                                                             </constraints>
                                                         </customView>
+                                                        <box autoresizesSubviews="NO" boxType="custom" cornerRadius="6" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="2ye-g4-fz5" userLabel="Switches Box">
+                                                            <rect key="frame" x="20" y="207" width="314" height="134"/>
+                                                            <view key="contentView" id="bBc-PP-gHz" userLabel="Switches Box View">
+                                                                <rect key="frame" x="1" y="1" width="312" height="132"/>
+                                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                <subviews>
+                                                                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="7z5-cT-Huj" userLabel="HWDecoding Switch" customClass="Switch" customModule="IINA" customModuleProvider="target">
+                                                                        <rect key="frame" x="12" y="92" width="288" height="36"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="height" constant="36" id="g7u-92-6a2"/>
+                                                                        </constraints>
+                                                                        <userDefinedRuntimeAttributes>
+                                                                            <userDefinedRuntimeAttribute type="string" keyPath="title" value="quicksetting.hwdec"/>
+                                                                        </userDefinedRuntimeAttributes>
+                                                                    </customView>
+                                                                    <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="PyM-xa-vx9" userLabel="Horizontal Line 1">
+                                                                        <rect key="frame" x="12" y="86" width="288" height="5"/>
+                                                                    </box>
+                                                                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="SMb-H5-j6h" userLabel="Deinterlace Switch" customClass="Switch" customModule="IINA" customModuleProvider="target">
+                                                                        <rect key="frame" x="12" y="48" width="288" height="36"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="height" constant="36" id="4kX-XS-rz3"/>
+                                                                        </constraints>
+                                                                        <userDefinedRuntimeAttributes>
+                                                                            <userDefinedRuntimeAttribute type="string" keyPath="title" value="quicksetting.deinterlace"/>
+                                                                        </userDefinedRuntimeAttributes>
+                                                                    </customView>
+                                                                    <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="qYi-uQ-6qo" userLabel="Horizontal Line 2">
+                                                                        <rect key="frame" x="12" y="42" width="288" height="5"/>
+                                                                    </box>
+                                                                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="U8P-fW-N3q" userLabel="HDR Switch" customClass="Switch" customModule="IINA" customModuleProvider="target">
+                                                                        <rect key="frame" x="12" y="4" width="288" height="36"/>
+                                                                        <constraints>
+                                                                            <constraint firstAttribute="height" constant="36" id="YSa-1m-THM"/>
+                                                                        </constraints>
+                                                                        <userDefinedRuntimeAttributes>
+                                                                            <userDefinedRuntimeAttribute type="string" keyPath="title" value="quicksetting.hdr"/>
+                                                                        </userDefinedRuntimeAttributes>
+                                                                    </customView>
+                                                                </subviews>
+                                                                <constraints>
+                                                                    <constraint firstAttribute="bottom" secondItem="U8P-fW-N3q" secondAttribute="bottom" constant="4" id="6lN-OM-fnO"/>
+                                                                    <constraint firstItem="SMb-H5-j6h" firstAttribute="leading" secondItem="7z5-cT-Huj" secondAttribute="leading" id="7Ja-DA-CwF"/>
+                                                                    <constraint firstItem="SMb-H5-j6h" firstAttribute="top" secondItem="7z5-cT-Huj" secondAttribute="bottom" constant="8" id="Fjd-9M-zZt"/>
+                                                                    <constraint firstItem="U8P-fW-N3q" firstAttribute="leading" secondItem="SMb-H5-j6h" secondAttribute="leading" id="GRQ-Bt-V3i"/>
+                                                                    <constraint firstItem="U8P-fW-N3q" firstAttribute="leading" secondItem="PyM-xa-vx9" secondAttribute="leading" id="I97-3I-Tnn"/>
+                                                                    <constraint firstItem="U8P-fW-N3q" firstAttribute="trailing" secondItem="SMb-H5-j6h" secondAttribute="trailing" id="MXl-9i-Z7z"/>
+                                                                    <constraint firstItem="qYi-uQ-6qo" firstAttribute="trailing" secondItem="PyM-xa-vx9" secondAttribute="trailing" id="W6Y-bH-eCi"/>
+                                                                    <constraint firstItem="7z5-cT-Huj" firstAttribute="top" secondItem="bBc-PP-gHz" secondAttribute="top" constant="4" id="X2a-Cb-juO"/>
+                                                                    <constraint firstItem="U8P-fW-N3q" firstAttribute="top" secondItem="qYi-uQ-6qo" secondAttribute="bottom" constant="4" id="ZPR-3B-WSW"/>
+                                                                    <constraint firstAttribute="trailing" secondItem="PyM-xa-vx9" secondAttribute="trailing" constant="12" id="Zny-ol-SPy"/>
+                                                                    <constraint firstItem="SMb-H5-j6h" firstAttribute="trailing" secondItem="7z5-cT-Huj" secondAttribute="trailing" id="bTG-eY-qrc"/>
+                                                                    <constraint firstItem="7z5-cT-Huj" firstAttribute="centerX" secondItem="bBc-PP-gHz" secondAttribute="centerX" id="bVd-8a-j88"/>
+                                                                    <constraint firstItem="PyM-xa-vx9" firstAttribute="leading" secondItem="bBc-PP-gHz" secondAttribute="leading" constant="12" id="cAs-bS-FEB"/>
+                                                                    <constraint firstItem="PyM-xa-vx9" firstAttribute="bottom" secondItem="7z5-cT-Huj" secondAttribute="bottom" constant="4" id="mXv-Bz-bFd"/>
+                                                                    <constraint firstItem="U8P-fW-N3q" firstAttribute="top" secondItem="SMb-H5-j6h" secondAttribute="bottom" constant="8" id="t4C-3L-HEY"/>
+                                                                    <constraint firstItem="qYi-uQ-6qo" firstAttribute="leading" secondItem="PyM-xa-vx9" secondAttribute="leading" id="tkm-Ze-qkw"/>
+                                                                    <constraint firstItem="U8P-fW-N3q" firstAttribute="trailing" secondItem="PyM-xa-vx9" secondAttribute="trailing" id="yTh-eK-yhj"/>
+                                                                </constraints>
+                                                            </view>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="134" id="mMk-SO-lBd"/>
+                                                            </constraints>
+                                                            <color key="borderColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                                            <color key="fillColor" red="0.99999600649999998" green="1" blue="1" alpha="0.10000000000000001" colorSpace="custom" customColorSpace="sRGB"/>
+                                                        </box>
+                                                        <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="7PK-hh-Xx5">
+                                                            <rect key="frame" x="0.0" y="184" width="354" height="5"/>
+                                                        </box>
+                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QqK-iZ-rFX" userLabel="EqualizerLabel Text Field">
+                                                            <rect key="frame" x="18" y="150" width="318" height="16"/>
+                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Equalizer" id="zcD-Tg-7Oi">
+                                                                <font key="font" metaFont="systemBold"/>
+                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                        </textField>
+                                                        <stackView distribution="equalCentering" orientation="vertical" alignment="leading" spacing="11" horizontalStackHuggingPriority="1000" verticalStackHuggingPriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="9Ua-jA-xuA" userLabel="EqualizerLabels Vertical Stack View">
+                                                            <rect key="frame" x="20" y="20" width="49" height="110"/>
+                                                            <subviews>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Kzg-Uw-tpM">
+                                                                    <rect key="frame" x="-2" y="97" width="53" height="13"/>
+                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Brightness:" id="kLX-08-cJm">
+                                                                        <font key="font" metaFont="message" size="11"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zeE-QB-5WQ">
+                                                                    <rect key="frame" x="-2" y="73" width="53" height="13"/>
+                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Contrast:" id="orm-fg-Pcr">
+                                                                        <font key="font" metaFont="message" size="11"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="inU-m8-46Z">
+                                                                    <rect key="frame" x="-2" y="48" width="53" height="14"/>
+                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Saturation:" id="Jtb-ax-aRg">
+                                                                        <font key="font" metaFont="message" size="11"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NFp-1S-x9x">
+                                                                    <rect key="frame" x="-2" y="24" width="53" height="13"/>
+                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Gamma:" id="Hqp-4g-tfS">
+                                                                        <font key="font" metaFont="message" size="11"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BdF-A5-VPG">
+                                                                    <rect key="frame" x="-2" y="0.0" width="53" height="13"/>
+                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Hue:" id="fqk-nd-STV">
+                                                                        <font key="font" metaFont="message" size="11"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                            </subviews>
+                                                            <constraints>
+                                                                <constraint firstItem="BdF-A5-VPG" firstAttribute="bottom" secondItem="Kzg-Uw-tpM" secondAttribute="top" constant="110" id="0cF-1Q-5Et"/>
+                                                                <constraint firstItem="inU-m8-46Z" firstAttribute="height" secondItem="Kzg-Uw-tpM" secondAttribute="height" id="B8c-8a-Bmv"/>
+                                                                <constraint firstItem="NFp-1S-x9x" firstAttribute="height" secondItem="Kzg-Uw-tpM" secondAttribute="height" id="aRf-Mh-zKA"/>
+                                                                <constraint firstItem="BdF-A5-VPG" firstAttribute="height" secondItem="Kzg-Uw-tpM" secondAttribute="height" id="ecB-OH-83m"/>
+                                                                <constraint firstItem="zeE-QB-5WQ" firstAttribute="height" secondItem="Kzg-Uw-tpM" secondAttribute="height" id="myf-5F-a3g"/>
+                                                            </constraints>
+                                                            <visibilityPriorities>
+                                                                <integer value="1000"/>
+                                                                <integer value="1000"/>
+                                                                <integer value="1000"/>
+                                                                <integer value="1000"/>
+                                                                <integer value="1000"/>
+                                                            </visibilityPriorities>
+                                                            <customSpacing>
+                                                                <real value="3.4028234663852886e+38"/>
+                                                                <real value="3.4028234663852886e+38"/>
+                                                                <real value="3.4028234663852886e+38"/>
+                                                                <real value="3.4028234663852886e+38"/>
+                                                                <real value="3.4028234663852886e+38"/>
+                                                            </customSpacing>
+                                                        </stackView>
+                                                        <stackView distribution="equalCentering" orientation="vertical" alignment="leading" spacing="11" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="pam-gJ-b3R" userLabel="EqualizerSliders Vertical Stack View">
+                                                            <rect key="frame" x="77" y="20" width="234" height="110"/>
+                                                            <subviews>
+                                                                <slider identifier="brightnessSlider" horizontalHuggingPriority="800" verticalHuggingPriority="750" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="eFW-a3-kWx" userLabel="Brightness Slider">
+                                                                    <rect key="frame" x="-2" y="95" width="238" height="17"/>
+                                                                    <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="7Km-3j-0F1"/>
+                                                                    <accessibility identifier="brightnessLabel"/>
+                                                                    <connections>
+                                                                        <action selector="equalizerSliderAction:" target="-2" id="D6V-VG-FTQ"/>
+                                                                    </connections>
+                                                                </slider>
+                                                                <slider identifier="contrastSlider" horizontalHuggingPriority="800" verticalHuggingPriority="750" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="mTb-L6-55O" userLabel="Contrast Slider">
+                                                                    <rect key="frame" x="-2" y="71" width="238" height="17"/>
+                                                                    <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="hgz-bN-WeD"/>
+                                                                    <connections>
+                                                                        <action selector="equalizerSliderAction:" target="-2" id="Nvx-FI-qAc"/>
+                                                                    </connections>
+                                                                </slider>
+                                                                <slider identifier="saturationSlider" horizontalHuggingPriority="800" verticalHuggingPriority="750" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="VlS-Jo-4C0" userLabel="Saturation Slider">
+                                                                    <rect key="frame" x="-2" y="46" width="238" height="18"/>
+                                                                    <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="XWl-TS-6CD"/>
+                                                                    <connections>
+                                                                        <action selector="equalizerSliderAction:" target="-2" id="lqV-jM-722"/>
+                                                                    </connections>
+                                                                </slider>
+                                                                <slider identifier="gammaSlider" horizontalHuggingPriority="100" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fLl-8b-pj0" userLabel="Gamma Slider">
+                                                                    <rect key="frame" x="-2" y="22" width="238" height="17"/>
+                                                                    <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="4De-8a-gIx"/>
+                                                                    <connections>
+                                                                        <action selector="equalizerSliderAction:" target="-2" id="eBS-E6-XBk"/>
+                                                                    </connections>
+                                                                </slider>
+                                                                <slider identifier="hueSlider" horizontalHuggingPriority="100" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mKB-Mu-l5Y" userLabel="Hue Slider">
+                                                                    <rect key="frame" x="-2" y="-2" width="238" height="17"/>
+                                                                    <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="Bwq-Om-Y6s"/>
+                                                                    <connections>
+                                                                        <action selector="equalizerSliderAction:" target="-2" id="Lkh-f1-UR2"/>
+                                                                    </connections>
+                                                                </slider>
+                                                            </subviews>
+                                                            <constraints>
+                                                                <constraint firstItem="fLl-8b-pj0" firstAttribute="height" secondItem="eFW-a3-kWx" secondAttribute="height" id="Boz-5a-gkt"/>
+                                                                <constraint firstItem="mKB-Mu-l5Y" firstAttribute="height" secondItem="eFW-a3-kWx" secondAttribute="height" id="IMb-Uf-aiY"/>
+                                                                <constraint firstItem="mTb-L6-55O" firstAttribute="height" secondItem="eFW-a3-kWx" secondAttribute="height" id="PYB-dj-5Ou"/>
+                                                                <constraint firstItem="VlS-Jo-4C0" firstAttribute="height" secondItem="eFW-a3-kWx" secondAttribute="height" id="qJM-QY-tdM"/>
+                                                            </constraints>
+                                                            <visibilityPriorities>
+                                                                <integer value="1000"/>
+                                                                <integer value="1000"/>
+                                                                <integer value="1000"/>
+                                                                <integer value="1000"/>
+                                                                <integer value="1000"/>
+                                                            </visibilityPriorities>
+                                                            <customSpacing>
+                                                                <real value="3.4028234663852886e+38"/>
+                                                                <real value="3.4028234663852886e+38"/>
+                                                                <real value="3.4028234663852886e+38"/>
+                                                                <real value="3.4028234663852886e+38"/>
+                                                                <real value="3.4028234663852886e+38"/>
+                                                            </customSpacing>
+                                                        </stackView>
+                                                        <stackView distribution="equalCentering" orientation="vertical" alignment="leading" spacing="11" horizontalStackHuggingPriority="1000" verticalStackHuggingPriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="iAC-lz-PuL" userLabel="EqualizerResetButtons Vertical Stack View">
+                                                            <rect key="frame" x="319" y="20" width="15" height="110"/>
+                                                            <subviews>
+                                                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cjG-f1-Mkg" userLabel="Brightness Square Button">
+                                                                    <rect key="frame" x="0.0" y="94" width="15" height="19"/>
+                                                                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRefreshFreestandingTemplate" imagePosition="overlaps" alignment="center" inset="2" id="63a-cd-eXa">
+                                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                                        <font key="font" metaFont="system"/>
+                                                                    </buttonCell>
+                                                                    <connections>
+                                                                        <action selector="resetEqualizerBtnAction:" target="-2" id="pnK-gu-1Jd"/>
+                                                                    </connections>
+                                                                </button>
+                                                                <button verticalHuggingPriority="750" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="KVl-YU-9O3" userLabel="Contrast Square Button">
+                                                                    <rect key="frame" x="0.0" y="70" width="15" height="19"/>
+                                                                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRefreshFreestandingTemplate" imagePosition="overlaps" alignment="center" inset="2" id="NIq-6H-Orr">
+                                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                                        <font key="font" metaFont="system"/>
+                                                                    </buttonCell>
+                                                                    <connections>
+                                                                        <action selector="resetEqualizerBtnAction:" target="-2" id="fkB-MT-0WI"/>
+                                                                    </connections>
+                                                                </button>
+                                                                <button verticalHuggingPriority="750" tag="2" translatesAutoresizingMaskIntoConstraints="NO" id="lgg-zH-OLr" userLabel="Saturation Square Button">
+                                                                    <rect key="frame" x="0.0" y="45" width="15" height="20"/>
+                                                                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRefreshFreestandingTemplate" imagePosition="overlaps" alignment="center" inset="2" id="D5D-O8-MdN">
+                                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                                        <font key="font" metaFont="system"/>
+                                                                    </buttonCell>
+                                                                    <connections>
+                                                                        <action selector="resetEqualizerBtnAction:" target="-2" id="C3s-y1-9aO"/>
+                                                                    </connections>
+                                                                </button>
+                                                                <button verticalHuggingPriority="750" tag="3" translatesAutoresizingMaskIntoConstraints="NO" id="fGZ-vI-EP8" userLabel="Gamma Square Button">
+                                                                    <rect key="frame" x="0.0" y="21" width="15" height="19"/>
+                                                                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRefreshFreestandingTemplate" imagePosition="overlaps" alignment="center" inset="2" id="7sd-9d-D6H">
+                                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                                        <font key="font" metaFont="system"/>
+                                                                    </buttonCell>
+                                                                    <connections>
+                                                                        <action selector="resetEqualizerBtnAction:" target="-2" id="HTf-KH-SVv"/>
+                                                                    </connections>
+                                                                </button>
+                                                                <button verticalHuggingPriority="750" tag="4" translatesAutoresizingMaskIntoConstraints="NO" id="W7J-wR-UH3" userLabel="Hue Square Button">
+                                                                    <rect key="frame" x="0.0" y="-3" width="15" height="19"/>
+                                                                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRefreshFreestandingTemplate" imagePosition="overlaps" alignment="center" inset="2" id="Mrx-t0-wfm">
+                                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                                        <font key="font" metaFont="system"/>
+                                                                    </buttonCell>
+                                                                    <connections>
+                                                                        <action selector="resetEqualizerBtnAction:" target="-2" id="z43-kY-r5n"/>
+                                                                    </connections>
+                                                                </button>
+                                                            </subviews>
+                                                            <constraints>
+                                                                <constraint firstItem="KVl-YU-9O3" firstAttribute="height" secondItem="cjG-f1-Mkg" secondAttribute="height" id="3Dj-Pa-cqs"/>
+                                                                <constraint firstItem="W7J-wR-UH3" firstAttribute="width" secondItem="cjG-f1-Mkg" secondAttribute="width" id="G6i-E8-li2"/>
+                                                                <constraint firstItem="cjG-f1-Mkg" firstAttribute="width" secondItem="iAC-lz-PuL" secondAttribute="width" id="QQR-g4-ove"/>
+                                                                <constraint firstItem="lgg-zH-OLr" firstAttribute="width" secondItem="cjG-f1-Mkg" secondAttribute="width" id="Rzt-nR-RLP"/>
+                                                                <constraint firstItem="fGZ-vI-EP8" firstAttribute="height" secondItem="cjG-f1-Mkg" secondAttribute="height" id="UAQ-aO-pfl"/>
+                                                                <constraint firstItem="fGZ-vI-EP8" firstAttribute="width" secondItem="cjG-f1-Mkg" secondAttribute="width" id="Zbs-eB-FlT"/>
+                                                                <constraint firstItem="W7J-wR-UH3" firstAttribute="height" secondItem="cjG-f1-Mkg" secondAttribute="height" id="bKm-mB-ZYz"/>
+                                                                <constraint firstItem="KVl-YU-9O3" firstAttribute="width" secondItem="cjG-f1-Mkg" secondAttribute="width" id="lff-hV-QFG"/>
+                                                                <constraint firstItem="lgg-zH-OLr" firstAttribute="height" secondItem="cjG-f1-Mkg" secondAttribute="height" id="yCh-nD-xHV"/>
+                                                            </constraints>
+                                                            <visibilityPriorities>
+                                                                <integer value="1000"/>
+                                                                <integer value="1000"/>
+                                                                <integer value="1000"/>
+                                                                <integer value="1000"/>
+                                                                <integer value="1000"/>
+                                                            </visibilityPriorities>
+                                                            <customSpacing>
+                                                                <real value="3.4028234663852886e+38"/>
+                                                                <real value="3.4028234663852886e+38"/>
+                                                                <real value="3.4028234663852886e+38"/>
+                                                                <real value="3.4028234663852886e+38"/>
+                                                                <real value="3.4028234663852886e+38"/>
+                                                            </customSpacing>
+                                                        </stackView>
                                                     </subviews>
                                                     <constraints>
-                                                        <constraint firstAttribute="trailing" secondItem="5v4-Te-950" secondAttribute="trailing" id="0H2-ck-Ef2"/>
-                                                        <constraint firstAttribute="bottom" secondItem="5v4-Te-950" secondAttribute="bottom" id="2BL-PR-TB4"/>
-                                                        <constraint firstItem="5v4-Te-950" firstAttribute="top" secondItem="ZGz-La-n9c" secondAttribute="top" id="DJb-yk-hIe"/>
-                                                        <constraint firstItem="5v4-Te-950" firstAttribute="leading" secondItem="ZGz-La-n9c" secondAttribute="leading" id="gIm-ro-HPr"/>
+                                                        <constraint firstItem="5v4-Te-950" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="0re-Ss-vgh"/>
+                                                        <constraint firstItem="CUa-0e-DwY" firstAttribute="top" secondItem="ykw-rb-M9D" secondAttribute="bottom" constant="20" id="18w-9C-Htc"/>
+                                                        <constraint firstItem="iAC-lz-PuL" firstAttribute="leading" secondItem="pam-gJ-b3R" secondAttribute="trailing" constant="8" id="29l-xI-5MV"/>
+                                                        <constraint firstItem="d4r-sL-0Vo" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="2jO-JJ-N1O"/>
+                                                        <constraint firstItem="sPT-jd-T7a" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="2ul-1b-OX5"/>
+                                                        <constraint firstItem="2ye-g4-fz5" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="44Q-AK-wMR"/>
+                                                        <constraint firstItem="Kzg-Uw-tpM" firstAttribute="top" secondItem="QqK-iZ-rFX" secondAttribute="bottom" constant="20" id="9DE-4W-Fjh"/>
+                                                        <constraint firstItem="Ng5-FC-tts" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="ATc-Y8-5g4"/>
+                                                        <constraint firstItem="5v4-Te-950" firstAttribute="top" secondItem="d4r-sL-0Vo" secondAttribute="bottom" constant="4" id="BQk-0k-lKI"/>
+                                                        <constraint firstItem="CUa-0e-DwY" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="Bds-Tt-2To"/>
+                                                        <constraint firstItem="Ng5-FC-tts" firstAttribute="top" secondItem="seu-WU-cTV" secondAttribute="bottom" id="Bee-nq-Jqn"/>
+                                                        <constraint firstItem="2ye-g4-fz5" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="CAc-p7-CMr"/>
+                                                        <constraint firstAttribute="trailing" secondItem="7PK-hh-Xx5" secondAttribute="trailing" id="CS1-Ac-ZtH"/>
+                                                        <constraint firstItem="oAm-jJ-3kE" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="EfX-U0-EIF"/>
+                                                        <constraint firstItem="7vv-En-VYY" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="HEy-h1-lqH"/>
+                                                        <constraint firstItem="seu-WU-cTV" firstAttribute="leading" secondItem="ZGz-La-n9c" secondAttribute="leading" constant="20" id="HfL-vM-J77"/>
+                                                        <constraint firstAttribute="trailing" secondItem="ykw-rb-M9D" secondAttribute="trailing" id="IBg-Q4-5QO"/>
+                                                        <constraint firstItem="QqK-iZ-rFX" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="JJs-e3-UKh"/>
+                                                        <constraint firstItem="Ljl-w6-gIf" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="L7x-Q3-ibY"/>
+                                                        <constraint firstItem="pam-gJ-b3R" firstAttribute="leading" secondItem="9Ua-jA-xuA" secondAttribute="trailing" constant="8" id="LuL-bM-125"/>
+                                                        <constraint firstItem="9Ua-jA-xuA" firstAttribute="bottom" secondItem="pam-gJ-b3R" secondAttribute="bottom" id="M47-JF-xr3"/>
+                                                        <constraint firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" constant="20" id="MdM-i9-hvu"/>
+                                                        <constraint firstItem="iAC-lz-PuL" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="N9R-AO-t8I"/>
+                                                        <constraint firstItem="sPT-jd-T7a" firstAttribute="top" secondItem="oAm-jJ-3kE" secondAttribute="bottom" constant="8" id="Qtq-cO-WY6"/>
+                                                        <constraint firstItem="7vv-En-VYY" firstAttribute="top" secondItem="sPT-jd-T7a" secondAttribute="bottom" constant="20" id="R1L-b4-S0z"/>
+                                                        <constraint firstItem="Ng5-FC-tts" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="S29-9J-zbt"/>
+                                                        <constraint firstItem="bza-SA-tXE" firstAttribute="top" secondItem="7vv-En-VYY" secondAttribute="bottom" constant="8" id="TaT-kr-h6n"/>
+                                                        <constraint firstItem="Ljl-w6-gIf" firstAttribute="top" secondItem="CUa-0e-DwY" secondAttribute="bottom" constant="8" id="VQG-QL-MrS"/>
+                                                        <constraint firstItem="iAC-lz-PuL" firstAttribute="top" secondItem="pam-gJ-b3R" secondAttribute="top" id="WDy-ol-Zpc"/>
+                                                        <constraint firstItem="7PK-hh-Xx5" firstAttribute="top" secondItem="2ye-g4-fz5" secondAttribute="bottom" constant="20" id="WHx-2i-Qb8"/>
+                                                        <constraint firstItem="sPT-jd-T7a" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="WhF-R9-ItL"/>
+                                                        <constraint firstItem="d4r-sL-0Vo" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="aI1-cp-e3U"/>
+                                                        <constraint firstItem="seu-WU-cTV" firstAttribute="top" secondItem="ZGz-La-n9c" secondAttribute="top" constant="20" id="aal-Nb-2Z5"/>
+                                                        <constraint firstItem="QqK-iZ-rFX" firstAttribute="top" secondItem="7PK-hh-Xx5" secondAttribute="bottom" constant="20" id="agN-ia-1uy"/>
+                                                        <constraint firstAttribute="bottom" secondItem="BdF-A5-VPG" secondAttribute="bottom" constant="20" id="arL-JQ-GVl"/>
+                                                        <constraint firstItem="2ye-g4-fz5" firstAttribute="top" secondItem="5v4-Te-950" secondAttribute="bottom" constant="20" id="csu-lc-eNH"/>
+                                                        <constraint firstItem="9Ua-jA-xuA" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="czg-lU-OMG"/>
+                                                        <constraint firstItem="9Ua-jA-xuA" firstAttribute="top" secondItem="pam-gJ-b3R" secondAttribute="top" id="dTe-2U-dda"/>
+                                                        <constraint firstItem="7vv-En-VYY" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="dkC-Ih-pd9"/>
+                                                        <constraint firstItem="XAI-y0-tcy" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="eDi-7P-BEj"/>
+                                                        <constraint firstItem="5v4-Te-950" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="eeP-VU-TPP"/>
+                                                        <constraint firstItem="bza-SA-tXE" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="fDz-nh-c5C"/>
+                                                        <constraint firstItem="iAC-lz-PuL" firstAttribute="bottom" secondItem="pam-gJ-b3R" secondAttribute="bottom" id="keh-UM-dNZ"/>
+                                                        <constraint firstItem="XAI-y0-tcy" firstAttribute="leading" secondItem="Ljl-w6-gIf" secondAttribute="trailing" constant="8" id="kgN-Qb-S24"/>
+                                                        <constraint firstItem="Ng5-FC-tts" firstAttribute="bottom" secondItem="ykw-rb-M9D" secondAttribute="top" constant="-8" id="lB5-5K-ADf"/>
+                                                        <constraint firstItem="QqK-iZ-rFX" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="raN-KU-S8w"/>
+                                                        <constraint firstItem="XAI-y0-tcy" firstAttribute="firstBaseline" secondItem="Ljl-w6-gIf" secondAttribute="firstBaseline" id="sgV-3o-i04"/>
+                                                        <constraint firstItem="d4r-sL-0Vo" firstAttribute="top" secondItem="bza-SA-tXE" secondAttribute="bottom" constant="20" id="srR-fD-fdH"/>
+                                                        <constraint firstItem="oAm-jJ-3kE" firstAttribute="top" secondItem="Ljl-w6-gIf" secondAttribute="bottom" constant="20" id="t9T-NG-qVR"/>
+                                                        <constraint firstItem="ykw-rb-M9D" firstAttribute="leading" secondItem="ZGz-La-n9c" secondAttribute="leading" id="vVO-4e-Lao"/>
+                                                        <constraint firstItem="oAm-jJ-3kE" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="xkj-ic-q9D"/>
+                                                        <constraint firstItem="7PK-hh-Xx5" firstAttribute="leading" secondItem="ZGz-La-n9c" secondAttribute="leading" id="y5p-Be-83s"/>
+                                                        <constraint firstItem="CUa-0e-DwY" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="yE8-pS-Zgy"/>
                                                     </constraints>
                                                 </view>
                                             </subviews>
                                             <constraints>
-                                                <constraint firstItem="ZGz-La-n9c" firstAttribute="top" secondItem="8Es-YX-dNf" secondAttribute="top" id="1nG-Qh-mRh"/>
-                                                <constraint firstAttribute="trailing" secondItem="ZGz-La-n9c" secondAttribute="trailing" id="DwA-Bu-zsf"/>
-                                                <constraint firstItem="ZGz-La-n9c" firstAttribute="leading" secondItem="8Es-YX-dNf" secondAttribute="leading" id="uwj-3K-ODq"/>
+                                                <constraint firstItem="ZGz-La-n9c" firstAttribute="leading" secondItem="8Es-YX-dNf" secondAttribute="leading" id="GY8-wi-aRg"/>
+                                                <constraint firstItem="ZGz-La-n9c" firstAttribute="top" secondItem="8Es-YX-dNf" secondAttribute="top" id="QX6-9q-Dx8"/>
+                                                <constraint firstAttribute="trailing" secondItem="ZGz-La-n9c" secondAttribute="trailing" id="d7r-rT-3ad"/>
                                             </constraints>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </clipView>
                                         <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="tk3-fh-4Dl">
                                             <rect key="frame" x="-100" y="-100" width="360" height="16"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
-                                        <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="Vtu-Wx-ydk">
-                                            <rect key="frame" x="344" y="0.0" width="16" height="739"/>
+                                        <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="Vtu-Wx-ydk">
+                                            <rect key="frame" x="345" y="0.0" width="15" height="738"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                     </scrollView>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstItem="SHU-hX-9MT" firstAttribute="leading" secondItem="NRI-ba-KMd" secondAttribute="leading" id="1TC-bU-AZC"/>
-                                    <constraint firstItem="SHU-hX-9MT" firstAttribute="top" secondItem="NRI-ba-KMd" secondAttribute="top" id="3a6-1b-6B6"/>
-                                    <constraint firstAttribute="bottom" secondItem="SHU-hX-9MT" secondAttribute="bottom" id="PVd-ds-phE"/>
-                                    <constraint firstAttribute="trailing" secondItem="SHU-hX-9MT" secondAttribute="trailing" id="R35-dQ-uur"/>
+                                    <constraint firstAttribute="bottom" secondItem="SHU-hX-9MT" secondAttribute="bottom" id="1MH-ay-Jwy"/>
+                                    <constraint firstItem="SHU-hX-9MT" firstAttribute="leading" secondItem="NRI-ba-KMd" secondAttribute="leading" id="6sl-nB-kPa"/>
+                                    <constraint firstAttribute="trailing" secondItem="SHU-hX-9MT" secondAttribute="trailing" id="cfV-LC-bmO"/>
+                                    <constraint firstItem="SHU-hX-9MT" firstAttribute="top" secondItem="NRI-ba-KMd" secondAttribute="top" id="qz1-oZ-Sxp"/>
                                 </constraints>
                             </view>
                         </tabViewItem>
-                        <tabViewItem label="Audio" identifier="2" id="bzk-c2-LH5">
-                            <view key="view" id="Dxl-wa-zgc">
-                                <rect key="frame" x="0.0" y="0.0" width="360" height="787"/>
+                        <tabViewItem label="Audio" identifier="2" id="bzk-c2-LH5" userLabel="AudioTab Tab View Item">
+                            <view key="view" id="Dxl-wa-zgc" userLabel="AudioTab View">
+                                <rect key="frame" x="0.0" y="0.0" width="360" height="827"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
-                                    <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wXn-sV-AmG">
-                                        <rect key="frame" x="0.0" y="-36" width="360" height="823"/>
-                                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="oVx-Sp-Lhl">
-                                            <rect key="frame" x="0.0" y="0.0" width="360" height="823"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                    <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wXn-sV-AmG" userLabel="AudioTab Scroll View">
+                                        <rect key="frame" x="0.0" y="0.0" width="360" height="827"/>
+                                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="oVx-Sp-Lhl" userLabel="AudioTab Clip View">
+                                            <rect key="frame" x="0.0" y="0.0" width="360" height="827"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
-                                                <customView translatesAutoresizingMaskIntoConstraints="NO" id="NZU-RD-Dm3" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="318" width="360" height="505"/>
+                                                <customView translatesAutoresizingMaskIntoConstraints="NO" id="NZU-RD-Dm3" userLabel="AudioTab Flipped View" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
+                                                    <rect key="frame" x="0.0" y="331" width="360" height="496"/>
                                                     <subviews>
-                                                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="my2-5o-bNb">
-                                                            <rect key="frame" x="0.0" y="0.0" width="360" height="505"/>
+                                                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="my2-5o-bNb" userLabel="AudioTab CONTENT VIEW">
+                                                            <rect key="frame" x="0.0" y="0.0" width="360" height="496"/>
                                                             <subviews>
+                                                                <customView translatesAutoresizingMaskIntoConstraints="NO" id="TA9-9G-tIE" userLabel="PANEL EDGE INSETS">
+                                                                    <rect key="frame" x="20" y="476" width="320" height="0.0"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="height" id="jt3-qe-0KY"/>
+                                                                    </constraints>
+                                                                </customView>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="E4v-kh-61H">
-                                                                    <rect key="frame" x="17" y="469" width="83" height="16"/>
+                                                                    <rect key="frame" x="18" y="460" width="324" height="16"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Audio track:" id="x39-62-7KC">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qal-0X-4kS">
-                                                                    <rect key="frame" x="0.0" y="385" width="360" height="76"/>
-                                                                    <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="vgF-KN-yHf">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="360" height="76"/>
-                                                                        <autoresizingMask key="autoresizingMask"/>
+                                                                <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qal-0X-4kS" userLabel="AudioTrackTable Scroll View">
+                                                                    <rect key="frame" x="0.0" y="377" width="360" height="75"/>
+                                                                    <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="vgF-KN-yHf" userLabel="AudioTrackTable Clip View">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="360" height="75"/>
+                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
-                                                                            <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="FLg-2m-Zaq">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="360" height="76"/>
+                                                                            <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="FLg-2m-Zaq" userLabel="AudioTrackTable Table View">
+                                                                                <rect key="frame" x="0.0" y="0.0" width="360" height="75"/>
                                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                                 <size key="intercellSpacing" width="3" height="2"/>
                                                                                 <color key="backgroundColor" white="1" alpha="0.080000000000000002" colorSpace="deviceWhite"/>
@@ -1059,7 +998,7 @@
                                                                                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="JVk-Od-tIT">
                                                                                                         <rect key="frame" x="0.0" y="0.0" width="21" height="17"/>
                                                                                                         <constraints>
-                                                                                                            <constraint firstAttribute="height" constant="17" id="T05-pw-yqi"/>
+                                                                                                            <constraint firstAttribute="height" constant="17" id="vjY-8T-n1G"/>
                                                                                                         </constraints>
                                                                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="vDh-JM-5Wz">
                                                                                                             <font key="font" metaFont="system"/>
@@ -1072,9 +1011,9 @@
                                                                                                     </textField>
                                                                                                 </subviews>
                                                                                                 <constraints>
-                                                                                                    <constraint firstItem="JVk-Od-tIT" firstAttribute="centerY" secondItem="YPg-3T-gYm" secondAttribute="centerY" id="Dgg-hT-oXs"/>
-                                                                                                    <constraint firstItem="JVk-Od-tIT" firstAttribute="leading" secondItem="YPg-3T-gYm" secondAttribute="leading" constant="2" id="OqQ-IR-YDG"/>
-                                                                                                    <constraint firstItem="JVk-Od-tIT" firstAttribute="centerX" secondItem="YPg-3T-gYm" secondAttribute="centerX" id="bXd-yg-s15"/>
+                                                                                                    <constraint firstItem="JVk-Od-tIT" firstAttribute="leading" secondItem="YPg-3T-gYm" secondAttribute="leading" constant="2" id="2Bt-id-0Kx"/>
+                                                                                                    <constraint firstItem="JVk-Od-tIT" firstAttribute="centerY" secondItem="YPg-3T-gYm" secondAttribute="centerY" id="3bg-HG-oBA"/>
+                                                                                                    <constraint firstItem="JVk-Od-tIT" firstAttribute="centerX" secondItem="YPg-3T-gYm" secondAttribute="centerX" id="4dW-UY-Zkt"/>
                                                                                                 </constraints>
                                                                                                 <connections>
                                                                                                     <outlet property="textField" destination="JVk-Od-tIT" id="T58-nt-RWg"/>
@@ -1082,7 +1021,7 @@
                                                                                             </tableCellView>
                                                                                         </prototypeCellViews>
                                                                                     </tableColumn>
-                                                                                    <tableColumn identifier="TrackId" width="22" minWidth="10" maxWidth="3.4028234663852886e+38" id="EYV-gb-3Pa">
+                                                                                    <tableColumn identifier="TrackId" width="22" minWidth="22" maxWidth="3.4028234663852886e+38" id="EYV-gb-3Pa">
                                                                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
                                                                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
@@ -1101,7 +1040,7 @@
                                                                                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="MSR-2Q-pOS">
                                                                                                         <rect key="frame" x="0.0" y="0.0" width="22" height="17"/>
                                                                                                         <constraints>
-                                                                                                            <constraint firstAttribute="height" constant="17" id="Qey-1X-4IJ"/>
+                                                                                                            <constraint firstAttribute="height" constant="17" id="s2f-ef-WYF"/>
                                                                                                         </constraints>
                                                                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="KyY-Ui-vAx">
                                                                                                             <font key="font" metaFont="systemBold"/>
@@ -1114,9 +1053,9 @@
                                                                                                     </textField>
                                                                                                 </subviews>
                                                                                                 <constraints>
-                                                                                                    <constraint firstItem="MSR-2Q-pOS" firstAttribute="leading" secondItem="UuQ-IW-yZg" secondAttribute="leading" constant="2" id="Mvf-lE-lbg"/>
-                                                                                                    <constraint firstItem="MSR-2Q-pOS" firstAttribute="centerY" secondItem="UuQ-IW-yZg" secondAttribute="centerY" id="cNP-1c-nLH"/>
-                                                                                                    <constraint firstItem="MSR-2Q-pOS" firstAttribute="centerX" secondItem="UuQ-IW-yZg" secondAttribute="centerX" id="oow-vG-bQd"/>
+                                                                                                    <constraint firstItem="MSR-2Q-pOS" firstAttribute="centerX" secondItem="UuQ-IW-yZg" secondAttribute="centerX" id="258-KD-r05"/>
+                                                                                                    <constraint firstItem="MSR-2Q-pOS" firstAttribute="leading" secondItem="UuQ-IW-yZg" secondAttribute="leading" constant="2" id="XLG-lN-23V"/>
+                                                                                                    <constraint firstItem="MSR-2Q-pOS" firstAttribute="centerY" secondItem="UuQ-IW-yZg" secondAttribute="centerY" id="ZNm-DN-1ac"/>
                                                                                                 </constraints>
                                                                                                 <connections>
                                                                                                     <outlet property="textField" destination="MSR-2Q-pOS" id="saV-nP-ICX"/>
@@ -1124,7 +1063,7 @@
                                                                                             </tableCellView>
                                                                                         </prototypeCellViews>
                                                                                     </tableColumn>
-                                                                                    <tableColumn identifier="TrackName" editable="NO" width="304" minWidth="40" maxWidth="3.4028234663852886e+38" id="cKa-XV-ATZ">
+                                                                                    <tableColumn identifier="TrackName" editable="NO" width="304" minWidth="100" maxWidth="3.4028234663852886e+38" id="cKa-XV-ATZ">
                                                                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
                                                                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
@@ -1141,10 +1080,7 @@
                                                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                                                 <subviews>
                                                                                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="6YE-jM-I4J">
-                                                                                                        <rect key="frame" x="0.0" y="0.0" width="308" height="17"/>
-                                                                                                        <constraints>
-                                                                                                            <constraint firstAttribute="height" constant="17" id="qoy-gV-v8T"/>
-                                                                                                        </constraints>
+                                                                                                        <rect key="frame" x="0.0" y="1" width="308" height="16"/>
                                                                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="Spe-xo-cXu">
                                                                                                             <font key="font" metaFont="system"/>
                                                                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1156,9 +1092,9 @@
                                                                                                     </textField>
                                                                                                 </subviews>
                                                                                                 <constraints>
-                                                                                                    <constraint firstItem="6YE-jM-I4J" firstAttribute="centerY" secondItem="zgo-9v-dTl" secondAttribute="centerY" id="3Tj-8l-EjA"/>
-                                                                                                    <constraint firstItem="6YE-jM-I4J" firstAttribute="centerX" secondItem="zgo-9v-dTl" secondAttribute="centerX" id="u02-tc-teP"/>
-                                                                                                    <constraint firstItem="6YE-jM-I4J" firstAttribute="leading" secondItem="zgo-9v-dTl" secondAttribute="leading" constant="2" id="ys9-mH-qtI"/>
+                                                                                                    <constraint firstItem="6YE-jM-I4J" firstAttribute="centerY" secondItem="zgo-9v-dTl" secondAttribute="centerY" id="6zV-9M-5AW"/>
+                                                                                                    <constraint firstItem="6YE-jM-I4J" firstAttribute="centerX" secondItem="zgo-9v-dTl" secondAttribute="centerX" id="IZA-BZ-Luh"/>
+                                                                                                    <constraint firstItem="6YE-jM-I4J" firstAttribute="leading" secondItem="zgo-9v-dTl" secondAttribute="leading" constant="2" id="o4O-fu-f2N"/>
                                                                                                 </constraints>
                                                                                                 <connections>
                                                                                                     <outlet property="textField" destination="6YE-jM-I4J" id="c8V-Nb-jHJ"/>
@@ -1171,7 +1107,7 @@
                                                                         </subviews>
                                                                     </clipView>
                                                                     <constraints>
-                                                                        <constraint firstAttribute="height" constant="76" id="sBV-Kf-cvi"/>
+                                                                        <constraint firstAttribute="height" constant="75" id="sBV-Kf-cvi"/>
                                                                     </constraints>
                                                                     <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="Pal-8c-4eQ">
                                                                         <rect key="frame" x="0.0" y="60" width="360" height="16"/>
@@ -1182,8 +1118,16 @@
                                                                         <autoresizingMask key="autoresizingMask"/>
                                                                     </scroller>
                                                                 </scrollView>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kvu-fg-olx">
+                                                                    <rect key="frame" x="18" y="341" width="324" height="16"/>
+                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="External audio:" id="Lnu-kz-cql">
+                                                                        <font key="font" metaFont="systemBold"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
                                                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="XdF-fV-DCz">
-                                                                    <rect key="frame" x="13" y="314" width="319" height="32"/>
+                                                                    <rect key="frame" x="13" y="304" width="334" height="32"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="305" id="J6K-sf-QKi"/>
                                                                     </constraints>
@@ -1195,297 +1139,121 @@
                                                                         <action selector="loadExternalAudioAction:" target="-2" id="Qlt-LO-puw"/>
                                                                     </connections>
                                                                 </button>
-                                                                <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="a7T-nr-ELY">
-                                                                    <rect key="frame" x="18" y="237" width="244" height="20"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="width" constant="240" id="Rhl-RX-l4v"/>
-                                                                    </constraints>
-                                                                    <sliderCell key="cell" controlSize="small" continuous="YES" alignment="left" minValue="-5" maxValue="5" tickMarkPosition="below" numberOfTickMarks="21" sliderType="linear" id="ERU-lE-Yhg"/>
-                                                                    <connections>
-                                                                        <action selector="audioDelayChangedAction:" target="-2" id="egE-eN-9bo"/>
-                                                                    </connections>
-                                                                </slider>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kvu-fg-olx">
-                                                                    <rect key="frame" x="17" y="349" width="310" height="16"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="External audio:" id="Lnu-kz-cql">
-                                                                        <font key="font" metaFont="systemBold"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="doa-7T-eeK">
-                                                                    <rect key="frame" x="18" y="228" width="20" height="11"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="-5s" id="YCG-xK-eAs">
-                                                                        <font key="font" metaFont="label" size="9"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kF3-Ee-Pha">
-                                                                    <rect key="frame" x="247" y="228" width="15" height="11"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="5s" id="C0t-gm-Tim">
-                                                                        <font key="font" metaFont="label" size="9"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="C39-jO-zwp">
-                                                                    <rect key="frame" x="131" y="228" width="19" height="11"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="0s" id="wgA-op-JP4">
-                                                                        <font key="font" metaFont="label" size="9"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0DM-CY-o8W" userLabel="Delay">
-                                                                    <rect key="frame" x="276" y="238" width="60" height="21"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="60" id="Alb-o2-pM2"/>
-                                                                    </constraints>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" title="0" drawsBackground="YES" usesSingleLineMode="YES" id="ejc-n7-36j" customClass="RoundedTextFieldCell" customModule="IINA" customModuleProvider="target">
-                                                                        <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="tIS-gm-4jb"/>
-                                                                        <font key="font" metaFont="system"/>
-                                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                    <connections>
-                                                                        <action selector="customAudioDelayEditFinishedAction:" target="-2" id="if3-IB-m6c"/>
-                                                                    </connections>
-                                                                </textField>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZPW-fz-5Oi">
-                                                                    <rect key="frame" x="17" y="278" width="84" height="16"/>
+                                                                    <rect key="frame" x="18" y="275" width="324" height="16"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Audio delay:" id="AKs-VQ-fKF">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gR7-cS-zmu" userLabel="Speed Slider Indicator">
-                                                                    <rect key="frame" x="130" y="257" width="20" height="13"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="0s" usesSingleLineMode="YES" id="s3F-Tl-Siy">
-                                                                        <font key="font" metaFont="system" size="10"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="KKr-0Y-831">
-                                                                    <rect key="frame" x="0.0" y="203" width="360" height="5"/>
-                                                                </box>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IHl-Ks-v7I">
-                                                                    <rect key="frame" x="17" y="171" width="305" height="16"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Equalizer" id="iS4-Zr-9Ig">
-                                                                        <font key="font" metaFont="systemBold"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <customView translatesAutoresizingMaskIntoConstraints="NO" id="PLF-x4-bMC">
-                                                                    <rect key="frame" x="0.0" y="24" width="360" height="139"/>
+                                                                <customView autoresizesSubviews="NO" horizontalHuggingPriority="200" horizontalCompressionResistancePriority="700" translatesAutoresizingMaskIntoConstraints="NO" id="j85-rj-toQ" userLabel="AudioDelaySlider Container View">
+                                                                    <rect key="frame" x="20" y="224" width="320" height="47"/>
                                                                     <subviews>
-                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pHR-ym-VeQ">
-                                                                            <rect key="frame" x="20" y="19" width="18" height="120"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="Twm-2U-8ou"/>
+                                                                        <slider horizontalHuggingPriority="1" verticalHuggingPriority="700" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="700" translatesAutoresizingMaskIntoConstraints="NO" id="gJr-l6-WQ2" userLabel="AudioDelaySlider Horizontal Tick Slider">
+                                                                            <rect key="frame" x="-2" y="10" width="244" height="25"/>
+                                                                            <constraints>
+                                                                                <constraint firstAttribute="width" constant="240" id="8FO-xx-ocZ"/>
+                                                                            </constraints>
+                                                                            <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" minValue="-5" maxValue="5" tickMarkPosition="below" numberOfTickMarks="21" sliderType="linear" id="Xty-CC-H0Z"/>
                                                                             <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="ywO-zh-sWU"/>
+                                                                                <action selector="audioDelayChangedAction:" target="-2" id="Rqw-fj-519"/>
                                                                             </connections>
                                                                         </slider>
-                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="Qhv-oC-xzP">
-                                                                            <rect key="frame" x="47" y="19" width="18" height="120"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="SCy-Om-bV6"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="xQb-Li-0pw"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="2" translatesAutoresizingMaskIntoConstraints="NO" id="iDT-gu-k7t">
-                                                                            <rect key="frame" x="74" y="19" width="18" height="120"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="a7E-4j-6g2"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="bCl-L6-1iR"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="3" translatesAutoresizingMaskIntoConstraints="NO" id="O2w-VO-03F">
-                                                                            <rect key="frame" x="101" y="19" width="18" height="120"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="TbE-dB-ORk"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="15r-Ui-dhW"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="4" translatesAutoresizingMaskIntoConstraints="NO" id="npn-V6-hjZ">
-                                                                            <rect key="frame" x="128" y="19" width="18" height="120"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="4Ra-VR-yOK"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="sWe-Hb-axh"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="5" translatesAutoresizingMaskIntoConstraints="NO" id="TKd-tg-Xtc">
-                                                                            <rect key="frame" x="155" y="19" width="18" height="120"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="xV9-OM-MHq"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="bVX-Tj-pgM"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="6" translatesAutoresizingMaskIntoConstraints="NO" id="nNf-gg-4tL">
-                                                                            <rect key="frame" x="182" y="19" width="18" height="120"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="TNb-Es-VsX"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="p1d-eK-UB3"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="7" translatesAutoresizingMaskIntoConstraints="NO" id="JaQ-EH-K1U">
-                                                                            <rect key="frame" x="209" y="19" width="18" height="120"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="P8O-pY-Nby"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="oxX-UX-l6i"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="8" translatesAutoresizingMaskIntoConstraints="NO" id="gbd-xf-hGS">
-                                                                            <rect key="frame" x="234" y="19" width="18" height="120"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="GEq-jW-WUw"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="pkI-fs-ZCs"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <slider horizontalHuggingPriority="750" fixedFrame="YES" tag="9" translatesAutoresizingMaskIntoConstraints="NO" id="w04-h5-qaz">
-                                                                            <rect key="frame" x="259" y="19" width="18" height="120"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="5FD-oT-GpE"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="I08-gI-z8e"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jUH-hL-3U3">
-                                                                            <rect key="frame" x="301" y="125" width="41" height="14"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="+12 dB" id="4BZ-H1-GEU">
-                                                                                <font key="font" metaFont="message" size="11"/>
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="giU-Mo-tN9" userLabel="AudioDelaySliderIndicator Text Field">
+                                                                            <rect key="frame" x="108" y="34" width="24" height="13"/>
+                                                                            <constraints>
+                                                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="20" id="F50-i5-7bi"/>
+                                                                            </constraints>
+                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="0s" usesSingleLineMode="YES" id="udN-rq-omw">
+                                                                                <font key="font" metaFont="system" size="10"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Wkv-a4-uiD">
-                                                                            <rect key="frame" x="303" y="20" width="39" height="14"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="-12 dB" id="Lpw-ws-Ezh">
-                                                                                <font key="font" metaFont="message" size="11"/>
-                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="izd-aj-gqV">
-                                                                            <rect key="frame" x="304" y="73" width="37" height="14"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="0 dB" id="lBn-YS-jL7">
-                                                                                <font key="font" metaFont="message" size="11"/>
-                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EDx-YH-ofM">
-                                                                            <rect key="frame" x="11" y="0.0" width="37" height="14"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="31.25" id="HBF-J7-Tie">
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tGk-m1-Vjc" userLabel="-5s Text Field">
+                                                                            <rect key="frame" x="-2" y="0.0" width="20" height="11"/>
+                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="-5s" id="IYU-eq-dls" userLabel="-5s">
                                                                                 <font key="font" metaFont="label" size="9"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gfz-yF-41J">
-                                                                            <rect key="frame" x="68" y="3" width="30" height="11"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="125" id="1cq-dc-JfM">
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3GW-C1-d0g" userLabel="0s Text Field">
+                                                                            <rect key="frame" x="111" y="0.0" width="19" height="11"/>
+                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="0s" id="kan-bp-QDi">
                                                                                 <font key="font" metaFont="label" size="9"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1he-Ll-CYl">
-                                                                            <rect key="frame" x="95" y="3" width="30" height="11"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="250" id="ekh-gc-2qo">
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MPz-pR-Ys8" userLabel="5s Text Field">
+                                                                            <rect key="frame" x="227" y="0.0" width="15" height="11"/>
+                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="5s" id="Kt8-Kg-i2O">
                                                                                 <font key="font" metaFont="label" size="9"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="j15-F0-7GR">
-                                                                            <rect key="frame" x="122" y="3" width="30" height="11"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="500" id="tHa-vN-OlI">
-                                                                                <font key="font" metaFont="label" size="9"/>
-                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Qiz-tS-aWT" userLabel="CustomAudioDelay Text Field">
+                                                                            <rect key="frame" x="248" y="12" width="61" height="21"/>
+                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" title="1" drawsBackground="YES" usesSingleLineMode="YES" id="EHa-PR-jHw" userLabel="CustomAudioDelay Text Field Cell" customClass="RoundedTextFieldCell" customModule="IINA" customModuleProvider="target">
+                                                                                <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="C53-E5-t2Z">
+                                                                                    <real key="minimum" value="0.01"/>
+                                                                                </numberFormatter>
+                                                                                <font key="font" metaFont="system"/>
+                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
+                                                                            <connections>
+                                                                                <action selector="customAudioDelayEditFinishedAction:" target="-2" id="wbu-lF-nTa"/>
+                                                                            </connections>
                                                                         </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wvc-3m-7dA">
-                                                                            <rect key="frame" x="149" y="3" width="30" height="11"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="1k" id="Rtc-Eg-J2u">
-                                                                                <font key="font" metaFont="label" size="9"/>
-                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cnq-7d-eC4">
-                                                                            <rect key="frame" x="176" y="3" width="30" height="11"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="2k" id="j9w-YU-EcC">
-                                                                                <font key="font" metaFont="label" size="9"/>
-                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uUe-VB-wyv">
-                                                                            <rect key="frame" x="203" y="3" width="30" height="11"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="4k" id="i0j-2a-vKD">
-                                                                                <font key="font" metaFont="label" size="9"/>
-                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eOZ-KM-xLa">
-                                                                            <rect key="frame" x="228" y="3" width="30" height="11"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="8k" id="e4X-H4-VxS">
-                                                                                <font key="font" metaFont="label" size="9"/>
-                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aOD-Qz-oE3">
-                                                                            <rect key="frame" x="253" y="3" width="30" height="11"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="16k" id="era-AG-bSl">
-                                                                                <font key="font" metaFont="label" size="9"/>
-                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dKk-CE-yY0">
-                                                                            <rect key="frame" x="41" y="3" width="30" height="11"/>
-                                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="62.5" id="4PG-5R-5G0">
-                                                                                <font key="font" metaFont="label" size="9"/>
+                                                                        <textField verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ImH-jg-Agp" userLabel="s">
+                                                                            <rect key="frame" x="307" y="15" width="15" height="16"/>
+                                                                            <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="s" id="1VY-EN-1mi">
+                                                                                <font key="font" metaFont="system"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                             </textFieldCell>
                                                                         </textField>
                                                                     </subviews>
                                                                     <constraints>
-                                                                        <constraint firstAttribute="height" constant="139" id="eMl-tL-SYh"/>
+                                                                        <constraint firstAttribute="trailing" secondItem="ImH-jg-Agp" secondAttribute="trailing" id="0Hm-Fa-s2l"/>
+                                                                        <constraint firstItem="Qiz-tS-aWT" firstAttribute="height" relation="lessThanOrEqual" secondItem="gJr-l6-WQ2" secondAttribute="height" id="4pT-hs-YkF"/>
+                                                                        <constraint firstItem="3GW-C1-d0g" firstAttribute="firstBaseline" secondItem="tGk-m1-Vjc" secondAttribute="firstBaseline" id="5Yt-IM-92q"/>
+                                                                        <constraint firstItem="giU-Mo-tN9" firstAttribute="centerX" secondItem="gJr-l6-WQ2" secondAttribute="leading" priority="800" constant="120" id="5oB-ve-G3c"/>
+                                                                        <constraint firstItem="Qiz-tS-aWT" firstAttribute="centerY" secondItem="gJr-l6-WQ2" secondAttribute="centerY" id="EuL-BL-hNW"/>
+                                                                        <constraint firstItem="tGk-m1-Vjc" firstAttribute="top" secondItem="gJr-l6-WQ2" secondAttribute="bottom" constant="1" id="JOa-Yf-S4K"/>
+                                                                        <constraint firstAttribute="bottom" secondItem="tGk-m1-Vjc" secondAttribute="bottom" id="LP9-eY-HFx"/>
+                                                                        <constraint firstItem="MPz-pR-Ys8" firstAttribute="trailing" secondItem="gJr-l6-WQ2" secondAttribute="trailing" id="OxL-FZ-Jgq"/>
+                                                                        <constraint firstItem="tGk-m1-Vjc" firstAttribute="leading" secondItem="gJr-l6-WQ2" secondAttribute="leading" id="T4d-XW-ILF"/>
+                                                                        <constraint firstItem="gJr-l6-WQ2" firstAttribute="top" secondItem="giU-Mo-tN9" secondAttribute="bottom" constant="1" id="VBE-Mf-Tzb"/>
+                                                                        <constraint firstItem="MPz-pR-Ys8" firstAttribute="firstBaseline" secondItem="tGk-m1-Vjc" secondAttribute="firstBaseline" id="gIk-ck-vZB"/>
+                                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="300" id="gtm-1I-YqP"/>
+                                                                        <constraint firstItem="MPz-pR-Ys8" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="3GW-C1-d0g" secondAttribute="trailing" id="l5Y-Zf-HQz"/>
+                                                                        <constraint firstItem="Qiz-tS-aWT" firstAttribute="trailing" secondItem="ImH-jg-Agp" secondAttribute="leading" id="nCE-1H-uD9"/>
+                                                                        <constraint firstItem="3GW-C1-d0g" firstAttribute="centerX" secondItem="gJr-l6-WQ2" secondAttribute="leading" constant="120" id="nkR-OW-RCf"/>
+                                                                        <constraint firstItem="3GW-C1-d0g" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="tGk-m1-Vjc" secondAttribute="trailing" id="qjs-Iq-1hl"/>
+                                                                        <constraint firstItem="Qiz-tS-aWT" firstAttribute="leading" secondItem="gJr-l6-WQ2" secondAttribute="trailing" constant="8" id="uSJ-g9-Azy"/>
+                                                                        <constraint firstItem="ImH-jg-Agp" firstAttribute="firstBaseline" secondItem="Qiz-tS-aWT" secondAttribute="firstBaseline" id="vOx-Zo-ayO"/>
+                                                                        <constraint firstItem="giU-Mo-tN9" firstAttribute="top" secondItem="j85-rj-toQ" secondAttribute="top" id="vc3-E4-DgR"/>
+                                                                        <constraint firstItem="giU-Mo-tN9" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="gJr-l6-WQ2" secondAttribute="leading" id="wwv-IQ-GEx"/>
                                                                     </constraints>
                                                                 </customView>
-                                                                <button translatesAutoresizingMaskIntoConstraints="NO" id="dB1-5J-5YU">
-                                                                    <rect key="frame" x="324" y="168.5" width="16" height="21"/>
+                                                                <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="KKr-0Y-831">
+                                                                    <rect key="frame" x="0.0" y="201" width="360" height="5"/>
+                                                                </box>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IHl-Ks-v7I" userLabel="Equalizer Label">
+                                                                    <rect key="frame" x="18" y="167" width="324" height="16"/>
+                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Equalizer" id="iS4-Zr-9Ig">
+                                                                        <font key="font" metaFont="systemBold"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <button translatesAutoresizingMaskIntoConstraints="NO" id="dB1-5J-5YU" userLabel="ResetAudioEQ Square Button">
+                                                                    <rect key="frame" x="324" y="164.5" width="16" height="21"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" constant="16" id="T2d-bE-Rq1"/>
                                                                         <constraint firstAttribute="height" constant="16" id="xEH-z6-Ltg"/>
@@ -1498,56 +1266,284 @@
                                                                         <action selector="resetAudioEqAction:" target="-2" id="2mv-yD-fAu"/>
                                                                     </connections>
                                                                 </button>
+                                                                <stackView distribution="equalSpacing" orientation="horizontal" alignment="top" spacing="13" horizontalStackHuggingPriority="1000" verticalStackHuggingPriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="xtT-Or-HjR" userLabel="AudioEQSliders HStack">
+                                                                    <rect key="frame" x="20" y="39" width="277" height="116"/>
+                                                                    <subviews>
+                                                                        <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" translatesAutoresizingMaskIntoConstraints="NO" id="pHR-ym-VeQ">
+                                                                            <rect key="frame" x="-2" y="-2" width="20" height="120"/>
+                                                                            <sliderCell key="cell" controlSize="small" state="on" alignment="left" minValue="-12" maxValue="12" doubleValue="3.4939236111111125" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="Twm-2U-8ou"/>
+                                                                            <connections>
+                                                                                <action selector="audioEqSliderAction:" target="-2" id="ywO-zh-sWU"/>
+                                                                            </connections>
+                                                                        </slider>
+                                                                        <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="Qhv-oC-xzP">
+                                                                            <rect key="frame" x="27" y="-2" width="20" height="120"/>
+                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="SCy-Om-bV6"/>
+                                                                            <connections>
+                                                                                <action selector="audioEqSliderAction:" target="-2" id="xQb-Li-0pw"/>
+                                                                            </connections>
+                                                                        </slider>
+                                                                        <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" tag="2" translatesAutoresizingMaskIntoConstraints="NO" id="iDT-gu-k7t">
+                                                                            <rect key="frame" x="56" y="-2" width="20" height="120"/>
+                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="a7E-4j-6g2"/>
+                                                                            <connections>
+                                                                                <action selector="audioEqSliderAction:" target="-2" id="bCl-L6-1iR"/>
+                                                                            </connections>
+                                                                        </slider>
+                                                                        <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" tag="3" translatesAutoresizingMaskIntoConstraints="NO" id="O2w-VO-03F">
+                                                                            <rect key="frame" x="85" y="-2" width="20" height="120"/>
+                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="TbE-dB-ORk"/>
+                                                                            <connections>
+                                                                                <action selector="audioEqSliderAction:" target="-2" id="15r-Ui-dhW"/>
+                                                                            </connections>
+                                                                        </slider>
+                                                                        <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" tag="4" translatesAutoresizingMaskIntoConstraints="NO" id="npn-V6-hjZ">
+                                                                            <rect key="frame" x="114" y="-2" width="20" height="120"/>
+                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="4Ra-VR-yOK"/>
+                                                                            <connections>
+                                                                                <action selector="audioEqSliderAction:" target="-2" id="sWe-Hb-axh"/>
+                                                                            </connections>
+                                                                        </slider>
+                                                                        <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" tag="5" translatesAutoresizingMaskIntoConstraints="NO" id="TKd-tg-Xtc">
+                                                                            <rect key="frame" x="143" y="-2" width="20" height="120"/>
+                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="xV9-OM-MHq"/>
+                                                                            <connections>
+                                                                                <action selector="audioEqSliderAction:" target="-2" id="bVX-Tj-pgM"/>
+                                                                            </connections>
+                                                                        </slider>
+                                                                        <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" tag="6" translatesAutoresizingMaskIntoConstraints="NO" id="nNf-gg-4tL">
+                                                                            <rect key="frame" x="172" y="-2" width="20" height="120"/>
+                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="TNb-Es-VsX"/>
+                                                                            <connections>
+                                                                                <action selector="audioEqSliderAction:" target="-2" id="p1d-eK-UB3"/>
+                                                                            </connections>
+                                                                        </slider>
+                                                                        <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" tag="7" translatesAutoresizingMaskIntoConstraints="NO" id="JaQ-EH-K1U">
+                                                                            <rect key="frame" x="201" y="-2" width="20" height="120"/>
+                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="P8O-pY-Nby"/>
+                                                                            <connections>
+                                                                                <action selector="audioEqSliderAction:" target="-2" id="oxX-UX-l6i"/>
+                                                                            </connections>
+                                                                        </slider>
+                                                                        <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" tag="8" translatesAutoresizingMaskIntoConstraints="NO" id="gbd-xf-hGS">
+                                                                            <rect key="frame" x="230" y="-2" width="20" height="120"/>
+                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="GEq-jW-WUw"/>
+                                                                            <connections>
+                                                                                <action selector="audioEqSliderAction:" target="-2" id="pkI-fs-ZCs"/>
+                                                                            </connections>
+                                                                        </slider>
+                                                                        <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" tag="9" translatesAutoresizingMaskIntoConstraints="NO" id="w04-h5-qaz">
+                                                                            <rect key="frame" x="259" y="-2" width="20" height="120"/>
+                                                                            <sliderCell key="cell" controlSize="small" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" numberOfTickMarks="13" sliderType="linear" id="5FD-oT-GpE"/>
+                                                                            <connections>
+                                                                                <action selector="audioEqSliderAction:" target="-2" id="I08-gI-z8e"/>
+                                                                            </connections>
+                                                                        </slider>
+                                                                    </subviews>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="height" constant="116" id="nDW-aS-hPT"/>
+                                                                    </constraints>
+                                                                    <visibilityPriorities>
+                                                                        <integer value="1000"/>
+                                                                        <integer value="1000"/>
+                                                                        <integer value="1000"/>
+                                                                        <integer value="1000"/>
+                                                                        <integer value="1000"/>
+                                                                        <integer value="1000"/>
+                                                                        <integer value="1000"/>
+                                                                        <integer value="1000"/>
+                                                                        <integer value="1000"/>
+                                                                        <integer value="1000"/>
+                                                                    </visibilityPriorities>
+                                                                    <customSpacing>
+                                                                        <real value="3.4028234663852886e+38"/>
+                                                                        <real value="3.4028234663852886e+38"/>
+                                                                        <real value="3.4028234663852886e+38"/>
+                                                                        <real value="3.4028234663852886e+38"/>
+                                                                        <real value="3.4028234663852886e+38"/>
+                                                                        <real value="3.4028234663852886e+38"/>
+                                                                        <real value="3.4028234663852886e+38"/>
+                                                                        <real value="3.4028234663852886e+38"/>
+                                                                        <real value="3.4028234663852886e+38"/>
+                                                                        <real value="3.4028234663852886e+38"/>
+                                                                    </customSpacing>
+                                                                </stackView>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jUH-hL-3U3" userLabel="+12 dB Text Field">
+                                                                    <rect key="frame" x="301" y="141" width="41" height="14"/>
+                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="+12 dB" id="4BZ-H1-GEU">
+                                                                        <font key="font" metaFont="smallSystem"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="izd-aj-gqV" userLabel="0 dB Text Field">
+                                                                    <rect key="frame" x="313" y="90" width="29" height="14"/>
+                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="0 dB" id="lBn-YS-jL7">
+                                                                        <font key="font" metaFont="smallSystem"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Wkv-a4-uiD" userLabel="-12 dB Text Field">
+                                                                    <rect key="frame" x="303" y="39" width="39" height="14"/>
+                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="-12 dB" id="Lpw-ws-Ezh">
+                                                                        <font key="font" metaFont="smallSystem"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EDx-YH-ofM">
+                                                                    <rect key="frame" x="11" y="20" width="32" height="11"/>
+                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="31.25" id="HBF-J7-Tie">
+                                                                        <font key="font" metaFont="label" size="9"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dKk-CE-yY0">
+                                                                    <rect key="frame" x="44" y="20" width="28" height="11"/>
+                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="62.5" id="4PG-5R-5G0">
+                                                                        <font key="font" metaFont="label" size="9"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gfz-yF-41J">
+                                                                    <rect key="frame" x="74" y="20" width="24" height="11"/>
+                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="125" id="1cq-dc-JfM">
+                                                                        <font key="font" metaFont="label" size="9"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1he-Ll-CYl">
+                                                                    <rect key="frame" x="102" y="20" width="26" height="11"/>
+                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="250" id="ekh-gc-2qo">
+                                                                        <font key="font" metaFont="label" size="9"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="j15-F0-7GR">
+                                                                    <rect key="frame" x="131" y="20" width="26" height="11"/>
+                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="500" id="tHa-vN-OlI">
+                                                                        <font key="font" metaFont="label" size="9"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wvc-3m-7dA">
+                                                                    <rect key="frame" x="164" y="20" width="18" height="11"/>
+                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="1k" id="Rtc-Eg-J2u">
+                                                                        <font key="font" metaFont="label" size="9"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cnq-7d-eC4">
+                                                                    <rect key="frame" x="193" y="20" width="19" height="11"/>
+                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="2k" id="j9w-YU-EcC">
+                                                                        <font key="font" metaFont="label" size="9"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uUe-VB-wyv">
+                                                                    <rect key="frame" x="221" y="20" width="20" height="11"/>
+                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="4k" id="i0j-2a-vKD">
+                                                                        <font key="font" metaFont="label" size="9"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eOZ-KM-xLa">
+                                                                    <rect key="frame" x="251" y="20" width="19" height="11"/>
+                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="8k" id="e4X-H4-VxS">
+                                                                        <font key="font" metaFont="label" size="9"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aOD-Qz-oE3">
+                                                                    <rect key="frame" x="277" y="20" width="24" height="11"/>
+                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="16k" id="era-AG-bSl">
+                                                                        <font key="font" metaFont="label" size="9"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
                                                             </subviews>
                                                             <constraints>
-                                                                <constraint firstItem="IHl-Ks-v7I" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" constant="19" id="0QV-7k-pBU"/>
-                                                                <constraint firstItem="kF3-Ee-Pha" firstAttribute="top" secondItem="a7T-nr-ELY" secondAttribute="bottom" id="0XD-ee-xVQ"/>
-                                                                <constraint firstItem="kF3-Ee-Pha" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="C39-jO-zwp" secondAttribute="trailing" id="1ZI-y0-iIA"/>
-                                                                <constraint firstAttribute="trailing" secondItem="PLF-x4-bMC" secondAttribute="trailing" id="1q2-vE-SkR"/>
-                                                                <constraint firstItem="E4v-kh-61H" firstAttribute="top" secondItem="my2-5o-bNb" secondAttribute="top" constant="20" id="1y4-Kv-vat"/>
-                                                                <constraint firstItem="0DM-CY-o8W" firstAttribute="leading" secondItem="a7T-nr-ELY" secondAttribute="trailing" constant="16" id="20o-RN-jw7"/>
-                                                                <constraint firstAttribute="trailing" secondItem="dB1-5J-5YU" secondAttribute="trailing" constant="20" id="2j8-Vy-2QJ"/>
-                                                                <constraint firstAttribute="trailing" secondItem="IHl-Ks-v7I" secondAttribute="trailing" constant="40" id="305-x4-mBU"/>
-                                                                <constraint firstItem="doa-7T-eeK" firstAttribute="leading" secondItem="a7T-nr-ELY" secondAttribute="leading" id="62g-RQ-baB"/>
-                                                                <constraint firstItem="ZPW-fz-5Oi" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" constant="19" id="9aM-rf-Ubw"/>
+                                                                <constraint firstItem="gbd-xf-hGS" firstAttribute="centerX" secondItem="eOZ-KM-xLa" secondAttribute="centerX" id="0eU-JU-3Np"/>
+                                                                <constraint firstItem="izd-aj-gqV" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="xtT-Or-HjR" secondAttribute="leading" constant="8" id="1do-g0-ogb"/>
+                                                                <constraint firstItem="izd-aj-gqV" firstAttribute="trailing" secondItem="TA9-9G-tIE" secondAttribute="trailing" priority="900" id="1xH-vk-y7P"/>
+                                                                <constraint firstItem="EDx-YH-ofM" firstAttribute="top" secondItem="pHR-ym-VeQ" secondAttribute="bottom" constant="8" id="3GI-bd-VUa"/>
+                                                                <constraint firstItem="dKk-CE-yY0" firstAttribute="centerX" secondItem="Qhv-oC-xzP" secondAttribute="centerX" constant="1" id="6U0-bD-UHn"/>
+                                                                <constraint firstItem="XdF-fV-DCz" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="TA9-9G-tIE" secondAttribute="trailing" id="8OK-le-NFN"/>
+                                                                <constraint firstItem="TA9-9G-tIE" firstAttribute="leading" secondItem="E4v-kh-61H" secondAttribute="leading" id="9So-jf-b5w"/>
                                                                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="E4v-kh-61H" secondAttribute="trailing" id="9ol-Ih-xQV"/>
                                                                 <constraint firstItem="KKr-0Y-831" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" id="AXq-h3-TVD"/>
-                                                                <constraint firstItem="0DM-CY-o8W" firstAttribute="centerY" secondItem="a7T-nr-ELY" secondAttribute="centerY" constant="-1" id="B5R-Ja-IjZ"/>
-                                                                <constraint firstItem="a7T-nr-ELY" firstAttribute="top" secondItem="gR7-cS-zmu" secondAttribute="bottom" constant="2" id="C2d-F4-WIg"/>
-                                                                <constraint firstAttribute="trailing" secondItem="0DM-CY-o8W" secondAttribute="trailing" constant="24" id="Did-nR-Yql"/>
-                                                                <constraint firstItem="gR7-cS-zmu" firstAttribute="centerX" secondItem="a7T-nr-ELY" secondAttribute="leading" constant="120" id="Er7-gv-OMp"/>
-                                                                <constraint firstItem="doa-7T-eeK" firstAttribute="top" secondItem="a7T-nr-ELY" secondAttribute="bottom" id="FFk-YH-GZp"/>
-                                                                <constraint firstItem="C39-jO-zwp" firstAttribute="top" secondItem="a7T-nr-ELY" secondAttribute="bottom" id="GZM-yD-gvm"/>
+                                                                <constraint firstItem="j85-rj-toQ" firstAttribute="top" secondItem="ZPW-fz-5Oi" secondAttribute="bottom" constant="4" id="Cv3-B2-U9b"/>
+                                                                <constraint firstItem="wvc-3m-7dA" firstAttribute="top" secondItem="EDx-YH-ofM" secondAttribute="top" id="Ebj-KB-Fia"/>
+                                                                <constraint firstItem="IHl-Ks-v7I" firstAttribute="leading" secondItem="TA9-9G-tIE" secondAttribute="leading" id="FcZ-qn-ZcQ"/>
+                                                                <constraint firstItem="1he-Ll-CYl" firstAttribute="top" secondItem="EDx-YH-ofM" secondAttribute="top" id="G46-BJ-iVG"/>
                                                                 <constraint firstAttribute="trailing" secondItem="KKr-0Y-831" secondAttribute="trailing" id="HbW-t2-Z43"/>
-                                                                <constraint firstItem="kvu-fg-olx" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" constant="19" id="LQR-09-ikh"/>
-                                                                <constraint firstItem="a7T-nr-ELY" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" constant="20" id="Mj2-sZ-AFW"/>
-                                                                <constraint firstAttribute="trailing" secondItem="kvu-fg-olx" secondAttribute="trailing" constant="35" id="O0T-4P-XQY"/>
-                                                                <constraint firstItem="kF3-Ee-Pha" firstAttribute="trailing" secondItem="a7T-nr-ELY" secondAttribute="trailing" id="PJ2-pg-wRS"/>
+                                                                <constraint firstItem="cnq-7d-eC4" firstAttribute="top" secondItem="EDx-YH-ofM" secondAttribute="top" id="Hrv-XD-CMS"/>
+                                                                <constraint firstItem="j15-F0-7GR" firstAttribute="centerX" secondItem="npn-V6-hjZ" secondAttribute="centerX" id="Km4-rZ-GeG"/>
+                                                                <constraint firstItem="uUe-VB-wyv" firstAttribute="top" secondItem="EDx-YH-ofM" secondAttribute="top" id="La7-D2-OgL"/>
+                                                                <constraint firstItem="Wkv-a4-uiD" firstAttribute="bottom" secondItem="xtT-Or-HjR" secondAttribute="bottom" id="MaV-fd-img"/>
+                                                                <constraint firstItem="gfz-yF-41J" firstAttribute="top" secondItem="EDx-YH-ofM" secondAttribute="top" id="Mwa-bq-dus"/>
+                                                                <constraint firstItem="kvu-fg-olx" firstAttribute="trailing" secondItem="TA9-9G-tIE" secondAttribute="trailing" id="OAI-WO-gae"/>
+                                                                <constraint firstItem="dB1-5J-5YU" firstAttribute="trailing" secondItem="TA9-9G-tIE" secondAttribute="trailing" id="OHg-XE-6c8"/>
+                                                                <constraint firstAttribute="bottom" secondItem="EDx-YH-ofM" secondAttribute="bottom" constant="20" id="Ovj-hj-4mO"/>
                                                                 <constraint firstItem="Qal-0X-4kS" firstAttribute="top" secondItem="E4v-kh-61H" secondAttribute="bottom" constant="8" id="PfL-cK-sd5"/>
-                                                                <constraint firstItem="C39-jO-zwp" firstAttribute="centerX" secondItem="a7T-nr-ELY" secondAttribute="centerX" id="Pq3-Ff-F3F"/>
-                                                                <constraint firstItem="IHl-Ks-v7I" firstAttribute="top" secondItem="KKr-0Y-831" secondAttribute="bottom" constant="18" id="Q61-jq-LnT"/>
+                                                                <constraint firstItem="IHl-Ks-v7I" firstAttribute="top" secondItem="KKr-0Y-831" secondAttribute="bottom" constant="20" id="Q61-jq-LnT"/>
+                                                                <constraint firstItem="1he-Ll-CYl" firstAttribute="centerX" secondItem="O2w-VO-03F" secondAttribute="centerX" id="R4m-Vs-AK3"/>
+                                                                <constraint firstItem="cnq-7d-eC4" firstAttribute="centerX" secondItem="nNf-gg-4tL" secondAttribute="centerX" id="Rge-iX-npw"/>
+                                                                <constraint firstItem="j15-F0-7GR" firstAttribute="top" secondItem="EDx-YH-ofM" secondAttribute="top" id="RvX-Nr-Tiv"/>
                                                                 <constraint firstItem="Qal-0X-4kS" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" id="SwW-S7-LX2"/>
-                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="XdF-fV-DCz" secondAttribute="trailing" constant="35" id="Vg4-yG-qta"/>
+                                                                <constraint firstItem="IHl-Ks-v7I" firstAttribute="trailing" secondItem="TA9-9G-tIE" secondAttribute="trailing" id="Uha-r6-SHs"/>
+                                                                <constraint firstItem="j85-rj-toQ" firstAttribute="width" secondItem="TA9-9G-tIE" secondAttribute="width" id="Wed-Pj-j0R"/>
+                                                                <constraint firstItem="xtT-Or-HjR" firstAttribute="top" secondItem="IHl-Ks-v7I" secondAttribute="bottom" constant="12" id="XfD-0d-53x"/>
+                                                                <constraint firstItem="KKr-0Y-831" firstAttribute="top" secondItem="j85-rj-toQ" secondAttribute="bottom" constant="20" id="YFM-EH-jIy"/>
                                                                 <constraint firstItem="dB1-5J-5YU" firstAttribute="centerY" secondItem="IHl-Ks-v7I" secondAttribute="centerY" id="Ym6-Rk-xwx"/>
-                                                                <constraint firstItem="XdF-fV-DCz" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" constant="20" id="aOX-MS-ZZW"/>
-                                                                <constraint firstItem="PLF-x4-bMC" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" id="dRT-Ri-a9H"/>
-                                                                <constraint firstItem="E4v-kh-61H" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" constant="19" id="f6t-BV-Nqr"/>
-                                                                <constraint firstAttribute="bottom" secondItem="PLF-x4-bMC" secondAttribute="bottom" constant="24" id="gbq-VK-CJq"/>
-                                                                <constraint firstItem="XdF-fV-DCz" firstAttribute="top" secondItem="kvu-fg-olx" secondAttribute="bottom" constant="8" id="gud-hM-Hf0"/>
-                                                                <constraint firstItem="a7T-nr-ELY" firstAttribute="top" secondItem="ZPW-fz-5Oi" secondAttribute="bottom" constant="23" id="h2O-at-cpJ"/>
-                                                                <constraint firstItem="KKr-0Y-831" firstAttribute="top" secondItem="a7T-nr-ELY" secondAttribute="bottom" constant="33" id="lUv-nd-FbU"/>
+                                                                <constraint firstItem="Wkv-a4-uiD" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="xtT-Or-HjR" secondAttribute="trailing" id="Zgg-St-FzR"/>
+                                                                <constraint firstItem="TA9-9G-tIE" firstAttribute="top" secondItem="my2-5o-bNb" secondAttribute="top" constant="20" id="aLW-0J-VPR"/>
+                                                                <constraint firstItem="TA9-9G-tIE" firstAttribute="leading" secondItem="ZPW-fz-5Oi" secondAttribute="leading" id="alo-ld-qH9"/>
+                                                                <constraint firstItem="ImH-jg-Agp" firstAttribute="trailing" secondItem="TA9-9G-tIE" secondAttribute="trailing" id="bO7-1x-a1O"/>
+                                                                <constraint firstItem="Wkv-a4-uiD" firstAttribute="trailing" secondItem="TA9-9G-tIE" secondAttribute="trailing" priority="900" id="dYP-Us-6bj"/>
+                                                                <constraint firstItem="dKk-CE-yY0" firstAttribute="top" secondItem="EDx-YH-ofM" secondAttribute="top" id="dw4-5m-LIU"/>
+                                                                <constraint firstItem="ZPW-fz-5Oi" firstAttribute="trailing" secondItem="TA9-9G-tIE" secondAttribute="trailing" id="e0g-tm-BF8"/>
+                                                                <constraint firstItem="jUH-hL-3U3" firstAttribute="trailing" secondItem="TA9-9G-tIE" secondAttribute="trailing" priority="900" id="f4B-e4-9IW"/>
+                                                                <constraint firstItem="eOZ-KM-xLa" firstAttribute="top" secondItem="EDx-YH-ofM" secondAttribute="top" id="fUd-pm-IiH"/>
+                                                                <constraint firstItem="aOD-Qz-oE3" firstAttribute="top" secondItem="EDx-YH-ofM" secondAttribute="top" id="gOd-gW-hDD"/>
+                                                                <constraint firstItem="XdF-fV-DCz" firstAttribute="top" secondItem="kvu-fg-olx" secondAttribute="bottom" constant="10" id="gud-hM-Hf0"/>
+                                                                <constraint firstItem="TA9-9G-tIE" firstAttribute="leading" secondItem="XdF-fV-DCz" secondAttribute="leading" id="hKL-gp-ucV"/>
+                                                                <constraint firstItem="uUe-VB-wyv" firstAttribute="centerX" secondItem="JaQ-EH-K1U" secondAttribute="centerX" id="iT9-ha-L66"/>
+                                                                <constraint firstItem="EDx-YH-ofM" firstAttribute="centerX" secondItem="pHR-ym-VeQ" secondAttribute="centerX" multiplier="1.1" constant="-4" id="idL-dD-1e3"/>
                                                                 <constraint firstAttribute="trailing" secondItem="Qal-0X-4kS" secondAttribute="trailing" id="lda-T8-U6J"/>
-                                                                <constraint firstItem="C39-jO-zwp" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="doa-7T-eeK" secondAttribute="trailing" id="nPa-vY-ceo"/>
-                                                                <constraint firstItem="ZPW-fz-5Oi" firstAttribute="top" secondItem="XdF-fV-DCz" secondAttribute="bottom" constant="27" id="pbW-gp-age"/>
+                                                                <constraint firstAttribute="trailing" secondItem="TA9-9G-tIE" secondAttribute="trailing" constant="20" id="nPX-nn-l3H"/>
+                                                                <constraint firstItem="izd-aj-gqV" firstAttribute="centerY" secondItem="xtT-Or-HjR" secondAttribute="centerY" id="nqS-iu-yym"/>
+                                                                <constraint firstItem="ZPW-fz-5Oi" firstAttribute="top" secondItem="XdF-fV-DCz" secondAttribute="bottom" constant="20" id="pbW-gp-age"/>
+                                                                <constraint firstItem="jUH-hL-3U3" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="xtT-Or-HjR" secondAttribute="leading" constant="8" id="rSH-0T-1ru"/>
+                                                                <constraint firstItem="pHR-ym-VeQ" firstAttribute="leading" secondItem="TA9-9G-tIE" secondAttribute="leading" id="rTs-z0-HWj"/>
+                                                                <constraint firstItem="jUH-hL-3U3" firstAttribute="top" secondItem="xtT-Or-HjR" secondAttribute="top" id="rir-xy-gWG"/>
                                                                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ZPW-fz-5Oi" secondAttribute="trailing" id="tRW-zx-YUE"/>
+                                                                <constraint firstItem="w04-h5-qaz" firstAttribute="centerX" secondItem="aOD-Qz-oE3" secondAttribute="centerX" id="u1s-K3-1TR"/>
+                                                                <constraint firstItem="wvc-3m-7dA" firstAttribute="centerX" secondItem="TKd-tg-Xtc" secondAttribute="centerX" id="vsl-Na-7AB"/>
+                                                                <constraint firstItem="E4v-kh-61H" firstAttribute="trailing" secondItem="TA9-9G-tIE" secondAttribute="trailing" id="vxi-gU-jaJ"/>
                                                                 <constraint firstItem="kvu-fg-olx" firstAttribute="top" secondItem="Qal-0X-4kS" secondAttribute="bottom" constant="20" id="wOv-GA-HuD"/>
-                                                                <constraint firstItem="PLF-x4-bMC" firstAttribute="top" secondItem="IHl-Ks-v7I" secondAttribute="bottom" constant="8" id="zPs-Z3-aNL"/>
+                                                                <constraint firstItem="kvu-fg-olx" firstAttribute="leading" secondItem="TA9-9G-tIE" secondAttribute="leading" id="xkY-DB-G0z"/>
+                                                                <constraint firstItem="gfz-yF-41J" firstAttribute="centerX" secondItem="iDT-gu-k7t" secondAttribute="centerX" id="xnf-hN-6Hv"/>
+                                                                <constraint firstItem="TA9-9G-tIE" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" constant="20" id="y32-7d-2YS"/>
+                                                                <constraint firstItem="gJr-l6-WQ2" firstAttribute="leading" secondItem="TA9-9G-tIE" secondAttribute="leading" id="zda-HN-bk0"/>
+                                                                <constraint firstItem="TA9-9G-tIE" firstAttribute="top" secondItem="E4v-kh-61H" secondAttribute="top" id="zoG-7o-Hig"/>
                                                             </constraints>
                                                         </customView>
                                                     </subviews>
                                                     <constraints>
+                                                        <constraint firstItem="my2-5o-bNb" firstAttribute="top" secondItem="NZU-RD-Dm3" secondAttribute="top" id="IWt-bk-0fS"/>
                                                         <constraint firstItem="my2-5o-bNb" firstAttribute="leading" secondItem="NZU-RD-Dm3" secondAttribute="leading" id="pxh-2E-RNE"/>
-                                                        <constraint firstItem="my2-5o-bNb" firstAttribute="top" secondItem="NZU-RD-Dm3" secondAttribute="top" id="sEV-DZ-FlL"/>
                                                         <constraint firstAttribute="trailing" secondItem="my2-5o-bNb" secondAttribute="trailing" id="uM8-H5-QwQ"/>
                                                         <constraint firstAttribute="bottom" secondItem="my2-5o-bNb" secondAttribute="bottom" id="zoi-sm-jxY"/>
                                                     </constraints>
@@ -1560,12 +1556,12 @@
                                             </constraints>
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </clipView>
-                                        <scroller key="horizontalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="klo-Db-oQE">
-                                            <rect key="frame" x="0.0" y="807" width="360" height="16"/>
+                                        <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="klo-Db-oQE" userLabel="AudioTab Horizontal Scroller">
+                                            <rect key="frame" x="-100" y="-100" width="360" height="15"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
-                                        <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="17z-n6-rH9">
-                                            <rect key="frame" x="344" y="0.0" width="16" height="823"/>
+                                        <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="17z-n6-rH9" userLabel="AudioTab Vertical Scroller">
+                                            <rect key="frame" x="360" y="0.0" width="15" height="738"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                     </scrollView>
@@ -1578,31 +1574,37 @@
                                 </constraints>
                             </view>
                         </tabViewItem>
-                        <tabViewItem label="Subtitle" identifier="" id="jND-MZ-sKB">
-                            <view key="view" id="MrM-2b-7ob">
-                                <rect key="frame" x="0.0" y="0.0" width="360" height="787"/>
+                        <tabViewItem label="Subtitle" identifier="" id="jND-MZ-sKB" userLabel="SubtitlesTab Tab View Item">
+                            <view key="view" id="MrM-2b-7ob" userLabel="SubtitlesTab View">
+                                <rect key="frame" x="0.0" y="0.0" width="360" height="827"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
-                                    <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3kA-IY-poi">
-                                        <rect key="frame" x="0.0" y="0.0" width="360" height="787"/>
-                                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="epy-wp-Ja5">
-                                            <rect key="frame" x="0.0" y="0.0" width="360" height="787"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                    <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3kA-IY-poi" userLabel="SubtitlesTab Scroll View">
+                                        <rect key="frame" x="0.0" y="0.0" width="375" height="827"/>
+                                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="epy-wp-Ja5" userLabel="SubtitlesTab Clip View">
+                                            <rect key="frame" x="0.0" y="0.0" width="360" height="827"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
-                                                <customView translatesAutoresizingMaskIntoConstraints="NO" id="pm4-x9-WJ5" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="-81" width="360" height="832"/>
+                                                <customView translatesAutoresizingMaskIntoConstraints="NO" id="pm4-x9-WJ5" userLabel="SubtitlesTab Flipped CONTENT VIEW" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
+                                                    <rect key="frame" x="0.0" y="-3" width="360" height="830"/>
                                                     <subviews>
-                                                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Wuf-PX-OYd" userLabel="Sub Basic">
-                                                            <rect key="frame" x="0.0" y="418" width="360" height="414"/>
+                                                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="PJb-5N-8QM" userLabel="PANEL EDGE INSETS">
+                                                            <rect key="frame" x="20" y="830" width="320" height="0.0"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" id="jai-Pg-hCw"/>
+                                                            </constraints>
+                                                        </customView>
+                                                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Wuf-PX-OYd" userLabel="SubBasicSection Container View">
+                                                            <rect key="frame" x="0.0" y="426" width="360" height="404"/>
                                                             <subviews>
-                                                                <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Fq-4o-8Hh">
-                                                                    <rect key="frame" x="0.0" y="298" width="360" height="72"/>
-                                                                    <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="dJV-R0-O3M">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="360" height="72"/>
-                                                                        <autoresizingMask key="autoresizingMask"/>
+                                                                <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Fq-4o-8Hh" userLabel="SubTable Scroll View">
+                                                                    <rect key="frame" x="0.0" y="285" width="360" height="75"/>
+                                                                    <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="dJV-R0-O3M" userLabel="SubTable Clip View">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="360" height="75"/>
+                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
-                                                                            <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="2vU-hm-gGB">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="360" height="72"/>
+                                                                            <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="2vU-hm-gGB" userLabel="SubTable Table View">
+                                                                                <rect key="frame" x="0.0" y="0.0" width="360" height="75"/>
                                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                                 <size key="intercellSpacing" width="3" height="2"/>
                                                                                 <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.080000000000000002" colorSpace="calibratedRGB"/>
@@ -1628,7 +1630,7 @@
                                                                                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="7Ky-LN-z9K">
                                                                                                         <rect key="frame" x="0.0" y="0.0" width="21" height="17"/>
                                                                                                         <constraints>
-                                                                                                            <constraint firstAttribute="height" constant="17" id="xDM-iw-yhI"/>
+                                                                                                            <constraint firstAttribute="height" constant="17" id="ANA-U2-c96"/>
                                                                                                         </constraints>
                                                                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="Jvb-cP-PSf">
                                                                                                             <font key="font" metaFont="system"/>
@@ -1641,9 +1643,9 @@
                                                                                                     </textField>
                                                                                                 </subviews>
                                                                                                 <constraints>
-                                                                                                    <constraint firstItem="7Ky-LN-z9K" firstAttribute="centerX" secondItem="0Gi-L0-dSi" secondAttribute="centerX" id="8hL-Nl-kv5"/>
-                                                                                                    <constraint firstItem="7Ky-LN-z9K" firstAttribute="leading" secondItem="0Gi-L0-dSi" secondAttribute="leading" constant="2" id="GTy-wf-hHe"/>
-                                                                                                    <constraint firstItem="7Ky-LN-z9K" firstAttribute="centerY" secondItem="0Gi-L0-dSi" secondAttribute="centerY" id="YSH-UG-soS"/>
+                                                                                                    <constraint firstItem="7Ky-LN-z9K" firstAttribute="centerY" secondItem="0Gi-L0-dSi" secondAttribute="centerY" id="KJ7-CB-ONK"/>
+                                                                                                    <constraint firstItem="7Ky-LN-z9K" firstAttribute="centerX" secondItem="0Gi-L0-dSi" secondAttribute="centerX" id="Q6E-Hs-h57"/>
+                                                                                                    <constraint firstItem="7Ky-LN-z9K" firstAttribute="leading" secondItem="0Gi-L0-dSi" secondAttribute="leading" constant="2" id="dH0-ya-hZR"/>
                                                                                                 </constraints>
                                                                                                 <connections>
                                                                                                     <outlet property="textField" destination="7Ky-LN-z9K" id="dZy-6W-J6f"/>
@@ -1651,7 +1653,7 @@
                                                                                             </tableCellView>
                                                                                         </prototypeCellViews>
                                                                                     </tableColumn>
-                                                                                    <tableColumn identifier="TrackId" width="22" minWidth="10" maxWidth="3.4028234663852886e+38" id="q3e-dd-aXM">
+                                                                                    <tableColumn identifier="TrackId" width="22" minWidth="22" maxWidth="3.4028234663852886e+38" id="q3e-dd-aXM">
                                                                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
                                                                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
@@ -1670,7 +1672,7 @@
                                                                                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Ydk-iU-8pQ">
                                                                                                         <rect key="frame" x="0.0" y="0.0" width="22" height="17"/>
                                                                                                         <constraints>
-                                                                                                            <constraint firstAttribute="height" constant="17" id="ske-v4-Svo"/>
+                                                                                                            <constraint firstAttribute="height" constant="17" id="hAr-TV-jh1"/>
                                                                                                         </constraints>
                                                                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="Mbq-Qm-2xb">
                                                                                                             <font key="font" metaFont="systemBold"/>
@@ -1683,9 +1685,9 @@
                                                                                                     </textField>
                                                                                                 </subviews>
                                                                                                 <constraints>
-                                                                                                    <constraint firstItem="Ydk-iU-8pQ" firstAttribute="centerX" secondItem="tbH-U7-ooT" secondAttribute="centerX" id="2Rt-uP-f3b"/>
-                                                                                                    <constraint firstItem="Ydk-iU-8pQ" firstAttribute="centerY" secondItem="tbH-U7-ooT" secondAttribute="centerY" id="Kuc-Dj-zzR"/>
-                                                                                                    <constraint firstItem="Ydk-iU-8pQ" firstAttribute="leading" secondItem="tbH-U7-ooT" secondAttribute="leading" constant="2" id="x82-pT-we7"/>
+                                                                                                    <constraint firstItem="Ydk-iU-8pQ" firstAttribute="centerX" secondItem="tbH-U7-ooT" secondAttribute="centerX" id="2In-Gw-XMG"/>
+                                                                                                    <constraint firstItem="Ydk-iU-8pQ" firstAttribute="centerY" secondItem="tbH-U7-ooT" secondAttribute="centerY" id="5I6-JL-iuh"/>
+                                                                                                    <constraint firstItem="Ydk-iU-8pQ" firstAttribute="leading" secondItem="tbH-U7-ooT" secondAttribute="leading" constant="2" id="YGU-lg-3bg"/>
                                                                                                 </constraints>
                                                                                                 <connections>
                                                                                                     <outlet property="textField" destination="Ydk-iU-8pQ" id="WBI-LA-u5S"/>
@@ -1693,7 +1695,7 @@
                                                                                             </tableCellView>
                                                                                         </prototypeCellViews>
                                                                                     </tableColumn>
-                                                                                    <tableColumn identifier="TrackName" width="282" minWidth="40" maxWidth="3.4028234663852886e+38" id="jxP-dI-qjH">
+                                                                                    <tableColumn identifier="TrackName" width="282" minWidth="100" maxWidth="3.4028234663852886e+38" id="jxP-dI-qjH">
                                                                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
                                                                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
@@ -1712,7 +1714,7 @@
                                                                                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="E2W-Vb-Tgt">
                                                                                                         <rect key="frame" x="0.0" y="0.0" width="286" height="17"/>
                                                                                                         <constraints>
-                                                                                                            <constraint firstAttribute="height" constant="17" id="boB-wV-lkU"/>
+                                                                                                            <constraint firstAttribute="height" constant="17" id="Z7t-1Z-ziR"/>
                                                                                                         </constraints>
                                                                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="Qpg-8B-Eks">
                                                                                                             <font key="font" metaFont="system"/>
@@ -1725,9 +1727,9 @@
                                                                                                     </textField>
                                                                                                 </subviews>
                                                                                                 <constraints>
-                                                                                                    <constraint firstItem="E2W-Vb-Tgt" firstAttribute="centerY" secondItem="Uvf-Ds-mrn" secondAttribute="centerY" id="5C9-pf-NOi"/>
-                                                                                                    <constraint firstItem="E2W-Vb-Tgt" firstAttribute="centerX" secondItem="Uvf-Ds-mrn" secondAttribute="centerX" id="8oM-kV-vMq"/>
-                                                                                                    <constraint firstItem="E2W-Vb-Tgt" firstAttribute="leading" secondItem="Uvf-Ds-mrn" secondAttribute="leading" constant="2" id="QKJ-Mv-BER"/>
+                                                                                                    <constraint firstItem="E2W-Vb-Tgt" firstAttribute="centerX" secondItem="Uvf-Ds-mrn" secondAttribute="centerX" id="CjW-1W-Ghg"/>
+                                                                                                    <constraint firstItem="E2W-Vb-Tgt" firstAttribute="leading" secondItem="Uvf-Ds-mrn" secondAttribute="leading" constant="2" id="i83-Js-1Hh"/>
+                                                                                                    <constraint firstItem="E2W-Vb-Tgt" firstAttribute="centerY" secondItem="Uvf-Ds-mrn" secondAttribute="centerY" id="wCF-Cd-UF3"/>
                                                                                                 </constraints>
                                                                                                 <connections>
                                                                                                     <outlet property="textField" destination="E2W-Vb-Tgt" id="0MJ-5K-pni"/>
@@ -1740,25 +1742,25 @@
                                                                         </subviews>
                                                                     </clipView>
                                                                     <constraints>
-                                                                        <constraint firstAttribute="height" constant="72" id="lC0-Wa-BTh"/>
+                                                                        <constraint firstAttribute="height" constant="75" id="lC0-Wa-BTh"/>
                                                                     </constraints>
-                                                                    <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="T7q-K8-765">
+                                                                    <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="T7q-K8-765" userLabel="SubTable Horizontal Scroller">
                                                                         <rect key="frame" x="0.0" y="56" width="360" height="16"/>
                                                                         <autoresizingMask key="autoresizingMask"/>
                                                                     </scroller>
-                                                                    <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="j0M-29-ecd">
+                                                                    <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="j0M-29-ecd" userLabel="SubTable Vertical Scroller">
                                                                         <rect key="frame" x="-16" y="0.0" width="16" height="0.0"/>
                                                                         <autoresizingMask key="autoresizingMask"/>
                                                                     </scroller>
                                                                 </scrollView>
-                                                                <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LMp-7Y-Rxg">
-                                                                    <rect key="frame" x="0.0" y="182" width="360" height="72"/>
-                                                                    <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="EKn-MX-Fao">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="360" height="72"/>
-                                                                        <autoresizingMask key="autoresizingMask"/>
+                                                                <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LMp-7Y-Rxg" userLabel="SecondarySub Scroll View">
+                                                                    <rect key="frame" x="0.0" y="166" width="360" height="75"/>
+                                                                    <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="EKn-MX-Fao" userLabel="SecondarySub Clip View">
+                                                                        <rect key="frame" x="0.0" y="0.0" width="360" height="75"/>
+                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
-                                                                            <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="Jve-qX-Agy">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="360" height="72"/>
+                                                                            <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="Jve-qX-Agy" userLabel="SecondarySub Table View">
+                                                                                <rect key="frame" x="0.0" y="0.0" width="360" height="75"/>
                                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                                 <size key="intercellSpacing" width="3" height="2"/>
                                                                                 <color key="backgroundColor" white="1" alpha="0.080000000000000002" colorSpace="deviceWhite"/>
@@ -1784,7 +1786,7 @@
                                                                                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="615-Ps-9YF">
                                                                                                         <rect key="frame" x="0.0" y="0.0" width="21" height="17"/>
                                                                                                         <constraints>
-                                                                                                            <constraint firstAttribute="height" constant="17" id="GQJ-yJ-OQs"/>
+                                                                                                            <constraint firstAttribute="height" constant="17" id="qtL-Np-vkj"/>
                                                                                                         </constraints>
                                                                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="f23-sU-Thx">
                                                                                                             <font key="font" metaFont="system"/>
@@ -1797,9 +1799,9 @@
                                                                                                     </textField>
                                                                                                 </subviews>
                                                                                                 <constraints>
-                                                                                                    <constraint firstItem="615-Ps-9YF" firstAttribute="centerY" secondItem="OdH-WH-l2U" secondAttribute="centerY" id="7gZ-mK-0dK"/>
-                                                                                                    <constraint firstItem="615-Ps-9YF" firstAttribute="centerX" secondItem="OdH-WH-l2U" secondAttribute="centerX" id="DNe-gm-JVz"/>
-                                                                                                    <constraint firstItem="615-Ps-9YF" firstAttribute="leading" secondItem="OdH-WH-l2U" secondAttribute="leading" constant="2" id="fYA-kz-43a"/>
+                                                                                                    <constraint firstItem="615-Ps-9YF" firstAttribute="centerX" secondItem="OdH-WH-l2U" secondAttribute="centerX" id="GOp-6I-AcY"/>
+                                                                                                    <constraint firstItem="615-Ps-9YF" firstAttribute="leading" secondItem="OdH-WH-l2U" secondAttribute="leading" constant="2" id="gvC-jA-iBO"/>
+                                                                                                    <constraint firstItem="615-Ps-9YF" firstAttribute="centerY" secondItem="OdH-WH-l2U" secondAttribute="centerY" id="viA-Z1-ctw"/>
                                                                                                 </constraints>
                                                                                                 <connections>
                                                                                                     <outlet property="textField" destination="615-Ps-9YF" id="nhJ-wW-r7t"/>
@@ -1826,7 +1828,7 @@
                                                                                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="CCb-vZ-l96">
                                                                                                         <rect key="frame" x="0.0" y="0.0" width="22" height="17"/>
                                                                                                         <constraints>
-                                                                                                            <constraint firstAttribute="height" constant="17" id="PXI-MQ-ZMv"/>
+                                                                                                            <constraint firstAttribute="height" constant="17" id="plc-pR-j5l"/>
                                                                                                         </constraints>
                                                                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="YOu-ft-k7r">
                                                                                                             <font key="font" metaFont="systemBold"/>
@@ -1839,9 +1841,9 @@
                                                                                                     </textField>
                                                                                                 </subviews>
                                                                                                 <constraints>
-                                                                                                    <constraint firstItem="CCb-vZ-l96" firstAttribute="centerX" secondItem="7bA-1U-4oy" secondAttribute="centerX" id="NIi-MQ-azk"/>
-                                                                                                    <constraint firstItem="CCb-vZ-l96" firstAttribute="centerY" secondItem="7bA-1U-4oy" secondAttribute="centerY" id="cUv-Se-wrC"/>
-                                                                                                    <constraint firstItem="CCb-vZ-l96" firstAttribute="leading" secondItem="7bA-1U-4oy" secondAttribute="leading" constant="2" id="gPt-bv-rvb"/>
+                                                                                                    <constraint firstItem="CCb-vZ-l96" firstAttribute="leading" secondItem="7bA-1U-4oy" secondAttribute="leading" constant="2" id="9FN-Mp-PWo"/>
+                                                                                                    <constraint firstItem="CCb-vZ-l96" firstAttribute="centerX" secondItem="7bA-1U-4oy" secondAttribute="centerX" id="FtS-zV-DsW"/>
+                                                                                                    <constraint firstItem="CCb-vZ-l96" firstAttribute="centerY" secondItem="7bA-1U-4oy" secondAttribute="centerY" id="ZUx-Ce-XBD"/>
                                                                                                 </constraints>
                                                                                                 <connections>
                                                                                                     <outlet property="textField" destination="CCb-vZ-l96" id="BKB-n2-rPJ"/>
@@ -1868,7 +1870,7 @@
                                                                                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="ig9-1H-Wpa">
                                                                                                         <rect key="frame" x="0.0" y="0.0" width="286" height="17"/>
                                                                                                         <constraints>
-                                                                                                            <constraint firstAttribute="height" constant="17" id="jbW-AI-Hij"/>
+                                                                                                            <constraint firstAttribute="height" constant="17" id="mlg-vW-akC"/>
                                                                                                         </constraints>
                                                                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="51L-l6-3vz">
                                                                                                             <font key="font" metaFont="system"/>
@@ -1881,9 +1883,9 @@
                                                                                                     </textField>
                                                                                                 </subviews>
                                                                                                 <constraints>
-                                                                                                    <constraint firstItem="ig9-1H-Wpa" firstAttribute="centerX" secondItem="pG0-Y6-Qgh" secondAttribute="centerX" id="7pK-nH-xdM"/>
-                                                                                                    <constraint firstItem="ig9-1H-Wpa" firstAttribute="leading" secondItem="pG0-Y6-Qgh" secondAttribute="leading" constant="2" id="iy5-YT-1bv"/>
-                                                                                                    <constraint firstItem="ig9-1H-Wpa" firstAttribute="centerY" secondItem="pG0-Y6-Qgh" secondAttribute="centerY" id="wuk-DC-VaS"/>
+                                                                                                    <constraint firstItem="ig9-1H-Wpa" firstAttribute="centerX" secondItem="pG0-Y6-Qgh" secondAttribute="centerX" id="0uX-1k-wPF"/>
+                                                                                                    <constraint firstItem="ig9-1H-Wpa" firstAttribute="centerY" secondItem="pG0-Y6-Qgh" secondAttribute="centerY" id="9ij-Pw-V2f"/>
+                                                                                                    <constraint firstItem="ig9-1H-Wpa" firstAttribute="leading" secondItem="pG0-Y6-Qgh" secondAttribute="leading" constant="2" id="eic-9d-9Mi"/>
                                                                                                 </constraints>
                                                                                                 <connections>
                                                                                                     <outlet property="textField" destination="ig9-1H-Wpa" id="GcF-vc-iAf"/>
@@ -1896,108 +1898,43 @@
                                                                         </subviews>
                                                                     </clipView>
                                                                     <constraints>
-                                                                        <constraint firstAttribute="height" constant="72" id="h9T-Pz-NPG"/>
+                                                                        <constraint firstAttribute="height" constant="75" id="h9T-Pz-NPG"/>
                                                                     </constraints>
-                                                                    <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="ZW0-tb-txz">
+                                                                    <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="ZW0-tb-txz" userLabel="SecondarySub Horizontal Scroller">
                                                                         <rect key="frame" x="0.0" y="56" width="360" height="16"/>
                                                                         <autoresizingMask key="autoresizingMask"/>
                                                                     </scroller>
-                                                                    <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="YIS-JA-mpZ">
+                                                                    <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="YIS-JA-mpZ" userLabel="SecondarySub Vertical Scroller">
                                                                         <rect key="frame" x="-16" y="0.0" width="16" height="0.0"/>
                                                                         <autoresizingMask key="autoresizingMask"/>
                                                                     </scroller>
                                                                 </scrollView>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mYH-DV-e4F" userLabel="Subtitle">
-                                                                    <rect key="frame" x="17" y="378" width="60" height="16"/>
+                                                                    <rect key="frame" x="18" y="368" width="324" height="16"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Subtitle:" id="eXZ-HN-qL4">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3xe-mv-ORw" userLabel="Subtitle">
-                                                                    <rect key="frame" x="17" y="262" width="131" height="16"/>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3xe-mv-ORw" userLabel="Secondary subtitle">
+                                                                    <rect key="frame" x="18" y="249" width="324" height="16"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Secondary subtitle:" id="bKb-pW-HnS">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="M2U-rq-X2L" userLabel="Sub Delay">
-                                                                    <rect key="frame" x="17" y="146" width="123" height="16"/>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="M2U-rq-X2L" userLabel="External subtitles">
+                                                                    <rect key="frame" x="18" y="130" width="324" height="16"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="External subtitles:" id="RA1-fF-OrB">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dXz-x4-sm5">
-                                                                    <rect key="frame" x="18" y="35" width="244" height="20"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="width" constant="240" id="Qpm-gC-Y2e"/>
-                                                                    </constraints>
-                                                                    <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" minValue="-5" maxValue="5" tickMarkPosition="below" numberOfTickMarks="21" sliderType="linear" id="h1D-gP-Dst"/>
-                                                                    <connections>
-                                                                        <action selector="subDelayChangedAction:" target="-2" id="rzg-cd-v6B"/>
-                                                                    </connections>
-                                                                </slider>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VbE-TV-lb5">
-                                                                    <rect key="frame" x="18" y="26" width="20" height="11"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="-5s" id="uCX-EC-jXM">
-                                                                        <font key="font" metaFont="label" size="9"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="r77-VA-Z1b">
-                                                                    <rect key="frame" x="241" y="26" width="21" height="11"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="+5s" id="xfX-wr-DTJ">
-                                                                        <font key="font" metaFont="label" size="9"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VdJ-nq-zaM" userLabel="Speed Slider Indicator">
-                                                                    <rect key="frame" x="130" y="55" width="20" height="13"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="0s" usesSingleLineMode="YES" id="upM-Lz-YwK">
-                                                                        <font key="font" metaFont="system" size="10"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cOv-Yl-KdH">
-                                                                    <rect key="frame" x="17" y="75" width="98" height="16"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Subtitle delay:" id="Wkz-wW-sOM">
-                                                                        <font key="font" metaFont="systemBold"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eOz-bB-vzM" userLabel="Delay">
-                                                                    <rect key="frame" x="276" y="36" width="60" height="21"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="60" id="ptd-kK-aWm"/>
-                                                                    </constraints>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" title="0" drawsBackground="YES" usesSingleLineMode="YES" id="bZu-Wx-06O" customClass="RoundedTextFieldCell" customModule="IINA" customModuleProvider="target">
-                                                                        <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="HxX-is-3eO"/>
-                                                                        <font key="font" metaFont="system"/>
-                                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                    <connections>
-                                                                        <action selector="customSubDelayEditFinishedAction:" target="-2" id="oMk-9O-MYn"/>
-                                                                    </connections>
-                                                                </textField>
-                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kzp-GR-Sy4">
-                                                                    <rect key="frame" x="131" y="26" width="19" height="11"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="0s" id="LEZ-fv-buL">
-                                                                        <font key="font" metaFont="label" size="9"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="zQu-u6-goi">
-                                                                    <rect key="frame" x="17" y="116" width="128" height="24"/>
+                                                                <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="zQu-u6-goi" userLabel="Load Subtitle and Disclosure Triangle">
+                                                                    <rect key="frame" x="17" y="100" width="128" height="24"/>
                                                                     <segmentedCell key="cell" borderStyle="border" alignment="left" style="rounded" trackingMode="momentary" id="AB5-UZ-euc">
                                                                         <font key="font" metaFont="system"/>
                                                                         <segments>
@@ -2011,8 +1948,8 @@
                                                                         <action selector="loadExternalSubAction:" target="-2" id="6k4-nh-xFo"/>
                                                                     </connections>
                                                                 </segmentedControl>
-                                                                <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YIE-pv-gCK">
-                                                                    <rect key="frame" x="147" y="116" width="111" height="24"/>
+                                                                <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YIE-pv-gCK" userLabel="Search Online Segmented Control">
+                                                                    <rect key="frame" x="147" y="100" width="111" height="24"/>
                                                                     <segmentedCell key="cell" borderStyle="border" alignment="left" style="rounded" trackingMode="momentary" id="Rbb-wh-cLc">
                                                                         <font key="font" metaFont="system"/>
                                                                         <segments>
@@ -2023,59 +1960,135 @@
                                                                         <action selector="searchOnlineAction:" target="-2" id="z9B-mh-JoN"/>
                                                                     </connections>
                                                                 </segmentedControl>
+                                                                <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dXz-x4-sm5" userLabel="SubDelay Horizontal Tick Bottom Slider">
+                                                                    <rect key="frame" x="18" y="30" width="244" height="20"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="width" constant="240" id="Qpm-gC-Y2e"/>
+                                                                    </constraints>
+                                                                    <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" minValue="-5" maxValue="5" tickMarkPosition="below" numberOfTickMarks="21" sliderType="linear" id="h1D-gP-Dst"/>
+                                                                    <connections>
+                                                                        <action selector="subDelayChangedAction:" target="-2" id="rzg-cd-v6B"/>
+                                                                    </connections>
+                                                                </slider>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VdJ-nq-zaM" userLabel="SubDelaySliderIndicator">
+                                                                    <rect key="frame" x="128" y="49" width="24" height="13"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="20" id="OZJ-QN-MzG"/>
+                                                                    </constraints>
+                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="0s" usesSingleLineMode="YES" id="upM-Lz-YwK">
+                                                                        <font key="font" metaFont="system" size="10"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cOv-Yl-KdH">
+                                                                    <rect key="frame" x="18" y="66" width="324" height="16"/>
+                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Subtitle delay:" id="Wkz-wW-sOM">
+                                                                        <font key="font" metaFont="systemBold"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VbE-TV-lb5">
+                                                                    <rect key="frame" x="18" y="20" width="20" height="11"/>
+                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="-5s" id="uCX-EC-jXM">
+                                                                        <font key="font" metaFont="label" size="9"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="r77-VA-Z1b">
+                                                                    <rect key="frame" x="241" y="20" width="21" height="11"/>
+                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="+5s" id="xfX-wr-DTJ">
+                                                                        <font key="font" metaFont="label" size="9"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eOz-bB-vzM" userLabel="CustomDelayEdit Text Field">
+                                                                    <rect key="frame" x="268" y="30" width="61" height="21"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="ptd-kK-aWm"/>
+                                                                    </constraints>
+                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" title="0" drawsBackground="YES" usesSingleLineMode="YES" id="bZu-Wx-06O" customClass="RoundedTextFieldCell" customModule="IINA" customModuleProvider="target">
+                                                                        <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="HxX-is-3eO"/>
+                                                                        <font key="font" metaFont="system"/>
+                                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                    <connections>
+                                                                        <action selector="customSubDelayEditFinishedAction:" target="-2" id="oMk-9O-MYn"/>
+                                                                    </connections>
+                                                                </textField>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4U2-kT-76O">
+                                                                    <rect key="frame" x="327" y="33" width="15" height="16"/>
+                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="s" id="bsT-FB-GhF">
+                                                                        <font key="font" metaFont="system"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
+                                                                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kzp-GR-Sy4">
+                                                                    <rect key="frame" x="133" y="20" width="15" height="11"/>
+                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="0s" id="LEZ-fv-buL">
+                                                                        <font key="font" metaFont="label" size="9"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
                                                             </subviews>
                                                             <constraints>
                                                                 <constraint firstAttribute="trailing" secondItem="LMp-7Y-Rxg" secondAttribute="trailing" id="0Gl-lc-Bm7"/>
                                                                 <constraint firstAttribute="trailing" secondItem="1Fq-4o-8Hh" secondAttribute="trailing" id="1hL-1o-nGN"/>
                                                                 <constraint firstItem="zQu-u6-goi" firstAttribute="top" secondItem="M2U-rq-X2L" secondAttribute="bottom" constant="8" id="26L-W9-3iG"/>
                                                                 <constraint firstItem="kzp-GR-Sy4" firstAttribute="centerX" secondItem="dXz-x4-sm5" secondAttribute="centerX" id="33J-Xb-Xbh"/>
-                                                                <constraint firstItem="cOv-Yl-KdH" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="19" id="55g-oO-gXc"/>
-                                                                <constraint firstItem="VdJ-nq-zaM" firstAttribute="centerX" secondItem="dXz-x4-sm5" secondAttribute="leading" constant="120" id="7t1-v0-J55"/>
+                                                                <constraint firstItem="VdJ-nq-zaM" firstAttribute="centerX" secondItem="dXz-x4-sm5" secondAttribute="leading" priority="800" constant="120" id="7t1-v0-J55"/>
                                                                 <constraint firstItem="r77-VA-Z1b" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="kzp-GR-Sy4" secondAttribute="trailing" id="8Vz-fK-wJu"/>
-                                                                <constraint firstItem="kzp-GR-Sy4" firstAttribute="top" secondItem="dXz-x4-sm5" secondAttribute="bottom" id="9mp-6s-MHB"/>
-                                                                <constraint firstItem="dXz-x4-sm5" firstAttribute="top" secondItem="cOv-Yl-KdH" secondAttribute="bottom" constant="22" id="Axq-IW-PvK"/>
-                                                                <constraint firstItem="3xe-mv-ORw" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="19" id="C4V-Gw-CZp"/>
-                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="3xe-mv-ORw" secondAttribute="trailing" constant="35" id="CWa-3H-hWP"/>
-                                                                <constraint firstItem="r77-VA-Z1b" firstAttribute="top" secondItem="dXz-x4-sm5" secondAttribute="bottom" id="Cev-r5-9om"/>
+                                                                <constraint firstItem="kzp-GR-Sy4" firstAttribute="top" secondItem="dXz-x4-sm5" secondAttribute="bottom" constant="1" id="9mp-6s-MHB"/>
+                                                                <constraint firstItem="eOz-bB-vzM" firstAttribute="firstBaseline" secondItem="4U2-kT-76O" secondAttribute="firstBaseline" id="A37-KG-QaU"/>
+                                                                <constraint firstItem="VdJ-nq-zaM" firstAttribute="top" secondItem="cOv-Yl-KdH" secondAttribute="bottom" constant="4" id="Axq-IW-PvK"/>
+                                                                <constraint firstItem="VdJ-nq-zaM" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="dXz-x4-sm5" secondAttribute="leading" id="CCu-4g-OKS"/>
                                                                 <constraint firstItem="YIE-pv-gCK" firstAttribute="leading" secondItem="zQu-u6-goi" secondAttribute="trailing" constant="8" id="DPc-T2-84N"/>
-                                                                <constraint firstAttribute="bottom" secondItem="dXz-x4-sm5" secondAttribute="bottom" constant="37" id="Doh-No-t5F"/>
-                                                                <constraint firstItem="dXz-x4-sm5" firstAttribute="top" secondItem="VdJ-nq-zaM" secondAttribute="bottom" constant="2" id="Fdp-D4-VPU"/>
+                                                                <constraint firstItem="dXz-x4-sm5" firstAttribute="top" secondItem="VdJ-nq-zaM" secondAttribute="bottom" constant="1" id="Fdp-D4-VPU"/>
                                                                 <constraint firstItem="3xe-mv-ORw" firstAttribute="top" secondItem="1Fq-4o-8Hh" secondAttribute="bottom" constant="20" id="I4y-iB-fWM"/>
                                                                 <constraint firstItem="mYH-DV-e4F" firstAttribute="top" secondItem="Wuf-PX-OYd" secondAttribute="top" constant="20" id="Izb-ki-XeU"/>
-                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="M2U-rq-X2L" secondAttribute="trailing" id="LH3-mi-eMt"/>
-                                                                <constraint firstItem="eOz-bB-vzM" firstAttribute="leading" secondItem="dXz-x4-sm5" secondAttribute="trailing" constant="16" id="LTf-pu-8fz"/>
+                                                                <constraint firstItem="eOz-bB-vzM" firstAttribute="leading" secondItem="dXz-x4-sm5" secondAttribute="trailing" constant="8" id="LTf-pu-8fz"/>
                                                                 <constraint firstItem="LMp-7Y-Rxg" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" id="O1s-aJ-7eK"/>
-                                                                <constraint firstItem="mYH-DV-e4F" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="19" id="O5J-FT-DtN"/>
                                                                 <constraint firstItem="VbE-TV-lb5" firstAttribute="leading" secondItem="dXz-x4-sm5" secondAttribute="leading" id="Q0F-ty-AhB"/>
-                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="cOv-Yl-KdH" secondAttribute="trailing" constant="35" id="SRy-t5-N0K"/>
-                                                                <constraint firstAttribute="trailing" secondItem="eOz-bB-vzM" secondAttribute="trailing" constant="24" id="VGX-aQ-yaY"/>
+                                                                <constraint firstAttribute="bottom" secondItem="kzp-GR-Sy4" secondAttribute="bottom" constant="20" id="Thn-5Q-9b9"/>
                                                                 <constraint firstItem="M2U-rq-X2L" firstAttribute="top" secondItem="LMp-7Y-Rxg" secondAttribute="bottom" constant="20" id="Y58-bK-q43"/>
+                                                                <constraint firstItem="kzp-GR-Sy4" firstAttribute="firstBaseline" secondItem="VbE-TV-lb5" secondAttribute="firstBaseline" id="ZeT-rD-nRd"/>
                                                                 <constraint firstItem="1Fq-4o-8Hh" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" id="eCR-6x-gEL"/>
+                                                                <constraint firstItem="r77-VA-Z1b" firstAttribute="firstBaseline" secondItem="VbE-TV-lb5" secondAttribute="firstBaseline" id="fRc-yO-K49"/>
                                                                 <constraint firstItem="1Fq-4o-8Hh" firstAttribute="top" secondItem="mYH-DV-e4F" secondAttribute="bottom" constant="8" id="hl3-X4-nod"/>
-                                                                <constraint firstItem="cOv-Yl-KdH" firstAttribute="top" secondItem="zQu-u6-goi" secondAttribute="bottom" constant="27" id="jYB-bh-14P"/>
+                                                                <constraint firstItem="cOv-Yl-KdH" firstAttribute="top" secondItem="zQu-u6-goi" secondAttribute="bottom" constant="20" id="jYB-bh-14P"/>
                                                                 <constraint firstItem="r77-VA-Z1b" firstAttribute="trailing" secondItem="dXz-x4-sm5" secondAttribute="trailing" id="kSN-80-IMR"/>
-                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="mYH-DV-e4F" secondAttribute="trailing" constant="35" id="kUD-ee-efc"/>
                                                                 <constraint firstItem="YIE-pv-gCK" firstAttribute="centerY" secondItem="zQu-u6-goi" secondAttribute="centerY" id="lUf-kQ-zMz"/>
                                                                 <constraint firstItem="kzp-GR-Sy4" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="VbE-TV-lb5" secondAttribute="trailing" id="llG-p4-ckS"/>
-                                                                <constraint firstItem="VbE-TV-lb5" firstAttribute="top" secondItem="dXz-x4-sm5" secondAttribute="bottom" id="nBf-Bg-Rdb"/>
-                                                                <constraint firstItem="zQu-u6-goi" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="20" id="oAh-Z4-paB"/>
-                                                                <constraint firstItem="eOz-bB-vzM" firstAttribute="centerY" secondItem="dXz-x4-sm5" secondAttribute="centerY" constant="-1" id="rgl-9k-oY7"/>
-                                                                <constraint firstItem="dXz-x4-sm5" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="20" id="t39-NF-kSH"/>
+                                                                <constraint firstItem="eOz-bB-vzM" firstAttribute="centerY" secondItem="dXz-x4-sm5" secondAttribute="centerY" id="rgl-9k-oY7"/>
+                                                                <constraint firstItem="4U2-kT-76O" firstAttribute="leading" secondItem="eOz-bB-vzM" secondAttribute="trailing" id="rnJ-T0-g1e"/>
                                                                 <constraint firstItem="LMp-7Y-Rxg" firstAttribute="top" secondItem="3xe-mv-ORw" secondAttribute="bottom" constant="8" id="uj7-Lc-oLk"/>
-                                                                <constraint firstItem="M2U-rq-X2L" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="19" id="vM3-dy-eKG"/>
                                                             </constraints>
                                                         </customView>
                                                         <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="jRc-VZ-Vv2">
-                                                            <rect key="frame" x="0.0" y="416" width="360" height="5"/>
+                                                            <rect key="frame" x="0.0" y="423" width="360" height="5"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" constant="1" id="W2h-DQ-cHB"/>
                                                             </constraints>
                                                         </box>
-                                                        <customView wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gSw-NK-ZU6" userLabel="Sub Style">
-                                                            <rect key="frame" x="0.0" y="0.0" width="360" height="418"/>
+                                                        <customView wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gSw-NK-ZU6" userLabel="SubStyleSection Container View">
+                                                            <rect key="frame" x="0.0" y="0.0" width="360" height="425"/>
                                                             <subviews>
+                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lkf-Yn-nsR" userLabel="Subtitle style options disclaimer">
+                                                                    <rect key="frame" x="18" y="377" width="324" height="28"/>
+                                                                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Subtitle style options may break ASS rendering, and some of them will be disabled depending on subtitle type." id="wBD-pZ-Bvu">
+                                                                        <font key="font" metaFont="message" size="11"/>
+                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                </textField>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9xm-5m-Q7G">
-                                                                    <rect key="frame" x="17" y="337" width="305" height="16"/>
+                                                                    <rect key="frame" x="18" y="341" width="324" height="16"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Scale:" id="Wbx-Ti-qiS">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -2083,33 +2096,25 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="B8f-KH-BaO">
-                                                                    <rect key="frame" x="18" y="303" width="324" height="28"/>
+                                                                    <rect key="frame" x="18" y="307" width="324" height="28"/>
                                                                     <sliderCell key="cell" continuous="YES" alignment="left" minValue="-5" maxValue="5" tickMarkPosition="above" sliderType="linear" id="Qpw-NH-Unh"/>
                                                                     <connections>
                                                                         <action selector="subScaleSliderAction:" target="-2" id="zEB-hd-cz8"/>
                                                                     </connections>
                                                                 </slider>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ipr-WR-eax">
-                                                                    <rect key="frame" x="17" y="215" width="310" height="16"/>
+                                                                    <rect key="frame" x="18" y="213" width="324" height="16"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Text Style:" id="ZBd-13-lA1">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
-                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lkf-Yn-nsR">
-                                                                    <rect key="frame" x="18" y="370" width="324" height="28"/>
-                                                                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Subtitle style options may break ASS rendering, and some of them will be disabled depending on subtitle type." id="wBD-pZ-Bvu">
-                                                                        <font key="font" metaFont="message" size="11"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
                                                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="XwE-7y-DXJ" customClass="SettingsListCellView" customModule="IINA" customModuleProvider="target">
-                                                                    <rect key="frame" x="0.0" y="24" width="360" height="183"/>
+                                                                    <rect key="frame" x="20" y="20" width="320" height="185"/>
                                                                     <subviews>
                                                                         <colorWell translatesAutoresizingMaskIntoConstraints="NO" id="9mo-uL-hfC" customClass="RoundedColorWell" customModule="IINA" customModuleProvider="target">
-                                                                            <rect key="frame" x="60" y="120" width="23" height="23"/>
+                                                                            <rect key="frame" x="57" y="120" width="29" height="27"/>
                                                                             <constraints>
                                                                                 <constraint firstAttribute="height" constant="23" id="Rgf-Cu-gr0"/>
                                                                                 <constraint firstAttribute="width" constant="23" id="tlC-zK-dZi"/>
@@ -2120,7 +2125,7 @@
                                                                             </connections>
                                                                         </colorWell>
                                                                         <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xtF-tn-m9W" userLabel="Text font size">
-                                                                            <rect key="frame" x="141" y="119" width="78" height="22"/>
+                                                                            <rect key="frame" x="130" y="121" width="78" height="22"/>
                                                                             <constraints>
                                                                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="70" id="d7u-5q-vDg"/>
                                                                             </constraints>
@@ -2146,7 +2151,7 @@
                                                                             </connections>
                                                                         </popUpButton>
                                                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jj7-9J-PmG">
-                                                                            <rect key="frame" x="18" y="124" width="36" height="14"/>
+                                                                            <rect key="frame" x="18" y="126" width="36" height="14"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Color:" id="6LO-6y-IsA">
                                                                                 <font key="font" metaFont="message" size="11"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -2154,7 +2159,7 @@
                                                                             </textFieldCell>
                                                                         </textField>
                                                                         <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vLY-cB-GEf">
-                                                                            <rect key="frame" x="89" y="124" width="50" height="14"/>
+                                                                            <rect key="frame" x="89" y="126" width="39" height="14"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Size:" id="s9l-Hb-SCk">
                                                                                 <font key="font" metaFont="message" size="11"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -2162,7 +2167,7 @@
                                                                             </textFieldCell>
                                                                         </textField>
                                                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xdm-hT-rQs">
-                                                                            <rect key="frame" x="18" y="97" width="324" height="14"/>
+                                                                            <rect key="frame" x="18" y="99" width="284" height="14"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="BORDER" id="GlZ-YU-dNm">
                                                                                 <font key="font" metaFont="smallSystemBold"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -2170,7 +2175,7 @@
                                                                             </textFieldCell>
                                                                         </textField>
                                                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BcK-R6-e8c">
-                                                                            <rect key="frame" x="18" y="72" width="36" height="14"/>
+                                                                            <rect key="frame" x="18" y="74" width="36" height="14"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Color:" id="ANn-CR-JOV">
                                                                                 <font key="font" metaFont="message" size="11"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -2178,7 +2183,7 @@
                                                                             </textFieldCell>
                                                                         </textField>
                                                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kaq-YT-MxI">
-                                                                            <rect key="frame" x="18" y="20" width="36" height="14"/>
+                                                                            <rect key="frame" x="18" y="22" width="36" height="14"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Color:" id="3kI-6i-ujt">
                                                                                 <font key="font" metaFont="message" size="11"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -2186,7 +2191,7 @@
                                                                             </textFieldCell>
                                                                         </textField>
                                                                         <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7Lw-84-lts">
-                                                                            <rect key="frame" x="89" y="72" width="50" height="14"/>
+                                                                            <rect key="frame" x="89" y="74" width="39" height="14"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Width:" id="22j-ra-GAY">
                                                                                 <font key="font" metaFont="message" size="11"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -2194,7 +2199,7 @@
                                                                             </textFieldCell>
                                                                         </textField>
                                                                         <colorWell translatesAutoresizingMaskIntoConstraints="NO" id="U2e-zB-Kue" customClass="RoundedColorWell" customModule="IINA" customModuleProvider="target">
-                                                                            <rect key="frame" x="60" y="68" width="23" height="23"/>
+                                                                            <rect key="frame" x="57" y="68" width="29" height="27"/>
                                                                             <constraints>
                                                                                 <constraint firstAttribute="height" constant="23" id="OaA-1O-DoB"/>
                                                                                 <constraint firstAttribute="width" constant="23" id="kwW-fi-4RZ"/>
@@ -2205,7 +2210,7 @@
                                                                             </connections>
                                                                         </colorWell>
                                                                         <colorWell translatesAutoresizingMaskIntoConstraints="NO" id="Ure-tT-JEy" customClass="RoundedColorWell" customModule="IINA" customModuleProvider="target">
-                                                                            <rect key="frame" x="60" y="16" width="23" height="23"/>
+                                                                            <rect key="frame" x="57" y="16" width="29" height="27"/>
                                                                             <constraints>
                                                                                 <constraint firstAttribute="height" constant="23" id="Ivi-Q0-PSs"/>
                                                                                 <constraint firstAttribute="width" constant="23" id="qQW-fy-gq5"/>
@@ -2216,7 +2221,7 @@
                                                                             </connections>
                                                                         </colorWell>
                                                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WJ6-Fb-q7a">
-                                                                            <rect key="frame" x="18" y="45" width="324" height="14"/>
+                                                                            <rect key="frame" x="18" y="47" width="284" height="14"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="BACKGROUND" id="uqb-mz-A22">
                                                                                 <font key="font" metaFont="smallSystemBold"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -2224,7 +2229,7 @@
                                                                             </textFieldCell>
                                                                         </textField>
                                                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jTT-rB-qLu">
-                                                                            <rect key="frame" x="18" y="149" width="324" height="14"/>
+                                                                            <rect key="frame" x="18" y="151" width="284" height="14"/>
                                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="FONT" id="g6B-DC-lJ0">
                                                                                 <font key="font" metaFont="smallSystemBold"/>
                                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -2232,7 +2237,7 @@
                                                                             </textFieldCell>
                                                                         </textField>
                                                                         <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bkX-rt-2bg" userLabel="Text Border Width">
-                                                                            <rect key="frame" x="141" y="67" width="79" height="22"/>
+                                                                            <rect key="frame" x="130" y="69" width="79" height="22"/>
                                                                             <constraints>
                                                                                 <constraint firstAttribute="width" constant="71" id="Udn-GZ-bGb"/>
                                                                             </constraints>
@@ -2259,7 +2264,7 @@
                                                                             </connections>
                                                                         </popUpButton>
                                                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qGz-rB-dsV">
-                                                                            <rect key="frame" x="250" y="116" width="76" height="27"/>
+                                                                            <rect key="frame" x="210" y="118" width="76" height="27"/>
                                                                             <constraints>
                                                                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="64" id="0zp-I9-Wwd"/>
                                                                             </constraints>
@@ -2281,7 +2286,7 @@
                                                                         <constraint firstItem="kaq-YT-MxI" firstAttribute="leading" secondItem="XwE-7y-DXJ" secondAttribute="leading" constant="20" id="Cm8-rC-nJU"/>
                                                                         <constraint firstAttribute="trailing" secondItem="jTT-rB-qLu" secondAttribute="trailing" constant="20" id="Cqc-Gb-Hn7"/>
                                                                         <constraint firstItem="bkX-rt-2bg" firstAttribute="baseline" secondItem="7Lw-84-lts" secondAttribute="baseline" id="DIl-FT-DyT"/>
-                                                                        <constraint firstAttribute="trailing" secondItem="qGz-rB-dsV" secondAttribute="trailing" constant="40" id="GuX-Wj-2jB"/>
+                                                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="qGz-rB-dsV" secondAttribute="trailing" constant="40" id="GuX-Wj-2jB"/>
                                                                         <constraint firstItem="WJ6-Fb-q7a" firstAttribute="top" secondItem="BcK-R6-e8c" secondAttribute="bottom" constant="13" id="Lwt-sS-fwH"/>
                                                                         <constraint firstItem="bkX-rt-2bg" firstAttribute="centerX" relation="greaterThanOrEqual" secondItem="XwE-7y-DXJ" secondAttribute="centerX" id="PIR-lu-2WE"/>
                                                                         <constraint firstItem="vLY-cB-GEf" firstAttribute="baseline" secondItem="jj7-9J-PmG" secondAttribute="baseline" id="PjW-fj-Uwz"/>
@@ -2289,7 +2294,7 @@
                                                                         <constraint firstAttribute="trailing" secondItem="xdm-hT-rQs" secondAttribute="trailing" constant="20" id="XAQ-zm-z3h"/>
                                                                         <constraint firstItem="jj7-9J-PmG" firstAttribute="leading" secondItem="XwE-7y-DXJ" secondAttribute="leading" constant="20" id="XYt-Vf-50K"/>
                                                                         <constraint firstItem="9mo-uL-hfC" firstAttribute="centerY" secondItem="jj7-9J-PmG" secondAttribute="centerY" id="YW2-hi-tRk"/>
-                                                                        <constraint firstItem="vLY-cB-GEf" firstAttribute="leading" secondItem="9mo-uL-hfC" secondAttribute="trailing" constant="8" id="YXX-5O-ooR"/>
+                                                                        <constraint firstItem="vLY-cB-GEf" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="9mo-uL-hfC" secondAttribute="trailing" constant="8" id="YXX-5O-ooR"/>
                                                                         <constraint firstAttribute="trailing" secondItem="WJ6-Fb-q7a" secondAttribute="trailing" constant="20" id="bHB-uf-Gw7"/>
                                                                         <constraint firstItem="xtF-tn-m9W" firstAttribute="leading" secondItem="vLY-cB-GEf" secondAttribute="trailing" constant="8" id="cCg-0c-LMp"/>
                                                                         <constraint firstItem="7Lw-84-lts" firstAttribute="leading" secondItem="U2e-zB-Kue" secondAttribute="trailing" constant="8" id="cu6-gj-FrG"/>
@@ -2300,8 +2305,8 @@
                                                                         <constraint firstItem="jj7-9J-PmG" firstAttribute="top" secondItem="jTT-rB-qLu" secondAttribute="bottom" constant="11" id="j3Z-Tc-teg"/>
                                                                         <constraint firstItem="jTT-rB-qLu" firstAttribute="top" secondItem="XwE-7y-DXJ" secondAttribute="top" constant="20" id="kIM-1C-00c"/>
                                                                         <constraint firstItem="7Lw-84-lts" firstAttribute="baseline" secondItem="BcK-R6-e8c" secondAttribute="baseline" id="kSf-Xa-B8J"/>
-                                                                        <constraint firstItem="qGz-rB-dsV" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="xtF-tn-m9W" secondAttribute="trailing" constant="8" id="oXK-RG-DYm"/>
-                                                                        <constraint firstAttribute="bottom" secondItem="kaq-YT-MxI" secondAttribute="bottom" constant="20" id="pzz-xW-JOD"/>
+                                                                        <constraint firstAttribute="bottom" secondItem="Ure-tT-JEy" secondAttribute="bottom" constant="18" id="oHe-yR-56i"/>
+                                                                        <constraint firstItem="qGz-rB-dsV" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="xtF-tn-m9W" secondAttribute="trailing" constant="12" id="oXK-RG-DYm"/>
                                                                         <constraint firstItem="Ure-tT-JEy" firstAttribute="leading" secondItem="kaq-YT-MxI" secondAttribute="trailing" constant="8" id="qnE-hM-7aL"/>
                                                                         <constraint firstItem="jTT-rB-qLu" firstAttribute="leading" secondItem="XwE-7y-DXJ" secondAttribute="leading" constant="20" id="qs9-eC-h1L"/>
                                                                         <constraint firstItem="xtF-tn-m9W" firstAttribute="baseline" secondItem="vLY-cB-GEf" secondAttribute="baseline" id="tJv-0k-NF2"/>
@@ -2312,7 +2317,7 @@
                                                                     </constraints>
                                                                 </customView>
                                                                 <button translatesAutoresizingMaskIntoConstraints="NO" id="8ZC-Wx-nt7">
-                                                                    <rect key="frame" x="324" y="334" width="16" height="21"/>
+                                                                    <rect key="frame" x="324" y="338.5" width="16" height="21"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="height" constant="16" id="GIz-PJ-9SR"/>
                                                                         <constraint firstAttribute="width" constant="16" id="HE1-PU-O12"/>
@@ -2326,7 +2331,7 @@
                                                                     </connections>
                                                                 </button>
                                                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OEX-Gn-xCa">
-                                                                    <rect key="frame" x="17" y="276" width="61" height="16"/>
+                                                                    <rect key="frame" x="18" y="277" width="324" height="16"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Position:" id="t03-36-Zge">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -2334,7 +2339,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lzW-d6-Asr">
-                                                                    <rect key="frame" x="18" y="242" width="324" height="28"/>
+                                                                    <rect key="frame" x="18" y="243" width="324" height="28"/>
                                                                     <sliderCell key="cell" continuous="YES" alignment="left" maxValue="100" tickMarkPosition="above" sliderType="linear" id="fZU-F1-3pO"/>
                                                                     <connections>
                                                                         <action selector="subPosSliderAction:" target="-2" id="Top-XW-i2A"/>
@@ -2342,44 +2347,59 @@
                                                                 </slider>
                                                             </subviews>
                                                             <constraints>
-                                                                <constraint firstItem="ipr-WR-eax" firstAttribute="leading" secondItem="gSw-NK-ZU6" secondAttribute="leading" constant="19" id="6Qf-qa-Ysv"/>
                                                                 <constraint firstItem="XwE-7y-DXJ" firstAttribute="top" secondItem="ipr-WR-eax" secondAttribute="bottom" constant="8" id="6Vb-CZ-GSt"/>
                                                                 <constraint firstItem="B8f-KH-BaO" firstAttribute="top" secondItem="8ZC-Wx-nt7" secondAttribute="bottom" constant="8" id="75S-2r-O03"/>
-                                                                <constraint firstAttribute="trailing" secondItem="8ZC-Wx-nt7" secondAttribute="trailing" constant="20" id="9c1-cn-GKO"/>
-                                                                <constraint firstItem="B8f-KH-BaO" firstAttribute="leading" secondItem="gSw-NK-ZU6" secondAttribute="leading" constant="20" id="G3N-KD-dhF"/>
-                                                                <constraint firstItem="ipr-WR-eax" firstAttribute="top" secondItem="lzW-d6-Asr" secondAttribute="bottom" constant="17" id="GBD-Yz-zZx"/>
-                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="OEX-Gn-xCa" secondAttribute="trailing" id="Gf4-uU-mKg"/>
-                                                                <constraint firstAttribute="trailing" secondItem="B8f-KH-BaO" secondAttribute="trailing" constant="20" id="Gha-iE-oGu"/>
-                                                                <constraint firstItem="Lkf-Yn-nsR" firstAttribute="leading" secondItem="gSw-NK-ZU6" secondAttribute="leading" constant="20" id="Ilc-HK-W4o"/>
-                                                                <constraint firstAttribute="trailing" secondItem="XwE-7y-DXJ" secondAttribute="trailing" id="J4W-zE-0MD"/>
-                                                                <constraint firstAttribute="trailing" secondItem="lzW-d6-Asr" secondAttribute="trailing" constant="20" id="M0t-y3-cDb"/>
-                                                                <constraint firstItem="lzW-d6-Asr" firstAttribute="leading" secondItem="gSw-NK-ZU6" secondAttribute="leading" constant="20" id="PFe-21-jCz"/>
-                                                                <constraint firstAttribute="trailing" secondItem="Lkf-Yn-nsR" secondAttribute="trailing" constant="20" id="Y6M-bh-B8P"/>
-                                                                <constraint firstItem="9xm-5m-Q7G" firstAttribute="leading" secondItem="gSw-NK-ZU6" secondAttribute="leading" constant="19" id="aHP-HN-SEj"/>
+                                                                <constraint firstItem="ipr-WR-eax" firstAttribute="top" secondItem="lzW-d6-Asr" secondAttribute="bottom" constant="20" id="GBD-Yz-zZx"/>
                                                                 <constraint firstItem="Lkf-Yn-nsR" firstAttribute="top" secondItem="gSw-NK-ZU6" secondAttribute="top" constant="20" id="atW-bb-cRk"/>
-                                                                <constraint firstItem="9xm-5m-Q7G" firstAttribute="top" secondItem="Lkf-Yn-nsR" secondAttribute="bottom" constant="17" id="bXP-av-Tgw"/>
-                                                                <constraint firstItem="XwE-7y-DXJ" firstAttribute="leading" secondItem="gSw-NK-ZU6" secondAttribute="leading" id="d2Y-xa-MBE"/>
-                                                                <constraint firstItem="OEX-Gn-xCa" firstAttribute="leading" secondItem="gSw-NK-ZU6" secondAttribute="leading" constant="19" id="gHR-MZ-XrC"/>
-                                                                <constraint firstAttribute="bottom" secondItem="XwE-7y-DXJ" secondAttribute="bottom" constant="24" id="jg3-w0-k4p"/>
+                                                                <constraint firstItem="9xm-5m-Q7G" firstAttribute="top" secondItem="Lkf-Yn-nsR" secondAttribute="bottom" constant="20" id="bXP-av-Tgw"/>
+                                                                <constraint firstAttribute="bottom" secondItem="XwE-7y-DXJ" secondAttribute="bottom" constant="20" id="jg3-w0-k4p"/>
                                                                 <constraint firstItem="8ZC-Wx-nt7" firstAttribute="centerY" secondItem="9xm-5m-Q7G" secondAttribute="centerY" id="mON-va-vGN"/>
-                                                                <constraint firstItem="OEX-Gn-xCa" firstAttribute="top" secondItem="B8f-KH-BaO" secondAttribute="bottom" constant="17" id="rNb-Fl-dTS"/>
+                                                                <constraint firstItem="OEX-Gn-xCa" firstAttribute="top" secondItem="B8f-KH-BaO" secondAttribute="bottom" constant="20" id="rNb-Fl-dTS"/>
                                                                 <constraint firstItem="lzW-d6-Asr" firstAttribute="top" secondItem="OEX-Gn-xCa" secondAttribute="bottom" constant="8" id="vn4-wP-Oee"/>
-                                                                <constraint firstAttribute="trailing" secondItem="ipr-WR-eax" secondAttribute="trailing" constant="35" id="vrO-Og-xsG"/>
-                                                                <constraint firstAttribute="trailing" secondItem="9xm-5m-Q7G" secondAttribute="trailing" constant="40" id="xB9-cG-jXW"/>
                                                             </constraints>
                                                         </customView>
                                                     </subviews>
                                                     <constraints>
+                                                        <constraint firstItem="zQu-u6-goi" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="1jU-tm-xfg"/>
                                                         <constraint firstItem="gSw-NK-ZU6" firstAttribute="leading" secondItem="pm4-x9-WJ5" secondAttribute="leading" id="3Q8-0S-K6q"/>
+                                                        <constraint firstItem="XwE-7y-DXJ" firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="9Nv-Nz-hxZ"/>
+                                                        <constraint firstItem="lzW-d6-Asr" firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="9Pl-tW-Dag"/>
                                                         <constraint firstItem="gSw-NK-ZU6" firstAttribute="top" secondItem="jRc-VZ-Vv2" secondAttribute="bottom" id="AKd-3V-cnm"/>
                                                         <constraint firstItem="Wuf-PX-OYd" firstAttribute="top" secondItem="pm4-x9-WJ5" secondAttribute="top" id="Asb-va-Eiv"/>
+                                                        <constraint firstItem="PJb-5N-8QM" firstAttribute="leading" secondItem="pm4-x9-WJ5" secondAttribute="leading" constant="20" id="BQV-10-Aft"/>
                                                         <constraint firstAttribute="trailing" secondItem="jRc-VZ-Vv2" secondAttribute="trailing" id="Bgp-ag-XCb"/>
+                                                        <constraint firstItem="XwE-7y-DXJ" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="E6E-nw-l3T"/>
+                                                        <constraint firstItem="3xe-mv-ORw" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="EM8-9Q-Yhw"/>
+                                                        <constraint firstItem="Lkf-Yn-nsR" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="FiQ-Xm-8Ps"/>
+                                                        <constraint firstItem="B8f-KH-BaO" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="FlI-9X-O0V"/>
+                                                        <constraint firstItem="M2U-rq-X2L" firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="H2R-H8-0CG"/>
+                                                        <constraint firstItem="lzW-d6-Asr" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="HCm-yU-vu2"/>
                                                         <constraint firstItem="Wuf-PX-OYd" firstAttribute="leading" secondItem="pm4-x9-WJ5" secondAttribute="leading" id="Hee-mM-GuU"/>
+                                                        <constraint firstItem="mYH-DV-e4F" firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="Iqu-ZF-4f5"/>
                                                         <constraint firstAttribute="bottom" secondItem="gSw-NK-ZU6" secondAttribute="bottom" id="Jmq-0f-8aF"/>
                                                         <constraint firstAttribute="trailing" secondItem="gSw-NK-ZU6" secondAttribute="trailing" id="K60-XN-ktT"/>
+                                                        <constraint firstItem="9xm-5m-Q7G" firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="Kib-uN-23k"/>
                                                         <constraint firstAttribute="trailing" secondItem="Wuf-PX-OYd" secondAttribute="trailing" id="NTd-uf-my8"/>
-                                                        <constraint firstItem="gSw-NK-ZU6" firstAttribute="top" secondItem="Wuf-PX-OYd" secondAttribute="bottom" id="V0h-N7-rhG"/>
+                                                        <constraint firstItem="ipr-WR-eax" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="STy-a7-NgJ"/>
+                                                        <constraint firstItem="YIE-pv-gCK" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="SXw-h1-5CU"/>
+                                                        <constraint firstItem="4U2-kT-76O" firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="Ve3-JU-eQO"/>
+                                                        <constraint firstItem="3xe-mv-ORw" firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="WC8-9a-fa5"/>
                                                         <constraint firstItem="jRc-VZ-Vv2" firstAttribute="leading" secondItem="pm4-x9-WJ5" secondAttribute="leading" id="XLU-g4-EAb"/>
+                                                        <constraint firstItem="mYH-DV-e4F" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="aMT-hN-hi6"/>
+                                                        <constraint firstItem="dXz-x4-sm5" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="ant-fM-6lp"/>
+                                                        <constraint firstItem="8ZC-Wx-nt7" firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="bzu-IK-uIu"/>
+                                                        <constraint firstItem="M2U-rq-X2L" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="cph-Mm-h9J"/>
+                                                        <constraint firstItem="cOv-Yl-KdH" firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="fPr-gV-64i"/>
+                                                        <constraint firstItem="OEX-Gn-xCa" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="gAG-3A-N0t"/>
+                                                        <constraint firstItem="B8f-KH-BaO" firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="ktB-Vi-i3u"/>
+                                                        <constraint firstItem="OEX-Gn-xCa" firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="lWH-MN-mSd"/>
+                                                        <constraint firstItem="PJb-5N-8QM" firstAttribute="top" secondItem="pm4-x9-WJ5" secondAttribute="top" id="m2Z-kA-64n"/>
+                                                        <constraint firstItem="jRc-VZ-Vv2" firstAttribute="top" secondItem="Wuf-PX-OYd" secondAttribute="bottom" id="mkT-Pq-Q4q"/>
+                                                        <constraint firstItem="9xm-5m-Q7G" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="nAx-en-C96"/>
+                                                        <constraint firstItem="Lkf-Yn-nsR" firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="nfu-St-QoC"/>
+                                                        <constraint firstItem="ipr-WR-eax" firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="pCo-Sx-uL5"/>
+                                                        <constraint firstItem="cOv-Yl-KdH" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="w4n-62-Th7"/>
+                                                        <constraint firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" constant="20" id="wXW-Nt-gpv"/>
                                                     </constraints>
                                                 </customView>
                                             </subviews>
@@ -2394,8 +2414,8 @@
                                             <rect key="frame" x="-100" y="-100" width="360" height="16"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
-                                        <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="0.19999999999999996" horizontal="NO" id="3ZS-ug-kkq">
-                                            <rect key="frame" x="344" y="0.0" width="16" height="787"/>
+                                        <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="3ZS-ug-kkq">
+                                            <rect key="frame" x="360" y="0.0" width="15" height="827"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                     </scrollView>
@@ -2408,13 +2428,13 @@
                                 </constraints>
                             </view>
                         </tabViewItem>
-                        <tabViewItem label="Plugin" identifier="" id="eE3-9i-hpU">
+                        <tabViewItem label="Plugin" identifier="" id="eE3-9i-hpU" userLabel="PluginTab Tab View Item">
                             <view key="view" id="rcL-IN-kt1">
-                                <rect key="frame" x="0.0" y="0.0" width="360" height="787"/>
+                                <rect key="frame" x="0.0" y="0.0" width="360" height="738"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="GeS-T1-vtB">
-                                        <rect key="frame" x="0.0" y="0.0" width="360" height="787"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="360" height="738"/>
                                     </customView>
                                 </subviews>
                                 <constraints>
@@ -2429,22 +2449,22 @@
                 </tabView>
             </subviews>
             <constraints>
-                <constraint firstItem="dNi-Ib-2vd" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="DJ3-t6-bea"/>
-                <constraint firstAttribute="trailing" secondItem="udA-m2-eJb" secondAttribute="trailing" id="De7-9o-KKe"/>
-                <constraint firstAttribute="trailing" secondItem="iNg-R1-bXw" secondAttribute="trailing" id="Dhv-PU-QtB"/>
-                <constraint firstItem="iNg-R1-bXw" firstAttribute="top" secondItem="dNi-Ib-2vd" secondAttribute="bottom" id="KoD-6G-Glt"/>
-                <constraint firstAttribute="width" constant="360" id="L4m-6z-09b"/>
-                <constraint firstAttribute="bottom" secondItem="udA-m2-eJb" secondAttribute="bottom" id="SOP-Fn-kKf"/>
-                <constraint firstItem="udA-m2-eJb" firstAttribute="top" secondItem="iNg-R1-bXw" secondAttribute="bottom" id="WKF-bw-yv1"/>
-                <constraint firstAttribute="trailing" secondItem="dNi-Ib-2vd" secondAttribute="trailing" id="ahR-QL-lPo"/>
-                <constraint firstItem="dNi-Ib-2vd" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="fh9-0T-pEX"/>
-                <constraint firstAttribute="trailing" secondItem="L78-cf-BxB" secondAttribute="trailing" id="kAA-wl-rsA"/>
-                <constraint firstItem="L78-cf-BxB" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="kgD-50-iI3"/>
-                <constraint firstItem="iNg-R1-bXw" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="o95-KY-Xuz"/>
-                <constraint firstItem="L78-cf-BxB" firstAttribute="top" secondItem="dNi-Ib-2vd" secondAttribute="bottom" id="rjI-Pa-q5L"/>
-                <constraint firstItem="udA-m2-eJb" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="tyn-5q-xAw"/>
+                <constraint firstItem="L78-cf-BxB" firstAttribute="trailing" secondItem="Hz6-mo-xeY" secondAttribute="trailing" id="55S-FG-sbw"/>
+                <constraint firstItem="iNg-R1-bXw" firstAttribute="top" secondItem="L78-cf-BxB" secondAttribute="bottom" id="6FU-jB-tn5"/>
+                <constraint firstAttribute="trailing" secondItem="dNi-Ib-2vd" secondAttribute="trailing" constant="20" id="Ul3-qM-JEr"/>
+                <constraint firstItem="L78-cf-BxB" firstAttribute="top" secondItem="dNi-Ib-2vd" secondAttribute="bottom" id="VjD-2S-qZr"/>
+                <constraint firstItem="udA-m2-eJb" firstAttribute="trailing" secondItem="iNg-R1-bXw" secondAttribute="trailing" id="Z18-rW-4G3"/>
+                <constraint firstItem="udA-m2-eJb" firstAttribute="leading" secondItem="iNg-R1-bXw" secondAttribute="leading" id="aAs-ug-WAK"/>
+                <constraint firstItem="dNi-Ib-2vd" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="20" id="aDg-IN-ivk"/>
+                <constraint firstItem="udA-m2-eJb" firstAttribute="top" secondItem="iNg-R1-bXw" secondAttribute="bottom" id="cJX-tf-pDr"/>
+                <constraint firstAttribute="bottom" secondItem="udA-m2-eJb" secondAttribute="bottom" id="grA-dL-eg4"/>
+                <constraint firstAttribute="trailing" secondItem="iNg-R1-bXw" secondAttribute="trailing" id="im6-JF-oJl"/>
+                <constraint firstItem="iNg-R1-bXw" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="j0a-1p-fwe"/>
+                <constraint firstItem="dNi-Ib-2vd" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="qd3-0i-qbr"/>
+                <constraint firstItem="L78-cf-BxB" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="tzm-Ub-xUS"/>
+                <constraint firstAttribute="width" constant="360" id="wbT-t0-p1J"/>
             </constraints>
-            <point key="canvasLocation" x="102" y="441.5"/>
+            <point key="canvasLocation" x="101" y="441.5"/>
         </customView>
         <customObject id="15X-3x-QZ1" customClass="NSFontManager"/>
         <viewController id="KVt-CA-hSE" userLabel="Popover View Controller"/>
@@ -2454,14 +2474,9 @@
             </connections>
         </popover>
         <userDefaultsController representsSharedInstance="YES" id="CE5-Ex-Oo6"/>
-        <box verticalHuggingPriority="750" boxType="separator" id="acz-Vd-7LD">
-            <rect key="frame" x="0.0" y="0.0" width="96" height="5"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-            <point key="canvasLocation" x="-33" y="-38"/>
-        </box>
     </objects>
     <resources>
-        <image name="NSRefreshFreestandingTemplate" width="15" height="15"/>
+        <image name="NSRefreshFreestandingTemplate" width="20" height="20"/>
         <image name="tab_audio" width="18" height="18"/>
         <image name="tab_sub" width="18" height="18"/>
         <image name="tab_video" width="18" height="18"/>

--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -88,7 +88,7 @@ class PlaybackInfo {
 
   /** The current applied aspect, used for find current aspect in menu, etc. Maybe not a good approach. */
   var unsureAspect: String = "Default"
-  var unsureCrop: String = "None"
+  var unsureCrop: String = "None" // TODO: rename this to "selectedCrop"
   var cropFilter: MPVFilter?
   var flipFilter: MPVFilter?
   var mirrorFilter: MPVFilter?


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #3790.

---

**Description:**

This update will:
* Fix the constraint errors in Quick Settings panels. In some cases these were causing clicks on the Audio tab to be ignored, and causing other phantom quirks
* Improve scroll behavior of the Video tab (as described in #3790): X axis is now completely fixed; but when Show Tabs = "Always" the content compresses slightly and gracefully to make space for the scrollbar
* Improve the layouts of the 3 tabs to clear warnings about ambiguous & missing constraints, improve overall consistency, and hopefully have much more robust response to future OS updates
* Merge the `Custom...` crop button into the segmented control with the other crops (see the comments in the above issue)