### PR TITLE
Allow OSD progress bar to scale for large text sizes

### DIFF
--- a/iina/Base.lproj/MainWindowController.xib
+++ b/iina/Base.lproj/MainWindowController.xib
@@ -338,9 +338,6 @@
                                     </textField>
                                     <progressIndicator wantsLayer="YES" horizontalHuggingPriority="270" misplaced="YES" maxValue="1" controlSize="small" style="bar" translatesAutoresizingMaskIntoConstraints="NO" id="i10-rt-9cb">
                                         <rect key="frame" x="0.0" y="0.0" width="161" height="12"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" constant="150" id="PvC-N6-ZBT"/>
-                                        </constraints>
                                     </progressIndicator>
                                 </beginningViews>
                                 <visibilityPriorities>


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #3171.

---

**Description:**

Was about to file a bug for this, but found that someone already filed this as an enhancement request.

Not sure why the progress bar was given this fixed width constraint; its width is already implicitly specified by virtue of being inside an `NSStackView`, and if the intent was to allow widths only up to 150 points, it's not the most reliable way to do it. Probably it was an artifact of some earlier development which was forgotten about.