### PR TITLE
Workaround for dimmed HDR content in full screen on macOS 13, #3844

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -550,6 +550,19 @@ class MainWindowController: PlayerWindowController {
     // gesture recognizer
     cv.addGestureRecognizer(magnificationGestureRecognizer)
 
+    // Workaround a bug in macOS Ventura where HDR content becomes dimmed when playing in full
+    // screen mode once overlaying views are fully hidden (issue #3844). After applying this
+    // workaround another bug in Ventura where an external monitor goes black could not be
+    // reproduced (issue #4015). The workaround adds a tiny subview with such a low alpha level it
+    // is invisible to the human eye.
+    if #available(macOS 13, *) {
+      let view = NSView(frame: NSRect(origin: .zero, size: NSSize(width: 0.1, height: 0.1)))
+      view.wantsLayer = true
+      view.layer?.backgroundColor = NSColor.black.cgColor
+      view.layer?.opacity = 0.01
+      cv.addSubview(view)
+    }
+
     player.initVideo()
 
     // init quick setting view now

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -550,11 +550,11 @@ class MainWindowController: PlayerWindowController {
     // gesture recognizer
     cv.addGestureRecognizer(magnificationGestureRecognizer)
 
-    // Workaround a bug in macOS Ventura where HDR content becomes dimmed when playing in full
+    // Work around a bug in macOS Ventura where HDR content becomes dimmed when playing in full
     // screen mode once overlaying views are fully hidden (issue #3844). After applying this
     // workaround another bug in Ventura where an external monitor goes black could not be
     // reproduced (issue #4015). The workaround adds a tiny subview with such a low alpha level it
-    // is invisible to the human eye.
+    // is invisible to the human eye. This workaround may not be effective in all cases.
     if #available(macOS 13, *) {
       let view = NSView(frame: NSRect(origin: .zero, size: NSSize(width: 0.1, height: 0.1)))
       view.wantsLayer = true


### PR DESCRIPTION
This workaround also addresses another macOS Ventura regression where an external monitor goes black, #4015.

This same dimming problem was reported in issues #3880, #4013 and #4014.

The workaround changes the windowDidLoad method of MainWindowController such that when running under macOS Ventura it will add a tiny subview with such a low alpha level it is invisible to the human eye.

Issue #4015 has been reproduced without IINA, so we are certain this is a regression in macOS 13. At this time we do not know the root cause and can not explain why this workaround works.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #3844.

---

**Description:**
Starting with macOS 13, some strange behavior can be seen when viewing videos in full screen in HDR mode. The screen will be dimmed when the player controls disappear. This workaround adds a tiny invisible subview when running under macOS 13 so that there is always more than one "visible" view in the window.

Many thanks to @royj  who came up with the original workaround. This PR addresses feedback from reviewers.