### PR TITLE
Fix unable to hide Quick Panel with OSC, #4071

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2616,7 +2616,7 @@ class MainWindowController: PlayerWindowController {
         self.showSideBar(viewController: view, type: .settings)
       }
     case .settings:
-      if view.currentTab == tab {
+      if view.currentTab == tab || tab == nil {
         if hideIfAlreadyShown {
           hideSideBar()
         }
@@ -2645,7 +2645,7 @@ class MainWindowController: PlayerWindowController {
         self.showSideBar(viewController: view, type: .playlist)
       }
     case .playlist:
-      if view.currentTab == tab {
+      if view.currentTab == tab || tab == nil {
         if hideIfAlreadyShown {
           hideSideBar()
         }


### PR DESCRIPTION
This commit will change the `MainWindowController` methods `showPlaylistSidebar` and `showSettingsSidebar` to hide or show the panel when no tab is specified.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4071.

---

**Description:**
