### PR TITLE
Fix crash & other LanguageTokenField issues

### DIFF
--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -422,6 +422,10 @@ extension String {
     return localizedCompare(other) == .orderedSame
   }
 
+  var quoted: String {
+    return "\"\(self)\""
+  }
+
   mutating func deleteLast(_ num: Int) {
     removeLast(Swift.min(num, count))
   }

--- a/iina/ISO639Helper.swift
+++ b/iina/ISO639Helper.swift
@@ -1,5 +1,5 @@
 //
-//  ISO639_2Helper.swift
+//  ISO639_Helper.swift
 //  iina
 //
 //  Created by lhc on 14/3/2017.
@@ -27,6 +27,8 @@ class ISO639Helper {
       let names = v.split(separator: ";").map { String($0) }
       result.append(Language(code: k, name: names))
     }
+    // Sort by description, ascending alpha order
+    result.sort{$0.description.localizedCompare($1.description) == .orderedAscending}
     return result
   }()
 

--- a/iina/LanguageTokenField.swift
+++ b/iina/LanguageTokenField.swift
@@ -8,47 +8,139 @@
 
 import Cocoa
 
-fileprivate class Token: NSObject {
-  var content: String
-  var code: String
+fileprivate let enableLookupLogging = false
 
-  init(_ content: String) {
-    self.content = content
-    self.code = ISO639Helper.descriptionRegex.captures(in: content)[at: 1] ?? content
+// Data structure: LangToken
+// A token suitable for use by an `NSTokenField`, which represents a single ISO639 language
+fileprivate struct LangToken: Equatable, Hashable, CustomStringConvertible {
+  // The 3-digit ISO639 language code, if a matching language was found:
+  let code: String?
+  // The `editingString` which shows up when a token is double-clicked.
+  // Will be equivalent to `description` field of matching `ISO639Helper.Language`, if match was found.
+  let editingString: String
+
+  // As a displayed token, this is used as the displayString. When stored in prefs CSV, this is used as the V[alue]:
+  var identifierString: String {
+    code ?? normalizedEditingString
+  }
+
+  // For logging and debugging only. Not to be confused with `ISO639Helper.Language.description`
+  var description: String {
+    return "LangToken(code: \(code?.quoted ?? "nil"), editStr: \(editingString.quoted))"
+  }
+
+  // "Normalizes" the editingString so it can be serialized to CSV. Removes whitespace and commas.
+  // Also makes lowercase, because it will be used as an case-agnostic identifier.
+  private var normalizedEditingString: String {
+    self.editingString.lowercased().replacingOccurrences(of: ",", with: ";").trimmingCharacters(in: .whitespaces)
+  }
+
+  // Need the following to prevent NSTokenField from doing an infinite loop
+
+  func equalTo(_ rhs: LangToken) -> Bool {
+    return self.editingString == rhs.editingString
+  }
+
+  static func ==(lhs: LangToken, rhs: LangToken) -> Bool {
+    return lhs.equalTo(rhs)
+  }
+
+  static func !=(lhs: LangToken, rhs: LangToken) -> Bool {
+    return !lhs.equalTo(rhs)
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(editingString)
+  }
+
+  // If code is valid, looks up its description and uses it for `editingString`.
+  // If code not found, falls back to init from editingString.
+  static func from(_ string: String) -> LangToken {
+    let matchingLangs = ISO639Helper.languages.filter({ $0.code == string })
+    if !matchingLangs.isEmpty {
+      let langDescription = matchingLangs[0].description
+      return LangToken(code: string, editingString: langDescription)
+    }
+    return LangToken(code: nil, editingString: string)
+  }
+}
+
+// Data structure: LangSet
+// A collection of unique languages (usually the field's entire contents)
+fileprivate struct LangSet {
+  let langTokens: [LangToken]
+
+  init(langTokens: [LangToken]) {
+    self.langTokens = langTokens
+  }
+
+  init(fromCSV csv: String) {
+    self.init(langTokens: csv.isEmpty ? [] : csv.components(separatedBy: ",").map{ LangToken.from($0.trimmingCharacters(in: .whitespaces)) })
+  }
+
+  init(fromObjectValue objectValue: Any?) {
+    self.init(langTokens: (objectValue as? NSArray)?.compactMap({ ($0 as? LangToken) }) ?? [])
+  }
+
+  func toCommaSeparatedValues() -> String {
+    return langTokens.map{ $0.identifierString }.joined(separator: ",")
+  }
+
+  func toNewlineSeparatedValues() -> String {
+    return langTokens.map{ $0.identifierString }.joined(separator: "\n")
+  }
+
+  func contains(_ token: LangToken) -> Bool {
+    return !langTokens.filter({ $0.identifierString == token.identifierString }).isEmpty
   }
 }
 
 class LanguageTokenField: NSTokenField {
   private var layoutManager: NSLayoutManager?
 
+  // Should match the value from the prefs.
+  // Is only changed when `commaSeparatedValues` is set, and by `submitChanges()`.
+  private var savedSet = LangSet(langTokens: [])
+
+  // may include unsaved tokens from the edit session
+  fileprivate var objectValueLangSet: LangSet {
+    LangSet(fromObjectValue: self.objectValue)
+  }
+
+  var commaSeparatedValues: String {
+    get {
+      let csv = savedSet.toCommaSeparatedValues()
+      Logger.log("LTF Generated CSV from savedSet: \(csv.quoted)", level: .verbose)
+      return csv
+    } set {
+      Logger.log("LTF Setting savedSet from CSV: \(newValue.quoted)", level: .verbose)
+      self.savedSet = LangSet(fromCSV: newValue)
+      // Need to convert from CSV to newline-SV
+      self.stringValue = self.savedSet.toNewlineSeparatedValues()
+    }
+  }
+
   override func awakeFromNib() {
     super.awakeFromNib()
     self.delegate = self
+    self.tokenStyle = .rounded
+    // Cannot use commas, because language descriptions are used as editing strings, and many of them contain commas, whitespace, quotes,
+    // and NSTokenField will internally tokenize editing strings. We should be able to keep using CSV in the prefs
+    self.tokenizingCharacterSet = .newlines
   }
 
-  override var stringValue: String {
-    set {
-      self.objectValue = newValue.count == 0 ?
-        [] : newValue.components(separatedBy: ",").map(Token.init)
-    }
-    get {
-      return (objectValue as? NSArray)?.map({ val in
-        if let token = val as? Token {
-          return token.code
-        } else if let str = val as? String {
-          return str
-        }
-        return ""
-      }).joined(separator: ",") ?? ""
-    }
+  @objc func controlTextDidEndEditing(_ notification: Notification) {
+    Logger.log("LTF Submitting changes from controlTextDidEndEditing()", level: .verbose)
+    submitChanges()
   }
 
   func controlTextDidChange(_ obj: Notification) {
     guard let layoutManager = layoutManager else { return }
     let attachmentChar = Character(UnicodeScalar(NSTextAttachment.character)!)
     let finished = layoutManager.attributedString().string.split(separator: attachmentChar).count == 0
-    if finished, let target = target, let action = action {
-      target.performSelector(onMainThread: action, with: self, waitUntilDone: false)
+    if finished {
+      Logger.log("LTF Submitting changes from controlTextDidChange()", level: .verbose)
+      submitChanges()
     }
   }
 
@@ -58,42 +150,159 @@ class LanguageTokenField: NSTokenField {
     }
     return true
   }
+
+  private func submitChanges() {
+    let langSetNew = filterDuplicates(from: self.objectValueLangSet, basedOn: self.savedSet)
+    makeUndoableUpdate(to: langSetNew)
+  }
+
+  // Filter out duplicates. Use the prev set to try to figure out which copy is newer, and favor that one.
+  private func filterDuplicates(from langSetNew: LangSet, basedOn langSetOld: LangSet) -> LangSet {
+    let dictOld: [String: [Int]] = countTokenIndexes(langSetOld)
+    let dictNew: [String: [Int]] = countTokenIndexes(langSetNew)
+
+    var indexesToRemove = Set<Int>()
+    // Iterate over only the duplicates:
+    for (dupString, indexesNew) in dictNew.filter({ $0.value.count > 1 }) {
+      if let indexesOld = dictOld[dupString] {
+        let oldIndex = indexesOld[0]
+        var indexToKeep = indexesNew[0]
+        for index in indexesNew {
+          // Keep the token which is farthest distance from old location
+          if abs(index - oldIndex) > abs(indexToKeep - oldIndex) {
+            indexToKeep = index
+          }
+        }
+        for index in indexesNew {
+          if index != indexToKeep {
+            indexesToRemove.insert(index)
+          }
+        }
+      }
+    }
+    let filteredTokens = langSetNew.langTokens.enumerated().filter({ !indexesToRemove.contains($0.offset) }).map({ $0.element })
+    return LangSet(langTokens: filteredTokens)
+  }
+
+  private func countTokenIndexes(_ langSet: LangSet) -> [String: [Int]] {
+    var dict: [String: [Int]] = [:]
+    for (index, token) in langSet.langTokens.enumerated() {
+      if var list = dict[token.identifierString] {
+        list.append(index)
+        dict[token.identifierString] = list
+      } else {
+        dict[token.identifierString] = [index]
+      }
+    }
+    return dict
+  }
+
+  private func makeUndoableUpdate(to langSetNew: LangSet) {
+    let langSetOld = self.savedSet
+    let csvOld = langSetOld.toCommaSeparatedValues()
+    let csvNew = langSetNew.toCommaSeparatedValues()
+
+    Logger.log("LTF Updating \(csvOld.quoted) -> \(csvNew.quoted)}", level: .verbose)
+    if csvOld == csvNew {
+      Logger.log("LTF No changes to lang set", level: .verbose)
+    } else {
+      self.savedSet = langSetNew
+      if let target = target, let action = action {
+        target.performSelector(onMainThread: action, with: self, waitUntilDone: false)
+      }
+
+      // Register for undo or redo. Needed because the change to stringValue below doesn't include it
+      if let undoManager = self.undoManager {
+        undoManager.registerUndo(withTarget: self, handler: { languageTokenField in
+          self.makeUndoableUpdate(to: langSetOld)
+        })
+      }
+    }
+
+    // Update tokenField value
+    self.stringValue = langSetNew.toNewlineSeparatedValues()
+  }
 }
 
 extension LanguageTokenField: NSTokenFieldDelegate {
-  func tokenField(_ tokenField: NSTokenField, styleForRepresentedObject representedObject: Any) -> NSTokenField.TokenStyle {
-    return .rounded
-  }
-
-  func tokenField(_ tokenField: NSTokenField, displayStringForRepresentedObject representedObject: Any) -> String? {
-    if let token = representedObject as? Token {
-      return token.code
-    } else {
-      return representedObject as? String
-    }
-  }
 
   func tokenField(_ tokenField: NSTokenField, hasMenuForRepresentedObject representedObject: Any) -> Bool {
+    // Tokens never have a context menu
     return false
   }
 
-  func tokenField(_ tokenField: NSTokenField, completionsForSubstring substring: String, indexOfToken tokenIndex: Int, indexOfSelectedItem selectedIndex: UnsafeMutablePointer<Int>?) -> [Any]? {
+  // Returns array of auto-completion results for user's typed string (`substring`)
+  func tokenField(_ tokenField: NSTokenField, completionsForSubstring substring: String,
+                  indexOfToken tokenIndex: Int, indexOfSelectedItem selectedIndex: UnsafeMutablePointer<Int>?) -> [Any]? {
     let lowSubString = substring.lowercased()
+    let currentLangCodes = Set(self.savedSet.langTokens.compactMap{$0.code})
     let matches = ISO639Helper.languages.filter { lang in
-      return lang.name.contains { $0.lowercased().hasPrefix(lowSubString) }
+      return !currentLangCodes.contains(lang.code) && lang.name.contains { $0.lowercased().hasPrefix(lowSubString) }
     }
-    return matches.map { $0.description }
+    let descriptions = matches.map { $0.description }
+    if enableLookupLogging {
+      Logger.log("LTF Given substring: \(substring.quoted) -> returning completions: \(descriptions)", level: .verbose)
+    }
+    return descriptions
   }
 
+  // Called by AppKit. Token -> DisplayStringString. Returns the string to use when displaying as a token
+  func tokenField(_ tokenField: NSTokenField, displayStringForRepresentedObject representedObject: Any) -> String? {
+    guard let token = representedObject as? LangToken else { return nil }
+
+    if enableLookupLogging {
+      Logger.log("LTF Given token: \(token) -> returning displayString: \(token.identifierString.quoted)", level: .verbose)
+    }
+    return token.identifierString
+  }
+
+  // Called by AppKit. Token -> EditingString. Returns the string to use when editing a token.
   func tokenField(_ tokenField: NSTokenField, editingStringForRepresentedObject representedObject: Any) -> String? {
-    if let token = representedObject as? Token {
-      return token.content
-    } else {
-      return representedObject as? String
+    guard let token = representedObject as? LangToken else { return nil }
+
+    if enableLookupLogging {
+      Logger.log("LTF Given token: \(token) -> returning editingString: \(token.editingString.quoted)", level: .verbose)
     }
+    return token.editingString
   }
 
+  // Called by AppKit. EditingString -> Token
   func tokenField(_ tokenField: NSTokenField, representedObjectForEditing editingString: String) -> Any? {
-    return Token(editingString)
+    // Return language code (if possible)
+    let token: LangToken
+    // editingString is description?
+    if let langCode = ISO639Helper.descriptionRegex.captures(in: editingString)[at: 1] {
+      token  = LangToken.from(langCode)
+    } else {
+      token  = LangToken.from(editingString)
+    }
+    if enableLookupLogging {
+      Logger.log("LTF Given editingString: \(editingString.quoted) -> returning: \(token)", level: .verbose)
+    }
+    return token
+  }
+
+  // Serializes an array of LangToken objects into a string of CSV (cut/copy/paste support)
+  // Need to override this because it will default to using `tokenizingCharacterSet`, which needed to be overriden for
+  // internal parsing of `editingString`s to work correctly, but we want to use CSV when exporting `identifierString`s
+  // because they are more user-readable.
+  func tokenField(_ tokenField: NSTokenField, writeRepresentedObjects objects: [Any], to pboard: NSPasteboard) -> Bool {
+    guard let tokens = objects as? [LangToken] else {
+      return false
+    }
+    let langSet = LangSet(langTokens: tokens)
+
+    pboard.clearContents()
+    pboard.setString(langSet.toCommaSeparatedValues(), forType: NSPasteboard.PasteboardType.string)
+    return true
+  }
+
+  // Parses CSV from the given pasteboard and returns an array of LangToken objects (cut/copy/paste support)
+  // See note for `tokenField(writeRepresentedObjects....)` above.
+  func tokenField(_ tokenField: NSTokenField, readFrom pboard: NSPasteboard) -> [Any]? {
+    if let pbString = pboard.string(forType: NSPasteboard.PasteboardType.string) {
+      return LangSet(fromCSV: pbString).langTokens
+    }
+    return []
   }
 }

--- a/iina/PrefCodecViewController.swift
+++ b/iina/PrefCodecViewController.swift
@@ -41,7 +41,7 @@ class PrefCodecViewController: PreferenceViewController, PreferenceWindowEmbedda
 
   override func viewDidLoad() {
     super.viewDidLoad()
-    audioLangTokenField.stringValue = Preference.string(for: .audioLanguage) ?? ""
+    audioLangTokenField.commaSeparatedValues = Preference.string(for: .audioLanguage) ?? ""
     updateHwdecDescription()
   }
 
@@ -88,7 +88,11 @@ class PrefCodecViewController: PreferenceViewController, PreferenceWindowEmbedda
   }
 
   @IBAction func preferredLanguageAction(_ sender: LanguageTokenField) {
-    Preference.set(sender.stringValue, for: .audioLanguage)
+    let csv = sender.commaSeparatedValues
+    if Preference.string(for: .audioLanguage) != csv {
+      Logger.log("Saving \(Preference.Key.audioLanguage.rawValue): \"\(csv)\"", level: .verbose)
+      Preference.set(csv, for: .audioLanguage)
+    }
   }
 
   private func updateHwdecDescription() {

--- a/iina/PrefSubViewController.swift
+++ b/iina/PrefSubViewController.swift
@@ -71,7 +71,7 @@ class PrefSubViewController: PreferenceViewController, PreferenceWindowEmbeddabl
     defaultEncodingList.menu?.insertItem(NSMenuItem.separator(), at: 1)
     loginIndicator.isHidden = true
 
-    subLangTokenView.stringValue = Preference.string(for: .subLang) ?? ""
+    subLangTokenView.commaSeparatedValues = Preference.string(for: .subLang) ?? ""
 
     refreshSubSources()
     refreshSubSourceAccessoryView()
@@ -149,7 +149,11 @@ class PrefSubViewController: PreferenceViewController, PreferenceWindowEmbeddabl
   }
 
   @IBAction func preferredLanguageAction(_ sender: LanguageTokenField) {
-    Preference.set(sender.stringValue, for: .subLang)
+    let csv = sender.commaSeparatedValues
+    if Preference.string(for: .subLang) != csv {
+      Logger.log("Saving \(Preference.Key.subLang.rawValue): \"\(csv)\"", level: .verbose)
+      Preference.set(csv, for: .subLang)
+    }
   }
 
   private func refreshSubSources() {


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #3505.

---

**Description:**

This was a really tricky one.

The crash log wasn't helpful at all, and the problem wasn't at all related to constraints, but it was accurate in hinting about an infinite loop which AppKit was detecting and killing. By placing log statements all over the code and running it, I was able to determine that the infinite loop was coming from the `LanguageTokenField` class.

For some reason, the `tokenField(displayStringForRepresentedObject)` and `tokenField(representedObjectForEditing)` methods were getting called endlessly and at a ratio of about 5:1. I know that AppKit is kind of messy and tends to call methods a lot more than it needs to, so I wasn't really concerned by all the `displayStringForRepresentedObject` calls, but the smoking gun was the repeated `representedObjectForEditing` calls, which is where AppKit asks the code what the represented object ("token") should be for the text in the text field. The fact that it was calling it over and over suggested that it either wasn't happy with the result it was getting, or thought it hadn't called it. From my experience doing object-mapping in the past, and seeing that a new Token() was being returned each time, I had a hunch that AppKit wasn't able to establish an identity for the Token objects it was getting back - and that turned out to be correct. I was able to get it to stop crashing by adding an override of `isEqual()` to the `Token` class which used its `code` field to check whether one token was identical to another. (Since `isEqual` was not overridden before, the system would default to comparing object references, but since a new `Token` was being returned each time, that would be seen as a new object.)

I don't know why it's doing what it's doing; it's AppKit and the source code isn't available, but during my research I found a commenter who seemed to sum it up well: `NSTokenField` doesn't really like to be customized. As far as I know, there's nothing documented about the need for a returned token to guarantee identity, and that is a glaring omission on Apple's part.

During the course of this investigation I tore the `LanguageTokenField` apart and pieced it back together again. There were a number of things which didn't seem like good ideas, like overriding `stringValue` and the strange use of `LayoutManager` looking for a Unicode attachment char as a way of figuring out whether the user finished typing. I refactored to get rid of the former...but the latter turned out to be essential, because it was catching cases where the standard events were not getting fired.

But there were a few other issues which I discovered and did fix in this update:
1. There were some cases where adding or removing tokens were not getting written to the prefs, because `controlTextDidChange` wasn't getting called. Fixed by adding more listeners.
2. There was a bug which occurred if a user set some languages and stored them to the prefs, then closed & reopened IINA and went back to the language token field: the `Token` object was getting its `content` field set to the same value as its `code` field. So double-clicking a token to edit it didn't show the full name of the language as it did before. I managed to remove the `Token` class entirely and replace it with language list lookups. Less code, so less chance for bugs, and still about as fast. Also removes the need to do a custom `isEqual`, because now it's just comparing `String`s.
3. It looks like language codes were being compared by their lowercase values in some places, but not others. I'm assuming that we don't want `fra` and `Fra` to be considered two different languages. So all the entries, including user entries which aren't recognized in the language dict, are now converted to lowercase before being stored in the prefs and before being checked for equality.
4. I assumed that we don't want the same language code listed twice in the list, so I added some checks to exclude already-added languages from the suggestions list, and added code to drop a duplicate tokens when they are added.

Let me know if that last point was an incorrect assumption to make and I can remove that check.