### PR TITLE
Rectify timeline in Touchbar freezes, #4058

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1643,17 +1643,17 @@ class MainWindowController: PlayerWindowController {
     }
 
     // Follow energy efficiency best practices and stop the timer that updates the OSC while it is
-    // hidden. However the timer can't be stopped if it is also updating the information being
-    // displayed in the touch bar. Does this host have a touch bar? Is the touch bar configured to
-    // show app controls? Is the touch bar awake? Is the host being operated in closed clamshell
-    // mode? This is the kind of information needed to avoid running the timer and updating controls
-    // that are not visible. Unfortunately in the documentation for NSTouchBar Apple indicates
-    // "There’s no need, and no API, for your app to know whether or not there’s a Touch Bar
-    // available". So this code keys off whether AppKit has requested that a NSTouchBar object be
-    // created. This avoids running the timer on Macs that do not have a touch bar. It also may
-    // avoid running the timer when a MacBook with a touch bar is being operated in closed
-    // clameshell mode.
-    if !player.hasTouchBar {
+    // hidden. However the timer can't be stopped if the mini player is being used as it always
+    // displays the the OSC or the timer is also updating the information being displayed in the
+    // touch bar. Does this host have a touch bar? Is the touch bar configured to show app controls?
+    // Is the touch bar awake? Is the host being operated in closed clamshell mode? This is the kind
+    // of information needed to avoid running the timer and updating controls that are not visible.
+    // Unfortunately in the documentation for NSTouchBar Apple indicates "There’s no need, and no
+    // API, for your app to know whether or not there’s a Touch Bar available". So this code keys
+    // off whether AppKit has requested that a NSTouchBar object be created. This avoids running the
+    // timer on Macs that do not have a touch bar. It also may avoid running the timer when a
+    // MacBook with a touch bar is being operated in closed clameshell mode.
+    if !player.isInMiniPlayer && !player.hasTouchBar {
       player.invalidateTimer()
     }
 

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1653,7 +1653,7 @@ class MainWindowController: PlayerWindowController {
     // off whether AppKit has requested that a NSTouchBar object be created. This avoids running the
     // timer on Macs that do not have a touch bar. It also may avoid running the timer when a
     // MacBook with a touch bar is being operated in closed clameshell mode.
-    if !player.isInMiniPlayer && !player.hasTouchBar {
+    if !player.isInMiniPlayer && !player.needsTouchBar {
       player.invalidateTimer()
     }
 

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -474,6 +474,12 @@ class PlayerCore: NSObject {
 
     miniPlayer.updateTitle()
     syncUITime()
+    // When not in the mini player the timer that updates the OSC may be stopped to conserve energy
+    // when the OSC is hidden. As the OSC is always displayed in the mini player ensure the timer is
+    // running if media is playing.
+    if !info.isPaused {
+      createSyncUITimer()
+    }
     let playlistView = mainWindow.playlistView.view
     let videoView = mainWindow.videoView
     // reset down shift for playlistView

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -97,7 +97,7 @@ class PlayerCore: NSObject {
   ///
   /// - Note: This is set based on whether `AppKit` has called `MakeTouchBar`, therefore it can, for example, be `false` for
   ///         a MacBook that has a touch bar if the touch bar is asleep because the Mac is in closed clamshell mode.
-  var hasTouchBar = false
+  var needsTouchBar = false
 
   /// A dispatch queue for auto load feature.
   let backgroundQueue = DispatchQueue(label: "IINAPlayerCoreTask", qos: .background)
@@ -1788,7 +1788,7 @@ class PlayerCore: NSObject {
   @available(macOS 10.12.2, *)
   func makeTouchBar() -> NSTouchBar {
     Logger.log("Activating Touch Bar", subsystem: subsystem)
-    hasTouchBar = true
+    needsTouchBar = true
     // The timer that synchronizes the UI is shutdown to conserve energy when the OSC is hidden.
     // However the timer can't be stopped if it is needed to update the information being displayed
     // in the touch bar. If currently playing make sure the timer is running.

--- a/iina/TouchBarSupport.swift
+++ b/iina/TouchBarSupport.swift
@@ -247,18 +247,16 @@ class TouchBarSupport: NSObject, NSTouchBarDelegate {
 extension MainWindowController {
 
   override func makeTouchBar() -> NSTouchBar? {
-    return player.touchBarSupport.touchBar
+    return player.makeTouchBar()
   }
-
 }
 
 @available(macOS 10.12.2, *)
 extension MiniPlayerWindowController {
 
   override func makeTouchBar() -> NSTouchBar? {
-    return player.touchBarSupport.touchBar
+    return player.makeTouchBar()
   }
-
 }
 
 // MARK: - Slider


### PR DESCRIPTION
This commit will:
- Add a new method makeTouchBar to PlayerCore
- Change MainWindowController and MiniPlayerWindowController extensions in TouchBarSupport to call the new method
- Add a hasTouchBar property to TouchBarSupport
- Change MainWindowController.hideUI to not stop the timer that synchronizes the UI if the Mac has a touch bar

This corrects a regression added by a change to hideUI to stop the timer when the OSC is hidden in order to save energy. That change failed to take into account that the timer also synchronizes controls in the touch bar on MacBooks that have one.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4058.

---

**Description:**
