### PR TITLE
Use float OpenGL buffer and extended linear colorspaces for HDR playback

### DIFF
--- a/iina/InspectorWindowController.swift
+++ b/iina/InspectorWindowController.swift
@@ -202,8 +202,17 @@ class InspectorWindowController: NSWindowController, NSTableViewDelegate, NSTabl
       self.setLabelColor(self.vprimariesField, by: sigPeak > 0)
 
       if PlayerCore.lastActive.mainWindow.loaded && controller.fileLoaded {
-        let colorspace = PlayerCore.lastActive.mainWindow.videoView.videoLayer.colorspace?.name;
-        self.vcolorspaceField.stringValue = colorspace == nil ? "Unspecified (SDR)" : String(colorspace!) + " (HDR)"
+        if let colorspace = PlayerCore.lastActive.mainWindow.videoView.videoLayer.colorspace, #available(macOS 10.15, *) {
+          var isHdr: Bool
+          if #available(macOS 11.0, *) {
+            isHdr = CGColorSpaceUsesExtendedRange(colorspace) || CGColorSpaceUsesITUR_2100TF(colorspace)
+          } else {
+            isHdr = colorspace.isHDR()
+          }
+          self.vcolorspaceField.stringValue = "\(colorspace.name!) (\(isHdr ? "H" : "S")DR)"
+        } else {
+          self.vcolorspaceField.stringValue = "Unspecified (SDR)"
+        }
       } else {
         self.vcolorspaceField.stringValue = "N/A"
       }

--- a/iina/InspectorWindowController.swift
+++ b/iina/InspectorWindowController.swift
@@ -202,7 +202,7 @@ class InspectorWindowController: NSWindowController, NSTableViewDelegate, NSTabl
       self.setLabelColor(self.vprimariesField, by: sigPeak > 0)
 
       if PlayerCore.lastActive.mainWindow.loaded && controller.fileLoaded {
-        if let colorspace = PlayerCore.lastActive.mainWindow.videoView.videoLayer.colorspace, #available(macOS 10.15, *) {
+        if #available(macOS 10.15, *), let colorspace = PlayerCore.lastActive.mainWindow.videoView.videoLayer.colorspace {
           var isHdr: Bool
           if #available(macOS 11.0, *) {
             isHdr = CGColorSpaceUsesExtendedRange(colorspace) || CGColorSpaceUsesITUR_2100TF(colorspace)

--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -47,6 +47,8 @@ class ViewLayer: CAOpenGLLayer {
     var attributeList: [CGLPixelFormatAttribute] = [
       kCGLPFADoubleBuffer,
       kCGLPFAAllowOfflineRenderers,
+      kCGLPFAColorFloat,
+      kCGLPFAColorSize, CGLPixelFormatAttribute(64),
       kCGLPFAOpenGLProfile, CGLPixelFormatAttribute(kCGLOGLPVersion_3_2_Core.rawValue),
       kCGLPFAAccelerated,
     ]


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #3772.

---

**Description:**
[This WWDC 2021 presentation](https://developer.apple.com/videos/play/wwdc2021/10161/) suggested to use floating point OpenGL buffers (see 20:56) and extended linear colorspaces (see 18:08) for EDR content. 

One may also note that [original mpv mac output code](https://github.com/mpv-player/mpv/blob/25b66256d7ff48254b2055a066e29f260414112f/video/out/mac/gl_layer.swift#L45) also use floating point OpenGL buffers for 10-bit playback, which format are most HDR videos in. Further, the official Apple Documentation notes that `itur_2020_PQ` colorspaces are [deprecated](https://developer.apple.com/documentation/coregraphics/cgcolorspace/3524230-itur_2020_pq). 

It turns out that these are all we need to match `QuickTime.app`'s HDR output.

Device: Macbook Pro 14" with M1 pro
Test clip:  [download](https://user-images.githubusercontent.com/30361859/211847796-c2ece693-78a8-49b4-a57e-fff9f40202d2.mp4)



- Left: IINA.app current `develop` branch
- Middle: this PR
- Right: QuickTime.app
![IMG_0377](https://user-images.githubusercontent.com/30361859/211843685-85a31c88-2b6c-425e-b93c-384f1e261113.jpg)
