### PR TITLE
Ignore warnings from FFmpeg' and mpv's header files

### DIFF
--- a/iina/FFmpegController.m
+++ b/iina/FFmpegController.m
@@ -10,7 +10,7 @@
 #import <Cocoa/Cocoa.h>
 
 #pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Weverything"
+#pragma clang diagnostic ignored "-Wdocumentation"
 #import <libavcodec/avcodec.h>
 #import <libavformat/avformat.h>
 #import <libswscale/swscale.h>

--- a/iina/FFmpegController.m
+++ b/iina/FFmpegController.m
@@ -9,11 +9,14 @@
 #import "FFmpegController.h"
 #import <Cocoa/Cocoa.h>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
 #import <libavcodec/avcodec.h>
 #import <libavformat/avformat.h>
 #import <libswscale/swscale.h>
 #import <libavutil/imgutils.h>
 #import <libavutil/mastering_display_metadata.h>
+#pragma clang diagnostic pop
 
 #define THUMB_COUNT_DEFAULT 100
 

--- a/iina/iina-Bridging-Header.h
+++ b/iina/iina-Bridging-Header.h
@@ -1,5 +1,7 @@
 #define MPV_ENABLE_DEPRECATED 0
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Weverything"
 #import <mpv/client.h>
 #import <mpv/render.h>
 #import <mpv/render_gl.h>
@@ -8,6 +10,7 @@
 #import <libavformat/avformat.h>
 #import <libavutil/avutil.h>
 #import <libswscale/swscale.h>
+#pragma clang diagnostic pop
 
 #import <stdio.h>
 #import <stdlib.h>

--- a/iina/iina-Bridging-Header.h
+++ b/iina/iina-Bridging-Header.h
@@ -1,7 +1,7 @@
 #define MPV_ENABLE_DEPRECATED 0
 
 #pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Weverything"
+#pragma clang diagnostic ignored "-Wdocumentation"
 #import <mpv/client.h>
 #import <mpv/render.h>
 #import <mpv/render_gl.h>


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
Ref: https://stackoverflow.com/questions/59720526/how-can-i-ignore-all-warnings-from-included-headers-in-clang-gcc