### PR TITLE
Use new colorwell on macOS 13

### DIFF
--- a/iina/Base.lproj/PrefSubViewController.xib
+++ b/iina/Base.lproj/PrefSubViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17156" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17156"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,7 +16,11 @@
                 <outlet property="sectionOtherView" destination="Iur-Ka-beI" id="PBO-Op-ouf"/>
                 <outlet property="sectionPositionView" destination="ZpT-fB-Daq" id="uop-Q7-Fgz"/>
                 <outlet property="sectionTextSubView" destination="ffZ-rE-7Zz" id="DJo-Jw-5nf"/>
+                <outlet property="subBackgroundColorWell" destination="6fT-hS-kdG" id="YYV-qw-ykn"/>
+                <outlet property="subBorderColorWell" destination="vyH-G4-g3c" id="vDq-Wc-kGQ"/>
+                <outlet property="subColorWell" destination="AaL-am-9qW" id="5cd-sf-HHl"/>
                 <outlet property="subLangTokenView" destination="bhV-Cx-zgK" id="ixc-wl-Y26"/>
+                <outlet property="subShadowColorWell" destination="Gtc-ii-hE0" id="hh5-ON-mLf"/>
                 <outlet property="subSourcePopUpButton" destination="UHS-ce-8t5" id="zmW-Jx-JMg"/>
                 <outlet property="subSourceStackView" destination="bSz-xd-6o2" id="UOh-XZ-MhE"/>
                 <outlet property="view" destination="Hz6-mo-xeY" id="0bl-1N-x8E"/>

--- a/iina/PrefSubViewController.swift
+++ b/iina/PrefSubViewController.swift
@@ -42,8 +42,19 @@ class PrefSubViewController: PreferenceViewController, PreferenceWindowEmbeddabl
   @IBOutlet weak var loginIndicator: NSProgressIndicator!
   @IBOutlet weak var defaultEncodingList: NSPopUpButton!
 
+  @IBOutlet weak var subColorWell: NSColorWell!
+  @IBOutlet weak var subBackgroundColorWell: NSColorWell!
+  @IBOutlet weak var subBorderColorWell: NSColorWell!
+  @IBOutlet weak var subShadowColorWell: NSColorWell!
+
   override func viewDidLoad() {
     super.viewDidLoad()
+
+    if #available(macOS 13.0, *) {
+      [subColorWell, subBackgroundColorWell, subBorderColorWell, subShadowColorWell].forEach {
+        $0?.colorWellStyle = .minimal
+      }
+    }
 
     let defaultEncoding = Preference.string(for: .defaultEncoding)
     for encoding in AppData.encodings {

--- a/iina/PrefSubViewController.swift
+++ b/iina/PrefSubViewController.swift
@@ -42,17 +42,17 @@ class PrefSubViewController: PreferenceViewController, PreferenceWindowEmbeddabl
   @IBOutlet weak var loginIndicator: NSProgressIndicator!
   @IBOutlet weak var defaultEncodingList: NSPopUpButton!
 
-  @IBOutlet weak var subColorWell: NSColorWell!
-  @IBOutlet weak var subBackgroundColorWell: NSColorWell!
-  @IBOutlet weak var subBorderColorWell: NSColorWell!
-  @IBOutlet weak var subShadowColorWell: NSColorWell!
+  @IBOutlet var subColorWell: NSColorWell!
+  @IBOutlet var subBackgroundColorWell: NSColorWell!
+  @IBOutlet var subBorderColorWell: NSColorWell!
+  @IBOutlet var subShadowColorWell: NSColorWell!
 
   override func viewDidLoad() {
     super.viewDidLoad()
 
     if #available(macOS 13.0, *) {
       [subColorWell, subBackgroundColorWell, subBorderColorWell, subShadowColorWell].forEach {
-        $0?.colorWellStyle = .minimal
+        $0.colorWellStyle = .minimal
       }
     }
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
Use the new colorwell option available in macOS 13. You can now select color without opening the color panel; and looks better.

Before:
![image](https://user-images.githubusercontent.com/20237141/200090901-829d391e-3c90-4645-a29d-3bd32d68d0ac.png)

After:
![image](https://user-images.githubusercontent.com/20237141/200090873-34bf1c13-a4a0-40ad-a696-ca3727ddfe98.png)
