### PR TITLE
Workaround cursor visible after button click, #4183

### DIFF
--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -109,6 +109,14 @@ class VideoView: NSView {
     return Preference.bool(for: .videoViewAcceptsFirstMouse)
   }
 
+  /// Workaround for issue #4183, Cursor remains visible after resuming playback with the touchpad using secondary click
+  ///
+  /// See `MainWindowController.workaroundCursorDefect` and the issue for details on this workaround.
+  override func rightMouseDown(with event: NSEvent) {
+    player.mainWindow.rightMouseDown(with: event)
+    super.rightMouseDown(with: event)
+  }
+
   /// Workaround for issue #3211, Legacy fullscreen is broken (11.0.1)
   ///
   /// Changes in Big Sur broke the legacy full screen feature. The `MainWindowController` method `legacyAnimateToWindowed`


### PR DESCRIPTION
This commit will:
- Add a new method workaroundCursorDefect to MainWindowController that will hide the cursor again if the OSC is hidden
- Change mouseDown and mouseUp to call workaroundCursorDefect
- Add methods otherMouseDown, otherMouseUp, rightMouseDown and rightMouseUp to MainWindowController that apply the workaround
- Add method rightMouseDown to VideoView to pass that mouse event to MainWindowController

These changes workaround a regression in the macOS AppKit method NSCursor.setHiddenUntilMouseMoves introduced in macOS Big Sur that causes the cursor to become visible when a mouse button is clicked even if the mouse does not move.

This problem has been reported to Apple.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4183.

---

**Description:**
This is a workaround for a macOS AppKit defect.