### PR TITLE
Fix incorrect playlist item moved to trash (issue #4061)

### DIFF
--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -637,20 +637,23 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
 
   @IBAction func contextMenuDeleteFile(_ sender: NSMenuItem) {
     guard let selectedRows = selectedRows else { return }
-    var count = 0
+    Logger.log("User chose to delete files from playlist at indexes: \(selectedRows.map{$0})")
+
+    var successes = IndexSet()
     for index in selectedRows {
-      player.playlistRemove(index)
       guard !player.info.playlist[index].isNetworkResource else { continue }
       let url = URL(fileURLWithPath: player.info.playlist[index].filename)
       do {
+        Logger.log("Trashing row \(index): \(url.standardizedFileURL)")
         try FileManager.default.trashItem(at: url, resultingItemURL: nil)
-        count += 1
+        successes.insert(index)
       } catch let error {
-        Utility.showAlert("playlist.error_deleting", arguments:
-          [error.localizedDescription])
+        Utility.showAlert("playlist.error_deleting", arguments: [error.localizedDescription])
       }
     }
-    playlistTableView.deselectAll(nil)
+    if !successes.isEmpty {
+      player.playlistRemove(successes)
+    }
   }
 
   @IBAction func contextMenuDeleteFileAfterPlayback(_ sender: NSMenuItem) {


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4061.

---

**Description:**
In Playlist context menu, `Move to Trash` was removing the item from the playlist before getting the filename from it, which resulted in either the incorrect file being sent to trash, or IINA crashing. Changed so that it first attempts to move each file to the trash, and only removes from the playlist at the end, and only removes the ones were successfully trashed.