### PR TITLE
Add more checks to prevent requests to mpv during shutdown (fix for issue #4020)

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1268,6 +1268,8 @@ class MainWindowController: PlayerWindowController {
   }
 
   func windowDidExitFullScreen(_ notification: Notification) {
+    guard !player.isShuttingDown else { return }
+    
     if AccessibilityPreferences.motionReductionEnabled {
       // When animation is not used exiting full screen does not restore the previous size of the
       // window. Restore it now.
@@ -1659,7 +1661,8 @@ class MainWindowController: PlayerWindowController {
   }
 
   private func showUI() {
-    if player.disableUI { return }
+    guard !player.disableUI && !player.isShuttingDown else { return }
+
     animationState = .willShow
     fadeableViews.forEach { (v) in
       v.isHidden = false

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1604,6 +1604,7 @@ class PlayerCore: NSObject {
   func syncUI(_ option: SyncUIOption) {
     // if window not loaded, ignore
     guard mainWindow.loaded else { return }
+    guard !disableUI && !isShuttingDown else { return }
     Logger.log("Syncing UI \(option)", level: .verbose, subsystem: subsystem)
 
     switch option {

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -292,6 +292,7 @@ class VideoView: NSView {
 @available(macOS 10.15, *)
 extension VideoView {
   func refreshEdrMode() {
+    guard !player.isShuttingDown else { return }
     guard player.mainWindow.loaded else { return }
     guard player.mpv.fileLoaded else { return }
     guard let displayId = currentDisplay else { return };


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4020.

---

**Description:**

The crash in the issue appears to be caused by a null pointer somewhere inside libmpv. According to the stack trace, `windowDidExitFullScreen()` called `showUI()`, which called `syncUI()`, which called `mpv_get_property`, which was bad because the mpv core was in the process of shutting down and setting all its pointers to null.

This update adds `isShuttingDown` checks to 4 places where `mpv_get_property` normally gets called and thus could be problematic. It expects that `isShuttingDown==true` only happens at application shutdown, and that it will still be true even when `isShutdown==true`.

As a side effect, IINA's shutdowns might be a tiny bit faster.