### PR TITLE
UX improvements to the “Jump to…” command

### DIFF
--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -130,7 +130,7 @@ extension MainMenuActionHandler {
   @objc func menuJumpTo(_ sender: NSMenuItem) {
     Utility.quickPromptPanel("jump_to", inputValue: self.player.info.videoPosition?.stringRepresentationWithPrecision(3)) { input in
       if let vt = VideoTime(input) {
-        self.player.seek(absoluteSecond: Double(vt.second))
+        self.player.seek(absoluteSecond: vt.second)
       }
     }
   }

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -128,7 +128,7 @@ extension MainMenuActionHandler {
   }
 
   @objc func menuJumpTo(_ sender: NSMenuItem) {
-    Utility.quickPromptPanel("jump_to") { input in
+    Utility.quickPromptPanel("jump_to", inputValue: self.player.info.videoPosition?.stringRepresentationWithPrecision(3)) { input in
       if let vt = VideoTime(input) {
         self.player.seek(absoluteSecond: Double(vt.second))
       }

--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -226,7 +226,7 @@ class Utility {
    - Returns: Whether user dismissed the panel by clicking OK. Only works when using `.modal` mode.
    */
   @discardableResult
-  static func quickPromptPanel(_ key: String, titleComment: String? = nil, messageComment: String? = nil, sheetWindow: NSWindow? = nil, callback: @escaping (String) -> Void) -> Bool {
+  static func quickPromptPanel(_ key: String, titleComment: String? = nil, messageComment: String? = nil, inputValue: String? = nil, sheetWindow: NSWindow? = nil, callback: @escaping (String) -> Void) -> Bool {
     let panel = NSAlert()
     let titleKey = "alert." + key + ".title"
     let messageKey = "alert." + key + ".message"
@@ -236,6 +236,9 @@ class Utility {
     input.lineBreakMode = .byClipping
     input.usesSingleLineMode = true
     input.cell?.isScrollable = true
+    if let inputValue = inputValue {
+      input.stringValue = inputValue
+    }
     panel.accessoryView = input
     panel.addButton(withTitle: NSLocalizedString("general.ok", comment: "OK"))
     panel.addButton(withTitle: NSLocalizedString("general.cancel", comment: "Cancel"))

--- a/iina/VideoTime.swift
+++ b/iina/VideoTime.swift
@@ -49,21 +49,13 @@ class VideoTime {
   }
 
   convenience init?(_ format: String) {
-    let split = format.split(separator: ":").map { (seq) -> Int? in
-      return Int(String(seq))
-    }
-    if !(split.contains {$0 == nil}) {
-      // if no nil in array
-      if split.count == 2 {
-        self.init(0, split[0]!, split[1]!)
-      } else if split.count == 3 {
-        self.init(split[0]!, split[1]!, split[2]!)
-      } else {
-        return nil
-      }
-    } else {
-      return nil
-    }
+    let split = Array(format.split(separator: ":").map { String($0) }.reversed())
+
+    let hour : Int? = split.count > 2 ? Int(split[2]) : nil
+    let minute : Int? = split.count > 1 ? Int(split[1]) : nil
+    let second : Double? = !split.isEmpty ? Double(split[0]) : nil
+
+    self.init(hour ?? 0, minute ?? 0, second ?? 0.0)
   }
 
   init(_ second: Double) {
@@ -71,8 +63,8 @@ class VideoTime {
 
   }
 
-  init(_ hour: Int, _ minute: Int, _ second: Int) {
-    self.second = Double(hour * 3600 + minute * 60 + second)
+  init(_ hour: Int, _ minute: Int, _ second: Double) {
+    self.second = Double(hour * 3600 + minute * 60) + second
   }
 
   /** whether self in [min, max) */

--- a/iina/VideoTime.swift
+++ b/iina/VideoTime.swift
@@ -9,7 +9,6 @@
 import Foundation
 
 class VideoTime {
-
   static let infinite = VideoTime(999, 0, 0)
   static let zero = VideoTime(0)
 
@@ -49,11 +48,15 @@ class VideoTime {
   }
 
   convenience init?(_ format: String) {
-    let split = Array(format.split(separator: ":").map { String($0) }.reversed())
+    let split = Array(format.split(separator: ":").reversed())
 
     let hour : Int? = split.count > 2 ? Int(split[2]) : nil
     let minute : Int? = split.count > 1 ? Int(split[1]) : nil
     let second : Double? = !split.isEmpty ? Double(split[0]) : nil
+
+    if hour == nil && minute == nil && second == nil {
+      return nil
+    }
 
     self.init(hour ?? 0, minute ?? 0, second ?? 0.0)
   }

--- a/iina/VideoTime.swift
+++ b/iina/VideoTime.swift
@@ -50,9 +50,9 @@ class VideoTime {
   convenience init?(_ format: String) {
     let split = Array(format.split(separator: ":").reversed())
 
-    let hour : Int? = split.count > 2 ? Int(split[2]) : nil
-    let minute : Int? = split.count > 1 ? Int(split[1]) : nil
-    let second : Double? = !split.isEmpty ? Double(split[0]) : nil
+    let hour: Int? = split.count > 2 ? Int(split[2]) : nil
+    let minute: Int? = split.count > 1 ? Int(split[1]) : nil
+    let second: Double? = !split.isEmpty ? Double(split[0]) : nil
 
     if hour == nil && minute == nil && second == nil {
       return nil


### PR DESCRIPTION
- [✔] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)

---

This PR adds small UX improvements to the *Playback* → *Jump to…* command:

1. Allows inputting sub-second precision timecodes to jump to
2. Displays the current video time code as the initial value
3. Has the added benefit of making the current time code easy to copy to the clipboard

Initially I had wanted a quick way to copy the current time code. I was already starting to implement a dedicated command for that when I realized the same could be accomplished more synergistically by beefing up the existing “Jump to…” command.

Will also fix #4547 