### PR TITLE
Update copyright to 2023

### DIFF
--- a/iina/Base.lproj/Contribution.rtf
+++ b/iina/Base.lproj/Contribution.rtf
@@ -23,7 +23,7 @@ Email:
 \ulnone \
 
 \f1\b0 The modern video player for macOS.\
-Copyright \'a9 2017-2022  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
+Copyright \'a9 2017-2023  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 \cf0 \
 \

--- a/iina/Info.plist
+++ b/iina/Info.plist
@@ -515,7 +515,7 @@
 		</dict>
 	</dict>
 	<key>NSHumanReadableCopyright</key>
-	<string>Copyright © 2017-2022
+	<string>Copyright © 2017-2023
 Collider LI, et al.
 Released under GPLv3.</string>
 	<key>NSMainNibFile</key>

--- a/iina/en.lproj/Contribution.rtf
+++ b/iina/en.lproj/Contribution.rtf
@@ -23,7 +23,7 @@ Email:
 \ulnone \
 
 \f1\b0 The modern video player for macOS.\
-Copyright \'a9 2017-2022  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
+Copyright \'a9 2017-2023  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\partightenfactor0
 \cf0 \
 \

--- a/other/update_copyright.sh
+++ b/other/update_copyright.sh
@@ -16,9 +16,19 @@ year=$(date +%Y)
 
 echo "Updating copyright year to $year"
 
+function update () {
+    local dir="$1"
+    local file="$2"
+    find "$(cd $srcdir/$dir; pwd)" -name "$file" -exec sed -i '' "s/ 2017-2[0-9]\{3\}/ 2017-$year/" {} +
+}
+
 # Update the copyright displayed in the macOS "Get Info" window for the application.
-find "$(cd $srcdir; pwd)" -name Info.plist -exec sed -i '' "s/ 2017-2[0-9]\{3\}/ 2017-$year/" {} +
+update . Info.plist
 
 # Update the copyright displayed in the about window.
-# This changes lots of files due to localization.
-find "$(cd $srcdir; pwd)" -name Contribution.rtf -exec sed -i '' "s/ 2017-2[0-9]\{3\}/ 2017-$year/" {} +
+# This copyright text is contained in Contribution.rtf which is localized.
+# To avoid conflicts when merging translations from Crowdin the procedure for
+# modifying localized source is to only update the base and English source in
+# GitHub. Changes for other languages must then be made using Crowdin.
+update Base.lproj Contribution.rtf
+update en.lproj Contribution.rtf


### PR DESCRIPTION
The commit in the pull request will:
- Change update_copyright.sh to not modify localized sources that must only be updated through Crowdin
- Update the copyright displayed in the macOS "Get Info" window
- Update the copyright displayed in the about window

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
This only updates the copyright in the English localization of the about window. The copyright for other locales must be updated through Crowdin.