### PR TITLE
Default mpv input conf: Remove {encode}, replace current-window-scale with window-scale

### DIFF
--- a/iina/config/input.conf
+++ b/iina/config/input.conf
@@ -32,9 +32,6 @@
 #@iina Shift+Meta+c chapter-panel
 #@iina Ctrl+Meta+p toggle-pip
 
-# If this is enabled, treat all the following bindings as default.
-# default-bindings start
-
 MBTN_LEFT     ignore              # don't do anything
 MBTN_LEFT_DBL cycle fullscreen    # toggle fullscreen
 MBTN_RIGHT    cycle pause         # toggle pause/playback mode
@@ -84,9 +81,7 @@ Shift+BS revert-seek                   # undo the previous (or marked) seek
 Shift+Ctrl+BS revert-seek mark         # mark the position for revert-seek
 q quit
 Q quit-watch-later                     # exit and remember the playback position
-q {encode} quit 4
 ESC set fullscreen no                  # leave fullscreen
-ESC {encode} quit 4
 p cycle pause                          # toggle pause/playback mode
 . frame-step                           # advance one frame and pause
 , frame-back-step                      # go back by one frame and pause
@@ -120,9 +115,9 @@ m cycle mute                           # toggle mute
 6 add gamma 1
 7 add saturation -1
 8 add saturation 1
-Alt+0 set current-window-scale 0.5     # halve the window size
-Alt+1 set current-window-scale 1.0     # reset the window size
-Alt+2 set current-window-scale 2.0     # double the window size
+Alt+0 set window-scale 0.5             # halve the normal window size
+Alt+1 set window-scale 1.0             # reset the window size
+Alt+2 set window-scale 2.0             # double the normal window size
 d cycle deinterlace                    # toggle the deinterlacing filter
 r add sub-pos -1                       # move subtitles up
 R add sub-pos +1                       # move subtitles down
@@ -160,7 +155,6 @@ VOLUME_UP add volume 2
 VOLUME_DOWN add volume -2
 MUTE cycle mute                        # toggle mute
 CLOSE_WIN quit
-CLOSE_WIN {encode} quit 4
 ctrl+w quit
 E cycle edition                        # switch edition
 l ab-loop                              # set/clear A-B loop points


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4053.

---

**Description:**

1. The `set window-scale` commands were changed to `set current-window-scale` in mpv 0.34, but IINA does not support them. This changes them back to prevent user confusion and to be more useful.
2. Removes the {encode} section bindings, which were erroneously added (by me) in that same commit, but they are also not used and will just cause confusion.
3. Removes `default-bindings start`. It was commented out, but users shouldn't assume it will work if uncommented.