### PR TITLE
Fix  crash during quit in windowDidExitFullScreen, #4020

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -241,12 +241,12 @@ class MainWindowController: PlayerWindowController {
 
   var fsState: FullScreenState = .windowed {
     didSet {
+      // Must not access mpv while it is asynchronously processing stop and quit commands.
+      guard !isClosing else { return }
       switch fsState {
       case .fullscreen: player.mpv.setFlag(MPVOption.Window.fullscreen, true)
       case .animating:  break
-      case .windowed:
-        guard !isClosing else { return }
-        player.mpv.setFlag(MPVOption.Window.fullscreen, false)
+      case .windowed:   player.mpv.setFlag(MPVOption.Window.fullscreen, false)
       }
     }
   }
@@ -1286,9 +1286,9 @@ class MainWindowController: PlayerWindowController {
     // this method. Because windows are tied to player cores and cores are cached and reused some
     // processing must be performed to leave the window in a consistent state for reuse. However
     // the windowWillClose method will have initiated unloading of the file being played. That
-    // operation is processed asynchronously by mpv. If the window is being close due to IINA
-    // quitting then mpv could be shutting down. Must not access mpv while it is asynchronously
-    // processing stop and quit commands.
+    // operation is processed asynchronously by mpv. If the window is being closed due to IINA
+    // quitting then mpv could be in the process of shutting down. Must not access mpv while it is
+    // asynchronously processing stop and quit commands.
     guard !isClosing else { return }
     videoView.videoLayer.suspend()
     player.mpv.setFlag(MPVOption.Window.keepaspect, false)
@@ -1318,6 +1318,7 @@ class MainWindowController: PlayerWindowController {
     window!.addTitlebarAccessoryViewController(titlebarAccesoryViewController)
 
     // Must not access mpv while it is asynchronously processing stop and quit commands.
+    // See comments in windowWillExitFullScreen for details.
     guard !isClosing else { return }
     showUI()
     updateTimer()
@@ -1554,6 +1555,9 @@ class MainWindowController: PlayerWindowController {
 
   // resize framebuffer in videoView after resizing.
   func windowDidEndLiveResize(_ notification: Notification) {
+    // Must not access mpv while it is asynchronously processing stop and quit commands.
+    // See comments in windowWillExitFullScreen for details.
+    guard !isClosing else { return }
     videoView.videoSize = window!.convertToBacking(videoView.bounds).size
     updateWindowParametersForMPV()
   }

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -178,6 +178,8 @@ class MainWindowController: PlayerWindowController {
   var isShowingPersistentOSD = false
   var osdContext: Any?
 
+  private var isClosing = false
+
   // MARK: - Enums
 
   // Window state
@@ -242,7 +244,9 @@ class MainWindowController: PlayerWindowController {
       switch fsState {
       case .fullscreen: player.mpv.setFlag(MPVOption.Window.fullscreen, true)
       case .animating:  break
-      case .windowed:   player.mpv.setFlag(MPVOption.Window.fullscreen, false)
+      case .windowed:
+        guard !isClosing else { return }
+        player.mpv.setFlag(MPVOption.Window.fullscreen, false)
       }
     }
   }
@@ -1040,6 +1044,7 @@ class MainWindowController: PlayerWindowController {
   // MARK: - Window delegate: Open / Close
 
   func windowWillOpen() {
+    isClosing = false
     if #available(macOS 12, *) {
       // Apparently Apple fixed AppKit for Monterey so the workaround below is only needed for
       // previous versions of macOS. Support for #unavailable is coming in Swift 5.6. The version of
@@ -1120,6 +1125,7 @@ class MainWindowController: PlayerWindowController {
   }
 
   func windowWillClose(_ notification: Notification) {
+    isClosing = true
     shouldApplyInitialWindowSize = true
     // Close PIP
     if pipStatus == .inPIP {
@@ -1276,6 +1282,14 @@ class MainWindowController: PlayerWindowController {
 
     fsState.startAnimatingToWindow()
 
+    // If a window is closed while in full screen mode (control-w pressed) AppKit will still call
+    // this method. Because windows are tied to player cores and cores are cached and reused some
+    // processing must be performed to leave the window in a consistent state for reuse. However
+    // the windowWillClose method will have initiated unloading of the file being played. That
+    // operation is processed asynchronously by mpv. If the window is being close due to IINA
+    // quitting then mpv could be shutting down. Must not access mpv while it is asynchronously
+    // processing stop and quit commands.
+    guard !isClosing else { return }
     videoView.videoLayer.suspend()
     player.mpv.setFlag(MPVOption.Window.keepaspect, false)
   }
@@ -1291,6 +1305,20 @@ class MainWindowController: PlayerWindowController {
     }
     addBackStandardButtonsToFadeableViews()
     titleBarView.isHidden = false
+    fsState.finishAnimating()
+
+    if Preference.bool(for: .blackOutMonitor) {
+      removeBlackWindow()
+    }
+
+    if #available(macOS 10.12.2, *) {
+      player.touchBarSupport.toggleTouchBarEsc(enteringFullScr: false)
+    }
+
+    window!.addTitlebarAccessoryViewController(titlebarAccesoryViewController)
+
+    // Must not access mpv while it is asynchronously processing stop and quit commands.
+    guard !isClosing else { return }
     showUI()
     updateTimer()
 
@@ -1299,25 +1327,14 @@ class MainWindowController: PlayerWindowController {
     videoView.layoutSubtreeIfNeeded()
     videoView.videoLayer.resume()
 
-    fsState.finishAnimating()
-
-    if Preference.bool(for: .blackOutMonitor) {
-      removeBlackWindow()
-    }
-
     if Preference.bool(for: .pauseWhenLeavingFullScreen) && player.info.isPlaying {
       player.pause()
-    }
-
-    if #available(macOS 10.12.2, *) {
-      player.touchBarSupport.toggleTouchBarEsc(enteringFullScr: false)
     }
 
     // restore ontop status
     if player.info.isPlaying {
       setWindowFloatingOnTop(isOntop, updateOnTopStatus: false)
     }
-    window!.addTitlebarAccessoryViewController(titlebarAccesoryViewController)
 
     resetCollectionBehavior()
     updateWindowParametersForMPV()


### PR DESCRIPTION
This commit will:
- Add a new isClosing property to MainWindowController
- Change windowWillClose to set isClosing to true
- Change windowWillExitFullScreen and windowDidExitFullScreen to not access mpv if window is closing
- Change fsState didSet to not access mpv if window is closing
- Change windowWillOpen to set isClosing to false

These changes prevent IINA from calling mpv while mpv is asynchronously unloading the file or shutting down.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4020.

---

**Description:**
