### PR TITLE
Allow user to set size of thumbnails + other thumbnail stuff

### DIFF
--- a/iina/AppData.swift
+++ b/iina/AppData.swift
@@ -37,6 +37,11 @@ struct AppData {
   static let seekAmountMapMouse = [0, 0.5, 1, 2, 4]
   static let volumeMap = [0, 0.25, 0.5, 0.75, 1]
 
+  // Time in seconds to wait before regenerating thumbnails.
+  // Each character the user types into the thumbnailWidth text field triggers a new thumb regen request.
+  // This should help cut down on unnecessary requests.
+  static let thumbnailRegenerationDelay = 2.0
+
   static let encodings = CharEncoding.list
 
   static let userInputConfFolder = "input_conf"

--- a/iina/Base.lproj/PrefAdvancedViewController.xib
+++ b/iina/Base.lproj/PrefAdvancedViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21225" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21225"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -20,16 +20,61 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="500" height="402"/>
-            <point key="canvasLocation" x="202" y="234"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY" userLabel="Prefs &gt; Advanced View">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="402"/>
+            <point key="canvasLocation" x="166" y="26"/>
         </customView>
         <userDefaultsController representsSharedInstance="YES" id="nyg-fH-Pug"/>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="vY6-lX-1l5">
-            <rect key="frame" x="0.0" y="0.0" width="500" height="322"/>
+        <customView id="vDK-ld-vAF" userLabel="Prefs &gt; Advanced: Top Section">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="52"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+            <subviews>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="M2l-at-Cbp">
+                    <rect key="frame" x="0.0" y="0.0" width="336" height="14"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="The following settings will require restarting IINA to take effect." id="HMa-Vz-EUk">
+                        <font key="font" metaFont="message" size="11"/>
+                        <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <button horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3Gg-Io-SlS">
+                    <rect key="frame" x="456" y="24" width="25" height="25"/>
+                    <buttonCell key="cell" type="help" bezelStyle="helpButton" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="jZ3-bn-f9w">
+                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="helpBtnAction:" target="-2" id="G8C-1V-IMW"/>
+                    </connections>
+                </button>
+                <customView translatesAutoresizingMaskIntoConstraints="NO" id="PCZ-06-pn4" customClass="Switch" customModule="IINA" customModuleProvider="target">
+                    <rect key="frame" x="0.0" y="18" width="459" height="28"/>
+                    <userDefinedRuntimeAttributes>
+                        <userDefinedRuntimeAttribute type="boolean" keyPath="switchOnLeft" value="YES"/>
+                        <userDefinedRuntimeAttribute type="string" keyPath="title" value="preference.enable_adv_settings"/>
+                        <userDefinedRuntimeAttribute type="boolean" keyPath="checkboxMargin" value="NO"/>
+                    </userDefinedRuntimeAttributes>
+                </customView>
+            </subviews>
+            <constraints>
+                <constraint firstAttribute="trailing" secondItem="3Gg-Io-SlS" secondAttribute="trailing" constant="1" id="1yC-lU-olv"/>
+                <constraint firstItem="PCZ-06-pn4" firstAttribute="top" secondItem="vDK-ld-vAF" secondAttribute="top" constant="6" id="42e-pN-GhV"/>
+                <constraint firstItem="M2l-at-Cbp" firstAttribute="top" secondItem="PCZ-06-pn4" secondAttribute="bottom" constant="4" id="I0C-I1-WT4"/>
+                <constraint firstItem="3Gg-Io-SlS" firstAttribute="leading" secondItem="PCZ-06-pn4" secondAttribute="trailing" id="Yta-lq-1XT"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="M2l-at-Cbp" secondAttribute="trailing" id="Zpp-lF-tHt"/>
+                <constraint firstAttribute="bottom" secondItem="M2l-at-Cbp" secondAttribute="bottom" id="gcW-kn-Puf"/>
+                <constraint firstItem="3Gg-Io-SlS" firstAttribute="top" secondItem="vDK-ld-vAF" secondAttribute="top" constant="4" id="kUt-ct-UDL"/>
+                <constraint firstItem="PCZ-06-pn4" firstAttribute="leading" secondItem="vDK-ld-vAF" secondAttribute="leading" id="rKi-JK-3FR"/>
+                <constraint firstItem="M2l-at-Cbp" firstAttribute="leading" secondItem="PCZ-06-pn4" secondAttribute="leading" constant="2" id="yi9-qH-iho"/>
+            </constraints>
+            <point key="canvasLocation" x="-397" y="-163.5"/>
+        </customView>
+        <customView id="vY6-lX-1l5" userLabel="Prefs &gt; Advanced: mpv Section">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="322"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="SHQ-mh-jeX">
-                    <rect key="frame" x="6" y="298" width="112" height="18"/>
+                    <rect key="frame" x="-1" y="297" width="116" height="18"/>
                     <buttonCell key="cell" type="check" title="Enable logging" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="LCd-uY-Yze">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -40,7 +85,7 @@
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="zKI-kU-PWr">
-                    <rect key="frame" x="6" y="276" width="117" height="18"/>
+                    <rect key="frame" x="-1" y="275" width="121" height="16"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="14" id="h0j-bq-bLh"/>
                     </constraints>
@@ -54,7 +99,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="shz-CZ-kqM">
-                    <rect key="frame" x="345" y="289" width="153" height="32"/>
+                    <rect key="frame" x="338" y="288" width="148" height="32"/>
                     <buttonCell key="cell" type="push" title="Open log directory" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="JDA-g3-RNX">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -65,13 +110,13 @@
                     </connections>
                 </button>
                 <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="bA7-7o-Vd0">
-                    <rect key="frame" x="8" y="103" width="484" height="134"/>
+                    <rect key="frame" x="0.0" y="93" width="480" height="142"/>
                     <clipView key="contentView" id="aL1-v5-nLY">
-                        <rect key="frame" x="1" y="0.0" width="482" height="133"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <rect key="frame" x="1" y="1" width="478" height="140"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" headerView="wiq-g9-ouS" id="LPs-2B-Pt0">
-                                <rect key="frame" x="0.0" y="0.0" width="482" height="110"/>
+                                <rect key="frame" x="0.0" y="0.0" width="478" height="117"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <size key="intercellSpacing" width="3" height="2"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -89,7 +134,7 @@
                                         </textFieldCell>
                                         <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                     </tableColumn>
-                                    <tableColumn identifier="Value" width="358" minWidth="40" maxWidth="1000" id="SX9-fy-bss">
+                                    <tableColumn identifier="Value" width="316" minWidth="40" maxWidth="1000" id="SX9-fy-bss">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Value">
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
@@ -109,23 +154,23 @@
                         </subviews>
                     </clipView>
                     <constraints>
-                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="130" id="TZF-vz-q9V"/>
+                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="60" id="TZF-vz-q9V"/>
                     </constraints>
                     <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="iUT-PB-HTE">
-                        <rect key="frame" x="1" y="121" width="458" height="16"/>
+                        <rect key="frame" x="1" y="125" width="398" height="16"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                     <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="JMO-G9-iKp">
                         <rect key="frame" x="-15" y="23" width="16" height="0.0"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
-                    <tableHeaderView key="headerView" id="wiq-g9-ouS">
-                        <rect key="frame" x="0.0" y="0.0" width="482" height="23"/>
+                    <tableHeaderView key="headerView" wantsLayer="YES" id="wiq-g9-ouS">
+                        <rect key="frame" x="0.0" y="0.0" width="478" height="23"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </tableHeaderView>
                 </scrollView>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wWR-n2-u2E">
-                    <rect key="frame" x="6" y="245" width="143" height="16"/>
+                    <rect key="frame" x="-2" y="243" width="143" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Additional mpv options" id="6F6-Y7-8oR">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -133,13 +178,13 @@
                     </textFieldCell>
                 </textField>
                 <box boxType="custom" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="1NU-Lr-cuR">
-                    <rect key="frame" x="8" y="82" width="484" height="22"/>
+                    <rect key="frame" x="0.0" y="72" width="480" height="22"/>
                     <view key="contentView" id="HB1-1I-BjW">
-                        <rect key="frame" x="1" y="1" width="482" height="20"/>
+                        <rect key="frame" x="1" y="1" width="478" height="20"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="RY9-rr-eGr">
-                                <rect key="frame" x="0.0" y="0.0" width="20" height="20"/>
+                                <rect key="frame" x="0.0" y="-1.5" width="20.5" height="24"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="20" id="XfO-xd-O4d"/>
                                     <constraint firstAttribute="width" secondItem="RY9-rr-eGr" secondAttribute="height" multiplier="1:1" id="zHQ-Qh-S3o"/>
@@ -154,7 +199,7 @@
                                 </connections>
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="EU2-5a-Lpj">
-                                <rect key="frame" x="20" y="0.0" width="20" height="20"/>
+                                <rect key="frame" x="20" y="3" width="20.5" height="15"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="EU2-5a-Lpj" secondAttribute="height" multiplier="1:1" id="Rtd-NO-VuP"/>
                                 </constraints>
@@ -181,7 +226,7 @@
                     <color key="fillColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                 </box>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="Gf8-9e-wu7">
-                    <rect key="frame" x="6" y="45" width="149" height="18"/>
+                    <rect key="frame" x="-1" y="36" width="153" height="16"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="14" id="nel-hG-EmW"/>
                     </constraints>
@@ -195,7 +240,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hbF-n4-jl3">
-                    <rect key="frame" x="344" y="36" width="154" height="32"/>
+                    <rect key="frame" x="338" y="27" width="148" height="32"/>
                     <buttonCell key="cell" type="push" title="Choose directory…" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="MRT-u8-xTX">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -214,7 +259,7 @@
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jsf-pn-h6s">
-                    <rect key="frame" x="26" y="18" width="466" height="21"/>
+                    <rect key="frame" x="19" y="8" width="461" height="21"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="~/.config/mpv/" drawsBackground="YES" id="gWN-ya-xRD">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -238,9 +283,9 @@
                         </binding>
                     </connections>
                 </textField>
-                <textField identifier="SectionTitleSettings" hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="HmN-IK-rGn">
-                    <rect key="frame" x="-2" y="0.0" width="55" height="16"/>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Settings" id="Qmc-Tb-d7d">
+                <textField identifier="SectionTitleSettings" hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dfL-W8-kmJ">
+                    <rect key="frame" x="427" y="306" width="55" height="16"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Settings" id="BZq-Iy-OSr">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -248,85 +293,41 @@
                 </textField>
             </subviews>
             <constraints>
+                <constraint firstItem="dfL-W8-kmJ" firstAttribute="top" secondItem="vY6-lX-1l5" secondAttribute="top" id="2b0-gB-iOM"/>
                 <constraint firstItem="1NU-Lr-cuR" firstAttribute="leading" secondItem="bA7-7o-Vd0" secondAttribute="leading" id="3Zo-e3-ao5"/>
-                <constraint firstItem="Gf8-9e-wu7" firstAttribute="leading" secondItem="vY6-lX-1l5" secondAttribute="leading" constant="8" id="77L-nm-7Wg"/>
-                <constraint firstItem="SHQ-mh-jeX" firstAttribute="leading" secondItem="vY6-lX-1l5" secondAttribute="leading" constant="8" id="7FO-Gh-VYL"/>
+                <constraint firstItem="Gf8-9e-wu7" firstAttribute="leading" secondItem="vY6-lX-1l5" secondAttribute="leading" constant="1" id="77L-nm-7Wg"/>
+                <constraint firstItem="SHQ-mh-jeX" firstAttribute="leading" secondItem="vY6-lX-1l5" secondAttribute="leading" constant="1" id="7FO-Gh-VYL"/>
                 <constraint firstItem="jsf-pn-h6s" firstAttribute="top" secondItem="Gf8-9e-wu7" secondAttribute="bottom" constant="8" id="8sD-5a-FXo"/>
-                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="480" id="9rR-Md-Sod"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="zKI-kU-PWr" secondAttribute="trailing" constant="8" id="A4q-u7-eZ7"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="zKI-kU-PWr" secondAttribute="trailing" id="A4q-u7-eZ7"/>
                 <constraint firstItem="wWR-n2-u2E" firstAttribute="top" secondItem="zKI-kU-PWr" secondAttribute="bottom" constant="17" id="Cg4-PA-TyS"/>
                 <constraint firstItem="SHQ-mh-jeX" firstAttribute="top" secondItem="vY6-lX-1l5" secondAttribute="top" constant="8" id="Dvs-6e-7wU"/>
-                <constraint firstAttribute="trailing" secondItem="hbF-n4-jl3" secondAttribute="trailing" constant="8" id="FDJ-Cp-psA"/>
+                <constraint firstAttribute="trailing" secondItem="hbF-n4-jl3" secondAttribute="trailing" constant="1" id="FDJ-Cp-psA"/>
                 <constraint firstItem="zKI-kU-PWr" firstAttribute="leading" secondItem="SHQ-mh-jeX" secondAttribute="leading" id="Fvw-CC-nKH"/>
                 <constraint firstItem="1NU-Lr-cuR" firstAttribute="trailing" secondItem="bA7-7o-Vd0" secondAttribute="trailing" id="HTl-7I-Zcu"/>
-                <constraint firstAttribute="bottom" secondItem="HmN-IK-rGn" secondAttribute="bottom" id="Ivk-KG-oyA"/>
                 <constraint firstItem="1NU-Lr-cuR" firstAttribute="top" secondItem="bA7-7o-Vd0" secondAttribute="bottom" constant="-1" id="KSl-QB-xiy"/>
-                <constraint firstAttribute="bottom" secondItem="jsf-pn-h6s" secondAttribute="bottom" constant="18" id="P70-PP-vNV"/>
+                <constraint firstAttribute="bottom" secondItem="jsf-pn-h6s" secondAttribute="bottom" constant="8" id="P70-PP-vNV"/>
                 <constraint firstItem="bA7-7o-Vd0" firstAttribute="top" secondItem="wWR-n2-u2E" secondAttribute="bottom" constant="8" id="ZB8-eK-Abf"/>
-                <constraint firstItem="HmN-IK-rGn" firstAttribute="leading" secondItem="vY6-lX-1l5" secondAttribute="leading" id="aAj-ev-1k6"/>
-                <constraint firstItem="wWR-n2-u2E" firstAttribute="leading" secondItem="vY6-lX-1l5" secondAttribute="leading" constant="8" id="bQ8-hg-8SK"/>
-                <constraint firstItem="shz-CZ-kqM" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="SHQ-mh-jeX" secondAttribute="trailing" constant="8" id="bZ0-vF-cve"/>
+                <constraint firstItem="wWR-n2-u2E" firstAttribute="leading" secondItem="vY6-lX-1l5" secondAttribute="leading" id="bQ8-hg-8SK"/>
+                <constraint firstItem="shz-CZ-kqM" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="SHQ-mh-jeX" secondAttribute="trailing" id="bZ0-vF-cve"/>
                 <constraint firstItem="zKI-kU-PWr" firstAttribute="top" secondItem="SHQ-mh-jeX" secondAttribute="bottom" constant="8" id="bmT-aS-rnS"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="wWR-n2-u2E" secondAttribute="trailing" constant="8" id="cWT-fx-J5u"/>
-                <constraint firstAttribute="trailing" secondItem="shz-CZ-kqM" secondAttribute="trailing" constant="8" id="eHI-S4-ALO"/>
-                <constraint firstAttribute="trailing" secondItem="bA7-7o-Vd0" secondAttribute="trailing" constant="8" id="foA-Yd-KGK"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="wWR-n2-u2E" secondAttribute="trailing" id="cWT-fx-J5u"/>
+                <constraint firstAttribute="trailing" secondItem="shz-CZ-kqM" secondAttribute="trailing" constant="1" id="eHI-S4-ALO"/>
+                <constraint firstAttribute="trailing" secondItem="bA7-7o-Vd0" secondAttribute="trailing" id="foA-Yd-KGK"/>
                 <constraint firstItem="hbF-n4-jl3" firstAttribute="baseline" secondItem="Gf8-9e-wu7" secondAttribute="baseline" id="j2y-sy-d0s"/>
+                <constraint firstAttribute="trailing" secondItem="dfL-W8-kmJ" secondAttribute="trailing" id="j5D-rm-Ypb"/>
                 <constraint firstItem="jsf-pn-h6s" firstAttribute="leading" secondItem="Gf8-9e-wu7" secondAttribute="leading" constant="18" id="kCk-Cy-eeA"/>
                 <constraint firstItem="hbF-n4-jl3" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Gf8-9e-wu7" secondAttribute="trailing" constant="8" id="ltk-Vb-ZZN"/>
-                <constraint firstItem="shz-CZ-kqM" firstAttribute="baseline" secondItem="SHQ-mh-jeX" secondAttribute="baseline" id="plm-KY-Yk5"/>
-                <constraint firstItem="bA7-7o-Vd0" firstAttribute="leading" secondItem="vY6-lX-1l5" secondAttribute="leading" constant="8" id="vIL-Pv-g7K"/>
+                <constraint firstItem="dfL-W8-kmJ" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="SHQ-mh-jeX" secondAttribute="trailing" id="pbf-C0-HQJ"/>
+                <constraint firstItem="shz-CZ-kqM" firstAttribute="firstBaseline" secondItem="SHQ-mh-jeX" secondAttribute="firstBaseline" id="plm-KY-Yk5"/>
+                <constraint firstItem="bA7-7o-Vd0" firstAttribute="leading" secondItem="vY6-lX-1l5" secondAttribute="leading" id="vIL-Pv-g7K"/>
                 <constraint firstItem="Gf8-9e-wu7" firstAttribute="top" secondItem="1NU-Lr-cuR" secondAttribute="bottom" constant="21" id="vlF-g2-sTm"/>
-                <constraint firstAttribute="trailing" secondItem="jsf-pn-h6s" secondAttribute="trailing" constant="8" id="xHU-Tk-fPb"/>
+                <constraint firstAttribute="trailing" secondItem="jsf-pn-h6s" secondAttribute="trailing" id="xHU-Tk-fPb"/>
             </constraints>
             <point key="canvasLocation" x="-397" y="73"/>
         </customView>
-        <customView id="vDK-ld-vAF">
-            <rect key="frame" x="0.0" y="0.0" width="500" height="60"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-            <subviews>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="M2l-at-Cbp">
-                    <rect key="frame" x="8" y="8" width="486" height="14"/>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="The following settings will require restarting IINA to take effect." id="HMa-Vz-EUk">
-                        <font key="font" metaFont="message" size="11"/>
-                        <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
-                <button horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3Gg-Io-SlS">
-                    <rect key="frame" x="469" y="27" width="25" height="25"/>
-                    <buttonCell key="cell" type="help" bezelStyle="helpButton" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="jZ3-bn-f9w">
-                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
-                    </buttonCell>
-                    <connections>
-                        <action selector="helpBtnAction:" target="-2" id="G8C-1V-IMW"/>
-                    </connections>
-                </button>
-                <customView translatesAutoresizingMaskIntoConstraints="NO" id="PCZ-06-pn4" customClass="Switch" customModule="IINA" customModuleProvider="target">
-                    <rect key="frame" x="8" y="26" width="463" height="26"/>
-                    <userDefinedRuntimeAttributes>
-                        <userDefinedRuntimeAttribute type="boolean" keyPath="switchOnLeft" value="YES"/>
-                        <userDefinedRuntimeAttribute type="string" keyPath="title" value="preference.enable_adv_settings"/>
-                        <userDefinedRuntimeAttribute type="boolean" keyPath="checkboxMargin" value="NO"/>
-                    </userDefinedRuntimeAttributes>
-                </customView>
-            </subviews>
-            <constraints>
-                <constraint firstAttribute="trailing" secondItem="3Gg-Io-SlS" secondAttribute="trailing" constant="8" id="1yC-lU-olv"/>
-                <constraint firstItem="PCZ-06-pn4" firstAttribute="top" secondItem="vDK-ld-vAF" secondAttribute="top" constant="8" id="42e-pN-GhV"/>
-                <constraint firstItem="M2l-at-Cbp" firstAttribute="top" secondItem="PCZ-06-pn4" secondAttribute="bottom" constant="4" id="I0C-I1-WT4"/>
-                <constraint firstItem="3Gg-Io-SlS" firstAttribute="leading" secondItem="PCZ-06-pn4" secondAttribute="trailing" id="Yta-lq-1XT"/>
-                <constraint firstAttribute="trailing" secondItem="M2l-at-Cbp" secondAttribute="trailing" constant="8" id="Zpp-lF-tHt"/>
-                <constraint firstAttribute="bottom" secondItem="M2l-at-Cbp" secondAttribute="bottom" constant="8" id="gcW-kn-Puf"/>
-                <constraint firstItem="3Gg-Io-SlS" firstAttribute="top" secondItem="vDK-ld-vAF" secondAttribute="top" constant="8" id="kUt-ct-UDL"/>
-                <constraint firstItem="PCZ-06-pn4" firstAttribute="leading" secondItem="vDK-ld-vAF" secondAttribute="leading" constant="8" id="rKi-JK-3FR"/>
-                <constraint firstItem="M2l-at-Cbp" firstAttribute="leading" secondItem="PCZ-06-pn4" secondAttribute="leading" constant="2" id="yi9-qH-iho"/>
-            </constraints>
-            <point key="canvasLocation" x="-397" y="-163.5"/>
-        </customView>
     </objects>
     <resources>
-        <image name="NSAddTemplate" width="11" height="11"/>
-        <image name="NSRemoveTemplate" width="11" height="11"/>
+        <image name="NSAddTemplate" width="18" height="17"/>
+        <image name="NSRemoveTemplate" width="18" height="5"/>
     </resources>
 </document>

--- a/iina/Base.lproj/PrefCodecViewController.xib
+++ b/iina/Base.lproj/PrefCodecViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21225" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21225"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -21,13 +21,13 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="500" height="288"/>
-            <point key="canvasLocation" x="218" y="203.5"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY" userLabel="Prefs &gt; Codec View">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="288"/>
+            <point key="canvasLocation" x="1331" y="416"/>
         </customView>
         <userDefaultsController representsSharedInstance="YES" id="pxc-7C-SGP"/>
-        <customView misplaced="YES" id="gZf-gF-XoY">
-            <rect key="frame" x="0.0" y="0.0" width="444" height="234"/>
+        <customView id="gZf-gF-XoY" userLabel="Prefs &gt; Codec &gt; Video">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="244"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField identifier="SectionTitleVideo" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2BH-mP-kfr">
@@ -97,7 +97,7 @@
                     </connections>
                 </popUpButton>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="0Re-PY-hmC">
-                    <rect key="frame" x="118" y="170" width="328" height="14"/>
+                    <rect key="frame" x="118" y="170" width="364" height="14"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Label" id="n3r-mP-f8V">
                         <font key="font" metaFont="label" size="11"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -123,7 +123,7 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="40Z-9R-jw0">
-                    <rect key="frame" x="118" y="110" width="328" height="28"/>
+                    <rect key="frame" x="118" y="110" width="364" height="28"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Always use the dedicated GPU for rendering (if it exists). This can improve performance but may reduce battery life." id="gCv-sJ-uQJ">
                         <font key="font" metaFont="label" size="11"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -141,7 +141,7 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="IQ8-K4-5CX">
-                    <rect key="frame" x="118" y="54" width="328" height="28"/>
+                    <rect key="frame" x="118" y="54" width="364" height="28"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Load the ICC profile for current display and use it to transform video RGB to screen output. (Only for SDR mode)" id="M2M-of-gjd">
                         <font key="font" metaFont="label" size="11"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -159,7 +159,7 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="f1i-M6-eNG">
-                    <rect key="frame" x="118" y="12" width="294" height="14"/>
+                    <rect key="frame" x="118" y="12" width="364" height="14"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="Enable HDR mode by default when playing HDR videos." id="ZgQ-bc-yEE">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -182,9 +182,11 @@
                 <constraint firstItem="2BH-mP-kfr" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="gZf-gF-XoY" secondAttribute="leading" constant="120" id="KBf-6v-pL9"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="xXS-nP-Chk" secondAttribute="trailing" constant="12" id="QNu-hr-TdO"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="H9a-N4-xDt" secondAttribute="trailing" constant="12" id="TxZ-c7-rVn"/>
+                <constraint firstAttribute="trailing" secondItem="f1i-M6-eNG" secondAttribute="trailing" id="UJF-Aa-p1k"/>
                 <constraint firstItem="IQ8-K4-5CX" firstAttribute="top" secondItem="H9a-N4-xDt" secondAttribute="bottom" constant="4" id="W29-Gj-v7X"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="kas-7q-TbK" secondAttribute="trailing" constant="20" symbolic="YES" id="XnT-jM-uWw"/>
                 <constraint firstItem="paR-ax-h5M" firstAttribute="top" secondItem="2BH-mP-kfr" secondAttribute="top" id="ZwF-7T-SvE"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="9Rd-yY-b8t" secondAttribute="trailing" id="Zza-J1-F3v"/>
                 <constraint firstItem="xXS-nP-Chk" firstAttribute="leading" secondItem="0Re-PY-hmC" secondAttribute="leading" id="aYZ-dq-yBE"/>
                 <constraint firstItem="kas-7q-TbK" firstAttribute="leading" secondItem="NZA-64-tXh" secondAttribute="trailing" constant="10" id="c73-Gh-U6L"/>
                 <constraint firstItem="IQ8-K4-5CX" firstAttribute="leading" secondItem="H9a-N4-xDt" secondAttribute="leading" id="cpx-2e-hcB"/>
@@ -207,7 +209,7 @@
             </constraints>
             <point key="canvasLocation" x="783" y="394.5"/>
         </customView>
-        <customView id="bsP-Kc-xXR">
+        <customView id="bsP-Kc-xXR" userLabel="Prefs &gt; Codec &gt; Audio">
             <rect key="frame" x="0.0" y="0.0" width="480" height="192"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
@@ -253,7 +255,7 @@
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="160" id="NAx-xr-hr8"/>
                     </constraints>
-                    <tokenFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" allowsEditingTextAttributes="YES" id="RBR-T9-Cw3">
+                    <tokenFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" allowsEditingTextAttributes="YES" id="RBR-T9-Cw3">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -381,9 +383,6 @@
                 </textField>
                 <popUpButton horizontalHuggingPriority="200" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Min-k4-E1V">
                     <rect key="frame" x="266" y="33" width="76" height="25"/>
-                    <constraints>
-                        <constraint firstAttribute="width" relation="lessThanOrEqual" constant="300" id="gCa-l2-dK8"/>
-                    </constraints>
                     <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="iQf-Gb-IuO" id="Eau-zf-my0">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="menu"/>
@@ -463,7 +462,7 @@
                 <constraint firstItem="iB2-dA-Y1E" firstAttribute="leading" secondItem="JFX-OT-X7j" secondAttribute="trailing" constant="8" id="vpv-fy-V0A"/>
                 <constraint firstItem="0Ig-J7-VYp" firstAttribute="top" secondItem="bsP-Kc-xXR" secondAttribute="top" constant="8" id="xTx-Rf-Dxq"/>
             </constraints>
-            <point key="canvasLocation" x="792" y="75"/>
+            <point key="canvasLocation" x="783" y="660"/>
         </customView>
     </objects>
 </document>

--- a/iina/Base.lproj/PrefControlViewController.xib
+++ b/iina/Base.lproj/PrefControlViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15702" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15702"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -17,33 +17,17 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="500" height="385"/>
-            <point key="canvasLocation" x="251" y="425"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY" userLabel="Prefs &gt; Control View">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="340"/>
+            <point key="canvasLocation" x="226" y="490"/>
         </customView>
         <userDefaultsController representsSharedInstance="YES" id="Yrj-d0-KaY"/>
-        <customView id="Wmg-PT-BGO">
-            <rect key="frame" x="0.0" y="0.0" width="516" height="308"/>
+        <customView id="Wmg-PT-BGO" userLabel="Prefs &gt; Control &gt; Mouse">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="310"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField identifier="SectionTitleMouse" hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="CKk-h3-h9Z">
-                    <rect key="frame" x="-2" y="0.0" width="45" height="16"/>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Mouse" id="eA4-AD-oUu">
-                        <font key="font" metaFont="system"/>
-                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
-                <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="h4p-a3-cku">
-                    <rect key="frame" x="20" y="265" width="38" height="43"/>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="38" id="KOb-mb-7Sc"/>
-                        <constraint firstAttribute="height" constant="43" id="wit-tn-7nT"/>
-                    </constraints>
-                    <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="toolbar_control" id="vfN-MS-l0X"/>
-                </imageView>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="zSQ-pa-Urx">
-                    <rect key="frame" x="78" y="226" width="168" height="16"/>
+                    <rect key="frame" x="56" y="228" width="168" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Seek type:" id="1yb-m4-1sK">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -51,7 +35,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hxT-iF-nwJ">
-                    <rect key="frame" x="78" y="264" width="168" height="16"/>
+                    <rect key="frame" x="56" y="266" width="168" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Scroll horizontally to:" id="w1Y-jy-vNc">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -59,10 +43,10 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VlR-LI-plv">
-                    <rect key="frame" x="250" y="220" width="225" height="25"/>
+                    <rect key="frame" x="227" y="221" width="227" height="25"/>
                     <popUpButtonCell key="cell" type="push" title="Keyframe seek" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="wBB-fx-Mao" id="BFn-Bz-29A">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="menu"/>
                         <menu key="menu" id="ktA-W7-cvw">
                             <items>
                                 <menuItem title="Keyframe seek" state="on" id="wBB-fx-Mao"/>
@@ -76,7 +60,7 @@
                     </connections>
                 </popUpButton>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="LN0-rs-jJB">
-                    <rect key="frame" x="78" y="204" width="440" height="14"/>
+                    <rect key="frame" x="56" y="206" width="426" height="14"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Exact seek is more precise but can cause lag and higher CPU usage." id="6FZ-Qm-0k0">
                         <font key="font" metaFont="message" size="11"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -84,7 +68,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="m0j-Zw-pcy">
-                    <rect key="frame" x="78" y="180" width="168" height="16"/>
+                    <rect key="frame" x="56" y="182" width="168" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Sensitivity for normal seek:" id="of2-ec-OkC">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -92,7 +76,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="E8B-5D-NHc">
-                    <rect key="frame" x="78" y="80" width="168" height="17"/>
+                    <rect key="frame" x="56" y="80" width="168" height="17"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="17" id="C2j-3C-GTX"/>
                     </constraints>
@@ -103,7 +87,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IGA-yr-g8l">
-                    <rect key="frame" x="78" y="56" width="168" height="16"/>
+                    <rect key="frame" x="56" y="56" width="168" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Double click to:" id="GPH-fM-XHN">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -111,7 +95,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2rD-uu-WVu">
-                    <rect key="frame" x="78" y="32" width="168" height="16"/>
+                    <rect key="frame" x="56" y="32" width="168" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Right click to:" id="Rqy-g2-AP2">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -119,10 +103,10 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ltc-ek-XnI">
-                    <rect key="frame" x="250" y="74" width="225" height="25"/>
+                    <rect key="frame" x="227" y="73" width="227" height="25"/>
                     <popUpButtonCell key="cell" type="push" title="Hide OSC" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="3" imageScaling="proportionallyDown" inset="2" selectedItem="9qx-ao-oxE" id="kx4-ff-K5Z">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="menu"/>
                         <menu key="menu" id="nPO-ET-BZ0">
                             <items>
                                 <menuItem title="Hide OSC" state="on" tag="3" id="9qx-ao-oxE">
@@ -138,10 +122,10 @@
                     </connections>
                 </popUpButton>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0Qc-Uz-odw">
-                    <rect key="frame" x="250" y="50" width="225" height="25"/>
+                    <rect key="frame" x="227" y="49" width="227" height="25"/>
                     <popUpButtonCell key="cell" type="push" title="Toggle fullscreen" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="1" imageScaling="proportionallyDown" inset="2" selectedItem="6F4-gm-oBg" id="ZmD-ZY-OrO">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="menu"/>
                         <menu key="menu" id="qI8-W1-aYW">
                             <items>
                                 <menuItem title="Toggle fullscreen" state="on" tag="1" id="6F4-gm-oBg">
@@ -158,7 +142,7 @@
                     </connections>
                 </popUpButton>
                 <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WC2-9P-fCe">
-                    <rect key="frame" x="252" y="178" width="111" height="15"/>
+                    <rect key="frame" x="228" y="179" width="115" height="17"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="111" id="kej-sl-3p8"/>
                     </constraints>
@@ -168,10 +152,10 @@
                     </connections>
                 </slider>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mdI-b4-54O">
-                    <rect key="frame" x="250" y="26" width="225" height="25"/>
+                    <rect key="frame" x="227" y="25" width="227" height="25"/>
                     <popUpButtonCell key="cell" type="push" title="Hide OSC" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="3" imageScaling="proportionallyDown" inset="2" selectedItem="OOM-jo-N4V" id="xO3-x1-Jqc">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="menu"/>
                         <menu key="menu" id="fcQ-e1-P2b">
                             <items>
                                 <menuItem title="Hide OSC" state="on" tag="3" id="OOM-jo-N4V">
@@ -188,7 +172,7 @@
                     </connections>
                 </popUpButton>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oVB-QD-c1C">
-                    <rect key="frame" x="78" y="288" width="168" height="16"/>
+                    <rect key="frame" x="56" y="290" width="168" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Scroll vertically to:" id="hNU-dJ-5Cj">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -196,13 +180,13 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ve7-Hz-Drk">
-                    <rect key="frame" x="250" y="282" width="225" height="25"/>
+                    <rect key="frame" x="227" y="283" width="227" height="25"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="220" id="Hnx-Hf-NpH"/>
                     </constraints>
                     <popUpButtonCell key="cell" type="push" title="Adjust volume" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="SYg-hW-b6r" id="q36-W8-OhN">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="menu"/>
                         <menu key="menu" id="Dar-xZ-hAs">
                             <items>
                                 <menuItem title="Adjust volume" state="on" id="SYg-hW-b6r"/>
@@ -216,10 +200,10 @@
                     </connections>
                 </popUpButton>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tL8-ht-RBh">
-                    <rect key="frame" x="250" y="258" width="225" height="25"/>
+                    <rect key="frame" x="227" y="259" width="227" height="25"/>
                     <popUpButtonCell key="cell" type="push" title="Seek" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="1" imageScaling="proportionallyDown" inset="2" selectedItem="wcS-tP-wav" id="haA-8R-BiR">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="menu"/>
                         <menu key="menu" id="aEA-Qe-wDM">
                             <items>
                                 <menuItem title="Seek" state="on" tag="1" id="wcS-tP-wav"/>
@@ -232,7 +216,7 @@
                     </connections>
                 </popUpButton>
                 <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Muz-Ou-Hbv">
-                    <rect key="frame" x="252" y="153" width="112" height="15"/>
+                    <rect key="frame" x="228" y="154" width="116" height="17"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="112" id="h0q-78-CNQ"/>
                     </constraints>
@@ -242,7 +226,7 @@
                     </connections>
                 </slider>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hVI-sA-syi">
-                    <rect key="frame" x="78" y="155" width="168" height="17"/>
+                    <rect key="frame" x="56" y="157" width="168" height="17"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="17" id="xjp-9y-KHA"/>
                     </constraints>
@@ -253,7 +237,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OhO-nN-LgD">
-                    <rect key="frame" x="78" y="8" width="168" height="16"/>
+                    <rect key="frame" x="56" y="8" width="168" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Middle click to:" id="Gyd-Qt-FEo">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -261,10 +245,10 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="36e-IQ-z4e">
-                    <rect key="frame" x="250" y="2" width="225" height="25"/>
+                    <rect key="frame" x="227" y="1" width="227" height="25"/>
                     <popUpButtonCell key="cell" type="push" title="Hide OSC" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="3" imageScaling="proportionallyDown" inset="2" selectedItem="iFF-Gq-tVx" id="7SX-h1-81s">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="menu"/>
                         <menu key="menu" id="0z9-rd-Jdo">
                             <items>
                                 <menuItem title="Hide OSC" state="on" tag="3" id="iFF-Gq-tVx">
@@ -284,7 +268,7 @@
                     </connections>
                 </popUpButton>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="l7e-jz-0cj">
-                    <rect key="frame" x="78" y="117" width="286" height="18"/>
+                    <rect key="frame" x="56" y="118" width="290" height="18"/>
                     <buttonCell key="cell" type="check" title="Accepts first mouse click when not focused" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="gZK-ry-lQs">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -293,6 +277,34 @@
                         <binding destination="Yrj-d0-KaY" name="value" keyPath="values.videoViewAcceptsFirstMouse" id="IGn-aI-caD"/>
                     </connections>
                 </button>
+                <customView translatesAutoresizingMaskIntoConstraints="NO" id="2ma-hh-43h" userLabel="Mouse Image Container View">
+                    <rect key="frame" x="0.0" y="267" width="38" height="43"/>
+                    <subviews>
+                        <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="h4p-a3-cku" userLabel="Mouse Image View">
+                            <rect key="frame" x="0.0" y="0.0" width="38" height="43"/>
+                            <constraints>
+                                <constraint firstAttribute="width" constant="38" id="KOb-mb-7Sc"/>
+                                <constraint firstAttribute="height" constant="43" id="wit-tn-7nT"/>
+                            </constraints>
+                            <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="toolbar_control" id="vfN-MS-l0X"/>
+                        </imageView>
+                    </subviews>
+                    <constraints>
+                        <constraint firstItem="h4p-a3-cku" firstAttribute="centerX" secondItem="2ma-hh-43h" secondAttribute="centerX" id="5Ke-JG-c8X"/>
+                        <constraint firstItem="h4p-a3-cku" firstAttribute="centerY" secondItem="2ma-hh-43h" secondAttribute="centerY" id="cKU-G4-e1C"/>
+                        <constraint firstAttribute="width" constant="38" id="h5i-0g-YS0"/>
+                        <constraint firstAttribute="height" constant="43" id="nr7-9l-bF7"/>
+                    </constraints>
+                </customView>
+                <textField identifier="SectionTitleMouse" hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fL5-By-MLE">
+                    <rect key="frame" x="-2" y="0.0" width="45" height="16"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Mouse" id="1c2-Py-3Bm">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
             </subviews>
             <constraints>
                 <constraint firstItem="zSQ-pa-Urx" firstAttribute="top" secondItem="hxT-iF-nwJ" secondAttribute="bottom" constant="22" id="1XW-7y-fJE"/>
@@ -301,7 +313,6 @@
                 <constraint firstItem="IGA-yr-g8l" firstAttribute="top" secondItem="E8B-5D-NHc" secondAttribute="bottom" constant="8" id="5Ig-Vb-KBM"/>
                 <constraint firstItem="hxT-iF-nwJ" firstAttribute="width" secondItem="zSQ-pa-Urx" secondAttribute="width" id="5LD-Au-7do"/>
                 <constraint firstItem="l7e-jz-0cj" firstAttribute="top" secondItem="hVI-sA-syi" secondAttribute="bottom" constant="22" id="6Vn-tG-HhK"/>
-                <constraint firstItem="CKk-h3-h9Z" firstAttribute="leading" secondItem="Wmg-PT-BGO" secondAttribute="leading" id="6x4-ly-68p"/>
                 <constraint firstItem="IGA-yr-g8l" firstAttribute="leading" secondItem="E8B-5D-NHc" secondAttribute="leading" id="7FB-et-Mqa"/>
                 <constraint firstItem="Ltc-ek-XnI" firstAttribute="leading" secondItem="E8B-5D-NHc" secondAttribute="trailing" constant="8" id="7Py-lX-xtd"/>
                 <constraint firstItem="m0j-Zw-pcy" firstAttribute="top" secondItem="LN0-rs-jJB" secondAttribute="bottom" constant="8" id="7Zs-pN-j39"/>
@@ -310,10 +321,11 @@
                 <constraint firstItem="Muz-Ou-Hbv" firstAttribute="centerY" secondItem="hVI-sA-syi" secondAttribute="centerY" constant="3" id="AkI-nJ-IIQ"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Ltc-ek-XnI" secondAttribute="trailing" constant="4" id="Be7-UJ-tR1"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="36e-IQ-z4e" secondAttribute="trailing" constant="4" id="CdV-uq-nlF"/>
+                <constraint firstItem="hxT-iF-nwJ" firstAttribute="leading" secondItem="2ma-hh-43h" secondAttribute="trailing" constant="20" id="CgG-RX-7sv"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ve7-Hz-Drk" secondAttribute="trailing" constant="4" id="DjU-WD-OiT"/>
                 <constraint firstItem="LN0-rs-jJB" firstAttribute="top" secondItem="zSQ-pa-Urx" secondAttribute="bottom" constant="8" id="F8K-f8-uyX"/>
-                <constraint firstItem="oVB-QD-c1C" firstAttribute="leading" secondItem="Wmg-PT-BGO" secondAttribute="leading" constant="80" id="F8R-Zl-dtx"/>
                 <constraint firstItem="tL8-ht-RBh" firstAttribute="leading" secondItem="hxT-iF-nwJ" secondAttribute="trailing" constant="8" id="GtA-NH-RPp"/>
+                <constraint firstItem="2ma-hh-43h" firstAttribute="top" secondItem="Wmg-PT-BGO" secondAttribute="top" id="INK-s4-pIL"/>
                 <constraint firstItem="VlR-LI-plv" firstAttribute="baseline" secondItem="zSQ-pa-Urx" secondAttribute="baseline" id="Ig1-Vr-8Ru"/>
                 <constraint firstItem="OhO-nN-LgD" firstAttribute="width" secondItem="2rD-uu-WVu" secondAttribute="width" id="J94-SW-BaC"/>
                 <constraint firstItem="tL8-ht-RBh" firstAttribute="width" secondItem="ve7-Hz-Drk" secondAttribute="width" id="Lm9-dw-tm7"/>
@@ -322,7 +334,6 @@
                 <constraint firstItem="OhO-nN-LgD" firstAttribute="top" secondItem="2rD-uu-WVu" secondAttribute="bottom" constant="8" id="PSg-FK-04i"/>
                 <constraint firstItem="tL8-ht-RBh" firstAttribute="baseline" secondItem="hxT-iF-nwJ" secondAttribute="baseline" id="Ruh-Yu-MAV"/>
                 <constraint firstItem="m0j-Zw-pcy" firstAttribute="leading" secondItem="LN0-rs-jJB" secondAttribute="leading" id="SLc-0m-bQH"/>
-                <constraint firstItem="h4p-a3-cku" firstAttribute="top" secondItem="Wmg-PT-BGO" secondAttribute="top" id="Snt-Di-ByP"/>
                 <constraint firstItem="oVB-QD-c1C" firstAttribute="top" secondItem="Wmg-PT-BGO" secondAttribute="top" constant="4" id="Thb-hZ-Sc2"/>
                 <constraint firstItem="0Qc-Uz-odw" firstAttribute="baseline" secondItem="IGA-yr-g8l" secondAttribute="baseline" id="Uyv-Gq-cEX"/>
                 <constraint firstItem="hxT-iF-nwJ" firstAttribute="top" secondItem="oVB-QD-c1C" secondAttribute="bottom" constant="8" id="V5N-Ni-OSu"/>
@@ -335,7 +346,7 @@
                 <constraint firstItem="zSQ-pa-Urx" firstAttribute="leading" secondItem="hxT-iF-nwJ" secondAttribute="leading" id="cl9-cl-5QE"/>
                 <constraint firstAttribute="bottom" secondItem="OhO-nN-LgD" secondAttribute="bottom" constant="8" id="dg9-BW-9dD"/>
                 <constraint firstItem="IGA-yr-g8l" firstAttribute="width" secondItem="zSQ-pa-Urx" secondAttribute="width" id="fO8-Jg-Tru"/>
-                <constraint firstItem="h4p-a3-cku" firstAttribute="leading" secondItem="Wmg-PT-BGO" secondAttribute="leading" constant="20" id="ffo-PU-HIJ"/>
+                <constraint firstItem="2ma-hh-43h" firstAttribute="leading" secondItem="Wmg-PT-BGO" secondAttribute="leading" id="fja-nS-h5Z"/>
                 <constraint firstItem="0Qc-Uz-odw" firstAttribute="leading" secondItem="IGA-yr-g8l" secondAttribute="trailing" constant="8" id="g3q-ll-dSo"/>
                 <constraint firstItem="VlR-LI-plv" firstAttribute="leading" secondItem="zSQ-pa-Urx" secondAttribute="trailing" constant="8" id="gYj-1t-06a"/>
                 <constraint firstItem="36e-IQ-z4e" firstAttribute="width" secondItem="mdI-b4-54O" secondAttribute="width" id="gZ4-tW-t0u"/>
@@ -352,7 +363,6 @@
                 <constraint firstItem="l7e-jz-0cj" firstAttribute="leading" secondItem="E8B-5D-NHc" secondAttribute="leading" id="pWc-nz-Uj7"/>
                 <constraint firstItem="mdI-b4-54O" firstAttribute="baseline" secondItem="2rD-uu-WVu" secondAttribute="baseline" id="pfD-jn-rps"/>
                 <constraint firstItem="E8B-5D-NHc" firstAttribute="leading" secondItem="hVI-sA-syi" secondAttribute="leading" id="qZC-ch-xVk"/>
-                <constraint firstAttribute="bottom" secondItem="CKk-h3-h9Z" secondAttribute="bottom" id="rmi-FB-Ffy"/>
                 <constraint firstItem="hxT-iF-nwJ" firstAttribute="leading" secondItem="oVB-QD-c1C" secondAttribute="leading" id="sOu-mG-Job"/>
                 <constraint firstItem="OhO-nN-LgD" firstAttribute="leading" secondItem="2rD-uu-WVu" secondAttribute="leading" id="te6-C6-9nQ"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="0Qc-Uz-odw" secondAttribute="trailing" constant="4" id="uGB-yu-D3m"/>
@@ -368,26 +378,18 @@
             </constraints>
             <point key="canvasLocation" x="-334" y="527"/>
         </customView>
-        <customView id="VSf-E0-Btw">
-            <rect key="frame" x="0.0" y="0.0" width="452" height="56"/>
+        <customView id="VSf-E0-Btw" userLabel="Prefs &gt; Control &gt; Trackpad">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="56"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="MJc-ye-l1u">
-                    <rect key="frame" x="24" y="13" width="32" height="43"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="43" id="4IT-m9-j1y"/>
-                        <constraint firstAttribute="width" constant="32" id="xYv-VW-Sk0"/>
-                    </constraints>
-                    <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="trackpad" id="Heg-gy-Ddq"/>
-                </imageView>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="nio-Fb-YPK">
-                    <rect key="frame" x="181" y="26" width="225" height="25"/>
+                    <rect key="frame" x="231" y="25" width="227" height="25"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="220" id="VqZ-W3-2hi"/>
                     </constraints>
                     <popUpButtonCell key="cell" type="push" title="Adjust window size" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="Ols-Lr-fiH" id="FbW-ce-yAK">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="menu"/>
                         <menu key="menu" id="B7Y-mP-CKn">
                             <items>
                                 <menuItem title="Adjust window size" state="on" id="Ols-Lr-fiH"/>
@@ -401,7 +403,10 @@
                     </connections>
                 </popUpButton>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="XJb-x1-5LL">
-                    <rect key="frame" x="78" y="32" width="99" height="16"/>
+                    <rect key="frame" x="56" y="32" width="172" height="16"/>
+                    <constraints>
+                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="168" id="YVG-Jz-3os"/>
+                    </constraints>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Pinch to:" id="E8H-pO-MLc">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -409,7 +414,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="rUe-Ix-oaI">
-                    <rect key="frame" x="78" y="8" width="99" height="16"/>
+                    <rect key="frame" x="56" y="8" width="172" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Force Touch to:" id="dpH-PO-WKt">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -417,10 +422,10 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="V5B-tS-TPW">
-                    <rect key="frame" x="181" y="2" width="225" height="25"/>
+                    <rect key="frame" x="231" y="1" width="227" height="25"/>
                     <popUpButtonCell key="cell" type="push" title="Hide OSC" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="3" imageScaling="proportionallyDown" inset="2" selectedItem="M6K-ME-cve" id="Q6M-Qd-bxY">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="menu"/>
                         <menu key="menu" id="Viy-vg-Zdf">
                             <items>
                                 <menuItem title="Hide OSC" state="on" tag="3" id="M6K-ME-cve">
@@ -438,9 +443,29 @@
                         <binding destination="Yrj-d0-KaY" name="selectedTag" keyPath="values.forceTouchAction" id="jcK-0X-6KO"/>
                     </connections>
                 </popUpButton>
-                <textField identifier="SectionTitleTrackpad" hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gdO-fa-rO1">
+                <customView translatesAutoresizingMaskIntoConstraints="NO" id="csk-yk-vkf" userLabel="Trackpad Image Container View">
+                    <rect key="frame" x="0.0" y="13" width="38" height="43"/>
+                    <subviews>
+                        <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="MJc-ye-l1u" userLabel="Trackpad Image View">
+                            <rect key="frame" x="3" y="0.0" width="32" height="43"/>
+                            <constraints>
+                                <constraint firstAttribute="height" constant="43" id="4IT-m9-j1y"/>
+                                <constraint firstAttribute="width" constant="32" id="xYv-VW-Sk0"/>
+                            </constraints>
+                            <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="trackpad" id="Heg-gy-Ddq"/>
+                        </imageView>
+                    </subviews>
+                    <constraints>
+                        <constraint firstItem="MJc-ye-l1u" firstAttribute="centerY" secondItem="csk-yk-vkf" secondAttribute="centerY" id="Fyr-5g-drP"/>
+                        <constraint firstAttribute="height" constant="43" id="N8m-Yq-bfl"/>
+                        <constraint firstAttribute="width" constant="38" id="adN-OK-g1o"/>
+                        <constraint firstItem="MJc-ye-l1u" firstAttribute="centerX" secondItem="csk-yk-vkf" secondAttribute="centerX" id="mlO-q2-zxA"/>
+                    </constraints>
+                </customView>
+                <textField identifier="SectionTitleTrackpad" hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nbu-IK-O9W">
                     <rect key="frame" x="-2" y="0.0" width="61" height="16"/>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Trackpad" id="I6k-ab-IwJ">
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Trackpad" id="dmO-jU-SEg">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -448,11 +473,10 @@
                 </textField>
             </subviews>
             <constraints>
-                <constraint firstItem="gdO-fa-rO1" firstAttribute="leading" secondItem="VSf-E0-Btw" secondAttribute="leading" id="0ur-Uz-85o"/>
+                <constraint firstItem="csk-yk-vkf" firstAttribute="leading" secondItem="VSf-E0-Btw" secondAttribute="leading" id="0kY-0I-psN"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="V5B-tS-TPW" secondAttribute="trailing" id="131-ep-FtB"/>
+                <constraint firstItem="XJb-x1-5LL" firstAttribute="leading" secondItem="csk-yk-vkf" secondAttribute="trailing" constant="20" id="5LP-4K-TMH"/>
                 <constraint firstItem="rUe-Ix-oaI" firstAttribute="width" secondItem="XJb-x1-5LL" secondAttribute="width" id="5st-tG-etU"/>
-                <constraint firstItem="MJc-ye-l1u" firstAttribute="leading" secondItem="VSf-E0-Btw" secondAttribute="leading" constant="24" id="9Cz-Cd-6hk"/>
-                <constraint firstItem="MJc-ye-l1u" firstAttribute="top" secondItem="VSf-E0-Btw" secondAttribute="top" id="Eay-88-l9g"/>
                 <constraint firstAttribute="bottom" secondItem="rUe-Ix-oaI" secondAttribute="bottom" constant="8" id="Klg-GA-yEf"/>
                 <constraint firstItem="V5B-tS-TPW" firstAttribute="leading" secondItem="rUe-Ix-oaI" secondAttribute="trailing" constant="8" id="LRc-cA-bIi"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="nio-Fb-YPK" secondAttribute="trailing" id="LXq-iR-Ktt"/>
@@ -462,11 +486,10 @@
                 <constraint firstItem="rUe-Ix-oaI" firstAttribute="leading" secondItem="XJb-x1-5LL" secondAttribute="leading" id="SjO-M9-2VS"/>
                 <constraint firstItem="nio-Fb-YPK" firstAttribute="baseline" secondItem="XJb-x1-5LL" secondAttribute="baseline" id="d34-8f-WW7"/>
                 <constraint firstItem="rUe-Ix-oaI" firstAttribute="top" secondItem="XJb-x1-5LL" secondAttribute="bottom" constant="8" id="dpb-nT-cnU"/>
-                <constraint firstItem="XJb-x1-5LL" firstAttribute="leading" secondItem="VSf-E0-Btw" secondAttribute="leading" constant="80" id="imi-KD-laa"/>
                 <constraint firstItem="V5B-tS-TPW" firstAttribute="width" secondItem="nio-Fb-YPK" secondAttribute="width" id="kBT-CW-4tO"/>
-                <constraint firstAttribute="bottom" secondItem="gdO-fa-rO1" secondAttribute="bottom" id="z6X-FD-kJn"/>
+                <constraint firstItem="csk-yk-vkf" firstAttribute="top" secondItem="VSf-E0-Btw" secondAttribute="top" id="xhA-QX-5nr"/>
             </constraints>
-            <point key="canvasLocation" x="-366" y="304"/>
+            <point key="canvasLocation" x="-334" y="307"/>
         </customView>
     </objects>
     <resources>

--- a/iina/Base.lproj/PrefGeneralViewController.xib
+++ b/iina/Base.lproj/PrefGeneralViewController.xib
@@ -19,12 +19,12 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="445" height="392"/>
-            <point key="canvasLocation" x="-1463" y="259"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY" userLabel="Prefs &gt; General View">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="392"/>
+            <point key="canvasLocation" x="-1607" y="64"/>
         </customView>
-        <customView id="6zR-96-iKB">
-            <rect key="frame" x="0.0" y="0.0" width="580" height="501"/>
+        <customView id="6zR-96-iKB" userLabel="Prefs &gt; General &gt; Behavior">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="501"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField identifier="SectionTitleBehavior" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="38y-2I-MGs">
@@ -62,6 +62,9 @@
                 </popUpButton>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="DUm-O0-pdI">
                     <rect key="frame" x="118" y="224" width="235" height="18"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="16" id="b1L-o2-7jn"/>
+                    </constraints>
                     <buttonCell key="cell" type="check" title="Always open media in new window" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="M0z-bI-88d">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -178,10 +181,10 @@
                     </connections>
                 </button>
                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aKH-Me-5XB" customClass="CollapseView" customModule="IINA" customModuleProvider="target">
-                    <rect key="frame" x="120" y="412" width="452" height="57"/>
+                    <rect key="frame" x="120" y="412" width="360" height="57"/>
                     <subviews>
                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Pga-vd-zGA">
-                            <rect key="frame" x="0.0" y="40" width="452" height="17"/>
+                            <rect key="frame" x="0.0" y="40" width="360" height="17"/>
                             <subviews>
                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="10b-EJ-N6W">
                                     <rect key="frame" x="13" y="0.0" width="146" height="17"/>
@@ -204,15 +207,15 @@
                                 <constraint firstItem="10b-EJ-N6W" firstAttribute="leading" secondItem="RH1-Rj-Zte" secondAttribute="trailing" constant="2" id="4dm-p4-QBo"/>
                                 <constraint firstAttribute="height" constant="17" id="9mt-6A-3cn"/>
                                 <constraint firstItem="10b-EJ-N6W" firstAttribute="top" secondItem="Pga-vd-zGA" secondAttribute="top" id="CgI-3n-dLZ"/>
-                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="10b-EJ-N6W" secondAttribute="trailing" id="KLM-eV-K4j"/>
+                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="10b-EJ-N6W" secondAttribute="trailing" priority="100" id="KLM-eV-K4j"/>
                                 <constraint firstAttribute="bottom" secondItem="10b-EJ-N6W" secondAttribute="bottom" id="hRT-m2-XyP"/>
                                 <constraint firstAttribute="bottom" secondItem="RH1-Rj-Zte" secondAttribute="bottom" id="u3n-QO-bLw"/>
                             </constraints>
                         </customView>
                         <box identifier="Content0" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="DZT-7n-S4M">
-                            <rect key="frame" x="-3" y="-4" width="458" height="42"/>
+                            <rect key="frame" x="-3" y="-4" width="366" height="42"/>
                             <view key="contentView" id="867-m1-aVc">
-                                <rect key="frame" x="4" y="5" width="450" height="34"/>
+                                <rect key="frame" x="4" y="5" width="358" height="34"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="8Ql-ym-BvF">
@@ -229,7 +232,7 @@
                                         </connections>
                                     </button>
                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="U8N-xw-dgL">
-                                        <rect key="frame" x="83" y="9" width="121" height="16"/>
+                                        <rect key="frame" x="83" y="11" width="121" height="12"/>
                                         <buttonCell key="cell" type="check" title="Enter fullscreen" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="MlG-hl-goB">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -242,7 +245,7 @@
                                 <constraints>
                                     <constraint firstItem="8Ql-ym-BvF" firstAttribute="leading" secondItem="867-m1-aVc" secondAttribute="leading" constant="16" id="8Kt-eK-ama"/>
                                     <constraint firstItem="8Ql-ym-BvF" firstAttribute="top" secondItem="867-m1-aVc" secondAttribute="top" constant="12" id="KQR-Hn-oxv"/>
-                                    <constraint firstItem="U8N-xw-dgL" firstAttribute="top" secondItem="867-m1-aVc" secondAttribute="top" constant="10" id="Xal-Le-LM1"/>
+                                    <constraint firstItem="U8N-xw-dgL" firstAttribute="height" secondItem="8Ql-ym-BvF" secondAttribute="height" id="MbS-mY-E77"/>
                                     <constraint firstItem="U8N-xw-dgL" firstAttribute="leading" secondItem="8Ql-ym-BvF" secondAttribute="trailing" constant="8" id="c9D-8h-Pib"/>
                                     <constraint firstAttribute="bottom" secondItem="8Ql-ym-BvF" secondAttribute="bottom" constant="12" id="gIj-Zr-OZv"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="U8N-xw-dgL" secondAttribute="trailing" constant="16" id="kVp-nN-EJU"/>
@@ -271,10 +274,10 @@
                     </customSpacing>
                 </stackView>
                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8iE-FU-0g0" customClass="CollapseView" customModule="IINA" customModuleProvider="target">
-                    <rect key="frame" x="120" y="257" width="452" height="147"/>
+                    <rect key="frame" x="120" y="257" width="360" height="147"/>
                     <subviews>
                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="W54-Em-Hx4">
-                            <rect key="frame" x="0.0" y="130" width="452" height="17"/>
+                            <rect key="frame" x="0.0" y="130" width="360" height="17"/>
                             <subviews>
                                 <button identifier="Trigger1" horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="CaQ-Om-AFL">
                                     <rect key="frame" x="0.0" y="0.0" width="13" height="13"/>
@@ -303,13 +306,13 @@
                             </constraints>
                         </customView>
                         <box identifier="Content1" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="5RN-PV-pOZ">
-                            <rect key="frame" x="-3" y="-4" width="458" height="132"/>
+                            <rect key="frame" x="-3" y="-4" width="366" height="132"/>
                             <view key="contentView" id="gWB-X2-AzC">
-                                <rect key="frame" x="4" y="5" width="450" height="124"/>
+                                <rect key="frame" x="4" y="5" width="358" height="124"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
-                                    <button verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UFY-vM-qHd">
-                                        <rect key="frame" x="14" y="96" width="174" height="18"/>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UFY-vM-qHd">
+                                        <rect key="frame" x="14" y="97" width="174" height="16"/>
                                         <buttonCell key="cell" type="check" title="Minimized/un-minimized" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="5Y9-bX-K0f">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -318,8 +321,8 @@
                                             <binding destination="IBP-Mz-Maa" name="value" keyPath="values.pauseWhenMinimized" id="DjO-5C-ymh"/>
                                         </connections>
                                     </button>
-                                    <button verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mr8-te-85z">
-                                        <rect key="frame" x="14" y="74" width="225" height="18"/>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mr8-te-85z">
+                                        <rect key="frame" x="14" y="76" width="225" height="15"/>
                                         <buttonCell key="cell" type="check" title="Window becomes inactive/active" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="J8g-aS-W6e">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -328,8 +331,8 @@
                                             <binding destination="IBP-Mz-Maa" name="value" keyPath="values.pauseWhenInactive" id="BpV-TH-O6m"/>
                                         </connections>
                                     </button>
-                                    <button verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="H40-Tk-atD">
-                                        <rect key="frame" x="14" y="52" width="206" height="18"/>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="H40-Tk-atD">
+                                        <rect key="frame" x="14" y="54" width="206" height="16"/>
                                         <buttonCell key="cell" type="check" title="Play upon entering full screen" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="lOw-pu-Llm">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -338,8 +341,8 @@
                                             <binding destination="IBP-Mz-Maa" name="value" keyPath="values.playWhenEnteringFullScreen" id="L4f-Rp-Kvc"/>
                                         </connections>
                                     </button>
-                                    <button verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="DX0-mO-Ick">
-                                        <rect key="frame" x="14" y="30" width="210" height="18"/>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DX0-mO-Ick">
+                                        <rect key="frame" x="14" y="33" width="210" height="15"/>
                                         <buttonCell key="cell" type="check" title="Pause upon leaving full screen" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="g2A-Kf-vct">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -348,8 +351,8 @@
                                             <binding destination="IBP-Mz-Maa" name="value" keyPath="values.pauseWhenLeavingFullScreen" id="bNZ-4U-cix"/>
                                         </connections>
                                     </button>
-                                    <button verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MJd-4d-ykB">
-                                        <rect key="frame" x="14" y="8" width="239" height="18"/>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="MJd-4d-ykB">
+                                        <rect key="frame" x="14" y="11" width="239" height="16"/>
                                         <buttonCell key="cell" type="check" title="Pause when machine goes to sleep" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="i4A-86-dGC">
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
@@ -358,10 +361,12 @@
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="DX0-mO-Ick" firstAttribute="top" secondItem="H40-Tk-atD" secondAttribute="bottom" constant="8" id="2bf-Yi-7JZ"/>
+                                    <constraint firstItem="MJd-4d-ykB" firstAttribute="height" secondItem="UFY-vM-qHd" secondAttribute="height" id="712-ht-eSn"/>
                                     <constraint firstItem="MJd-4d-ykB" firstAttribute="leading" secondItem="gWB-X2-AzC" secondAttribute="leading" constant="16" id="9rs-fj-ecW"/>
                                     <constraint firstItem="UFY-vM-qHd" firstAttribute="leading" secondItem="gWB-X2-AzC" secondAttribute="leading" constant="16" id="BYI-IT-W2G"/>
                                     <constraint firstItem="H40-Tk-atD" firstAttribute="top" secondItem="mr8-te-85z" secondAttribute="bottom" constant="8" id="L96-wP-FQU"/>
                                     <constraint firstItem="UFY-vM-qHd" firstAttribute="top" secondItem="gWB-X2-AzC" secondAttribute="top" constant="12" id="M28-VE-MMP"/>
+                                    <constraint firstItem="DX0-mO-Ick" firstAttribute="height" secondItem="UFY-vM-qHd" secondAttribute="height" id="OUd-hx-K5S"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="MJd-4d-ykB" secondAttribute="trailing" constant="16" id="Rub-0B-HeP"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="mr8-te-85z" secondAttribute="trailing" constant="16" id="TpM-U0-fum"/>
                                     <constraint firstItem="mr8-te-85z" firstAttribute="top" secondItem="UFY-vM-qHd" secondAttribute="bottom" constant="8" id="WO9-uu-y18"/>
@@ -370,9 +375,11 @@
                                     <constraint firstItem="MJd-4d-ykB" firstAttribute="top" secondItem="DX0-mO-Ick" secondAttribute="bottom" constant="8" id="fBY-T0-PMR"/>
                                     <constraint firstItem="DX0-mO-Ick" firstAttribute="leading" secondItem="gWB-X2-AzC" secondAttribute="leading" constant="16" id="hLJ-NT-FCE"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="DX0-mO-Ick" secondAttribute="trailing" constant="16" id="j3z-3M-mEG"/>
+                                    <constraint firstItem="H40-Tk-atD" firstAttribute="height" secondItem="UFY-vM-qHd" secondAttribute="height" id="jbh-8y-KKr"/>
                                     <constraint firstItem="H40-Tk-atD" firstAttribute="leading" secondItem="gWB-X2-AzC" secondAttribute="leading" constant="16" id="oTi-j9-wws"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="UFY-vM-qHd" secondAttribute="trailing" constant="16" id="ocE-2U-Fcu"/>
                                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="H40-Tk-atD" secondAttribute="trailing" constant="16" id="vWE-H2-oPU"/>
+                                    <constraint firstItem="mr8-te-85z" firstAttribute="height" secondItem="UFY-vM-qHd" secondAttribute="height" id="wPM-p2-rB9"/>
                                 </constraints>
                             </view>
                             <constraints>
@@ -398,47 +405,55 @@
                 </stackView>
             </subviews>
             <constraints>
+                <constraint firstItem="ibu-Tq-kBr" firstAttribute="height" secondItem="DUm-O0-pdI" secondAttribute="height" id="3Oe-KF-l3A"/>
+                <constraint firstItem="5G0-Ih-CIb" firstAttribute="height" secondItem="DUm-O0-pdI" secondAttribute="height" id="3k4-Eu-Tew"/>
                 <constraint firstItem="OXi-vL-mzp" firstAttribute="leading" secondItem="6zR-96-iKB" secondAttribute="leading" constant="120" id="4O3-ht-PYG"/>
                 <constraint firstItem="8iE-FU-0g0" firstAttribute="top" secondItem="aKH-Me-5XB" secondAttribute="bottom" constant="8" id="59d-ue-PTZ"/>
+                <constraint firstItem="QvG-Ma-br0" firstAttribute="height" secondItem="DUm-O0-pdI" secondAttribute="height" id="5Sj-zN-kO5"/>
                 <constraint firstItem="F6o-D4-gDa" firstAttribute="top" secondItem="Xi9-i5-9V4" secondAttribute="bottom" constant="8" id="6Jr-af-XZC"/>
-                <constraint firstAttribute="trailing" secondItem="aKH-Me-5XB" secondAttribute="trailing" constant="8" id="7gW-uv-Fba"/>
+                <constraint firstAttribute="trailing" secondItem="aKH-Me-5XB" secondAttribute="trailing" id="7gW-uv-Fba"/>
                 <constraint firstItem="QvG-Ma-br0" firstAttribute="top" secondItem="6Hg-O4-cBP" secondAttribute="bottom" constant="8" id="85F-05-dDh"/>
                 <constraint firstItem="bV8-LP-cwH" firstAttribute="leading" secondItem="OXi-vL-mzp" secondAttribute="trailing" constant="8" id="8Kb-Fe-QIo"/>
                 <constraint firstItem="b7I-2V-MYa" firstAttribute="top" secondItem="QvG-Ma-br0" secondAttribute="bottom" constant="16" id="9H8-4r-eDa"/>
                 <constraint firstItem="bV8-LP-cwH" firstAttribute="baseline" secondItem="OXi-vL-mzp" secondAttribute="baseline" id="9fY-Y6-onK"/>
                 <constraint firstItem="tUl-6f-ClP" firstAttribute="top" secondItem="ibu-Tq-kBr" secondAttribute="bottom" constant="8" id="DQg-F2-jP7"/>
                 <constraint firstItem="38y-2I-MGs" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="6zR-96-iKB" secondAttribute="leading" constant="120" id="Dd3-CV-21F"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="6Hg-O4-cBP" secondAttribute="trailing" id="EU4-oh-Sn4"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="6Hg-O4-cBP" secondAttribute="trailing" priority="100" id="EU4-oh-Sn4"/>
+                <constraint firstItem="Xi9-i5-9V4" firstAttribute="height" secondItem="DUm-O0-pdI" secondAttribute="height" id="Eee-r5-9jP"/>
                 <constraint firstItem="38y-2I-MGs" firstAttribute="top" secondItem="6zR-96-iKB" secondAttribute="top" constant="8" id="EkZ-1t-Li0"/>
+                <constraint firstItem="6Hg-O4-cBP" firstAttribute="height" secondItem="DUm-O0-pdI" secondAttribute="height" id="FS1-AW-faa"/>
                 <constraint firstItem="ONF-nX-zDm" firstAttribute="baseline" secondItem="ibu-Tq-kBr" secondAttribute="baseline" id="GtH-hr-0BD"/>
                 <constraint firstItem="ibu-Tq-kBr" firstAttribute="leading" secondItem="b7I-2V-MYa" secondAttribute="leading" id="Iut-G6-4zl"/>
                 <constraint firstItem="aKH-Me-5XB" firstAttribute="leading" secondItem="OXi-vL-mzp" secondAttribute="leading" id="NEg-jy-N85"/>
                 <constraint firstItem="F6o-D4-gDa" firstAttribute="leading" secondItem="Xi9-i5-9V4" secondAttribute="leading" id="ONu-Gw-6jM"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="bV8-LP-cwH" secondAttribute="trailing" constant="20" symbolic="YES" id="Plb-z2-kxR"/>
+                <constraint firstItem="F6o-D4-gDa" firstAttribute="height" secondItem="DUm-O0-pdI" secondAttribute="height" id="Owa-Fs-41I"/>
+                <constraint firstItem="tUl-6f-ClP" firstAttribute="height" secondItem="DUm-O0-pdI" secondAttribute="height" id="PId-am-AqK"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="bV8-LP-cwH" secondAttribute="trailing" id="Plb-z2-kxR"/>
                 <constraint firstItem="OXi-vL-mzp" firstAttribute="baseline" secondItem="38y-2I-MGs" secondAttribute="baseline" id="RqH-AX-8dj"/>
                 <constraint firstItem="DUm-O0-pdI" firstAttribute="top" secondItem="8iE-FU-0g0" secondAttribute="bottom" constant="16" id="RqT-Pp-kVR"/>
                 <constraint firstItem="8iE-FU-0g0" firstAttribute="leading" secondItem="aKH-Me-5XB" secondAttribute="leading" id="SRe-Ue-ubz"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="QvG-Ma-br0" secondAttribute="trailing" id="Sai-n4-ewq"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="QvG-Ma-br0" secondAttribute="trailing" priority="100" id="Sai-n4-ewq"/>
+                <constraint firstItem="b7I-2V-MYa" firstAttribute="height" secondItem="DUm-O0-pdI" secondAttribute="height" id="Y3C-r1-4Ae"/>
                 <constraint firstItem="Xi9-i5-9V4" firstAttribute="top" secondItem="5G0-Ih-CIb" secondAttribute="bottom" constant="8" id="YOU-SQ-93U"/>
                 <constraint firstItem="6Hg-O4-cBP" firstAttribute="top" secondItem="F6o-D4-gDa" secondAttribute="bottom" constant="16" id="a76-ej-aJs"/>
                 <constraint firstItem="ONF-nX-zDm" firstAttribute="top" secondItem="b7I-2V-MYa" secondAttribute="bottom" constant="16" id="awt-JH-Sx1"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="DUm-O0-pdI" secondAttribute="trailing" id="c2z-9x-EKo"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="DUm-O0-pdI" secondAttribute="trailing" priority="100" id="c2z-9x-EKo"/>
                 <constraint firstItem="tUl-6f-ClP" firstAttribute="leading" secondItem="ibu-Tq-kBr" secondAttribute="leading" id="d7A-WU-gG9"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ONF-nX-zDm" secondAttribute="trailing" id="esl-VM-bcw"/>
                 <constraint firstItem="DUm-O0-pdI" firstAttribute="leading" secondItem="8iE-FU-0g0" secondAttribute="leading" id="ez5-7v-y5R"/>
                 <constraint firstItem="aKH-Me-5XB" firstAttribute="top" secondItem="OXi-vL-mzp" secondAttribute="bottom" constant="8" id="gTe-Cv-cgu"/>
                 <constraint firstItem="6Hg-O4-cBP" firstAttribute="leading" secondItem="F6o-D4-gDa" secondAttribute="leading" id="hbH-qB-dC3"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="b7I-2V-MYa" secondAttribute="trailing" id="kla-t0-rVJ"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="b7I-2V-MYa" secondAttribute="trailing" priority="100" id="kla-t0-rVJ"/>
                 <constraint firstItem="ONF-nX-zDm" firstAttribute="leading" secondItem="ibu-Tq-kBr" secondAttribute="trailing" constant="8" id="myc-5t-FrF"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="5G0-Ih-CIb" secondAttribute="trailing" id="n4Z-6X-Oou"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="5G0-Ih-CIb" secondAttribute="trailing" priority="100" id="n4Z-6X-Oou"/>
                 <constraint firstItem="b7I-2V-MYa" firstAttribute="leading" secondItem="QvG-Ma-br0" secondAttribute="leading" id="o0g-jc-tgK"/>
-                <constraint firstAttribute="trailing" secondItem="8iE-FU-0g0" secondAttribute="trailing" constant="8" id="oIv-Ho-Lbb"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Xi9-i5-9V4" secondAttribute="trailing" id="oZd-sR-YOa"/>
+                <constraint firstAttribute="trailing" secondItem="8iE-FU-0g0" secondAttribute="trailing" id="oIv-Ho-Lbb"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Xi9-i5-9V4" secondAttribute="trailing" priority="100" id="oZd-sR-YOa"/>
                 <constraint firstItem="5G0-Ih-CIb" firstAttribute="top" secondItem="DUm-O0-pdI" secondAttribute="bottom" constant="8" id="qiu-A2-Mtr"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="tUl-6f-ClP" secondAttribute="trailing" id="rJU-fV-3iD"/>
                 <constraint firstAttribute="bottom" secondItem="tUl-6f-ClP" secondAttribute="bottom" constant="8" id="s4G-EO-NkU"/>
                 <constraint firstItem="QvG-Ma-br0" firstAttribute="leading" secondItem="6Hg-O4-cBP" secondAttribute="leading" id="snr-fe-bxJ"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="F6o-D4-gDa" secondAttribute="trailing" id="tRu-Sz-D5y"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="F6o-D4-gDa" secondAttribute="trailing" priority="100" id="tRu-Sz-D5y"/>
                 <constraint firstItem="5G0-Ih-CIb" firstAttribute="leading" secondItem="DUm-O0-pdI" secondAttribute="leading" id="uxk-Ul-hVP"/>
                 <constraint firstItem="Xi9-i5-9V4" firstAttribute="leading" secondItem="5G0-Ih-CIb" secondAttribute="leading" id="vs3-xk-YxI"/>
                 <constraint firstItem="38y-2I-MGs" firstAttribute="leading" secondItem="6zR-96-iKB" secondAttribute="leading" id="ykt-2x-cLQ"/>
@@ -446,8 +461,8 @@
             <point key="canvasLocation" x="-2189" y="118.5"/>
         </customView>
         <userDefaultsController representsSharedInstance="YES" id="IBP-Mz-Maa"/>
-        <customView id="y7O-rd-dnT">
-            <rect key="frame" x="0.0" y="0.0" width="580" height="122"/>
+        <customView id="y7O-rd-dnT" userLabel="Prefs &gt; General &gt; Playlist">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="122"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField identifier="SectionTitlePlaylist" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="6gO-wx-MWj">
@@ -460,6 +475,9 @@
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="xmd-ef-R8e">
                     <rect key="frame" x="118" y="97" width="276" height="18"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="16" id="mAR-Rs-xaK"/>
+                    </constraints>
                     <buttonCell key="cell" type="check" title="Add files in the same folder automatically" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="QJq-fO-hhK">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -510,8 +528,10 @@
             </subviews>
             <constraints>
                 <constraint firstItem="YDQ-cu-7vE" firstAttribute="leading" secondItem="UHf-eK-ba5" secondAttribute="leading" id="0Kh-Ym-ocl"/>
+                <constraint firstItem="ey2-TT-Tl9" firstAttribute="height" secondItem="xmd-ef-R8e" secondAttribute="height" id="8IH-xs-ONO"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="OVz-Nv-1WW" secondAttribute="trailing" id="9pX-b8-Q44"/>
                 <constraint firstItem="UHf-eK-ba5" firstAttribute="top" secondItem="OVz-Nv-1WW" secondAttribute="bottom" constant="8" id="Cp1-Yt-5u8"/>
+                <constraint firstItem="YDQ-cu-7vE" firstAttribute="height" secondItem="xmd-ef-R8e" secondAttribute="height" id="Dz2-et-QXI"/>
                 <constraint firstItem="6gO-wx-MWj" firstAttribute="leading" secondItem="y7O-rd-dnT" secondAttribute="leading" id="HHh-Ci-kWH"/>
                 <constraint firstItem="ey2-TT-Tl9" firstAttribute="top" secondItem="YDQ-cu-7vE" secondAttribute="bottom" constant="8" id="MQj-y6-fEt"/>
                 <constraint firstAttribute="bottom" secondItem="ey2-TT-Tl9" secondAttribute="bottom" constant="8" id="OH2-dz-anH"/>
@@ -519,24 +539,25 @@
                 <constraint firstItem="UHf-eK-ba5" firstAttribute="leading" secondItem="xmd-ef-R8e" secondAttribute="leading" id="QpE-IK-2rs"/>
                 <constraint firstItem="6gO-wx-MWj" firstAttribute="top" secondItem="y7O-rd-dnT" secondAttribute="top" constant="8" id="R9Q-BW-yNL"/>
                 <constraint firstItem="xmd-ef-R8e" firstAttribute="leading" secondItem="y7O-rd-dnT" secondAttribute="leading" constant="120" id="WmZ-xJ-nJr"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="YDQ-cu-7vE" secondAttribute="trailing" id="a4R-ug-WId"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="YDQ-cu-7vE" secondAttribute="trailing" priority="100" id="a4R-ug-WId"/>
                 <constraint firstItem="ey2-TT-Tl9" firstAttribute="leading" secondItem="YDQ-cu-7vE" secondAttribute="leading" constant="20" id="aVN-BA-zZz"/>
                 <constraint firstItem="YDQ-cu-7vE" firstAttribute="top" secondItem="UHf-eK-ba5" secondAttribute="bottom" constant="8" id="fru-O3-rhE"/>
                 <constraint firstItem="6gO-wx-MWj" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="y7O-rd-dnT" secondAttribute="leading" constant="120" id="hMc-8k-u0x"/>
                 <constraint firstItem="OVz-Nv-1WW" firstAttribute="top" secondItem="xmd-ef-R8e" secondAttribute="bottom" constant="4" id="knP-0X-jJU"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="xmd-ef-R8e" secondAttribute="trailing" id="o3a-bC-bx3"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="xmd-ef-R8e" secondAttribute="trailing" priority="100" id="o3a-bC-bx3"/>
+                <constraint firstItem="UHf-eK-ba5" firstAttribute="height" secondItem="xmd-ef-R8e" secondAttribute="height" id="olS-mZ-kec"/>
                 <constraint firstItem="6gO-wx-MWj" firstAttribute="top" secondItem="xmd-ef-R8e" secondAttribute="top" id="q99-S9-zIq"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ey2-TT-Tl9" secondAttribute="trailing" id="uQH-zS-Roq"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="UHf-eK-ba5" secondAttribute="trailing" id="z5V-cR-cmi"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ey2-TT-Tl9" secondAttribute="trailing" priority="100" id="uQH-zS-Roq"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="UHf-eK-ba5" secondAttribute="trailing" priority="100" id="z5V-cR-cmi"/>
             </constraints>
-            <point key="canvasLocation" x="-2190" y="621.5"/>
+            <point key="canvasLocation" x="-2189" y="617"/>
         </customView>
-        <customView misplaced="YES" id="ym1-pZ-4SZ">
-            <rect key="frame" x="0.0" y="0.0" width="580" height="184"/>
+        <customView id="ym1-pZ-4SZ" userLabel="Prefs &gt; General &gt; Screenshots">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="184"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField identifier="SectionTitleScreenshots" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="iLE-bn-UWS">
-                    <rect key="frame" x="-2" y="166" width="90" height="16"/>
+                    <rect key="frame" x="-2" y="160" width="90" height="16"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Screenshots:" id="pdx-zt-kf2">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -544,7 +565,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aEK-1q-7Vr">
-                    <rect key="frame" x="137" y="118" width="51" height="16"/>
+                    <rect key="frame" x="137" y="112" width="51" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Format:" id="oJY-Iz-3sO">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -552,7 +573,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="LvL-fW-PG1">
-                    <rect key="frame" x="191" y="111" width="128" height="25"/>
+                    <rect key="frame" x="191" y="105" width="128" height="25"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="121" id="Bqk-oQ-3wU"/>
                     </constraints>
@@ -573,7 +594,7 @@
                     </connections>
                 </popUpButton>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="tV0-X6-PhP">
-                    <rect key="frame" x="118" y="37" width="126" height="18"/>
+                    <rect key="frame" x="118" y="31" width="126" height="18"/>
                     <buttonCell key="cell" type="check" title="Include subtitles" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="lvA-Rc-Sh6">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -583,7 +604,10 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Frw-Lf-9ka">
-                    <rect key="frame" x="118" y="141" width="71" height="18"/>
+                    <rect key="frame" x="118" y="135" width="71" height="18"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="16" id="tF4-fO-Sgr"/>
+                    </constraints>
                     <buttonCell key="cell" type="check" title="Save to" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="2rJ-mg-OuU">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -593,7 +617,7 @@
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZA7-QS-FAH">
-                    <rect key="frame" x="191" y="142" width="162" height="16"/>
+                    <rect key="frame" x="191" y="136" width="162" height="16"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="16" id="ECP-qk-dP6"/>
                     </constraints>
@@ -608,7 +632,7 @@
                     </connections>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="PKl-oI-CuN">
-                    <rect key="frame" x="359" y="139" width="16" height="22"/>
+                    <rect key="frame" x="359" y="133" width="16" height="22"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="16" id="Pcz-fn-1lE"/>
                         <constraint firstAttribute="height" constant="16" id="wSK-Z6-UzY"/>
@@ -623,7 +647,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="pYE-LR-OAu">
-                    <rect key="frame" x="118" y="93" width="134" height="18"/>
+                    <rect key="frame" x="118" y="87" width="134" height="18"/>
                     <buttonCell key="cell" type="check" title="Copy to clipboard" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="3gs-3w-rg6">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -633,7 +657,7 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="7zO-JV-oG5">
-                    <rect key="frame" x="118" y="166" width="77" height="16"/>
+                    <rect key="frame" x="118" y="160" width="77" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="Destination:" id="PhL-vP-i7L">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -641,7 +665,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="nvy-Qn-oAE">
-                    <rect key="frame" x="118" y="62" width="56" height="16"/>
+                    <rect key="frame" x="118" y="56" width="56" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="Options:" id="4Qe-7S-8xK">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -649,7 +673,7 @@
                     </textFieldCell>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="vCw-Bd-YFb">
-                    <rect key="frame" x="118" y="7" width="267" height="24"/>
+                    <rect key="frame" x="118" y="7" width="267" height="18"/>
                     <buttonCell key="cell" type="check" title="Show previews after taking screenshots" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="xE7-Uu-19f">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -664,14 +688,16 @@
                 <constraint firstItem="ZA7-QS-FAH" firstAttribute="leading" secondItem="Frw-Lf-9ka" secondAttribute="trailing" constant="4" id="3UC-eQ-6le"/>
                 <constraint firstItem="aEK-1q-7Vr" firstAttribute="leading" secondItem="Frw-Lf-9ka" secondAttribute="leading" constant="19" id="8BJ-9f-tA2"/>
                 <constraint firstItem="iLE-bn-UWS" firstAttribute="top" secondItem="ym1-pZ-4SZ" secondAttribute="top" constant="8" id="8LP-jE-AHt"/>
+                <constraint firstItem="vCw-Bd-YFb" firstAttribute="height" secondItem="Frw-Lf-9ka" secondAttribute="height" id="9O1-0G-HWW"/>
                 <constraint firstItem="Frw-Lf-9ka" firstAttribute="leading" secondItem="ym1-pZ-4SZ" secondAttribute="leading" constant="120" id="9bE-6x-1ro"/>
                 <constraint firstItem="iLE-bn-UWS" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="ym1-pZ-4SZ" secondAttribute="leading" constant="120" id="9xX-jB-SlI"/>
                 <constraint firstItem="pYE-LR-OAu" firstAttribute="leading" secondItem="Frw-Lf-9ka" secondAttribute="leading" id="Ben-El-cDI"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="7zO-JV-oG5" secondAttribute="trailing" id="Gbb-qY-zhc"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="pYE-LR-OAu" secondAttribute="trailing" id="Gso-zO-p5Q"/>
                 <constraint firstItem="PKl-oI-CuN" firstAttribute="centerY" secondItem="Frw-Lf-9ka" secondAttribute="centerY" id="I7q-82-mzg"/>
+                <constraint firstItem="tV0-X6-PhP" firstAttribute="height" secondItem="Frw-Lf-9ka" secondAttribute="height" id="Kek-2q-NXb"/>
                 <constraint firstItem="aEK-1q-7Vr" firstAttribute="top" secondItem="Frw-Lf-9ka" secondAttribute="bottom" constant="8" id="McK-PO-jyd"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="tV0-X6-PhP" secondAttribute="trailing" id="Moh-Du-SXe"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="tV0-X6-PhP" secondAttribute="trailing" priority="100" id="Moh-Du-SXe"/>
                 <constraint firstItem="7zO-JV-oG5" firstAttribute="top" secondItem="iLE-bn-UWS" secondAttribute="top" id="NH3-uV-S8y"/>
                 <constraint firstItem="iLE-bn-UWS" firstAttribute="leading" secondItem="ym1-pZ-4SZ" secondAttribute="leading" id="OPk-QW-QHI"/>
                 <constraint firstItem="pYE-LR-OAu" firstAttribute="top" secondItem="aEK-1q-7Vr" secondAttribute="bottom" constant="8" id="Oxo-LE-vWU"/>
@@ -680,27 +706,27 @@
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="nvy-Qn-oAE" secondAttribute="trailing" id="ZzK-ZK-SmI"/>
                 <constraint firstItem="nvy-Qn-oAE" firstAttribute="top" secondItem="pYE-LR-OAu" secondAttribute="bottom" constant="16" id="ft0-5r-p0s"/>
                 <constraint firstItem="ZA7-QS-FAH" firstAttribute="firstBaseline" secondItem="Frw-Lf-9ka" secondAttribute="firstBaseline" id="gRB-CT-Qmv"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="vCw-Bd-YFb" secondAttribute="trailing" id="ixF-yb-NCf"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="vCw-Bd-YFb" secondAttribute="trailing" priority="100" id="ixF-yb-NCf"/>
+                <constraint firstItem="pYE-LR-OAu" firstAttribute="height" secondItem="Frw-Lf-9ka" secondAttribute="height" id="j1h-4U-f65"/>
                 <constraint firstItem="vCw-Bd-YFb" firstAttribute="top" secondItem="tV0-X6-PhP" secondAttribute="bottom" constant="8" id="j8Y-fR-MCn"/>
                 <constraint firstItem="LvL-fW-PG1" firstAttribute="leading" secondItem="aEK-1q-7Vr" secondAttribute="trailing" constant="8" id="ldm-ou-kEt"/>
                 <constraint firstItem="tV0-X6-PhP" firstAttribute="leading" secondItem="Frw-Lf-9ka" secondAttribute="leading" id="mOG-2g-8V0"/>
                 <constraint firstItem="7zO-JV-oG5" firstAttribute="leading" secondItem="ym1-pZ-4SZ" secondAttribute="leading" constant="120" id="me9-8P-Q8Z"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="LvL-fW-PG1" secondAttribute="trailing" id="nc9-h5-iNW"/>
-                <constraint firstAttribute="bottom" secondItem="tV0-X6-PhP" secondAttribute="bottom" constant="38" id="q5o-f0-7NU"/>
                 <constraint firstItem="nvy-Qn-oAE" firstAttribute="leading" secondItem="7zO-JV-oG5" secondAttribute="leading" id="uUA-Z7-irA"/>
                 <constraint firstItem="vCw-Bd-YFb" firstAttribute="leading" secondItem="tV0-X6-PhP" secondAttribute="leading" id="vLW-FD-gFN"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="PKl-oI-CuN" secondAttribute="trailing" constant="8" id="vfN-bZ-HHg"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="PKl-oI-CuN" secondAttribute="trailing" id="vfN-bZ-HHg"/>
                 <constraint firstAttribute="bottom" secondItem="vCw-Bd-YFb" secondAttribute="bottom" constant="8" id="yky-60-OaL"/>
                 <constraint firstItem="PKl-oI-CuN" firstAttribute="leading" secondItem="ZA7-QS-FAH" secondAttribute="trailing" constant="8" id="zkv-na-jFg"/>
             </constraints>
-            <point key="canvasLocation" x="-2190" y="790"/>
+            <point key="canvasLocation" x="-2190" y="815"/>
         </customView>
-        <customView id="Kmu-J1-cbE">
-            <rect key="frame" x="0.0" y="0.0" width="580" height="98"/>
+        <customView id="Kmu-J1-cbE" userLabel="Prefs &gt; General &gt; History">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="112"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField identifier="SectionTitleHistory" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="pfH-CF-O2T">
-                    <rect key="frame" x="-2" y="74" width="57" height="16"/>
+                    <rect key="frame" x="-2" y="88" width="57" height="16"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="History:" id="jeK-46-2BG">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -708,7 +734,10 @@
                     </textFieldCell>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="AUU-c3-fW5">
-                    <rect key="frame" x="118" y="73" width="170" height="18"/>
+                    <rect key="frame" x="118" y="87" width="170" height="18"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="16" id="JvK-Q5-bZH"/>
+                    </constraints>
                     <buttonCell key="cell" type="check" title="Enable playback history" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="iGS-qN-f5q">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -718,7 +747,7 @@
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="4zm-YX-iM8">
-                    <rect key="frame" x="118" y="49" width="199" height="18"/>
+                    <rect key="frame" x="118" y="63" width="199" height="18"/>
                     <buttonCell key="cell" type="check" title="Enable &quot;Open Recent&quot; menu" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="55O-ik-ql6">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -729,7 +758,7 @@
                     </connections>
                 </button>
                 <textField autoresizesSubviews="NO" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="da1-EI-Ny1">
-                    <rect key="frame" x="156" y="8" width="426" height="14"/>
+                    <rect key="frame" x="156" y="8" width="326" height="28"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Otherwise only files that opened manually will show up in this menu." id="XFC-Lr-LmP">
                         <font key="font" metaFont="message" size="11"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -737,7 +766,7 @@
                     </textFieldCell>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="gxK-Zo-PtQ">
-                    <rect key="frame" x="138" y="25" width="295" height="18"/>
+                    <rect key="frame" x="138" y="39" width="295" height="18"/>
                     <buttonCell key="cell" type="check" title="Track all played files in &quot;Open Recent&quot; menu" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Ci8-j2-QS3">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -749,7 +778,9 @@
                 </button>
             </subviews>
             <constraints>
+                <constraint firstItem="4zm-YX-iM8" firstAttribute="height" secondItem="AUU-c3-fW5" secondAttribute="height" id="1Gt-Si-m80"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="AUU-c3-fW5" secondAttribute="trailing" id="Ac0-Im-2ue"/>
+                <constraint firstItem="gxK-Zo-PtQ" firstAttribute="height" secondItem="AUU-c3-fW5" secondAttribute="height" id="IfR-eu-MGg"/>
                 <constraint firstItem="da1-EI-Ny1" firstAttribute="leading" secondItem="gxK-Zo-PtQ" secondAttribute="leading" constant="18" id="Vgd-16-VLR"/>
                 <constraint firstItem="4zm-YX-iM8" firstAttribute="leading" secondItem="AUU-c3-fW5" secondAttribute="leading" id="Vm5-Wp-mWy"/>
                 <constraint firstItem="da1-EI-Ny1" firstAttribute="top" secondItem="gxK-Zo-PtQ" secondAttribute="bottom" constant="4" id="X9d-Gp-Gd2"/>
@@ -761,16 +792,16 @@
                 <constraint firstItem="pfH-CF-O2T" firstAttribute="leading" secondItem="Kmu-J1-cbE" secondAttribute="leading" id="c9q-SG-bJV"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="4zm-YX-iM8" secondAttribute="trailing" id="ca7-1x-vvq"/>
                 <constraint firstItem="pfH-CF-O2T" firstAttribute="top" secondItem="Kmu-J1-cbE" secondAttribute="top" constant="8" id="di6-Om-iYm"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="gxK-Zo-PtQ" secondAttribute="trailing" id="eWv-bL-SZ2"/>
-                <constraint firstAttribute="trailing" secondItem="da1-EI-Ny1" secondAttribute="trailing" id="l2x-XY-er0"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="gxK-Zo-PtQ" secondAttribute="trailing" priority="100" id="eWv-bL-SZ2"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="da1-EI-Ny1" secondAttribute="trailing" id="l2x-XY-er0"/>
                 <constraint firstItem="gxK-Zo-PtQ" firstAttribute="top" secondItem="4zm-YX-iM8" secondAttribute="bottom" constant="8" id="lnd-OY-DqJ"/>
                 <constraint firstItem="4zm-YX-iM8" firstAttribute="top" secondItem="AUU-c3-fW5" secondAttribute="bottom" constant="8" id="loj-lX-llR"/>
             </constraints>
-            <point key="canvasLocation" x="-2189" y="483"/>
+            <point key="canvasLocation" x="-2190" y="463"/>
         </customView>
         <customObject id="xyA-SE-Ihh" customClass="SPUStandardUpdaterController"/>
     </objects>
     <resources>
-        <image name="NSRevealFreestandingTemplate" width="19" height="19"/>
+        <image name="NSRevealFreestandingTemplate" width="20" height="20"/>
     </resources>
 </document>

--- a/iina/Base.lproj/PrefKeyBindingViewController.xib
+++ b/iina/Base.lproj/PrefKeyBindingViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21225" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21225"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -25,11 +25,11 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="695" height="506"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY" userLabel="Prefs &gt; Key Bindings View">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="311"/>
             <subviews>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="LU9-QU-BFL">
-                    <rect key="frame" x="6" y="486" width="117" height="18"/>
+                    <rect key="frame" x="-1" y="286" width="121" height="16"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="14" id="lOm-I3-MpB"/>
                     </constraints>
@@ -42,16 +42,16 @@
                     </connections>
                 </button>
                 <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="ER0-iU-7fy">
-                    <rect key="frame" x="8" y="469" width="679" height="5"/>
+                    <rect key="frame" x="0.0" y="268" width="480" height="5"/>
                 </box>
                 <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="2pX-29-I87">
-                    <rect key="frame" x="196" y="63" width="491" height="320"/>
+                    <rect key="frame" x="188" y="62" width="292" height="120"/>
                     <clipView key="contentView" id="Hxb-1N-pOY">
-                        <rect key="frame" x="1" y="0.0" width="489" height="319"/>
+                        <rect key="frame" x="1" y="1" width="290" height="118"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" headerView="OOd-BT-w3p" id="1Z4-NL-6P3">
-                                <rect key="frame" x="0.0" y="0.0" width="489" height="296"/>
+                            <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" headerView="OOd-BT-w3p" id="1Z4-NL-6P3" userLabel="Key Bindings Table View">
+                                <rect key="frame" x="0.0" y="0.0" width="290" height="95"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <size key="intercellSpacing" width="3" height="2"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -59,7 +59,6 @@
                                 <tableColumns>
                                     <tableColumn identifier="Key" width="116" minWidth="40" maxWidth="1000" id="JwC-60-7Hp">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Key">
-                                            <font key="font" metaFont="message" size="11"/>
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                         </tableHeaderCell>
@@ -73,9 +72,8 @@
                                             <binding destination="xGz-Vh-hMb" name="value" keyPath="arrangedObjects.keyForDisplay" id="FWk-cQ-DIx"/>
                                         </connections>
                                     </tableColumn>
-                                    <tableColumn identifier="Action" width="367" minWidth="40" maxWidth="1000" id="4Bn-MF-dfY">
+                                    <tableColumn identifier="Action" width="159" minWidth="40" maxWidth="1000" id="4Bn-MF-dfY">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Action">
-                                            <font key="font" metaFont="message" size="11"/>
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                         </tableHeaderCell>
@@ -84,7 +82,7 @@
                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
-                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
                                         <connections>
                                             <binding destination="xGz-Vh-hMb" name="value" keyPath="arrangedObjects.actionForDisplay" id="lft-aO-sfz"/>
                                         </connections>
@@ -98,23 +96,23 @@
                         </subviews>
                     </clipView>
                     <constraints>
-                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="320" id="5me-gl-Ien"/>
+                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="120" id="5me-gl-Ien"/>
                     </constraints>
                     <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="1PH-Mk-JzT">
-                        <rect key="frame" x="1" y="275" width="465" height="16"/>
+                        <rect key="frame" x="1" y="304" width="275" height="15"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                     <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="YwQ-kF-wlj">
-                        <rect key="frame" x="-15" y="23" width="16" height="0.0"/>
+                        <rect key="frame" x="276" y="24" width="15" height="280"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
-                    <tableHeaderView key="headerView" id="OOd-BT-w3p">
-                        <rect key="frame" x="0.0" y="0.0" width="489" height="23"/>
+                    <tableHeaderView key="headerView" wantsLayer="YES" id="OOd-BT-w3p">
+                        <rect key="frame" x="0.0" y="0.0" width="290" height="23"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </tableHeaderView>
                 </scrollView>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZWR-gT-S2p">
-                    <rect key="frame" x="8" y="439" width="91" height="16"/>
+                    <rect key="frame" x="0.0" y="238" width="91" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Configuration:" id="au5-6f-s55">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -122,7 +120,7 @@
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KZA-hu-vhZ">
-                    <rect key="frame" x="1" y="1" width="210" height="32"/>
+                    <rect key="frame" x="-6" y="1" width="210" height="32"/>
                     <buttonCell key="cell" type="push" title="Show the config file in Finder" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="gDo-JL-a9k">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -132,14 +130,16 @@
                     </connections>
                 </button>
                 <box boxType="custom" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="mLe-eI-lIk">
-                    <rect key="frame" x="196" y="42" width="491" height="22"/>
+                    <rect key="frame" x="188" y="41" width="292" height="22"/>
                     <view key="contentView" id="0le-1T-r5f">
-                        <rect key="frame" x="1" y="1" width="489" height="20"/>
+                        <rect key="frame" x="1" y="1" width="290" height="20"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="f5l-5w-zmm">
-                                <rect key="frame" x="0.0" y="0.0" width="20" height="20"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                            <button translatesAutoresizingMaskIntoConstraints="NO" id="f5l-5w-zmm">
+                                <rect key="frame" x="0.0" y="-1.5" width="20.5" height="24"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="f5l-5w-zmm" secondAttribute="height" multiplier="1:1" id="nxu-Es-dAW"/>
+                                </constraints>
                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" inset="2" id="De2-o3-Acv">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -148,9 +148,11 @@
                                     <action selector="addKeyMappingBtnAction:" target="-2" id="oNc-c8-i9c"/>
                                 </connections>
                             </button>
-                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uFG-OF-DJ5">
-                                <rect key="frame" x="20" y="0.0" width="20" height="20"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                            <button translatesAutoresizingMaskIntoConstraints="NO" id="uFG-OF-DJ5">
+                                <rect key="frame" x="20" y="3" width="20.5" height="15"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="uFG-OF-DJ5" secondAttribute="height" multiplier="1:1" id="ka8-vi-ux9"/>
+                                </constraints>
                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" inset="2" id="nAC-n9-1YJ">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -160,7 +162,7 @@
                                 </connections>
                             </button>
                             <button toolTip="Show the raw mpv key code and command." translatesAutoresizingMaskIntoConstraints="NO" id="l2M-TH-eCt">
-                                <rect key="frame" x="381" y="1" width="104" height="18"/>
+                                <rect key="frame" x="184" y="3" width="100" height="12"/>
                                 <buttonCell key="cell" type="check" title="Display raw values" bezelStyle="regularSquare" imagePosition="left" controlSize="mini" inset="2" id="3RK-1k-otl">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="label" size="9"/>
@@ -171,15 +173,22 @@
                                 </connections>
                             </button>
                             <box horizontalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="GnK-98-Zrg">
-                                <rect key="frame" x="374" y="0.0" width="5" height="20"/>
+                                <rect key="frame" x="173" y="0.0" width="5" height="20"/>
                             </box>
                         </subviews>
                         <constraints>
+                            <constraint firstAttribute="bottom" secondItem="uFG-OF-DJ5" secondAttribute="bottom" id="Kev-zL-xU3"/>
                             <constraint firstItem="l2M-TH-eCt" firstAttribute="leading" secondItem="GnK-98-Zrg" secondAttribute="trailing" constant="8" id="Qbj-KE-dFO"/>
                             <constraint firstItem="GnK-98-Zrg" firstAttribute="top" secondItem="0le-1T-r5f" secondAttribute="top" id="XSn-ja-Q3m"/>
+                            <constraint firstItem="uFG-OF-DJ5" firstAttribute="top" secondItem="0le-1T-r5f" secondAttribute="top" id="ZfQ-Vd-66B"/>
+                            <constraint firstItem="GnK-98-Zrg" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="uFG-OF-DJ5" secondAttribute="trailing" id="bMg-gh-g0b"/>
                             <constraint firstAttribute="trailing" secondItem="l2M-TH-eCt" secondAttribute="trailing" constant="6" id="ced-22-S2H"/>
                             <constraint firstItem="l2M-TH-eCt" firstAttribute="centerY" secondItem="0le-1T-r5f" secondAttribute="centerY" constant="1" id="umX-M8-lLx"/>
+                            <constraint firstAttribute="bottom" secondItem="f5l-5w-zmm" secondAttribute="bottom" id="vhs-Bl-OW7"/>
                             <constraint firstAttribute="bottom" secondItem="GnK-98-Zrg" secondAttribute="bottom" id="wG6-Hf-CPU"/>
+                            <constraint firstItem="uFG-OF-DJ5" firstAttribute="leading" secondItem="f5l-5w-zmm" secondAttribute="trailing" id="xh6-AE-0sz"/>
+                            <constraint firstItem="f5l-5w-zmm" firstAttribute="leading" secondItem="0le-1T-r5f" secondAttribute="leading" id="zf0-Sa-GO1"/>
+                            <constraint firstItem="f5l-5w-zmm" firstAttribute="top" secondItem="0le-1T-r5f" secondAttribute="top" id="zpw-dX-Qe9"/>
                         </constraints>
                     </view>
                     <constraints>
@@ -189,7 +198,7 @@
                     <color key="fillColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                 </box>
                 <button horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bm5-rb-Qjb">
-                    <rect key="frame" x="664" y="481" width="25" height="25"/>
+                    <rect key="frame" x="456" y="280" width="25" height="25"/>
                     <buttonCell key="cell" type="help" bezelStyle="helpButton" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="vf9-A9-dKA">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -199,21 +208,20 @@
                     </connections>
                 </button>
                 <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Mhk-DT-3CM">
-                    <rect key="frame" x="8" y="63" width="180" height="350"/>
+                    <rect key="frame" x="0.0" y="62" width="180" height="150"/>
                     <clipView key="contentView" id="4gB-i6-I71">
-                        <rect key="frame" x="1" y="1" width="178" height="348"/>
+                        <rect key="frame" x="1" y="1" width="178" height="148"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" floatsGroupRows="NO" id="AYj-6d-niF">
-                                <rect key="frame" x="0.0" y="0.0" width="178" height="348"/>
+                            <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" floatsGroupRows="NO" id="AYj-6d-niF">
+                                <rect key="frame" x="0.0" y="0.0" width="178" height="148"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                <size key="intercellSpacing" width="3" height="2"/>
+                                <size key="intercellSpacing" width="2" height="2"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                 <tableColumns>
-                                    <tableColumn width="175" minWidth="40" maxWidth="1000" id="aNh-vK-2CP">
+                                    <tableColumn width="166" minWidth="140" maxWidth="1000" id="aNh-vK-2CP">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
-                                            <font key="font" metaFont="message" size="11"/>
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                         </tableHeaderCell>
@@ -225,11 +233,11 @@
                                         <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                         <prototypeCellViews>
                                             <tableCellView id="NPn-qi-L4Y">
-                                                <rect key="frame" x="1" y="1" width="175" height="17"/>
+                                                <rect key="frame" x="1" y="1" width="176" height="17"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="k3i-eY-hmO">
-                                                        <rect key="frame" x="0.0" y="1" width="161" height="16"/>
+                                                        <rect key="frame" x="0.0" y="1" width="96" height="16"/>
                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="rVW-78-nDm">
                                                             <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -240,7 +248,7 @@
                                                         </connections>
                                                     </textField>
                                                     <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="3VI-bM-Xn1">
-                                                        <rect key="frame" x="159" y="3" width="12" height="12"/>
+                                                        <rect key="frame" x="164" y="-1.5" width="12.5" height="22"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="12" id="Du5-ms-7jx"/>
                                                             <constraint firstAttribute="height" constant="12" id="p6c-c0-YEO"/>
@@ -252,11 +260,11 @@
                                                     </imageView>
                                                 </subviews>
                                                 <constraints>
-                                                    <constraint firstItem="3VI-bM-Xn1" firstAttribute="leading" secondItem="k3i-eY-hmO" secondAttribute="trailing" id="2ot-xa-0H7"/>
-                                                    <constraint firstAttribute="trailing" secondItem="3VI-bM-Xn1" secondAttribute="trailing" constant="4" id="5b2-mM-stK"/>
+                                                    <constraint firstItem="3VI-bM-Xn1" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="k3i-eY-hmO" secondAttribute="trailing" constant="2" id="2ot-xa-0H7"/>
                                                     <constraint firstItem="3VI-bM-Xn1" firstAttribute="centerY" secondItem="NPn-qi-L4Y" secondAttribute="centerY" id="Akv-cb-1aU"/>
                                                     <constraint firstItem="k3i-eY-hmO" firstAttribute="centerY" secondItem="NPn-qi-L4Y" secondAttribute="centerY" id="R3f-Hn-lS3"/>
-                                                    <constraint firstItem="k3i-eY-hmO" firstAttribute="leading" secondItem="NPn-qi-L4Y" secondAttribute="leading" constant="2" id="a9c-yj-vF4"/>
+                                                    <constraint firstAttribute="trailing" secondItem="3VI-bM-Xn1" secondAttribute="trailing" id="ReK-Za-lrS"/>
+                                                    <constraint firstItem="k3i-eY-hmO" firstAttribute="leading" secondItem="NPn-qi-L4Y" secondAttribute="leading" constant="2" id="VUa-ES-DhA"/>
                                                 </constraints>
                                                 <connections>
                                                     <outlet property="imageView" destination="3VI-bM-Xn1" id="enY-h0-741"/>
@@ -282,14 +290,16 @@
                     </scroller>
                 </scrollView>
                 <box boxType="custom" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="Le4-ai-PiB">
-                    <rect key="frame" x="8" y="42" width="180" height="22"/>
+                    <rect key="frame" x="0.0" y="41" width="180" height="22"/>
                     <view key="contentView" id="Mvx-13-iEj">
                         <rect key="frame" x="1" y="1" width="178" height="20"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="iCp-ho-SlQ">
-                                <rect key="frame" x="0.0" y="0.0" width="20" height="20"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                            <button translatesAutoresizingMaskIntoConstraints="NO" id="iCp-ho-SlQ" userLabel="Square + Button">
+                                <rect key="frame" x="0.0" y="-1.5" width="20.5" height="24"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="iCp-ho-SlQ" secondAttribute="height" multiplier="1:1" id="W5T-Sa-grr"/>
+                                </constraints>
                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" inset="2" id="sxT-LD-iKe">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -298,9 +308,11 @@
                                     <action selector="newConfFileAction:" target="-2" id="zyI-2f-FHa"/>
                                 </connections>
                             </button>
-                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EpF-t6-PtC">
-                                <rect key="frame" x="20" y="0.0" width="20" height="20"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                            <button translatesAutoresizingMaskIntoConstraints="NO" id="EpF-t6-PtC" userLabel="Square - Button">
+                                <rect key="frame" x="20" y="3" width="20.5" height="15"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="EpF-t6-PtC" secondAttribute="height" multiplier="1:1" id="NBy-aM-7Gt"/>
+                                </constraints>
                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" inset="2" id="mZx-Q0-d48">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -324,12 +336,19 @@
                             </box>
                         </subviews>
                         <constraints>
+                            <constraint firstItem="iCp-ho-SlQ" firstAttribute="top" secondItem="Mvx-13-iEj" secondAttribute="top" id="3uh-95-h0I"/>
+                            <constraint firstItem="iCp-ho-SlQ" firstAttribute="leading" secondItem="Mvx-13-iEj" secondAttribute="leading" id="4oq-2L-6zN"/>
                             <constraint firstAttribute="bottom" secondItem="nTU-Bf-Utf" secondAttribute="bottom" id="A8G-za-nzo"/>
                             <constraint firstItem="5WK-s3-J9x" firstAttribute="leading" secondItem="nTU-Bf-Utf" secondAttribute="trailing" constant="4" id="HkI-Ag-x2j"/>
+                            <constraint firstItem="nTU-Bf-Utf" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="EpF-t6-PtC" secondAttribute="trailing" id="IXS-jS-rs0"/>
                             <constraint firstAttribute="trailing" secondItem="5WK-s3-J9x" secondAttribute="trailing" constant="4" id="NlB-hd-hMZ"/>
                             <constraint firstItem="nTU-Bf-Utf" firstAttribute="top" secondItem="Mvx-13-iEj" secondAttribute="top" id="Wsu-Ie-37S"/>
+                            <constraint firstAttribute="bottom" secondItem="EpF-t6-PtC" secondAttribute="bottom" id="XUb-wd-Q7m"/>
                             <constraint firstAttribute="bottom" secondItem="5WK-s3-J9x" secondAttribute="bottom" id="ZlX-FT-PIV"/>
                             <constraint firstItem="5WK-s3-J9x" firstAttribute="top" secondItem="Mvx-13-iEj" secondAttribute="top" id="hGe-15-t41"/>
+                            <constraint firstItem="EpF-t6-PtC" firstAttribute="top" secondItem="Mvx-13-iEj" secondAttribute="top" id="nNy-xV-noG"/>
+                            <constraint firstItem="EpF-t6-PtC" firstAttribute="leading" secondItem="iCp-ho-SlQ" secondAttribute="trailing" id="oxu-sV-ch1"/>
+                            <constraint firstAttribute="bottom" secondItem="iCp-ho-SlQ" secondAttribute="bottom" id="szb-XO-VMw"/>
                         </constraints>
                     </view>
                     <constraints>
@@ -338,16 +357,8 @@
                     <color key="borderColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                     <color key="fillColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                 </box>
-                <textField identifier="SectionTitleSettings" hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OY4-8W-63j">
-                    <rect key="frame" x="642" y="494" width="55" height="16"/>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Settings" id="veZ-Si-Hv5">
-                        <font key="font" metaFont="system"/>
-                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="tP6-Ua-acA">
-                    <rect key="frame" x="8" y="421" width="679" height="14"/>
+                    <rect key="frame" x="0.0" y="220" width="480" height="14"/>
                     <textFieldCell key="cell" controlSize="small" title="Label" id="M4N-eg-JA8">
                         <font key="font" metaFont="message" size="11"/>
                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -355,7 +366,7 @@
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="AuR-Lj-Iz4">
-                    <rect key="frame" x="202" y="1" width="212" height="32"/>
+                    <rect key="frame" x="202" y="1" width="206" height="32"/>
                     <buttonCell key="cell" type="push" title="Import an existing config file" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="6cO-C0-33g">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -365,7 +376,7 @@
                     </connections>
                 </button>
                 <searchField wantsLayer="YES" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="x6N-6q-HiV">
-                    <rect key="frame" x="197" y="391" width="489" height="22"/>
+                    <rect key="frame" x="188" y="190" width="292" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="aql-K3-x6M"/>
                     </constraints>
@@ -382,55 +393,65 @@
                         </binding>
                     </connections>
                 </searchField>
+                <textField identifier="SectionTitleSettings" hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JxQ-iv-eAN">
+                    <rect key="frame" x="427" y="255" width="55" height="16"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Settings" id="8yJ-Rj-GWo">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
             </subviews>
             <constraints>
                 <constraint firstItem="KZA-hu-vhZ" firstAttribute="top" secondItem="0le-1T-r5f" secondAttribute="bottom" constant="14" id="2Pk-ll-iUo"/>
-                <constraint firstItem="KZA-hu-vhZ" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="8" id="3kW-5w-PxP"/>
-                <constraint firstAttribute="trailing" secondItem="tP6-Ua-acA" secondAttribute="trailing" constant="10" id="AGg-nV-dJe"/>
-                <constraint firstItem="bm5-rb-Qjb" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="LU9-QU-BFL" secondAttribute="trailing" constant="8" id="ASF-wJ-2pT"/>
+                <constraint firstItem="KZA-hu-vhZ" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="1" id="3kW-5w-PxP"/>
+                <constraint firstAttribute="trailing" secondItem="tP6-Ua-acA" secondAttribute="trailing" constant="2" id="AGg-nV-dJe"/>
+                <constraint firstItem="bm5-rb-Qjb" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="LU9-QU-BFL" secondAttribute="trailing" id="ASF-wJ-2pT"/>
                 <constraint firstItem="Le4-ai-PiB" firstAttribute="top" secondItem="Mhk-DT-3CM" secondAttribute="bottom" constant="-1" id="BKz-av-lUx"/>
-                <constraint firstItem="x6N-6q-HiV" firstAttribute="trailing" secondItem="1Z4-NL-6P3" secondAttribute="trailing" id="BNb-HG-BLr"/>
+                <constraint firstAttribute="trailing" secondItem="x6N-6q-HiV" secondAttribute="trailing" id="BSj-hy-lRC"/>
                 <constraint firstItem="x6N-6q-HiV" firstAttribute="top" secondItem="tP6-Ua-acA" secondAttribute="bottom" constant="8" id="Cf7-8P-UBX"/>
                 <constraint firstItem="Le4-ai-PiB" firstAttribute="trailing" secondItem="Mhk-DT-3CM" secondAttribute="trailing" id="DeO-7U-TYb"/>
                 <constraint firstItem="ER0-iU-7fy" firstAttribute="top" secondItem="LU9-QU-BFL" secondAttribute="bottom" constant="16" id="GGr-Xs-9iJ"/>
                 <constraint firstItem="AuR-Lj-Iz4" firstAttribute="firstBaseline" secondItem="KZA-hu-vhZ" secondAttribute="firstBaseline" id="Hrm-F3-qj5"/>
                 <constraint firstItem="AuR-Lj-Iz4" firstAttribute="leading" secondItem="KZA-hu-vhZ" secondAttribute="trailing" constant="12" id="LWW-j6-UPY"/>
                 <constraint firstItem="mLe-eI-lIk" firstAttribute="top" secondItem="2pX-29-I87" secondAttribute="bottom" constant="-1" id="LeQ-qP-FVe"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="AuR-Lj-Iz4" secondAttribute="trailing" constant="8" id="M6E-Ra-d8q"/>
-                <constraint firstItem="Mhk-DT-3CM" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="8" id="OLU-oB-Se7"/>
+                <constraint firstAttribute="trailing" secondItem="JxQ-iv-eAN" secondAttribute="trailing" id="Lof-xj-4mu"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="AuR-Lj-Iz4" secondAttribute="trailing" id="M6E-Ra-d8q"/>
+                <constraint firstItem="2pX-29-I87" firstAttribute="leading" secondItem="x6N-6q-HiV" secondAttribute="leading" id="M6f-I3-YHV"/>
+                <constraint firstItem="Mhk-DT-3CM" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="OLU-oB-Se7"/>
                 <constraint firstAttribute="bottom" secondItem="KZA-hu-vhZ" secondAttribute="bottom" constant="8" id="QtF-OP-vXc"/>
-                <constraint firstItem="ER0-iU-7fy" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="8" id="Rc3-GT-Hhr"/>
-                <constraint firstAttribute="trailing" secondItem="mLe-eI-lIk" secondAttribute="trailing" constant="8" id="U9K-pE-0CL"/>
+                <constraint firstItem="ER0-iU-7fy" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="Rc3-GT-Hhr"/>
+                <constraint firstAttribute="trailing" secondItem="mLe-eI-lIk" secondAttribute="trailing" id="U9K-pE-0CL"/>
                 <constraint firstItem="Mhk-DT-3CM" firstAttribute="top" secondItem="tP6-Ua-acA" secondAttribute="bottom" constant="8" id="Ud4-VR-43k"/>
                 <constraint firstItem="2pX-29-I87" firstAttribute="leading" secondItem="Mhk-DT-3CM" secondAttribute="trailing" constant="8" id="VX8-3k-wdZ"/>
-                <constraint firstAttribute="trailing" secondItem="ER0-iU-7fy" secondAttribute="trailing" constant="8" id="Y4g-9e-aDt"/>
+                <constraint firstAttribute="trailing" secondItem="ER0-iU-7fy" secondAttribute="trailing" id="Y4g-9e-aDt"/>
                 <constraint firstItem="ZWR-gT-S2p" firstAttribute="top" secondItem="ER0-iU-7fy" secondAttribute="bottom" constant="16" id="ZX7-1F-af0"/>
                 <constraint firstItem="2pX-29-I87" firstAttribute="top" secondItem="x6N-6q-HiV" secondAttribute="bottom" constant="8" id="aGz-Kt-wfl"/>
                 <constraint firstItem="Mhk-DT-3CM" firstAttribute="bottom" secondItem="2pX-29-I87" secondAttribute="bottom" id="bIy-L9-gJ1"/>
                 <constraint firstItem="Le4-ai-PiB" firstAttribute="leading" secondItem="Mhk-DT-3CM" secondAttribute="leading" id="bgz-zS-geZ"/>
+                <constraint firstItem="JxQ-iv-eAN" firstAttribute="top" secondItem="ER0-iU-7fy" secondAttribute="top" id="cVf-ox-nAM"/>
                 <constraint firstItem="bm5-rb-Qjb" firstAttribute="centerY" secondItem="LU9-QU-BFL" secondAttribute="centerY" id="dVn-Pj-vDl"/>
-                <constraint firstItem="LU9-QU-BFL" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="8" id="eIu-AE-LI1"/>
-                <constraint firstItem="OY4-8W-63j" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="eh7-Md-lD0"/>
-                <constraint firstItem="ZWR-gT-S2p" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="10" id="eyA-gW-IBL"/>
-                <constraint firstAttribute="trailing" secondItem="OY4-8W-63j" secondAttribute="trailing" id="fZe-ej-w66"/>
+                <constraint firstItem="LU9-QU-BFL" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="1" id="eIu-AE-LI1"/>
+                <constraint firstItem="ZWR-gT-S2p" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="2" id="eyA-gW-IBL"/>
                 <constraint firstItem="tP6-Ua-acA" firstAttribute="top" secondItem="ZWR-gT-S2p" secondAttribute="bottom" constant="4" id="krb-us-D9G"/>
-                <constraint firstItem="x6N-6q-HiV" firstAttribute="leading" secondItem="1Z4-NL-6P3" secondAttribute="leading" id="oGi-TP-9ub"/>
-                <constraint firstItem="tP6-Ua-acA" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="10" id="olF-Fw-cWs"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ZWR-gT-S2p" secondAttribute="trailing" constant="8" id="tWl-b9-AcQ"/>
-                <constraint firstAttribute="trailing" secondItem="2pX-29-I87" secondAttribute="trailing" constant="8" id="tl2-El-aGp"/>
-                <constraint firstItem="OY4-8W-63j" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="twb-9l-3Mq"/>
-                <constraint firstItem="LU9-QU-BFL" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="8" id="uzh-oa-t27"/>
+                <constraint firstItem="tP6-Ua-acA" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="2" id="olF-Fw-cWs"/>
+                <constraint firstItem="JxQ-iv-eAN" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="q2V-Iu-xwo"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ZWR-gT-S2p" secondAttribute="trailing" id="tWl-b9-AcQ"/>
+                <constraint firstAttribute="trailing" secondItem="2pX-29-I87" secondAttribute="trailing" id="tl2-El-aGp"/>
+                <constraint firstItem="LU9-QU-BFL" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="10" id="uzh-oa-t27"/>
                 <constraint firstItem="mLe-eI-lIk" firstAttribute="leading" secondItem="2pX-29-I87" secondAttribute="leading" id="y2u-f9-ILB"/>
-                <constraint firstAttribute="trailing" secondItem="bm5-rb-Qjb" secondAttribute="trailing" constant="8" id="yu6-lr-z6o"/>
+                <constraint firstAttribute="trailing" secondItem="bm5-rb-Qjb" secondAttribute="trailing" constant="1" id="yu6-lr-z6o"/>
             </constraints>
             <point key="canvasLocation" x="121.5" y="248.5"/>
         </customView>
         <userDefaultsController representsSharedInstance="YES" id="XM5-Sj-lhw"/>
-        <arrayController objectClassName="KeyMapping" id="xGz-Vh-hMb"/>
+        <arrayController objectClassName="KeyMapping" id="xGz-Vh-hMb">
+            <classReference key="objectClass" className="KeyMapping"/>
+        </arrayController>
     </objects>
     <resources>
-        <image name="NSAddTemplate" width="11" height="11"/>
-        <image name="NSLockLockedTemplate" width="10" height="14"/>
-        <image name="NSRemoveTemplate" width="11" height="11"/>
+        <image name="NSAddTemplate" width="18" height="17"/>
+        <image name="NSLockLockedTemplate" width="19" height="19"/>
+        <image name="NSRemoveTemplate" width="18" height="5"/>
     </resources>
 </document>

--- a/iina/Base.lproj/PrefNetworkViewController.xib
+++ b/iina/Base.lproj/PrefNetworkViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="15705" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="15705"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -16,17 +16,16 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="500" height="444"/>
-            <point key="canvasLocation" x="136" y="498"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY" userLabel="Prefs &gt; Network View">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="380"/>
+            <point key="canvasLocation" x="136" y="495"/>
         </customView>
         <userDefaultsController representsSharedInstance="YES" id="KNf-nq-d77"/>
-        <customView id="dQy-nE-EW3">
-            <rect key="frame" x="0.0" y="0.0" width="476" height="78"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="dQy-nE-EW3" userLabel="Prefs &gt; Network &gt; Cache">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="80"/>
             <subviews>
                 <textField identifier="SectionTitleCache" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2xw-S1-tBi">
-                    <rect key="frame" x="-2" y="54" width="50" height="16"/>
+                    <rect key="frame" x="-2" y="56" width="50" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Cache:" id="LNk-io-MM7">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -34,7 +33,7 @@
                     </textFieldCell>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="1Nn-zY-Z5N">
-                    <rect key="frame" x="118" y="54" width="103" height="18"/>
+                    <rect key="frame" x="118" y="55" width="107" height="18"/>
                     <buttonCell key="cell" type="check" title="Enable cache" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="fpV-al-bn7">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -112,7 +111,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Aw2-n0-Y53">
-                    <rect key="frame" x="377" y="8" width="68" height="14"/>
+                    <rect key="frame" x="377" y="8" width="84" height="14"/>
                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Default: 36000" id="fab-7d-mMQ">
                         <font key="font" metaFont="message" size="11"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -122,14 +121,14 @@
             </subviews>
             <constraints>
                 <constraint firstItem="d3H-1Y-XVT" firstAttribute="top" secondItem="1Nn-zY-Z5N" secondAttribute="bottom" constant="8" id="3Jq-26-MfC"/>
-                <constraint firstItem="2xw-S1-tBi" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="dQy-nE-EW3" secondAttribute="leading" constant="120" id="4Th-wf-ROb"/>
                 <constraint firstItem="1Nn-zY-Z5N" firstAttribute="leading" secondItem="dQy-nE-EW3" secondAttribute="leading" constant="120" id="6g1-RW-Ln1"/>
                 <constraint firstItem="1Nn-zY-Z5N" firstAttribute="top" secondItem="2xw-S1-tBi" secondAttribute="top" id="7s0-Y8-rwl"/>
                 <constraint firstItem="DH1-5d-J02" firstAttribute="leading" secondItem="d3H-1Y-XVT" secondAttribute="trailing" constant="8" id="8F3-63-DE4"/>
                 <constraint firstItem="VFl-PR-eId" firstAttribute="leading" secondItem="DH1-5d-J02" secondAttribute="trailing" constant="10" id="8GT-RZ-oW1"/>
                 <constraint firstAttribute="bottom" secondItem="jlx-wF-OsB" secondAttribute="bottom" constant="8" id="8Le-qG-0IO"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="1Nn-zY-Z5N" secondAttribute="trailing" id="C1g-NA-RRP"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Aw2-n0-Y53" secondAttribute="trailing" constant="20" symbolic="YES" id="Djk-O6-TKh"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Aw2-n0-Y53" secondAttribute="trailing" id="Djk-O6-TKh"/>
+                <constraint firstItem="1Nn-zY-Z5N" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="2xw-S1-tBi" secondAttribute="trailing" id="EfG-ue-Zyb"/>
                 <constraint firstItem="jlx-wF-OsB" firstAttribute="leading" secondItem="1Nn-zY-Z5N" secondAttribute="leading" id="FBP-lN-PFP"/>
                 <constraint firstItem="Aw2-n0-Y53" firstAttribute="baseline" secondItem="jlx-wF-OsB" secondAttribute="baseline" id="GOi-Ar-e7U"/>
                 <constraint firstItem="2xw-S1-tBi" firstAttribute="top" secondItem="dQy-nE-EW3" secondAttribute="top" constant="8" id="O4M-hr-wLv"/>
@@ -142,13 +141,12 @@
                 <constraint firstItem="2xw-S1-tBi" firstAttribute="leading" secondItem="dQy-nE-EW3" secondAttribute="leading" id="ouH-0a-jhg"/>
                 <constraint firstItem="8qr-PT-G7W" firstAttribute="baseline" secondItem="jlx-wF-OsB" secondAttribute="baseline" id="pEU-Gj-mK5"/>
                 <constraint firstItem="DH1-5d-J02" firstAttribute="baseline" secondItem="d3H-1Y-XVT" secondAttribute="baseline" id="sbv-yD-zJG"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="VFl-PR-eId" secondAttribute="trailing" constant="12" id="tne-hD-A8r"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="VFl-PR-eId" secondAttribute="trailing" id="tne-hD-A8r"/>
             </constraints>
             <point key="canvasLocation" x="-385" y="313"/>
         </customView>
-        <customView id="Rzl-e7-tgj">
-            <rect key="frame" x="0.0" y="0.0" width="444" height="103"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Rzl-e7-tgj" userLabel="Prefs &gt; Network &gt; Network">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="103"/>
             <subviews>
                 <textField identifier="SectionTitleNetwork" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HdV-Xi-RWi">
                     <rect key="frame" x="-2" y="79" width="64" height="16"/>
@@ -166,8 +164,8 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FE2-RS-jZf">
-                    <rect key="frame" x="203" y="76" width="241" height="21"/>
+                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="FE2-RS-jZf">
+                    <rect key="frame" x="203" y="76" width="277" height="21"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="Jw4-M2-mMx">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -190,13 +188,13 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qEG-Qx-abX">
-                    <rect key="frame" x="322" y="2" width="85" height="25"/>
+                    <rect key="frame" x="321" y="1" width="87" height="25"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="80" id="63b-Mz-B7s"/>
                     </constraints>
                     <popUpButtonCell key="cell" type="push" title="Auto" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="aNr-lv-K0r" id="aQI-Yi-iRl">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="menu"/>
                         <menu key="menu" id="wKy-No-ulG">
                             <items>
                                 <menuItem title="Auto" state="on" id="aNr-lv-K0r"/>
@@ -218,8 +216,8 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JPi-nK-njc">
-                    <rect key="frame" x="245" y="52" width="199" height="21"/>
+                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="JPi-nK-njc">
+                    <rect key="frame" x="244" y="52" width="236" height="21"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="ah9-Ow-96R">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -234,7 +232,7 @@
                     </connections>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="8XM-Bb-OoC">
-                    <rect key="frame" x="201" y="32" width="245" height="14"/>
+                    <rect key="frame" x="201" y="32" width="206" height="14"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Requires restarting IINA to take effect." id="RwW-JS-iTv">
                         <font key="font" metaFont="message" size="11"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -242,7 +240,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="LJ5-Mm-ydF">
-                    <rect key="frame" x="201" y="55" width="42" height="16"/>
+                    <rect key="frame" x="201" y="55" width="41" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="http://" id="WTb-HK-6vU">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -252,9 +250,9 @@
             </subviews>
             <constraints>
                 <constraint firstItem="qEG-Qx-abX" firstAttribute="leading" secondItem="xX8-Nn-BdK" secondAttribute="trailing" constant="8" id="3vK-Fa-Wxd"/>
+                <constraint firstItem="jI5-X0-mph" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="HdV-Xi-RWi" secondAttribute="trailing" id="6Xx-M8-5Jp"/>
                 <constraint firstItem="LJ5-Mm-ydF" firstAttribute="leading" secondItem="Xq3-48-bOX" secondAttribute="trailing" constant="8" id="7aM-3G-Bvf"/>
                 <constraint firstItem="LJ5-Mm-ydF" firstAttribute="baseline" secondItem="Xq3-48-bOX" secondAttribute="baseline" id="8mV-KV-02U"/>
-                <constraint firstItem="HdV-Xi-RWi" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="Rzl-e7-tgj" secondAttribute="leading" constant="120" id="F4U-lH-4xn"/>
                 <constraint firstItem="FE2-RS-jZf" firstAttribute="leading" secondItem="jI5-X0-mph" secondAttribute="trailing" constant="8" id="F6V-QA-sT3"/>
                 <constraint firstItem="xX8-Nn-BdK" firstAttribute="leading" secondItem="Xq3-48-bOX" secondAttribute="leading" id="MCa-uK-JB7"/>
                 <constraint firstAttribute="trailing" secondItem="FE2-RS-jZf" secondAttribute="trailing" id="PM9-Z9-Aur"/>
@@ -263,12 +261,12 @@
                 <constraint firstItem="8XM-Bb-OoC" firstAttribute="leading" secondItem="Xq3-48-bOX" secondAttribute="trailing" constant="8" id="TlF-4L-cUZ"/>
                 <constraint firstItem="JPi-nK-njc" firstAttribute="baseline" secondItem="Xq3-48-bOX" secondAttribute="baseline" id="U88-wQ-wey"/>
                 <constraint firstItem="HdV-Xi-RWi" firstAttribute="top" secondItem="Rzl-e7-tgj" secondAttribute="top" constant="8" id="UP3-Nu-2OH"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="qEG-Qx-abX" secondAttribute="trailing" constant="20" symbolic="YES" id="aEB-tr-H4o"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="qEG-Qx-abX" secondAttribute="trailing" id="aEB-tr-H4o"/>
                 <constraint firstItem="HdV-Xi-RWi" firstAttribute="leading" secondItem="Rzl-e7-tgj" secondAttribute="leading" id="dpL-GF-20c"/>
                 <constraint firstAttribute="trailing" secondItem="JPi-nK-njc" secondAttribute="trailing" id="eb2-Lo-as5"/>
                 <constraint firstItem="Xq3-48-bOX" firstAttribute="leading" secondItem="jI5-X0-mph" secondAttribute="leading" id="h5C-6X-gPk"/>
                 <constraint firstItem="8XM-Bb-OoC" firstAttribute="top" secondItem="JPi-nK-njc" secondAttribute="bottom" constant="6" id="iuT-tl-rRj"/>
-                <constraint firstAttribute="trailing" secondItem="8XM-Bb-OoC" secondAttribute="trailing" id="ltl-sS-GT1"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="8XM-Bb-OoC" secondAttribute="trailing" id="ltl-sS-GT1"/>
                 <constraint firstItem="xX8-Nn-BdK" firstAttribute="top" secondItem="8XM-Bb-OoC" secondAttribute="bottom" constant="8" id="mCC-XQ-snZ"/>
                 <constraint firstItem="jI5-X0-mph" firstAttribute="top" secondItem="HdV-Xi-RWi" secondAttribute="top" id="tqI-rO-oqN"/>
                 <constraint firstItem="Xq3-48-bOX" firstAttribute="width" secondItem="jI5-X0-mph" secondAttribute="width" id="tyV-8L-Tfm"/>
@@ -277,22 +275,24 @@
                 <constraint firstAttribute="bottom" secondItem="xX8-Nn-BdK" secondAttribute="bottom" constant="8" id="xVq-mt-EKM"/>
                 <constraint firstItem="jI5-X0-mph" firstAttribute="leading" secondItem="Rzl-e7-tgj" secondAttribute="leading" constant="120" id="zP3-um-4co"/>
             </constraints>
-            <point key="canvasLocation" x="-385" y="514"/>
+            <point key="canvasLocation" x="-385" y="470.5"/>
         </customView>
-        <customView id="GHK-tq-Ssh">
-            <rect key="frame" x="0.0" y="0.0" width="444" height="136"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="GHK-tq-Ssh" userLabel="Prefs &gt; Network &gt; youtube-dl">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="122"/>
             <subviews>
                 <textField identifier="SectionTitleYtdl" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mRg-vm-guk">
-                    <rect key="frame" x="-2" y="112" width="80" height="16"/>
+                    <rect key="frame" x="-2" y="98" width="80" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="youtube-dl:" id="1Ex-0X-pjo">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="keb-Tn-A5F">
-                    <rect key="frame" x="206" y="25" width="238" height="21"/>
+                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="keb-Tn-A5F">
+                    <rect key="frame" x="206" y="25" width="274" height="21"/>
+                    <constraints>
+                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="200" id="4tm-Q5-1eg"/>
+                    </constraints>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="nKq-aq-AMN">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -308,7 +308,10 @@
                     </connections>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="iwI-aJ-5PQ">
-                    <rect key="frame" x="118" y="96" width="133" height="34"/>
+                    <rect key="frame" x="118" y="97" width="137" height="18"/>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="16" id="12u-7g-S9J"/>
+                    </constraints>
                     <buttonCell key="cell" type="check" title="Enable youtube-dl" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="cyH-Md-FAD">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -326,7 +329,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="zou-44-0mz">
-                    <rect key="frame" x="118" y="8" width="328" height="14"/>
+                    <rect key="frame" x="118" y="8" width="243" height="14"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="14" id="8rc-uN-wbB"/>
                     </constraints>
@@ -344,8 +347,11 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ePv-ZR-5fY">
-                    <rect key="frame" x="280" y="71" width="164" height="21"/>
+                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="ePv-ZR-5fY">
+                    <rect key="frame" x="280" y="71" width="200" height="21"/>
+                    <constraints>
+                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="100" id="f3s-3F-sX9"/>
+                    </constraints>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="/usr/local/bin" drawsBackground="YES" id="Smc-bL-Dvq">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -362,7 +368,7 @@
                     </connections>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="YLm-l6-HXj">
-                    <rect key="frame" x="118" y="52" width="328" height="14"/>
+                    <rect key="frame" x="118" y="52" width="303" height="14"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="14" id="74z-l3-NRT"/>
                     </constraints>
@@ -373,7 +379,7 @@
                     </textFieldCell>
                 </textField>
                 <button horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1hj-6T-EBw">
-                    <rect key="frame" x="255" y="91" width="25" height="25"/>
+                    <rect key="frame" x="260" y="93" width="25" height="25"/>
                     <buttonCell key="cell" type="help" bezelStyle="helpButton" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="nVU-MZ-yE4">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -385,19 +391,18 @@
             </subviews>
             <constraints>
                 <constraint firstItem="iwI-aJ-5PQ" firstAttribute="top" secondItem="mRg-vm-guk" secondAttribute="top" id="2aY-ta-abM"/>
+                <constraint firstItem="iwI-aJ-5PQ" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="mRg-vm-guk" secondAttribute="trailing" id="3Yh-o2-SsN"/>
                 <constraint firstItem="mRg-vm-guk" firstAttribute="leading" secondItem="GHK-tq-Ssh" secondAttribute="leading" id="5TM-HE-Id6"/>
                 <constraint firstItem="keb-Tn-A5F" firstAttribute="leading" secondItem="oFK-vb-I8Q" secondAttribute="trailing" constant="8" id="8fW-As-rsP"/>
                 <constraint firstItem="YLm-l6-HXj" firstAttribute="top" secondItem="aSG-qR-qgc" secondAttribute="bottom" constant="8" id="CT8-tl-vQe"/>
                 <constraint firstItem="oFK-vb-I8Q" firstAttribute="leading" secondItem="aSG-qR-qgc" secondAttribute="leading" id="Fhd-gR-JXd"/>
-                <constraint firstAttribute="trailing" secondItem="zou-44-0mz" secondAttribute="trailing" id="HOg-1v-tvx"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="zou-44-0mz" secondAttribute="trailing" id="HOg-1v-tvx"/>
                 <constraint firstItem="keb-Tn-A5F" firstAttribute="baseline" secondItem="oFK-vb-I8Q" secondAttribute="baseline" id="IZw-zP-Kvb"/>
                 <constraint firstItem="1hj-6T-EBw" firstAttribute="leading" secondItem="iwI-aJ-5PQ" secondAttribute="trailing" constant="8" id="JKg-e4-72c"/>
                 <constraint firstItem="ePv-ZR-5fY" firstAttribute="leading" secondItem="aSG-qR-qgc" secondAttribute="trailing" constant="8" id="JKo-eU-eBQ"/>
-                <constraint firstAttribute="trailing" secondItem="YLm-l6-HXj" secondAttribute="trailing" id="Lrb-aT-YRB"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="YLm-l6-HXj" secondAttribute="trailing" id="Lrb-aT-YRB"/>
                 <constraint firstItem="oFK-vb-I8Q" firstAttribute="top" secondItem="YLm-l6-HXj" secondAttribute="bottom" constant="8" id="RxE-jV-2sN"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="iwI-aJ-5PQ" secondAttribute="trailing" constant="20" symbolic="YES" id="SpV-h7-A91"/>
                 <constraint firstAttribute="bottom" secondItem="zou-44-0mz" secondAttribute="bottom" constant="8" id="T0o-Eb-wsc"/>
-                <constraint firstItem="mRg-vm-guk" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="GHK-tq-Ssh" secondAttribute="leading" constant="120" id="XTt-bi-7WH"/>
                 <constraint firstItem="YLm-l6-HXj" firstAttribute="leading" secondItem="aSG-qR-qgc" secondAttribute="leading" id="Yg3-d9-JGH"/>
                 <constraint firstItem="mRg-vm-guk" firstAttribute="top" secondItem="GHK-tq-Ssh" secondAttribute="top" constant="8" id="ZqN-ot-aiW"/>
                 <constraint firstAttribute="trailing" secondItem="ePv-ZR-5fY" secondAttribute="trailing" id="aAK-g3-gQN"/>
@@ -411,7 +416,7 @@
                 <constraint firstItem="aSG-qR-qgc" firstAttribute="leading" secondItem="iwI-aJ-5PQ" secondAttribute="leading" id="xKM-6D-Zvt"/>
                 <constraint firstItem="ePv-ZR-5fY" firstAttribute="baseline" secondItem="aSG-qR-qgc" secondAttribute="baseline" id="yez-4d-eID"/>
             </constraints>
-            <point key="canvasLocation" x="-385" y="711"/>
+            <point key="canvasLocation" x="-385" y="649"/>
         </customView>
     </objects>
 </document>

--- a/iina/Base.lproj/PrefOSCToolbarSettingsSheetController.xib
+++ b/iina/Base.lproj/PrefOSCToolbarSettingsSheetController.xib
@@ -19,7 +19,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" fullSizeContentView="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="425" height="355"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="875"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1792" height="1095"/>
             <view key="contentView" wantsLayer="YES" id="se5-gp-TjO">
                 <rect key="frame" x="0.0" y="0.0" width="340" height="355"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/iina/Base.lproj/PrefSubViewController.xib
+++ b/iina/Base.lproj/PrefSubViewController.xib
@@ -28,25 +28,24 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="531" height="369"/>
-            <point key="canvasLocation" x="-50.5" y="320.5"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY" userLabel="Prefs &gt; Subtitle View">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="369"/>
+            <point key="canvasLocation" x="-244" y="-173"/>
         </customView>
         <userDefaultsController representsSharedInstance="YES" id="5Up-Ab-aAm"/>
-        <customView id="n8c-of-fDQ">
-            <rect key="frame" x="0.0" y="0.0" width="666" height="180"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="n8c-of-fDQ" userLabel="Prefs &gt; Subtitle &gt; Auto Load">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="193"/>
             <subviews>
                 <textField identifier="SectionTitleAutoLoad" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Tej-f2-5d5">
-                    <rect key="frame" x="-2" y="156" width="70" height="16"/>
-                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Auto load:" id="raf-Yu-ck0">
+                    <rect key="frame" x="-2" y="169" width="74" height="16"/>
+                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Auto Load:" id="raf-Yu-ck0">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="if4-Ls-9s6">
-                    <rect key="frame" x="118" y="148" width="254" height="25"/>
+                    <rect key="frame" x="117" y="161" width="255" height="25"/>
                     <popUpButtonCell key="cell" type="push" title="Disabled" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="u31-eV-Arr" id="cQ9-BU-DYg">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="menu"/>
@@ -62,13 +61,13 @@
                         <binding destination="5Up-Ab-aAm" name="selectedTag" keyPath="values.subAutoLoadIINA" id="Pi3-G7-Eho"/>
                     </connections>
                 </popUpButton>
-                <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cZs-HF-wZQ" customClass="CollapseView" customModule="IINA" customModuleProvider="target">
-                    <rect key="frame" x="120" y="4" width="546" height="139"/>
+                <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" horizontalCompressionResistancePriority="251" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cZs-HF-wZQ" customClass="CollapseView" customModule="IINA" customModuleProvider="target">
+                    <rect key="frame" x="120" y="4" width="360" height="153"/>
                     <subviews>
-                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="FkP-nh-hj4">
-                            <rect key="frame" x="0.0" y="122" width="546" height="17"/>
+                        <customView horizontalCompressionResistancePriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="FkP-nh-hj4">
+                            <rect key="frame" x="0.0" y="136" width="360" height="17"/>
                             <subviews>
-                                <button identifier="Trigger0" horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="F0d-QD-wgF">
+                                <button identifier="Trigger0" horizontalHuggingPriority="750" verticalHuggingPriority="750" horizontalCompressionResistancePriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="F0d-QD-wgF">
                                     <rect key="frame" x="0.0" y="0.0" width="13" height="13"/>
                                     <buttonCell key="cell" type="disclosureTriangle" bezelStyle="disclosure" imagePosition="only" alignment="left" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="JH0-QA-eIN">
                                         <behavior key="behavior" pushIn="YES" changeBackground="YES" changeGray="YES" lightByContents="YES"/>
@@ -95,18 +94,18 @@
                             </constraints>
                         </customView>
                         <customView identifier="Content0" translatesAutoresizingMaskIntoConstraints="NO" id="sK4-SO-u4b">
-                            <rect key="frame" x="0.0" y="0.0" width="546" height="118"/>
+                            <rect key="frame" x="0.0" y="0.0" width="360" height="132"/>
                             <subviews>
                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="C4b-sm-2kc">
-                                    <rect key="frame" x="-2" y="100" width="259" height="14"/>
+                                    <rect key="frame" x="-2" y="114" width="259" height="14"/>
                                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Subtitles have priority when filename containing:" id="7pf-Kb-TNr">
                                         <font key="font" metaFont="message" size="11"/>
                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
                                 </textField>
-                                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="S8g-xi-5Ez">
-                                    <rect key="frame" x="0.0" y="77" width="546" height="19"/>
+                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="S8g-xi-5Ez">
+                                    <rect key="frame" x="0.0" y="91" width="360" height="19"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="19" id="5Qw-dU-xAc"/>
                                     </constraints>
@@ -124,7 +123,7 @@
                                     </connections>
                                 </textField>
                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aJd-if-ImI">
-                                    <rect key="frame" x="-2" y="61" width="550" height="14"/>
+                                    <rect key="frame" x="-2" y="75" width="253" height="14"/>
                                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Please enter a comma-separated list of strings." id="Mk1-sv-QB8">
                                         <font key="font" metaFont="message" size="11"/>
                                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -132,15 +131,15 @@
                                     </textFieldCell>
                                 </textField>
                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Qkw-vv-CeA">
-                                    <rect key="frame" x="-2" y="39" width="239" height="14"/>
+                                    <rect key="frame" x="-2" y="53" width="239" height="14"/>
                                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Also search subtitles in following directories:" id="QsS-wD-2hY">
                                         <font key="font" metaFont="message" size="11"/>
                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                     </textFieldCell>
                                 </textField>
-                                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="83N-r3-wZ6">
-                                    <rect key="frame" x="0.0" y="16" width="546" height="19"/>
+                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="83N-r3-wZ6">
+                                    <rect key="frame" x="0.0" y="30" width="360" height="19"/>
                                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="Mbv-Nx-tdp">
                                         <font key="font" metaFont="message" size="11"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -155,7 +154,7 @@
                                     </connections>
                                 </textField>
                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="T4U-Ii-SK6">
-                                    <rect key="frame" x="-2" y="0.0" width="550" height="14"/>
+                                    <rect key="frame" x="-2" y="0.0" width="364" height="28"/>
                                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Directories are separated by colons (:). Relative paths and wildcards (*) at the end are allowed." id="Luv-2B-9v8">
                                         <font key="font" metaFont="message" size="11"/>
                                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -173,8 +172,8 @@
                                 <constraint firstItem="C4b-sm-2kc" firstAttribute="top" secondItem="sK4-SO-u4b" secondAttribute="top" constant="4" id="Ks1-XQ-pXn"/>
                                 <constraint firstItem="S8g-xi-5Ez" firstAttribute="leading" secondItem="C4b-sm-2kc" secondAttribute="leading" id="Lei-rS-iZi"/>
                                 <constraint firstItem="Qkw-vv-CeA" firstAttribute="leading" secondItem="aJd-if-ImI" secondAttribute="leading" id="OAh-h3-6gQ"/>
-                                <constraint firstAttribute="trailing" secondItem="aJd-if-ImI" secondAttribute="trailing" id="Wqn-in-Cld"/>
-                                <constraint firstAttribute="trailing" secondItem="T4U-Ii-SK6" secondAttribute="trailing" id="Xy8-xt-q1t"/>
+                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="aJd-if-ImI" secondAttribute="trailing" id="Wqn-in-Cld"/>
+                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="T4U-Ii-SK6" secondAttribute="trailing" id="Xy8-xt-q1t"/>
                                 <constraint firstItem="C4b-sm-2kc" firstAttribute="leading" secondItem="sK4-SO-u4b" secondAttribute="leading" id="bMo-7R-XO5"/>
                                 <constraint firstItem="83N-r3-wZ6" firstAttribute="top" secondItem="Qkw-vv-CeA" secondAttribute="bottom" constant="4" id="bfP-F5-NKA"/>
                                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Qkw-vv-CeA" secondAttribute="trailing" id="eti-q5-QeE"/>
@@ -215,111 +214,27 @@
                 <constraint firstItem="Tej-f2-5d5" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="n8c-of-fDQ" secondAttribute="leading" constant="120" id="o8G-bb-tes"/>
                 <constraint firstItem="Tej-f2-5d5" firstAttribute="leading" secondItem="n8c-of-fDQ" secondAttribute="leading" id="xHQ-K2-9l0"/>
             </constraints>
-            <point key="canvasLocation" x="-722" y="-252.5"/>
+            <point key="canvasLocation" x="-782" y="-260"/>
         </customView>
-        <customView id="Iur-Ka-beI">
-            <rect key="frame" x="0.0" y="0.0" width="546" height="90"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-            <subviews>
-                <textField identifier="SectionTitleOther" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MEh-II-li7">
-                    <rect key="frame" x="-2" y="66" width="46" height="16"/>
-                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Other:" id="LiG-iV-AQK">
-                        <font key="font" metaFont="systemBold"/>
-                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ahb-ha-Bd8">
-                    <rect key="frame" x="118" y="66" width="124" height="16"/>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Preferred language:" id="zaE-bH-XfT">
-                        <font key="font" metaFont="system"/>
-                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="6zR-BO-yhX">
-                    <rect key="frame" x="118" y="32" width="430" height="28"/>
-                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="This option will be stored as ISO 639-2 language code and will works for both mpv and opensubtitles." id="Z2M-dh-eq1">
-                        <font key="font" metaFont="message" size="11"/>
-                        <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
-                <tokenField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bhV-Cx-zgK" customClass="LanguageTokenField" customModule="IINA" customModuleProvider="target">
-                    <rect key="frame" x="248" y="64" width="298" height="20"/>
-                    <tokenFieldCell key="cell" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="left" drawsBackground="YES" allowsEditingTextAttributes="YES" id="MPJ-dp-jsH">
-                        <font key="font" metaFont="cellTitle"/>
-                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                    </tokenFieldCell>
-                    <connections>
-                        <action selector="preferredLanguageAction:" target="-2" id="j9t-7r-Rzk"/>
-                    </connections>
-                </tokenField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dOC-a0-BI4">
-                    <rect key="frame" x="118" y="8" width="112" height="16"/>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Default encoding:" id="Y75-4k-2Du">
-                        <font key="font" metaFont="system"/>
-                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
-                <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1L9-wU-gfj">
-                    <rect key="frame" x="234" y="1" width="125" height="25"/>
-                    <constraints>
-                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="120" id="pOY-9e-lvC"/>
-                    </constraints>
-                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="unJ-fK-oZh">
-                        <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="menu"/>
-                        <menu key="menu" id="QdY-Ba-1k0"/>
-                    </popUpButtonCell>
-                    <connections>
-                        <action selector="changeDefaultEncoding:" target="-2" id="jIO-eq-6So"/>
-                    </connections>
-                </popUpButton>
-            </subviews>
-            <constraints>
-                <constraint firstItem="bhV-Cx-zgK" firstAttribute="baseline" secondItem="ahb-ha-Bd8" secondAttribute="baseline" id="4e1-FJ-t5K"/>
-                <constraint firstItem="dOC-a0-BI4" firstAttribute="baseline" secondItem="1L9-wU-gfj" secondAttribute="baseline" id="5M9-qK-fjf"/>
-                <constraint firstItem="dOC-a0-BI4" firstAttribute="top" secondItem="6zR-BO-yhX" secondAttribute="bottom" constant="8" id="D4x-Hk-XX7"/>
-                <constraint firstItem="ahb-ha-Bd8" firstAttribute="leading" secondItem="Iur-Ka-beI" secondAttribute="leading" constant="120" id="DLa-Hu-Hsu"/>
-                <constraint firstItem="bhV-Cx-zgK" firstAttribute="leading" secondItem="ahb-ha-Bd8" secondAttribute="trailing" constant="8" id="H00-EI-iem"/>
-                <constraint firstAttribute="trailing" secondItem="bhV-Cx-zgK" secondAttribute="trailing" id="PF2-Wf-LtR"/>
-                <constraint firstAttribute="trailing" secondItem="6zR-BO-yhX" secondAttribute="trailing" id="Q22-5Z-DYd"/>
-                <constraint firstItem="6zR-BO-yhX" firstAttribute="leading" secondItem="ahb-ha-Bd8" secondAttribute="leading" id="QGJ-sL-Nzb"/>
-                <constraint firstAttribute="bottom" secondItem="dOC-a0-BI4" secondAttribute="bottom" constant="8" id="VTK-Vf-cBi"/>
-                <constraint firstItem="6zR-BO-yhX" firstAttribute="top" secondItem="ahb-ha-Bd8" secondAttribute="bottom" constant="6" id="c9L-vJ-3S9"/>
-                <constraint firstItem="dOC-a0-BI4" firstAttribute="leading" secondItem="ahb-ha-Bd8" secondAttribute="leading" id="cR3-Eo-SrY"/>
-                <constraint firstItem="MEh-II-li7" firstAttribute="leading" secondItem="Iur-Ka-beI" secondAttribute="leading" id="dms-Ko-OqB"/>
-                <constraint firstItem="MEh-II-li7" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="Iur-Ka-beI" secondAttribute="leading" constant="120" id="dxI-On-Voh"/>
-                <constraint firstItem="MEh-II-li7" firstAttribute="top" secondItem="Iur-Ka-beI" secondAttribute="top" constant="8" id="lcP-SH-XZf"/>
-                <constraint firstItem="ahb-ha-Bd8" firstAttribute="top" secondItem="MEh-II-li7" secondAttribute="top" id="lin-I0-luW"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="1L9-wU-gfj" secondAttribute="trailing" id="ndi-hc-GPJ"/>
-                <constraint firstItem="1L9-wU-gfj" firstAttribute="leading" secondItem="dOC-a0-BI4" secondAttribute="trailing" constant="8" id="t70-ri-Fo8"/>
-            </constraints>
-            <point key="canvasLocation" x="-722" y="855"/>
-        </customView>
-        <customView id="y44-Ej-vIC">
-            <rect key="frame" x="0.0" y="0.0" width="546" height="161"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="y44-Ej-vIC" userLabel="Prefs &gt; Subtitle &gt; Online Subtitles">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="166"/>
             <subviews>
                 <textField identifier="SectionTitleOnlineSub" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="NlE-eQ-ofV">
-                    <rect key="frame" x="-2" y="72" width="112" height="81"/>
+                    <rect key="frame" x="-2" y="142" width="112" height="16"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Online Subtitles:" id="0fB-es-DmV">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bSz-xd-6o2">
-                    <rect key="frame" x="120" y="72" width="426" height="81"/>
+                <stackView distribution="fillEqually" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bSz-xd-6o2">
+                    <rect key="frame" x="120" y="74" width="360" height="87"/>
                     <subviews>
                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="S8h-wJ-vNN">
-                            <rect key="frame" x="0.0" y="60" width="426" height="21"/>
+                            <rect key="frame" x="0.0" y="64" width="360" height="23"/>
                             <subviews>
                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="p4E-J3-eff">
-                                    <rect key="frame" x="-2" y="4" width="155" height="16"/>
+                                    <rect key="frame" x="-2" y="4" width="156" height="16"/>
                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Download subtitles from:" id="TPK-CJ-HX7">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -327,7 +242,7 @@
                                     </textFieldCell>
                                 </textField>
                                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UHS-ce-8t5">
-                                    <rect key="frame" x="157" y="-3" width="165" height="25"/>
+                                    <rect key="frame" x="157" y="-4" width="167" height="26"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="21" id="6er-PT-s9c"/>
                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="160" id="jeq-2f-ivK"/>
@@ -344,19 +259,19 @@
                                 </popUpButton>
                             </subviews>
                             <constraints>
-                                <constraint firstItem="UHS-ce-8t5" firstAttribute="top" secondItem="S8h-wJ-vNN" secondAttribute="top" id="ACk-AK-j5b"/>
+                                <constraint firstItem="UHS-ce-8t5" firstAttribute="top" secondItem="S8h-wJ-vNN" secondAttribute="top" constant="2" id="ACk-AK-j5b"/>
                                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="UHS-ce-8t5" secondAttribute="trailing" id="UPG-b7-fKe"/>
                                 <constraint firstAttribute="bottom" secondItem="UHS-ce-8t5" secondAttribute="bottom" id="W1o-uh-IYh"/>
-                                <constraint firstItem="UHS-ce-8t5" firstAttribute="baseline" secondItem="p4E-J3-eff" secondAttribute="baseline" id="YOH-uR-j8V"/>
+                                <constraint firstItem="UHS-ce-8t5" firstAttribute="firstBaseline" secondItem="p4E-J3-eff" secondAttribute="firstBaseline" id="YOH-uR-j8V"/>
                                 <constraint firstItem="UHS-ce-8t5" firstAttribute="leading" secondItem="p4E-J3-eff" secondAttribute="trailing" constant="8" id="mZj-RC-40f"/>
                                 <constraint firstItem="p4E-J3-eff" firstAttribute="leading" secondItem="S8h-wJ-vNN" secondAttribute="leading" id="pB7-lb-Zsy"/>
                             </constraints>
                         </customView>
                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="C38-iH-EaR">
-                            <rect key="frame" x="0.0" y="30" width="426" height="22"/>
+                            <rect key="frame" x="0.0" y="32" width="360" height="24"/>
                             <subviews>
                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3Le-C6-vNr">
-                                    <rect key="frame" x="23" y="3" width="147" height="16"/>
+                                    <rect key="frame" x="24" y="2" width="147" height="16"/>
                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="OpenSubtitles account:" id="Iax-cc-YIO">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -364,10 +279,10 @@
                                     </textFieldCell>
                                 </textField>
                                 <progressIndicator wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="100" bezeled="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="JPS-9i-fOz">
-                                    <rect key="frame" x="308" y="2" width="16" height="16"/>
+                                    <rect key="frame" x="310" y="1" width="16" height="16"/>
                                 </progressIndicator>
                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="7Mg-Vi-hfK">
-                                    <rect key="frame" x="174" y="3" width="75" height="14"/>
+                                    <rect key="frame" x="175" y="2" width="75" height="14"/>
                                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Not logged in" id="cov-Uy-wnc">
                                         <font key="font" metaFont="message" size="11"/>
                                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -382,7 +297,7 @@
                                     </connections>
                                 </textField>
                                 <button horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dsK-Rb-mz5">
-                                    <rect key="frame" x="-2" y="-3" width="25" height="25"/>
+                                    <rect key="frame" x="-1" y="-3" width="25" height="26"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="21" id="DK8-n1-2bK"/>
                                     </constraints>
@@ -395,7 +310,7 @@
                                     </connections>
                                 </button>
                                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Fcc-I5-Ri2">
-                                    <rect key="frame" x="255" y="0.0" width="45" height="19"/>
+                                    <rect key="frame" x="256" y="-1" width="46" height="19"/>
                                     <buttonCell key="cell" type="roundRect" title="Login" bezelStyle="roundedRect" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="WHk-sk-gmK">
                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                         <font key="font" metaFont="cellTitle"/>
@@ -414,7 +329,7 @@
                                 <constraint firstItem="JPS-9i-fOz" firstAttribute="leading" secondItem="Fcc-I5-Ri2" secondAttribute="trailing" constant="8" id="5qR-tt-Vz4"/>
                                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="JPS-9i-fOz" secondAttribute="trailing" id="D57-Jw-Hxo"/>
                                 <constraint firstItem="Fcc-I5-Ri2" firstAttribute="baseline" secondItem="7Mg-Vi-hfK" secondAttribute="baseline" id="EMy-KQ-CUk"/>
-                                <constraint firstItem="dsK-Rb-mz5" firstAttribute="leading" secondItem="C38-iH-EaR" secondAttribute="leading" id="JmE-S0-GHm"/>
+                                <constraint firstItem="dsK-Rb-mz5" firstAttribute="leading" secondItem="C38-iH-EaR" secondAttribute="leading" constant="2" id="JmE-S0-GHm"/>
                                 <constraint firstItem="7Mg-Vi-hfK" firstAttribute="leading" secondItem="3Le-C6-vNr" secondAttribute="trailing" constant="8" id="QwB-yK-kKt"/>
                                 <constraint firstItem="Fcc-I5-Ri2" firstAttribute="leading" secondItem="7Mg-Vi-hfK" secondAttribute="trailing" constant="8" id="Txl-iL-MWp"/>
                                 <constraint firstItem="JPS-9i-fOz" firstAttribute="centerY" secondItem="Fcc-I5-Ri2" secondAttribute="centerY" id="VvL-xH-LmY"/>
@@ -422,14 +337,14 @@
                                 <constraint firstItem="7Mg-Vi-hfK" firstAttribute="baseline" secondItem="3Le-C6-vNr" secondAttribute="baseline" id="hx2-nA-jTL"/>
                                 <constraint firstItem="3Le-C6-vNr" firstAttribute="baseline" secondItem="dsK-Rb-mz5" secondAttribute="baseline" id="k7q-ax-csW"/>
                                 <constraint firstItem="3Le-C6-vNr" firstAttribute="leading" secondItem="dsK-Rb-mz5" secondAttribute="trailing" constant="4" id="ktJ-Gd-Xtz"/>
-                                <constraint firstItem="dsK-Rb-mz5" firstAttribute="top" secondItem="C38-iH-EaR" secondAttribute="top" id="qst-PD-E1d"/>
+                                <constraint firstItem="dsK-Rb-mz5" firstAttribute="top" secondItem="C38-iH-EaR" secondAttribute="top" constant="2" id="qst-PD-E1d"/>
                             </constraints>
                         </customView>
                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="3Sa-mf-YQ3">
-                            <rect key="frame" x="0.0" y="0.0" width="426" height="22"/>
+                            <rect key="frame" x="0.0" y="0.0" width="360" height="24"/>
                             <subviews>
                                 <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FrB-U7-atb">
-                                    <rect key="frame" x="130" y="0.0" width="296" height="21"/>
+                                    <rect key="frame" x="131" y="-1" width="229" height="21"/>
                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="DaP-6c-nfz">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -444,7 +359,7 @@
                                     </connections>
                                 </textField>
                                 <button horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="b7J-VO-Tgn">
-                                    <rect key="frame" x="-2" y="-3" width="25" height="25"/>
+                                    <rect key="frame" x="-1" y="-3" width="25" height="26"/>
                                     <constraints>
                                         <constraint firstAttribute="height" constant="21" id="QAL-8S-ztf"/>
                                     </constraints>
@@ -457,7 +372,7 @@
                                     </connections>
                                 </button>
                                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bgS-sJ-Egb">
-                                    <rect key="frame" x="23" y="3" width="101" height="16"/>
+                                    <rect key="frame" x="24" y="2" width="101" height="16"/>
                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Assrt API token:" id="0aU-O1-R6G">
                                         <font key="font" metaFont="system"/>
                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -467,11 +382,11 @@
                             </subviews>
                             <constraints>
                                 <constraint firstItem="bgS-sJ-Egb" firstAttribute="baseline" secondItem="b7J-VO-Tgn" secondAttribute="baseline" id="2j6-Di-U10"/>
-                                <constraint firstItem="b7J-VO-Tgn" firstAttribute="top" secondItem="3Sa-mf-YQ3" secondAttribute="top" id="4rh-dd-teE"/>
+                                <constraint firstItem="b7J-VO-Tgn" firstAttribute="top" secondItem="3Sa-mf-YQ3" secondAttribute="top" constant="2" id="4rh-dd-teE"/>
                                 <constraint firstAttribute="bottom" secondItem="b7J-VO-Tgn" secondAttribute="bottom" constant="1" id="Kwf-Kp-zTf"/>
                                 <constraint firstAttribute="trailing" secondItem="FrB-U7-atb" secondAttribute="trailing" id="PmD-Sa-R9O"/>
                                 <constraint firstItem="bgS-sJ-Egb" firstAttribute="leading" secondItem="b7J-VO-Tgn" secondAttribute="trailing" constant="4" id="SYR-wJ-Bme"/>
-                                <constraint firstItem="b7J-VO-Tgn" firstAttribute="leading" secondItem="3Sa-mf-YQ3" secondAttribute="leading" id="TBN-OP-EhO"/>
+                                <constraint firstItem="b7J-VO-Tgn" firstAttribute="leading" secondItem="3Sa-mf-YQ3" secondAttribute="leading" constant="2" id="TBN-OP-EhO"/>
                                 <constraint firstItem="FrB-U7-atb" firstAttribute="baseline" secondItem="bgS-sJ-Egb" secondAttribute="baseline" id="j4R-si-5eg"/>
                                 <constraint firstItem="FrB-U7-atb" firstAttribute="leading" secondItem="bgS-sJ-Egb" secondAttribute="trailing" constant="8" id="qg9-It-iM3"/>
                             </constraints>
@@ -497,7 +412,7 @@
                     </customSpacing>
                 </stackView>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="pN7-Bv-pLw">
-                    <rect key="frame" x="118" y="40" width="244" height="18"/>
+                    <rect key="frame" x="118" y="41" width="248" height="18"/>
                     <buttonCell key="cell" type="check" title="Search online subtitles automatically" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="C3p-uP-8u8">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -507,7 +422,7 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="L5b-oD-GdQ">
-                    <rect key="frame" x="118" y="8" width="430" height="28"/>
+                    <rect key="frame" x="118" y="8" width="364" height="28"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" id="vYb-qH-XkH">
                         <font key="font" metaFont="message" size="11"/>
                         <string key="title">If enabled, IINA will automatically search online subtitles only for videos without loaded subtitles and longer than 20 mintues.</string>
@@ -517,7 +432,7 @@
                 </textField>
             </subviews>
             <constraints>
-                <constraint firstItem="bSz-xd-6o2" firstAttribute="top" secondItem="NlE-eQ-ofV" secondAttribute="top" id="6fM-o1-xVO"/>
+                <constraint firstItem="p4E-J3-eff" firstAttribute="firstBaseline" secondItem="NlE-eQ-ofV" secondAttribute="firstBaseline" id="7HY-5k-7l7"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="pN7-Bv-pLw" secondAttribute="trailing" id="Abb-4w-jNq"/>
                 <constraint firstAttribute="bottom" secondItem="L5b-oD-GdQ" secondAttribute="bottom" constant="8" id="HlH-Cw-O9F"/>
                 <constraint firstItem="NlE-eQ-ofV" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="y44-Ej-vIC" secondAttribute="leading" constant="120" id="Ira-dr-djv"/>
@@ -525,35 +440,33 @@
                 <constraint firstItem="L5b-oD-GdQ" firstAttribute="top" secondItem="pN7-Bv-pLw" secondAttribute="bottom" constant="6" id="SfZ-tS-w1E"/>
                 <constraint firstItem="pN7-Bv-pLw" firstAttribute="top" secondItem="bSz-xd-6o2" secondAttribute="bottom" constant="16" id="Uls-Tr-J0I"/>
                 <constraint firstItem="bSz-xd-6o2" firstAttribute="leading" secondItem="L5b-oD-GdQ" secondAttribute="leading" id="VPb-8f-iBh"/>
-                <constraint firstItem="bSz-xd-6o2" firstAttribute="centerY" secondItem="NlE-eQ-ofV" secondAttribute="centerY" id="byU-cW-07s"/>
                 <constraint firstItem="NlE-eQ-ofV" firstAttribute="leading" secondItem="y44-Ej-vIC" secondAttribute="leading" id="gj9-Zi-nys"/>
-                <constraint firstAttribute="trailing" secondItem="L5b-oD-GdQ" secondAttribute="trailing" id="hab-Vk-i9Q"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="L5b-oD-GdQ" secondAttribute="trailing" id="hab-Vk-i9Q"/>
                 <constraint firstItem="bSz-xd-6o2" firstAttribute="leading" secondItem="y44-Ej-vIC" secondAttribute="leading" constant="120" id="ljC-3f-gyR"/>
                 <constraint firstItem="NlE-eQ-ofV" firstAttribute="top" secondItem="y44-Ej-vIC" secondAttribute="top" constant="8" id="obM-hS-TjF"/>
                 <constraint firstAttribute="trailing" secondItem="bSz-xd-6o2" secondAttribute="trailing" id="rDC-XB-xxo"/>
             </constraints>
-            <point key="canvasLocation" x="-722" y="674"/>
+            <point key="canvasLocation" x="-244" y="137.5"/>
         </customView>
-        <customView id="ffZ-rE-7Zz">
-            <rect key="frame" x="0.0" y="0.0" width="546" height="293"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="ffZ-rE-7Zz" userLabel="Prefs &gt; Subtitle &gt; Text Subtitles">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="321"/>
             <subviews>
                 <textField identifier="SectionTitleText" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Yw3-tf-Rka">
-                    <rect key="frame" x="-2" y="277" width="97" height="16"/>
-                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Text subtitles:" id="Qda-dp-nhg">
+                    <rect key="frame" x="-2" y="297" width="98" height="16"/>
+                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Text Subtitles:" id="Qda-dp-nhg">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
                 <box title="Font" translatesAutoresizingMaskIntoConstraints="NO" id="9pv-1r-nuH">
-                    <rect key="frame" x="117" y="193" width="432" height="100"/>
+                    <rect key="frame" x="117" y="205" width="366" height="108"/>
                     <view key="contentView" id="aHT-R0-nxi">
-                        <rect key="frame" x="3" y="3" width="426" height="82"/>
+                        <rect key="frame" x="4" y="5" width="358" height="88"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ZnB-Tk-bG4">
-                                <rect key="frame" x="8" y="60" width="31" height="14"/>
+                                <rect key="frame" x="10" y="64" width="31" height="14"/>
                                 <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Font:" id="C4C-XP-i2S">
                                     <font key="font" metaFont="message" size="11"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -561,7 +474,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="W8T-T8-H6B">
-                                <rect key="frame" x="8" y="34" width="36" height="14"/>
+                                <rect key="frame" x="10" y="38" width="36" height="14"/>
                                 <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Size:" id="Vbl-Im-3UI">
                                     <font key="font" metaFont="message" size="11"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -569,7 +482,7 @@
                                 </textFieldCell>
                             </textField>
                             <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="LYh-2j-Fsx">
-                                <rect key="frame" x="54" y="32" width="38" height="19"/>
+                                <rect key="frame" x="56" y="36" width="38" height="19"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="38" id="tS9-vz-vnj"/>
                                 </constraints>
@@ -590,7 +503,7 @@
                                 </connections>
                             </textField>
                             <colorWell translatesAutoresizingMaskIntoConstraints="NO" id="AaL-am-9qW">
-                                <rect key="frame" x="54" y="6" width="38" height="19"/>
+                                <rect key="frame" x="53" y="8" width="44" height="23"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="19" id="6DX-D0-Bqk"/>
                                     <constraint firstAttribute="width" constant="38" id="t9B-Ns-4Pf"/>
@@ -605,7 +518,7 @@
                                 </connections>
                             </colorWell>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1rB-s8-3s0">
-                                <rect key="frame" x="8" y="8" width="36" height="14"/>
+                                <rect key="frame" x="10" y="12" width="36" height="14"/>
                                 <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Color:" id="xid-E9-FC9">
                                     <font key="font" metaFont="message" size="11"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -613,7 +526,7 @@
                                 </textFieldCell>
                             </textField>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="LnO-CD-ImJ">
-                                <rect key="frame" x="160" y="33" width="51" height="18"/>
+                                <rect key="frame" x="168" y="37" width="55" height="18"/>
                                 <buttonCell key="cell" type="check" title="Italic" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="pNF-Fw-QtW">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -623,7 +536,7 @@
                                 </connections>
                             </button>
                             <colorWell translatesAutoresizingMaskIntoConstraints="NO" id="6fT-hS-kdG">
-                                <rect key="frame" x="178" y="6" width="38" height="19"/>
+                                <rect key="frame" x="177" y="8" width="44" height="23"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="38" id="7vO-WO-Jfm"/>
                                     <constraint firstAttribute="height" constant="19" id="RCS-3D-h4Z"/>
@@ -638,7 +551,7 @@
                                 </connections>
                             </colorWell>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="zCF-pU-dtb">
-                                <rect key="frame" x="102" y="8" width="70" height="14"/>
+                                <rect key="frame" x="104" y="12" width="70" height="14"/>
                                 <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Background:" id="eYO-c0-Rjp">
                                     <font key="font" metaFont="message" size="11"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -646,7 +559,7 @@
                                 </textFieldCell>
                             </textField>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="EV7-O7-x1O">
-                                <rect key="frame" x="102" y="33" width="50" height="18"/>
+                                <rect key="frame" x="104" y="37" width="54" height="18"/>
                                 <buttonCell key="cell" type="check" title="Bold" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="hEk-7E-10r">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -656,7 +569,7 @@
                                 </connections>
                             </button>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JHb-3k-TMv">
-                                <rect key="frame" x="43" y="60" width="57" height="14"/>
+                                <rect key="frame" x="45" y="64" width="57" height="14"/>
                                 <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="sans-serif" id="azJ-oz-BKZ">
                                     <font key="font" metaFont="message" size="11"/>
                                     <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -667,7 +580,7 @@
                                 </connections>
                             </textField>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QUk-An-HgX">
-                                <rect key="frame" x="347" y="52" width="76" height="27"/>
+                                <rect key="frame" x="278" y="56" width="78" height="27"/>
                                 <buttonCell key="cell" type="push" title="Choose..." bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="nH7-kO-S15">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="message" size="11"/>
@@ -679,28 +592,31 @@
                         </subviews>
                         <constraints>
                             <constraint firstItem="EV7-O7-x1O" firstAttribute="leading" secondItem="LYh-2j-Fsx" secondAttribute="trailing" constant="12" id="5d6-ap-EnA"/>
+                            <constraint firstItem="W8T-T8-H6B" firstAttribute="height" secondItem="ZnB-Tk-bG4" secondAttribute="height" id="6ab-kx-oE8"/>
+                            <constraint firstItem="zCF-pU-dtb" firstAttribute="height" secondItem="ZnB-Tk-bG4" secondAttribute="height" id="7PF-b4-ZLD"/>
                             <constraint firstItem="1rB-s8-3s0" firstAttribute="top" secondItem="W8T-T8-H6B" secondAttribute="bottom" constant="12" id="8OP-b7-qVg"/>
-                            <constraint firstItem="W8T-T8-H6B" firstAttribute="leading" secondItem="aHT-R0-nxi" secondAttribute="leading" constant="10" id="993-UC-lUr"/>
+                            <constraint firstItem="W8T-T8-H6B" firstAttribute="leading" secondItem="aHT-R0-nxi" secondAttribute="leading" constant="12" id="993-UC-lUr"/>
                             <constraint firstItem="6fT-hS-kdG" firstAttribute="leading" secondItem="zCF-pU-dtb" secondAttribute="trailing" constant="8" id="9we-lA-Drd"/>
                             <constraint firstItem="zCF-pU-dtb" firstAttribute="leading" secondItem="AaL-am-9qW" secondAttribute="trailing" constant="12" id="DFA-N5-1p6"/>
-                            <constraint firstItem="ZnB-Tk-bG4" firstAttribute="top" secondItem="aHT-R0-nxi" secondAttribute="top" constant="8" id="DQR-jl-lR2"/>
+                            <constraint firstItem="ZnB-Tk-bG4" firstAttribute="top" secondItem="aHT-R0-nxi" secondAttribute="top" constant="10" id="DQR-jl-lR2"/>
                             <constraint firstItem="LYh-2j-Fsx" firstAttribute="leading" secondItem="W8T-T8-H6B" secondAttribute="trailing" constant="12" id="Ehb-tI-T9B"/>
                             <constraint firstItem="QUk-An-HgX" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="JHb-3k-TMv" secondAttribute="trailing" id="Ge2-Sk-uAf"/>
-                            <constraint firstItem="1rB-s8-3s0" firstAttribute="leading" secondItem="aHT-R0-nxi" secondAttribute="leading" constant="10" id="Glb-8s-fOe"/>
+                            <constraint firstItem="1rB-s8-3s0" firstAttribute="leading" secondItem="aHT-R0-nxi" secondAttribute="leading" constant="12" id="Glb-8s-fOe"/>
                             <constraint firstItem="zCF-pU-dtb" firstAttribute="baseline" secondItem="1rB-s8-3s0" secondAttribute="baseline" id="HMr-e5-UON"/>
                             <constraint firstItem="LYh-2j-Fsx" firstAttribute="centerY" secondItem="W8T-T8-H6B" secondAttribute="centerY" id="JsS-M0-ac3"/>
                             <constraint firstItem="1rB-s8-3s0" firstAttribute="width" secondItem="W8T-T8-H6B" secondAttribute="width" id="L6d-iD-Xmb"/>
                             <constraint firstItem="LnO-CD-ImJ" firstAttribute="baseline" secondItem="W8T-T8-H6B" secondAttribute="baseline" id="OQS-Ou-LJo"/>
-                            <constraint firstItem="QUk-An-HgX" firstAttribute="baseline" secondItem="ZnB-Tk-bG4" secondAttribute="baseline" id="PAB-hk-qGj"/>
+                            <constraint firstItem="QUk-An-HgX" firstAttribute="firstBaseline" secondItem="ZnB-Tk-bG4" secondAttribute="firstBaseline" id="PAB-hk-qGj"/>
                             <constraint firstItem="LnO-CD-ImJ" firstAttribute="leading" secondItem="EV7-O7-x1O" secondAttribute="trailing" constant="12" id="Unt-BA-NgS"/>
                             <constraint firstItem="AaL-am-9qW" firstAttribute="centerY" secondItem="1rB-s8-3s0" secondAttribute="centerY" id="YSW-z5-Zow"/>
-                            <constraint firstItem="ZnB-Tk-bG4" firstAttribute="leading" secondItem="aHT-R0-nxi" secondAttribute="leading" constant="10" id="g2i-rf-hkO"/>
-                            <constraint firstAttribute="bottom" secondItem="1rB-s8-3s0" secondAttribute="bottom" constant="8" id="i2s-r7-sy2"/>
+                            <constraint firstItem="ZnB-Tk-bG4" firstAttribute="leading" secondItem="aHT-R0-nxi" secondAttribute="leading" constant="12" id="g2i-rf-hkO"/>
+                            <constraint firstAttribute="bottom" secondItem="1rB-s8-3s0" secondAttribute="bottom" constant="12" id="i2s-r7-sy2"/>
                             <constraint firstItem="JHb-3k-TMv" firstAttribute="leading" secondItem="ZnB-Tk-bG4" secondAttribute="trailing" constant="8" id="j5w-Bq-Ck9"/>
                             <constraint firstItem="6fT-hS-kdG" firstAttribute="centerY" secondItem="zCF-pU-dtb" secondAttribute="centerY" id="jR3-Q3-Rw9"/>
                             <constraint firstItem="JHb-3k-TMv" firstAttribute="baseline" secondItem="ZnB-Tk-bG4" secondAttribute="baseline" id="kKG-xO-lcH"/>
                             <constraint firstItem="EV7-O7-x1O" firstAttribute="baseline" secondItem="W8T-T8-H6B" secondAttribute="baseline" id="lYU-ZM-1UI"/>
                             <constraint firstAttribute="trailing" secondItem="QUk-An-HgX" secondAttribute="trailing" constant="8" id="nPL-ym-Rf8"/>
+                            <constraint firstItem="1rB-s8-3s0" firstAttribute="height" secondItem="ZnB-Tk-bG4" secondAttribute="height" id="qBL-dx-esB"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="LnO-CD-ImJ" secondAttribute="trailing" constant="20" symbolic="YES" id="rec-gI-oPf"/>
                             <constraint firstItem="AaL-am-9qW" firstAttribute="leading" secondItem="1rB-s8-3s0" secondAttribute="trailing" constant="12" id="v2e-J6-FYi"/>
                             <constraint firstItem="W8T-T8-H6B" firstAttribute="top" secondItem="ZnB-Tk-bG4" secondAttribute="bottom" constant="12" id="xRB-Af-MAE"/>
@@ -708,9 +624,9 @@
                     </view>
                 </box>
                 <box title="Border" translatesAutoresizingMaskIntoConstraints="NO" id="t5n-mc-dss">
-                    <rect key="frame" x="117" y="137" width="432" height="52"/>
+                    <rect key="frame" x="117" y="145" width="366" height="56"/>
                     <view key="contentView" id="UBk-oC-2Bk">
-                        <rect key="frame" x="3" y="3" width="426" height="34"/>
+                        <rect key="frame" x="4" y="5" width="358" height="36"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3da-N5-q7K">
@@ -751,7 +667,7 @@
                                 </textFieldCell>
                             </textField>
                             <colorWell translatesAutoresizingMaskIntoConstraints="NO" id="vyH-G4-g3c">
-                                <rect key="frame" x="136" y="10" width="38" height="19"/>
+                                <rect key="frame" x="133" y="8" width="44" height="23"/>
                                 <constraints>
                                     <constraint firstAttribute="height" constant="19" id="IM2-kY-8ZR"/>
                                     <constraint firstAttribute="width" constant="38" id="jeQ-Sj-dJw"/>
@@ -768,10 +684,11 @@
                         </subviews>
                         <constraints>
                             <constraint firstItem="vyH-G4-g3c" firstAttribute="leading" secondItem="rMx-RX-CdW" secondAttribute="trailing" constant="8" id="0B3-dg-dcR"/>
-                            <constraint firstItem="3da-N5-q7K" firstAttribute="top" secondItem="UBk-oC-2Bk" secondAttribute="top" constant="8" id="Ksx-al-0EQ"/>
+                            <constraint firstItem="3da-N5-q7K" firstAttribute="top" secondItem="UBk-oC-2Bk" secondAttribute="top" constant="10" id="Ksx-al-0EQ"/>
                             <constraint firstItem="TbV-3r-Wuz" firstAttribute="centerY" secondItem="3da-N5-q7K" secondAttribute="centerY" id="Ygt-Dk-ygl"/>
                             <constraint firstItem="TbV-3r-Wuz" firstAttribute="leading" secondItem="3da-N5-q7K" secondAttribute="trailing" constant="8" id="ccr-HV-sfZ"/>
                             <constraint firstAttribute="bottom" secondItem="3da-N5-q7K" secondAttribute="bottom" constant="12" id="czg-Uk-stJ"/>
+                            <constraint firstItem="rMx-RX-CdW" firstAttribute="height" secondItem="3da-N5-q7K" secondAttribute="height" id="dNF-WD-rQt"/>
                             <constraint firstItem="3da-N5-q7K" firstAttribute="leading" secondItem="UBk-oC-2Bk" secondAttribute="leading" constant="12" id="kKo-6Q-qQk"/>
                             <constraint firstItem="vyH-G4-g3c" firstAttribute="centerY" secondItem="rMx-RX-CdW" secondAttribute="centerY" id="rVj-Bz-fld"/>
                             <constraint firstItem="rMx-RX-CdW" firstAttribute="leading" secondItem="TbV-3r-Wuz" secondAttribute="trailing" constant="12" id="vMw-oJ-EBk"/>
@@ -780,10 +697,10 @@
                     </view>
                 </box>
                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="hxf-aG-hFQ" customClass="CollapseView" customModule="IINA" customModuleProvider="target">
-                    <rect key="frame" x="120" y="8" width="426" height="125"/>
+                    <rect key="frame" x="120" y="8" width="360" height="133"/>
                     <subviews>
                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Reu-yJ-jRj">
-                            <rect key="frame" x="0.0" y="108" width="426" height="17"/>
+                            <rect key="frame" x="0.0" y="116" width="360" height="17"/>
                             <subviews>
                                 <button identifier="Trigger" horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aJw-hn-4g8">
                                     <rect key="frame" x="0.0" y="0.0" width="13" height="13"/>
@@ -812,12 +729,12 @@
                             </constraints>
                         </customView>
                         <customView identifier="Content" translatesAutoresizingMaskIntoConstraints="NO" id="P64-Bc-yqP">
-                            <rect key="frame" x="0.0" y="0.0" width="426" height="104"/>
+                            <rect key="frame" x="0.0" y="0.0" width="360" height="112"/>
                             <subviews>
                                 <box title="Shadow" translatesAutoresizingMaskIntoConstraints="NO" id="BgE-Kk-MXC">
-                                    <rect key="frame" x="-3" y="52" width="432" height="52"/>
+                                    <rect key="frame" x="-3" y="56" width="366" height="56"/>
                                     <view key="contentView" id="p8N-g9-dv4">
-                                        <rect key="frame" x="3" y="3" width="426" height="34"/>
+                                        <rect key="frame" x="4" y="5" width="358" height="36"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <subviews>
                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fYo-wy-ajn">
@@ -829,7 +746,7 @@
                                                 </textFieldCell>
                                             </textField>
                                             <colorWell translatesAutoresizingMaskIntoConstraints="NO" id="Gtc-ii-hE0">
-                                                <rect key="frame" x="146" y="10" width="38" height="19"/>
+                                                <rect key="frame" x="143" y="8" width="44" height="23"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="38" id="23T-cD-NiZ"/>
                                                     <constraint firstAttribute="height" constant="19" id="fIQ-g2-dKI"/>
@@ -875,21 +792,22 @@
                                         </subviews>
                                         <constraints>
                                             <constraint firstItem="fYo-wy-ajn" firstAttribute="leading" secondItem="p8N-g9-dv4" secondAttribute="leading" constant="12" id="Bi3-Zl-kY6"/>
-                                            <constraint firstItem="fYo-wy-ajn" firstAttribute="top" secondItem="p8N-g9-dv4" secondAttribute="top" constant="8" id="FUS-yN-zdz"/>
+                                            <constraint firstItem="fYo-wy-ajn" firstAttribute="top" secondItem="p8N-g9-dv4" secondAttribute="top" constant="10" id="FUS-yN-zdz"/>
                                             <constraint firstItem="4fR-L1-2nd" firstAttribute="leading" secondItem="fYo-wy-ajn" secondAttribute="trailing" constant="8" id="InD-z0-0NF"/>
                                             <constraint firstItem="Gtc-ii-hE0" firstAttribute="centerY" secondItem="vJN-TB-EyM" secondAttribute="centerY" id="K4z-vg-NOp"/>
-                                            <constraint firstItem="vJN-TB-EyM" firstAttribute="baseline" secondItem="fYo-wy-ajn" secondAttribute="baseline" id="X6H-2i-4KU"/>
+                                            <constraint firstItem="vJN-TB-EyM" firstAttribute="firstBaseline" secondItem="fYo-wy-ajn" secondAttribute="firstBaseline" id="X6H-2i-4KU"/>
                                             <constraint firstItem="4fR-L1-2nd" firstAttribute="centerY" secondItem="fYo-wy-ajn" secondAttribute="centerY" id="Yzk-bP-JTy"/>
                                             <constraint firstItem="vJN-TB-EyM" firstAttribute="leading" secondItem="4fR-L1-2nd" secondAttribute="trailing" constant="12" id="gVG-pZ-UgS"/>
                                             <constraint firstItem="Gtc-ii-hE0" firstAttribute="leading" secondItem="vJN-TB-EyM" secondAttribute="trailing" constant="8" id="gua-j0-IGp"/>
+                                            <constraint firstItem="vJN-TB-EyM" firstAttribute="height" secondItem="fYo-wy-ajn" secondAttribute="height" id="tzn-c1-Lug"/>
                                             <constraint firstAttribute="bottom" secondItem="fYo-wy-ajn" secondAttribute="bottom" constant="12" id="zQ6-TB-nFB"/>
                                         </constraints>
                                     </view>
                                 </box>
                                 <box title="Other Styles" translatesAutoresizingMaskIntoConstraints="NO" id="egf-g3-b7a">
-                                    <rect key="frame" x="-3" y="-4" width="432" height="52"/>
+                                    <rect key="frame" x="-3" y="-4" width="366" height="56"/>
                                     <view key="contentView" id="P8c-Nb-ONs">
-                                        <rect key="frame" x="3" y="3" width="426" height="34"/>
+                                        <rect key="frame" x="4" y="5" width="358" height="36"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                         <subviews>
                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Isx-yj-hf3">
@@ -952,15 +870,15 @@
                                         </subviews>
                                         <constraints>
                                             <constraint firstItem="owJ-Ny-vZ8" firstAttribute="leading" secondItem="u2l-jt-Ehx" secondAttribute="trailing" constant="24" id="1ba-jT-Kl1"/>
-                                            <constraint firstItem="u2l-jt-Ehx" firstAttribute="baseline" secondItem="Isx-yj-hf3" secondAttribute="baseline" id="5uD-tu-jJA"/>
+                                            <constraint firstItem="owJ-Ny-vZ8" firstAttribute="height" secondItem="Isx-yj-hf3" secondAttribute="height" id="BY5-gC-7FS"/>
                                             <constraint firstItem="Isx-yj-hf3" firstAttribute="leading" secondItem="P8c-Nb-ONs" secondAttribute="leading" constant="12" id="DP8-k0-AuO"/>
                                             <constraint firstAttribute="bottom" secondItem="Isx-yj-hf3" secondAttribute="bottom" constant="12" id="GPb-uq-FAs"/>
                                             <constraint firstItem="owJ-Ny-vZ8" firstAttribute="baseline" secondItem="Isx-yj-hf3" secondAttribute="baseline" id="LG0-rz-558"/>
-                                            <constraint firstItem="owJ-Ny-vZ8" firstAttribute="baseline" secondItem="u2l-jt-Ehx" secondAttribute="baseline" id="fSZ-7m-KgL"/>
+                                            <constraint firstItem="owJ-Ny-vZ8" firstAttribute="centerY" secondItem="u2l-jt-Ehx" secondAttribute="centerY" id="fSZ-7m-KgL"/>
                                             <constraint firstItem="kdB-R4-fML" firstAttribute="leading" secondItem="owJ-Ny-vZ8" secondAttribute="trailing" constant="8" id="fsr-8V-aYk"/>
                                             <constraint firstItem="u2l-jt-Ehx" firstAttribute="leading" secondItem="Isx-yj-hf3" secondAttribute="trailing" constant="12" id="iEf-a7-OXE"/>
-                                            <constraint firstItem="Isx-yj-hf3" firstAttribute="top" secondItem="P8c-Nb-ONs" secondAttribute="top" constant="8" id="luw-ZB-5wo"/>
-                                            <constraint firstItem="kdB-R4-fML" firstAttribute="baseline" secondItem="owJ-Ny-vZ8" secondAttribute="baseline" id="vNS-nt-GBa"/>
+                                            <constraint firstItem="Isx-yj-hf3" firstAttribute="top" secondItem="P8c-Nb-ONs" secondAttribute="top" constant="10" id="luw-ZB-5wo"/>
+                                            <constraint firstItem="kdB-R4-fML" firstAttribute="centerY" secondItem="owJ-Ny-vZ8" secondAttribute="centerY" id="vNS-nt-GBa"/>
                                         </constraints>
                                     </view>
                                 </box>
@@ -998,7 +916,7 @@
                 <constraint firstAttribute="trailing" secondItem="t5n-mc-dss" secondAttribute="trailing" id="8Tn-tT-RrN"/>
                 <constraint firstItem="Yw3-tf-Rka" firstAttribute="leading" secondItem="ffZ-rE-7Zz" secondAttribute="leading" id="9Ze-ig-M7j"/>
                 <constraint firstItem="hxf-aG-hFQ" firstAttribute="leading" secondItem="t5n-mc-dss" secondAttribute="leading" id="Eay-wU-JTe"/>
-                <constraint firstItem="Yw3-tf-Rka" firstAttribute="top" secondItem="ffZ-rE-7Zz" secondAttribute="top" id="MCg-bp-jXd"/>
+                <constraint firstItem="Yw3-tf-Rka" firstAttribute="top" secondItem="ffZ-rE-7Zz" secondAttribute="top" constant="8" id="MCg-bp-jXd"/>
                 <constraint firstItem="9pv-1r-nuH" firstAttribute="top" secondItem="Yw3-tf-Rka" secondAttribute="top" id="YPc-Nm-GaO"/>
                 <constraint firstItem="Yw3-tf-Rka" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="ffZ-rE-7Zz" secondAttribute="leading" constant="120" id="euq-Na-AQ3"/>
                 <constraint firstItem="t5n-mc-dss" firstAttribute="leading" secondItem="9pv-1r-nuH" secondAttribute="leading" id="gsM-U5-7lh"/>
@@ -1008,14 +926,98 @@
                 <constraint firstItem="9pv-1r-nuH" firstAttribute="leading" secondItem="ffZ-rE-7Zz" secondAttribute="leading" constant="120" id="rZy-OK-rR4"/>
                 <constraint firstAttribute="trailing" secondItem="9pv-1r-nuH" secondAttribute="trailing" id="z2c-Rg-pGA"/>
             </constraints>
-            <point key="canvasLocation" x="-722" y="145"/>
+            <point key="canvasLocation" x="-782" y="174"/>
         </customView>
-        <customView id="ZpT-fB-Daq">
-            <rect key="frame" x="0.0" y="0.0" width="546" height="196"/>
+        <customView id="ATO-g6-mEy" userLabel="Prefs &gt; Subtitle &gt; ASS Subtitles">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="72"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
+                <textField identifier="SectionTitleASS" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="utN-qX-5BH">
+                    <rect key="frame" x="-2" y="48" width="97" height="16"/>
+                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="ASS Subtitles:" id="mFm-Q6-aja">
+                        <font key="font" metaFont="systemBold"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <button translatesAutoresizingMaskIntoConstraints="NO" id="VF9-G7-jts">
+                    <rect key="frame" x="118" y="47" width="133" height="18"/>
+                    <buttonCell key="cell" type="check" title="Ignore ASS styles" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="rZf-bj-qbV">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="5Up-Ab-aAm" name="value" keyPath="values.ignoreAssStyles" id="aqp-Hh-E8I"/>
+                    </connections>
+                </button>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Uf9-KF-ykH">
+                    <rect key="frame" x="118" y="30" width="342" height="14"/>
+                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="If enabled, all ASS subtitles will be drawn using the styles below." id="OcF-0z-7qe">
+                        <font key="font" metaFont="message" size="11"/>
+                        <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Dg7-OH-h2a">
+                    <rect key="frame" x="118" y="8" width="80" height="14"/>
+                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Override level:" id="gAq-Vr-hRY">
+                        <font key="font" metaFont="message" size="11"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="7UX-IL-hdk">
+                    <rect key="frame" x="202" y="5" width="96" height="20"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="92" id="EJa-Kl-S4K"/>
+                    </constraints>
+                    <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" maxValue="2" doubleValue="2" tickMarkPosition="below" numberOfTickMarks="3" allowsTickMarkValuesOnly="YES" sliderType="linear" id="63l-gO-fEV"/>
+                    <connections>
+                        <binding destination="5Up-Ab-aAm" name="value" keyPath="values.subOverrideLevel" id="ofs-dB-Q12"/>
+                    </connections>
+                </slider>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FR3-Ar-5Dw">
+                    <rect key="frame" x="302" y="8" width="28" height="14"/>
+                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="strip" id="3H8-Ei-cTm">
+                        <font key="font" metaFont="message" size="11"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                    <connections>
+                        <binding destination="5Up-Ab-aAm" name="value" keyPath="values.subOverrideLevel" id="0Y9-zY-OjE">
+                            <dictionary key="options">
+                                <string key="NSValueTransformerName">ASSOverrideLevelTransformer</string>
+                            </dictionary>
+                        </binding>
+                    </connections>
+                </textField>
+            </subviews>
+            <constraints>
+                <constraint firstItem="7UX-IL-hdk" firstAttribute="leading" secondItem="Dg7-OH-h2a" secondAttribute="trailing" constant="8" id="0ma-x0-z28"/>
+                <constraint firstItem="utN-qX-5BH" firstAttribute="leading" secondItem="ATO-g6-mEy" secondAttribute="leading" id="4Cw-zR-zEc"/>
+                <constraint firstItem="VF9-G7-jts" firstAttribute="leading" secondItem="ATO-g6-mEy" secondAttribute="leading" constant="120" id="6cV-31-ZIg"/>
+                <constraint firstItem="Uf9-KF-ykH" firstAttribute="leading" secondItem="VF9-G7-jts" secondAttribute="leading" id="8Fi-Ar-xYi"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Uf9-KF-ykH" secondAttribute="trailing" id="HAl-88-Oo5"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="VF9-G7-jts" secondAttribute="trailing" id="LFD-KL-D2R"/>
+                <constraint firstItem="FR3-Ar-5Dw" firstAttribute="leading" secondItem="7UX-IL-hdk" secondAttribute="trailing" constant="8" id="Pp8-Z0-oaO"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="FR3-Ar-5Dw" secondAttribute="trailing" id="V1O-hm-hOZ"/>
+                <constraint firstItem="FR3-Ar-5Dw" firstAttribute="baseline" secondItem="Dg7-OH-h2a" secondAttribute="baseline" id="ZDT-Nr-ntX"/>
+                <constraint firstItem="Uf9-KF-ykH" firstAttribute="top" secondItem="VF9-G7-jts" secondAttribute="bottom" constant="4" id="csH-rE-1HY"/>
+                <constraint firstItem="VF9-G7-jts" firstAttribute="top" secondItem="utN-qX-5BH" secondAttribute="top" id="k4E-TY-EdR"/>
+                <constraint firstItem="7UX-IL-hdk" firstAttribute="centerY" secondItem="Dg7-OH-h2a" secondAttribute="centerY" id="ncs-DD-GD6"/>
+                <constraint firstItem="Dg7-OH-h2a" firstAttribute="top" secondItem="Uf9-KF-ykH" secondAttribute="bottom" constant="8" id="p0C-xp-ndA"/>
+                <constraint firstItem="utN-qX-5BH" firstAttribute="top" secondItem="ATO-g6-mEy" secondAttribute="top" constant="8" id="pVk-D1-vRK"/>
+                <constraint firstAttribute="bottom" secondItem="Dg7-OH-h2a" secondAttribute="bottom" constant="8" id="rbY-5T-ZoB"/>
+                <constraint firstItem="utN-qX-5BH" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="ATO-g6-mEy" secondAttribute="leading" constant="120" id="z5s-tB-6So"/>
+                <constraint firstItem="Dg7-OH-h2a" firstAttribute="leading" secondItem="VF9-G7-jts" secondAttribute="leading" id="z8L-ky-0tU"/>
+            </constraints>
+            <point key="canvasLocation" x="-782" y="-73"/>
+        </customView>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="ZpT-fB-Daq" userLabel="Prefs &gt; Subtitle &gt; Position">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="208"/>
+            <subviews>
                 <textField identifier="SectionTitlePosition" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WeJ-3X-tJy">
-                    <rect key="frame" x="-2" y="172" width="61" height="16"/>
+                    <rect key="frame" x="-2" y="184" width="61" height="16"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Position:" id="4Tb-Yh-PdP">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1023,9 +1025,9 @@
                     </textFieldCell>
                 </textField>
                 <box title="Align" translatesAutoresizingMaskIntoConstraints="NO" id="kvJ-Tj-KMb">
-                    <rect key="frame" x="117" y="136" width="432" height="52"/>
+                    <rect key="frame" x="117" y="144" width="366" height="56"/>
                     <view key="contentView" id="cX3-et-J5U">
-                        <rect key="frame" x="3" y="3" width="426" height="34"/>
+                        <rect key="frame" x="4" y="5" width="358" height="36"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Tsd-qL-09E">
@@ -1045,7 +1047,7 @@
                                 </textFieldCell>
                             </textField>
                             <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aCG-Kk-8cj">
-                                <rect key="frame" x="28" y="7" width="86" height="22"/>
+                                <rect key="frame" x="27" y="7" width="88" height="22"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="80" id="QMo-1u-fpJ"/>
                                 </constraints>
@@ -1065,7 +1067,7 @@
                                 </connections>
                             </popUpButton>
                             <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xLj-wb-RMU">
-                                <rect key="frame" x="146" y="7" width="86" height="22"/>
+                                <rect key="frame" x="145" y="7" width="88" height="22"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="80" id="Dvh-s8-7yp"/>
                                 </constraints>
@@ -1093,14 +1095,14 @@
                             <constraint firstItem="xLj-wb-RMU" firstAttribute="baseline" secondItem="mHe-zb-8Ou" secondAttribute="baseline" id="dhs-uq-Mr9"/>
                             <constraint firstItem="mHe-zb-8Ou" firstAttribute="leading" secondItem="aCG-Kk-8cj" secondAttribute="trailing" constant="20" id="gXm-Jv-san"/>
                             <constraint firstItem="aCG-Kk-8cj" firstAttribute="baseline" secondItem="Tsd-qL-09E" secondAttribute="baseline" id="gvv-kG-RpO"/>
-                            <constraint firstItem="Tsd-qL-09E" firstAttribute="top" secondItem="cX3-et-J5U" secondAttribute="top" constant="8" id="o8h-V3-ucW"/>
+                            <constraint firstItem="Tsd-qL-09E" firstAttribute="top" secondItem="cX3-et-J5U" secondAttribute="top" constant="10" id="o8h-V3-ucW"/>
                             <constraint firstAttribute="bottom" secondItem="Tsd-qL-09E" secondAttribute="bottom" constant="12" id="oLp-m1-exK"/>
                             <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="xLj-wb-RMU" secondAttribute="trailing" constant="20" symbolic="YES" id="xYV-BA-aLz"/>
                         </constraints>
                     </view>
                 </box>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eAH-hV-xRg">
-                    <rect key="frame" x="118" y="60" width="106" height="16"/>
+                    <rect key="frame" x="118" y="64" width="106" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Vertical position:" id="9N4-Zg-M7m">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1108,7 +1110,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="HKD-K0-lsV">
-                    <rect key="frame" x="230" y="57" width="80" height="21"/>
+                    <rect key="frame" x="230" y="61" width="80" height="21"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="80" id="4Sv-7x-c6d"/>
                     </constraints>
@@ -1130,7 +1132,7 @@
                     </connections>
                 </textField>
                 <textField identifier="AccessoryLabelVerticalPos" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9sd-YV-QMQ">
-                    <rect key="frame" x="316" y="60" width="15" height="16"/>
+                    <rect key="frame" x="316" y="64" width="16" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="%" id="JZo-4H-owW">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1138,7 +1140,7 @@
                     </textFieldCell>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="pyx-K4-cgm">
-                    <rect key="frame" x="118" y="28" width="323" height="18"/>
+                    <rect key="frame" x="118" y="31" width="327" height="18"/>
                     <buttonCell key="cell" type="check" title="Display subtitles in letterboxes while in full screen" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="2XY-Un-0Fg">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -1148,7 +1150,7 @@
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="YBq-kz-Xxb">
-                    <rect key="frame" x="118" y="6" width="217" height="18"/>
+                    <rect key="frame" x="118" y="7" width="221" height="18"/>
                     <buttonCell key="cell" type="check" title="Scale subtitles with window size" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="8hj-ki-R0h">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -1158,9 +1160,9 @@
                     </connections>
                 </button>
                 <box title="Margin" translatesAutoresizingMaskIntoConstraints="NO" id="pRe-wv-VVi">
-                    <rect key="frame" x="117" y="80" width="432" height="52"/>
+                    <rect key="frame" x="117" y="84" width="366" height="56"/>
                     <view key="contentView" id="UPu-fp-QvO">
-                        <rect key="frame" x="3" y="3" width="426" height="34"/>
+                        <rect key="frame" x="4" y="5" width="358" height="36"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Rio-JZ-zuo">
@@ -1227,7 +1229,7 @@
                             <constraint firstItem="ROh-ew-evK" firstAttribute="leading" secondItem="UPu-fp-QvO" secondAttribute="leading" constant="8" id="cAu-Si-tti"/>
                             <constraint firstItem="Rio-JZ-zuo" firstAttribute="leading" secondItem="zNH-bp-deO" secondAttribute="trailing" constant="20" id="qyO-y3-clb"/>
                             <constraint firstItem="zNH-bp-deO" firstAttribute="leading" secondItem="ROh-ew-evK" secondAttribute="trailing" constant="8" id="rm0-cW-hCG"/>
-                            <constraint firstItem="ROh-ew-evK" firstAttribute="top" secondItem="UPu-fp-QvO" secondAttribute="top" constant="8" id="uGg-ey-mAS"/>
+                            <constraint firstItem="ROh-ew-evK" firstAttribute="top" secondItem="UPu-fp-QvO" secondAttribute="top" constant="10" id="uGg-ey-mAS"/>
                         </constraints>
                     </view>
                 </box>
@@ -1255,94 +1257,91 @@
                 <constraint firstItem="WeJ-3X-tJy" firstAttribute="leading" secondItem="ZpT-fB-Daq" secondAttribute="leading" id="pJT-C6-3JH"/>
                 <constraint firstItem="pyx-K4-cgm" firstAttribute="top" secondItem="eAH-hV-xRg" secondAttribute="bottom" constant="16" id="rl5-bs-BFj"/>
                 <constraint firstItem="pRe-wv-VVi" firstAttribute="leading" secondItem="kvJ-Tj-KMb" secondAttribute="leading" id="sZg-mz-LOl"/>
-                <constraint firstItem="HKD-K0-lsV" firstAttribute="baseline" secondItem="eAH-hV-xRg" secondAttribute="baseline" id="vFi-8B-moM"/>
+                <constraint firstItem="HKD-K0-lsV" firstAttribute="firstBaseline" secondItem="eAH-hV-xRg" secondAttribute="firstBaseline" id="vFi-8B-moM"/>
             </constraints>
-            <point key="canvasLocation" x="-722" y="444.5"/>
+            <point key="canvasLocation" x="-782" y="480"/>
         </customView>
-        <customView id="ATO-g6-mEy">
-            <rect key="frame" x="0.0" y="0.0" width="546" height="70"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Iur-Ka-beI" userLabel="Prefs &gt; Subtitle &gt; Other">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="90"/>
             <subviews>
-                <textField identifier="SectionTitleASS" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="utN-qX-5BH">
-                    <rect key="frame" x="-2" y="46" width="96" height="16"/>
-                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="ASS subtitles:" id="mFm-Q6-aja">
+                <textField identifier="SectionTitleOther" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MEh-II-li7">
+                    <rect key="frame" x="-2" y="66" width="46" height="16"/>
+                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Other:" id="LiG-iV-AQK">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button translatesAutoresizingMaskIntoConstraints="NO" id="VF9-G7-jts">
-                    <rect key="frame" x="118" y="46" width="129" height="18"/>
-                    <buttonCell key="cell" type="check" title="Ignore ASS styles" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="rZf-bj-qbV">
-                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ahb-ha-Bd8">
+                    <rect key="frame" x="118" y="66" width="124" height="16"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Preferred language:" id="zaE-bH-XfT">
                         <font key="font" metaFont="system"/>
-                    </buttonCell>
-                    <connections>
-                        <binding destination="5Up-Ab-aAm" name="value" keyPath="values.ignoreAssStyles" id="aqp-Hh-E8I"/>
-                    </connections>
-                </button>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Uf9-KF-ykH">
-                    <rect key="frame" x="118" y="30" width="430" height="14"/>
-                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="If enabled, all ASS subtitles will be drawn using the styles below." id="OcF-0z-7qe">
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="6zR-BO-yhX">
+                    <rect key="frame" x="118" y="32" width="364" height="28"/>
+                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="This option will be stored as ISO 639-2 language code and will works for both mpv and opensubtitles." id="Z2M-dh-eq1">
                         <font key="font" metaFont="message" size="11"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Dg7-OH-h2a">
-                    <rect key="frame" x="118" y="8" width="80" height="14"/>
-                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Override level:" id="gAq-Vr-hRY">
-                        <font key="font" metaFont="message" size="11"/>
+                <tokenField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bhV-Cx-zgK" customClass="LanguageTokenField" customModule="IINA" customModuleProvider="target">
+                    <rect key="frame" x="248" y="63" width="232" height="21"/>
+                    <tokenFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" alignment="left" drawsBackground="YES" allowsEditingTextAttributes="YES" tokenStyle="rounded" id="MPJ-dp-jsH">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </tokenFieldCell>
+                    <connections>
+                        <action selector="preferredLanguageAction:" target="-2" id="j9t-7r-Rzk"/>
+                    </connections>
+                </tokenField>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dOC-a0-BI4">
+                    <rect key="frame" x="118" y="8" width="112" height="16"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Default encoding:" id="Y75-4k-2Du">
+                        <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="7UX-IL-hdk">
-                    <rect key="frame" x="204" y="6" width="92" height="18"/>
+                <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1L9-wU-gfj">
+                    <rect key="frame" x="233" y="1" width="127" height="25"/>
                     <constraints>
-                        <constraint firstAttribute="width" constant="92" id="EJa-Kl-S4K"/>
+                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="120" id="pOY-9e-lvC"/>
                     </constraints>
-                    <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" maxValue="2" doubleValue="2" tickMarkPosition="below" numberOfTickMarks="3" allowsTickMarkValuesOnly="YES" sliderType="linear" id="63l-gO-fEV"/>
+                    <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="unJ-fK-oZh">
+                        <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="menu"/>
+                        <menu key="menu" id="QdY-Ba-1k0"/>
+                    </popUpButtonCell>
                     <connections>
-                        <binding destination="5Up-Ab-aAm" name="value" keyPath="values.subOverrideLevel" id="ofs-dB-Q12"/>
+                        <action selector="changeDefaultEncoding:" target="-2" id="jIO-eq-6So"/>
                     </connections>
-                </slider>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FR3-Ar-5Dw">
-                    <rect key="frame" x="302" y="8" width="28" height="14"/>
-                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="strip" id="3H8-Ei-cTm">
-                        <font key="font" metaFont="message" size="11"/>
-                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                    <connections>
-                        <binding destination="5Up-Ab-aAm" name="value" keyPath="values.subOverrideLevel" id="0Y9-zY-OjE">
-                            <dictionary key="options">
-                                <string key="NSValueTransformerName">ASSOverrideLevelTransformer</string>
-                            </dictionary>
-                        </binding>
-                    </connections>
-                </textField>
+                </popUpButton>
             </subviews>
             <constraints>
-                <constraint firstItem="7UX-IL-hdk" firstAttribute="leading" secondItem="Dg7-OH-h2a" secondAttribute="trailing" constant="8" id="0ma-x0-z28"/>
-                <constraint firstItem="utN-qX-5BH" firstAttribute="leading" secondItem="ATO-g6-mEy" secondAttribute="leading" id="4Cw-zR-zEc"/>
-                <constraint firstItem="VF9-G7-jts" firstAttribute="leading" secondItem="ATO-g6-mEy" secondAttribute="leading" constant="120" id="6cV-31-ZIg"/>
-                <constraint firstItem="Uf9-KF-ykH" firstAttribute="leading" secondItem="VF9-G7-jts" secondAttribute="leading" id="8Fi-Ar-xYi"/>
-                <constraint firstAttribute="trailing" secondItem="Uf9-KF-ykH" secondAttribute="trailing" id="HAl-88-Oo5"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="VF9-G7-jts" secondAttribute="trailing" id="LFD-KL-D2R"/>
-                <constraint firstItem="FR3-Ar-5Dw" firstAttribute="leading" secondItem="7UX-IL-hdk" secondAttribute="trailing" constant="8" id="Pp8-Z0-oaO"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="FR3-Ar-5Dw" secondAttribute="trailing" constant="20" symbolic="YES" id="V1O-hm-hOZ"/>
-                <constraint firstItem="FR3-Ar-5Dw" firstAttribute="baseline" secondItem="Dg7-OH-h2a" secondAttribute="baseline" id="ZDT-Nr-ntX"/>
-                <constraint firstItem="Uf9-KF-ykH" firstAttribute="top" secondItem="VF9-G7-jts" secondAttribute="bottom" constant="4" id="csH-rE-1HY"/>
-                <constraint firstItem="VF9-G7-jts" firstAttribute="top" secondItem="utN-qX-5BH" secondAttribute="top" id="k4E-TY-EdR"/>
-                <constraint firstItem="7UX-IL-hdk" firstAttribute="centerY" secondItem="Dg7-OH-h2a" secondAttribute="centerY" id="ncs-DD-GD6"/>
-                <constraint firstItem="Dg7-OH-h2a" firstAttribute="top" secondItem="Uf9-KF-ykH" secondAttribute="bottom" constant="8" id="p0C-xp-ndA"/>
-                <constraint firstItem="utN-qX-5BH" firstAttribute="top" secondItem="ATO-g6-mEy" secondAttribute="top" constant="8" id="pVk-D1-vRK"/>
-                <constraint firstAttribute="bottom" secondItem="Dg7-OH-h2a" secondAttribute="bottom" constant="8" id="rbY-5T-ZoB"/>
-                <constraint firstItem="utN-qX-5BH" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="ATO-g6-mEy" secondAttribute="leading" constant="120" id="z5s-tB-6So"/>
-                <constraint firstItem="Dg7-OH-h2a" firstAttribute="leading" secondItem="VF9-G7-jts" secondAttribute="leading" id="z8L-ky-0tU"/>
+                <constraint firstItem="bhV-Cx-zgK" firstAttribute="firstBaseline" secondItem="ahb-ha-Bd8" secondAttribute="firstBaseline" id="4e1-FJ-t5K"/>
+                <constraint firstItem="dOC-a0-BI4" firstAttribute="baseline" secondItem="1L9-wU-gfj" secondAttribute="baseline" id="5M9-qK-fjf"/>
+                <constraint firstItem="ahb-ha-Bd8" firstAttribute="firstBaseline" secondItem="MEh-II-li7" secondAttribute="firstBaseline" id="5p7-xE-wZG"/>
+                <constraint firstItem="dOC-a0-BI4" firstAttribute="top" secondItem="6zR-BO-yhX" secondAttribute="bottom" constant="8" id="D4x-Hk-XX7"/>
+                <constraint firstItem="ahb-ha-Bd8" firstAttribute="leading" secondItem="Iur-Ka-beI" secondAttribute="leading" constant="120" id="DLa-Hu-Hsu"/>
+                <constraint firstItem="bhV-Cx-zgK" firstAttribute="leading" secondItem="ahb-ha-Bd8" secondAttribute="trailing" constant="8" id="H00-EI-iem"/>
+                <constraint firstAttribute="trailing" secondItem="bhV-Cx-zgK" secondAttribute="trailing" id="PF2-Wf-LtR"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="6zR-BO-yhX" secondAttribute="trailing" id="Q22-5Z-DYd"/>
+                <constraint firstItem="6zR-BO-yhX" firstAttribute="leading" secondItem="ahb-ha-Bd8" secondAttribute="leading" id="QGJ-sL-Nzb"/>
+                <constraint firstAttribute="bottom" secondItem="dOC-a0-BI4" secondAttribute="bottom" constant="8" id="VTK-Vf-cBi"/>
+                <constraint firstItem="6zR-BO-yhX" firstAttribute="top" secondItem="ahb-ha-Bd8" secondAttribute="bottom" constant="6" id="c9L-vJ-3S9"/>
+                <constraint firstItem="dOC-a0-BI4" firstAttribute="leading" secondItem="ahb-ha-Bd8" secondAttribute="leading" id="cR3-Eo-SrY"/>
+                <constraint firstItem="MEh-II-li7" firstAttribute="leading" secondItem="Iur-Ka-beI" secondAttribute="leading" id="dms-Ko-OqB"/>
+                <constraint firstItem="MEh-II-li7" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="Iur-Ka-beI" secondAttribute="leading" constant="120" id="dxI-On-Voh"/>
+                <constraint firstItem="MEh-II-li7" firstAttribute="top" secondItem="Iur-Ka-beI" secondAttribute="top" constant="8" id="lcP-SH-XZf"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="1L9-wU-gfj" secondAttribute="trailing" id="ndi-hc-GPJ"/>
+                <constraint firstItem="1L9-wU-gfj" firstAttribute="leading" secondItem="dOC-a0-BI4" secondAttribute="trailing" constant="8" id="t70-ri-Fo8"/>
             </constraints>
-            <point key="canvasLocation" x="-722" y="-83"/>
+            <point key="canvasLocation" x="-244" y="326"/>
         </customView>
     </objects>
 </document>

--- a/iina/Base.lproj/PrefUIViewController.xib
+++ b/iina/Base.lproj/PrefUIViewController.xib
@@ -42,17 +42,17 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="567" height="293"/>
-            <point key="canvasLocation" x="813" y="226"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY" userLabel="Prefs &gt; UI View">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="500"/>
+            <point key="canvasLocation" x="545" y="471"/>
         </customView>
         <userDefaultsController representsSharedInstance="YES" id="lH7-Vv-0M1"/>
-        <customView id="D77-Iw-nrY">
-            <rect key="frame" x="0.0" y="0.0" width="588" height="408"/>
+        <customView misplaced="YES" id="D77-Iw-nrY" userLabel="Prefs &gt; UI &gt; Window">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="411"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField identifier="SectionTitleWindow" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="RFk-nU-SGL">
-                    <rect key="frame" x="-2" y="384" width="61" height="16"/>
+                    <rect key="frame" x="-2" y="387" width="61" height="16"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Window:" id="GKy-3g-4MB">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -81,13 +81,13 @@
                     </textFieldCell>
                 </textField>
                 <box title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="0kj-QC-B9P">
-                    <rect key="frame" x="117" y="88" width="466" height="96"/>
+                    <rect key="frame" x="117" y="88" width="366" height="96"/>
                     <view key="contentView" id="EMo-yB-IEL">
-                        <rect key="frame" x="4" y="5" width="458" height="88"/>
+                        <rect key="frame" x="4" y="5" width="358" height="88"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button verticalHuggingPriority="750" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="Wn6-zz-utQ">
-                                <rect key="frame" x="15" y="48" width="190" height="16"/>
+                                <rect key="frame" x="15" y="48" width="190" height="15"/>
                                 <buttonCell key="cell" type="radio" title="When media is opened manually" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="CJE-ap-IH8">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="message" size="11"/>
@@ -97,7 +97,7 @@
                                 </connections>
                             </button>
                             <button verticalHuggingPriority="750" tag="2" translatesAutoresizingMaskIntoConstraints="NO" id="UhD-Lf-aPQ">
-                                <rect key="frame" x="15" y="30" width="67" height="16"/>
+                                <rect key="frame" x="15" y="30" width="67" height="15"/>
                                 <buttonCell key="cell" type="radio" title="Disabled" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="duf-3s-3bL">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="message" size="11"/>
@@ -139,7 +139,7 @@
                                 </connections>
                             </popUpButton>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="z5X-oj-MdV">
-                                <rect key="frame" x="15" y="66" width="58" height="16"/>
+                                <rect key="frame" x="15" y="66" width="58" height="15"/>
                                 <buttonCell key="cell" type="radio" title="Always" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="yIN-jg-MxS">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="message" size="11"/>
@@ -182,10 +182,10 @@
                     </connections>
                 </button>
                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fnx-bb-tli" customClass="CollapseView" customModule="IINA" customModuleProvider="target">
-                    <rect key="frame" x="120" y="346" width="460" height="54"/>
+                    <rect key="frame" x="120" y="346" width="360" height="57"/>
                     <subviews>
                         <button identifier="Trigger0" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dvv-kN-b5O">
-                            <rect key="frame" x="-2" y="37" width="139" height="18"/>
+                            <rect key="frame" x="-2" y="40" width="139" height="18"/>
                             <buttonCell key="cell" type="check" title="Initial window size:" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="zOq-Em-wUe">
                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                 <font key="font" metaFont="system"/>
@@ -195,13 +195,13 @@
                             </connections>
                         </button>
                         <box identifier="Content0" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="L5c-uf-ged">
-                            <rect key="frame" x="-3" y="-4" width="466" height="40"/>
+                            <rect key="frame" x="-3" y="-4" width="366" height="43"/>
                             <view key="contentView" id="dCZ-8R-c9z">
-                                <rect key="frame" x="4" y="5" width="458" height="32"/>
+                                <rect key="frame" x="4" y="5" width="358" height="35"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sCc-NR-e8c">
-                                        <rect key="frame" x="16" y="7" width="59" height="17"/>
+                                        <rect key="frame" x="16" y="7" width="59" height="20"/>
                                         <popUpButtonCell key="cell" type="roundRect" title="Width:" bezelStyle="roundedRect" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" selectedItem="B1c-oO-fIs" id="I4X-oi-ewe">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="message" size="11"/>
@@ -281,7 +281,7 @@
                     </customSpacing>
                 </stackView>
                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="100" verticalStackHuggingPriority="249.99998474121094" horizontalHuggingPriority="100" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="5zT-kW-YFh" customClass="CollapseView" customModule="IINA" customModuleProvider="target">
-                    <rect key="frame" x="120" y="220" width="460" height="118"/>
+                    <rect key="frame" x="120" y="220" width="360" height="118"/>
                     <subviews>
                         <button identifier="Trigger1" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tLm-Qr-UNX">
                             <rect key="frame" x="-2" y="101" width="164" height="18"/>
@@ -294,9 +294,9 @@
                             </connections>
                         </button>
                         <box identifier="Content1" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="Mye-uz-WUr">
-                            <rect key="frame" x="-3" y="-4" width="466" height="104"/>
+                            <rect key="frame" x="-3" y="-4" width="366" height="104"/>
                             <view key="contentView" id="Z8T-H5-nff">
-                                <rect key="frame" x="4" y="5" width="458" height="96"/>
+                                <rect key="frame" x="4" y="5" width="358" height="96"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <textField identifier="AccessoryLabelXL" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="HYE-ax-4VK">
@@ -518,7 +518,7 @@
                 <constraint firstItem="WJ8-tU-wDW" firstAttribute="leading" secondItem="5zT-kW-YFh" secondAttribute="leading" id="0VP-lp-pYQ"/>
                 <constraint firstItem="CFe-du-HcB" firstAttribute="top" secondItem="Cut-Nf-Jsy" secondAttribute="bottom" constant="8" id="2fD-Pk-57p"/>
                 <constraint firstItem="WJ8-tU-wDW" firstAttribute="top" secondItem="5zT-kW-YFh" secondAttribute="bottom" constant="16" id="3cG-Qb-5F8"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="5zT-kW-YFh" secondAttribute="trailing" constant="8" id="9WI-qV-TkP"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="5zT-kW-YFh" secondAttribute="trailing" id="9WI-qV-TkP"/>
                 <constraint firstItem="RRL-GG-R45" firstAttribute="leading" secondItem="WJ8-tU-wDW" secondAttribute="leading" id="H4F-KJ-ROh"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="RRL-GG-R45" secondAttribute="trailing" id="M2G-OJ-xCg"/>
                 <constraint firstItem="fnx-bb-tli" firstAttribute="trailing" secondItem="5zT-kW-YFh" secondAttribute="trailing" id="OZl-pu-hra"/>
@@ -530,22 +530,22 @@
                 <constraint firstItem="fnx-bb-tli" firstAttribute="top" secondItem="RFk-nU-SGL" secondAttribute="top" id="dyU-Te-izn"/>
                 <constraint firstItem="RFk-nU-SGL" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="D77-Iw-nrY" secondAttribute="leading" constant="120" id="fQs-qt-2Vt"/>
                 <constraint firstItem="0kj-QC-B9P" firstAttribute="leading" secondItem="WJ8-tU-wDW" secondAttribute="leading" id="g3g-ki-HYK"/>
-                <constraint firstAttribute="trailing" secondItem="0kj-QC-B9P" secondAttribute="trailing" constant="8" id="glg-NR-fBi"/>
+                <constraint firstAttribute="trailing" secondItem="0kj-QC-B9P" secondAttribute="trailing" id="glg-NR-fBi"/>
                 <constraint firstItem="5zT-kW-YFh" firstAttribute="top" secondItem="fnx-bb-tli" secondAttribute="bottom" constant="8" id="iej-wS-fCn"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="CFe-du-HcB" secondAttribute="trailing" id="kvz-Hm-NW2"/>
                 <constraint firstItem="5zT-kW-YFh" firstAttribute="leading" secondItem="fnx-bb-tli" secondAttribute="leading" id="rgK-bi-rUt"/>
                 <constraint firstItem="0kj-QC-B9P" firstAttribute="top" secondItem="WJ8-tU-wDW" secondAttribute="bottom" constant="6" id="s0d-gk-rGR"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="WJ8-tU-wDW" secondAttribute="trailing" id="vAC-40-v5V"/>
-                <constraint firstAttribute="trailing" secondItem="fnx-bb-tli" secondAttribute="trailing" constant="8" id="w6b-NT-bWy"/>
+                <constraint firstAttribute="trailing" secondItem="fnx-bb-tli" secondAttribute="trailing" id="w6b-NT-bWy"/>
                 <constraint firstItem="Cut-Nf-Jsy" firstAttribute="leading" secondItem="RRL-GG-R45" secondAttribute="leading" id="xup-WK-JZO"/>
                 <constraint firstItem="RFk-nU-SGL" firstAttribute="top" secondItem="D77-Iw-nrY" secondAttribute="top" constant="8" id="xx1-FM-HKh"/>
                 <constraint firstItem="RRL-GG-R45" firstAttribute="top" secondItem="0kj-QC-B9P" secondAttribute="bottom" constant="16" id="y83-Np-mrT"/>
                 <constraint firstItem="RFk-nU-SGL" firstAttribute="leading" secondItem="D77-Iw-nrY" secondAttribute="leading" id="ypV-gE-Ld4"/>
             </constraints>
-            <point key="canvasLocation" x="19" y="-20"/>
+            <point key="canvasLocation" x="14" y="-20"/>
         </customView>
-        <customView id="gjB-It-iFS">
-            <rect key="frame" x="0.0" y="0.0" width="580" height="319"/>
+        <customView id="gjB-It-iFS" userLabel="Prefs &gt; UI &gt; OSC">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="319"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField identifier="SectionTitleOSC" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4XH-GU-VhV">
@@ -681,7 +681,7 @@
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gVR-so-xgt">
-                    <rect key="frame" x="268" y="144" width="109" height="32"/>
+                    <rect key="frame" x="268" y="144" width="110" height="32"/>
                     <buttonCell key="cell" type="push" title="Customize…" bezelStyle="rounded" alignment="center" borderStyle="border" inset="2" id="1nM-AX-Ozm">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -737,8 +737,8 @@
                         <rect key="frame" x="4" y="5" width="88" height="16"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <stackView wantsLayer="YES" orientation="horizontal" alignment="centerY" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="1000" horizontalHuggingPriority="249" verticalHuggingPriority="249" horizontalCompressionResistancePriority="749" verticalCompressionResistancePriority="749" misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8jY-9m-q4O">
-                                <rect key="frame" x="4" y="0.0" width="80" height="24"/>
+                            <stackView wantsLayer="YES" orientation="horizontal" alignment="centerY" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="1000" horizontalHuggingPriority="249" verticalHuggingPriority="249" horizontalCompressionResistancePriority="749" verticalCompressionResistancePriority="749" translatesAutoresizingMaskIntoConstraints="NO" id="8jY-9m-q4O">
+                                <rect key="frame" x="4" y="0.0" width="80" height="16"/>
                                 <constraints>
                                     <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="16" id="mKe-A0-QKf"/>
                                     <constraint firstAttribute="width" secondItem="8jY-9m-q4O" secondAttribute="height" multiplier="5" id="yOv-Se-feH"/>
@@ -758,7 +758,7 @@
                 </box>
             </subviews>
             <constraints>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="hkU-0W-pJb" secondAttribute="trailing" constant="20" symbolic="YES" id="05o-de-xI5"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="hkU-0W-pJb" secondAttribute="trailing" id="05o-de-xI5"/>
                 <constraint firstItem="nDu-Yq-tPI" firstAttribute="leading" secondItem="6ml-Xj-nVX" secondAttribute="leading" id="0XB-yO-8qz"/>
                 <constraint firstItem="q8D-b2-H0y" firstAttribute="top" secondItem="bYj-5g-zYO" secondAttribute="bottom" constant="16" id="0ab-9h-p8P"/>
                 <constraint firstItem="GbG-nw-ict" firstAttribute="baseline" secondItem="jbc-22-59W" secondAttribute="baseline" id="1NW-su-1ra"/>
@@ -767,9 +767,9 @@
                 <constraint firstItem="gVR-so-xgt" firstAttribute="leading" secondItem="omS-tS-OVJ" secondAttribute="trailing" constant="8" id="3MP-4O-Z3K"/>
                 <constraint firstItem="OMM-mG-Uts" firstAttribute="leading" secondItem="nDu-Yq-tPI" secondAttribute="leading" id="42v-nR-3AT"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="nDu-Yq-tPI" secondAttribute="trailing" id="6zN-Xx-pSS"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="SyB-0R-TLF" secondAttribute="trailing" constant="8" id="8ox-SI-Bqn"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="SyB-0R-TLF" secondAttribute="trailing" id="8ox-SI-Bqn"/>
                 <constraint firstItem="4XH-GU-VhV" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="gjB-It-iFS" secondAttribute="leading" constant="120" id="A6A-Wt-sRz"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="GbG-nw-ict" secondAttribute="trailing" constant="8" id="EZR-gN-Vng"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="GbG-nw-ict" secondAttribute="trailing" id="EZR-gN-Vng"/>
                 <constraint firstItem="rft-T0-lds" firstAttribute="top" secondItem="OMM-mG-Uts" secondAttribute="bottom" constant="8" id="GKq-oC-uGE"/>
                 <constraint firstItem="HgG-px-UUt" firstAttribute="leading" secondItem="jbc-22-59W" secondAttribute="leading" id="GnR-7V-SWW"/>
                 <constraint firstItem="jbc-22-59W" firstAttribute="top" secondItem="4XH-GU-VhV" secondAttribute="top" id="H5x-dR-Abd"/>
@@ -786,13 +786,13 @@
                 <constraint firstItem="omS-tS-OVJ" firstAttribute="centerY" secondItem="q8D-b2-H0y" secondAttribute="centerY" id="QuW-aH-6lC"/>
                 <constraint firstItem="GbG-nw-ict" firstAttribute="leading" secondItem="jbc-22-59W" secondAttribute="trailing" constant="8" id="RJP-q0-KaO"/>
                 <constraint firstItem="rft-T0-lds" firstAttribute="leading" secondItem="OMM-mG-Uts" secondAttribute="leading" id="Rkx-mT-jHK"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="OMM-mG-Uts" secondAttribute="trailing" constant="20" symbolic="YES" id="Yxo-AW-upP"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="OMM-mG-Uts" secondAttribute="trailing" id="Yxo-AW-upP"/>
                 <constraint firstItem="vC3-U1-cHH" firstAttribute="centerY" secondItem="2Fc-2d-hIJ" secondAttribute="centerY" id="ZIt-uS-S1A"/>
                 <constraint firstItem="OMM-mG-Uts" firstAttribute="top" secondItem="nDu-Yq-tPI" secondAttribute="bottom" constant="8" id="cMP-rL-iku"/>
                 <constraint firstItem="6ml-Xj-nVX" firstAttribute="leading" secondItem="jbc-22-59W" secondAttribute="leading" id="dih-lM-xdM"/>
                 <constraint firstItem="bYj-5g-zYO" firstAttribute="leading" secondItem="GbG-nw-ict" secondAttribute="leading" id="dlC-Go-Abt"/>
                 <constraint firstItem="6ml-Xj-nVX" firstAttribute="top" secondItem="HgG-px-UUt" secondAttribute="bottom" constant="16" id="e2z-eu-gPq"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="gVR-so-xgt" secondAttribute="trailing" constant="8" id="f0U-Y7-QR7"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="gVR-so-xgt" secondAttribute="trailing" id="f0U-Y7-QR7"/>
                 <constraint firstItem="2Fc-2d-hIJ" firstAttribute="leading" secondItem="vC3-U1-cHH" secondAttribute="trailing" constant="8" id="fPX-XY-3Lq"/>
                 <constraint firstItem="hkU-0W-pJb" firstAttribute="baseline" secondItem="6ml-Xj-nVX" secondAttribute="baseline" id="fZu-Se-zGx"/>
                 <constraint firstItem="4XH-GU-VhV" firstAttribute="leading" secondItem="gjB-It-iFS" secondAttribute="leading" id="iTX-Ic-VCy"/>
@@ -800,15 +800,15 @@
                 <constraint firstItem="Abq-vA-BcZ" firstAttribute="leading" secondItem="6ml-Xj-nVX" secondAttribute="trailing" constant="8" id="kzs-oS-ICG"/>
                 <constraint firstItem="SyB-0R-TLF" firstAttribute="baseline" secondItem="HgG-px-UUt" secondAttribute="baseline" id="mcc-vX-Jfk"/>
                 <constraint firstItem="HgG-px-UUt" firstAttribute="leading" secondItem="2Fc-2d-hIJ" secondAttribute="trailing" constant="8" id="qRb-M3-igm"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="rft-T0-lds" secondAttribute="trailing" constant="20" symbolic="YES" id="sbH-ic-ioS"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="rft-T0-lds" secondAttribute="trailing" id="sbH-ic-ioS"/>
                 <constraint firstItem="HgG-px-UUt" firstAttribute="top" secondItem="q8D-b2-H0y" secondAttribute="bottom" constant="16" id="smG-JU-uL5"/>
                 <constraint firstItem="4XH-GU-VhV" firstAttribute="top" secondItem="gjB-It-iFS" secondAttribute="top" constant="8" id="stm-U9-kuB"/>
                 <constraint firstItem="SyB-0R-TLF" firstAttribute="leading" secondItem="HgG-px-UUt" secondAttribute="trailing" constant="8" id="z4E-Tj-yG1"/>
             </constraints>
-            <point key="canvasLocation" x="15" y="368"/>
+            <point key="canvasLocation" x="14" y="381"/>
         </customView>
-        <customView id="c8m-G4-or8">
-            <rect key="frame" x="0.0" y="0.0" width="515" height="120"/>
+        <customView id="c8m-G4-or8" userLabel="Prefs &gt; UI &gt; OSD">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="120"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField identifier="SectionTitleOSD" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zyi-J3-lSp">
@@ -934,7 +934,7 @@
                 <constraint firstItem="HcO-CN-3qi" firstAttribute="baseline" secondItem="63o-gu-DxA" secondAttribute="baseline" id="VQQ-1l-vxW"/>
                 <constraint firstItem="MU2-yF-bjd" firstAttribute="leading" secondItem="c8m-G4-or8" secondAttribute="leading" constant="120" id="XOy-xv-UQT"/>
                 <constraint firstItem="wDT-XM-dyY" firstAttribute="leading" secondItem="63o-gu-DxA" secondAttribute="trailing" constant="8" id="Yas-Qc-aZh"/>
-                <constraint firstItem="zyi-J3-lSp" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="c8m-G4-or8" secondAttribute="leading" constant="120" id="Ytt-RS-SYl"/>
+                <constraint firstAttribute="leading" secondItem="zyi-J3-lSp" secondAttribute="trailing" constant="-120" id="Ytt-RS-SYl"/>
                 <constraint firstItem="qNv-Yk-nvp" firstAttribute="leading" secondItem="bGH-kO-7Rd" secondAttribute="trailing" constant="8" id="ZTP-CX-Nq5"/>
                 <constraint firstAttribute="bottom" secondItem="2xg-kt-Cz4" secondAttribute="bottom" constant="8" id="d5A-Ct-HNP"/>
                 <constraint firstItem="oz1-yC-uZC" firstAttribute="leading" secondItem="qNv-Yk-nvp" secondAttribute="trailing" constant="8" id="gNU-dG-Iah"/>
@@ -944,10 +944,10 @@
                 <constraint firstItem="63o-gu-DxA" firstAttribute="leading" secondItem="bGH-kO-7Rd" secondAttribute="leading" id="yem-Xi-Hum"/>
                 <constraint firstItem="bGH-kO-7Rd" firstAttribute="top" secondItem="MU2-yF-bjd" secondAttribute="bottom" constant="16" id="zHi-Hz-WHg"/>
             </constraints>
-            <point key="canvasLocation" x="-30.5" y="670"/>
+            <point key="canvasLocation" x="14" y="637"/>
         </customView>
-        <customView id="3uJ-UU-1zw">
-            <rect key="frame" x="0.0" y="0.0" width="586" height="56"/>
+        <customView id="3uJ-UU-1zw" userLabel="Prefs &gt; UI &gt; Thumbnail Viewer">
+            <rect key="frame" x="0.0" y="0.0" width="493" height="56"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField identifier="SectionTitleThumb" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="maZ-e8-1vw">
@@ -1053,7 +1053,7 @@
                 <constraint firstItem="mvX-qm-iUh" firstAttribute="leading" secondItem="3uJ-UU-1zw" secondAttribute="leading" constant="120" id="TeW-h0-jeX"/>
                 <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="maZ-e8-1vw" secondAttribute="bottom" constant="8" id="Ty1-mR-i3A"/>
                 <constraint firstItem="maZ-e8-1vw" firstAttribute="leading" secondItem="3uJ-UU-1zw" secondAttribute="leading" id="VMF-e9-dcW"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="3kE-zA-EH8" secondAttribute="trailing" constant="8" id="fgQ-os-aSK"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="3kE-zA-EH8" secondAttribute="trailing" id="fgQ-os-aSK"/>
                 <constraint firstItem="VqQ-ue-KEO" firstAttribute="leading" secondItem="Oba-nc-n1C" secondAttribute="trailing" constant="20" id="gzY-vY-vB8"/>
                 <constraint firstItem="Oba-nc-n1C" firstAttribute="leading" secondItem="bWp-lc-kLe" secondAttribute="trailing" constant="8" id="j47-cM-6lS"/>
                 <constraint firstItem="QSd-B9-68V" firstAttribute="centerY" secondItem="VqQ-ue-KEO" secondAttribute="centerY" id="kNj-eJ-gn0"/>
@@ -1064,10 +1064,10 @@
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="mvX-qm-iUh" secondAttribute="trailing" id="zVT-gB-Pix"/>
                 <constraint firstItem="3kE-zA-EH8" firstAttribute="leading" secondItem="QSd-B9-68V" secondAttribute="trailing" constant="8" id="zpr-Wi-BPS"/>
             </constraints>
-            <point key="canvasLocation" x="5" y="832"/>
+            <point key="canvasLocation" x="14" y="771"/>
         </customView>
-        <customView id="M9c-Ak-HmK">
-            <rect key="frame" x="0.0" y="0.0" width="580" height="32"/>
+        <customView id="M9c-Ak-HmK" userLabel="Prefs &gt; UI &gt; Appearance">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="32"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField identifier="SectionTitleAppearance" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="APB-Nm-aTA">
@@ -1111,7 +1111,7 @@
             </subviews>
             <constraints>
                 <constraint firstItem="BMi-Ax-7wP" firstAttribute="top" secondItem="APB-Nm-aTA" secondAttribute="top" id="10w-fI-BXX"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="FNR-0h-DtW" secondAttribute="trailing" constant="20" symbolic="YES" id="1i1-XP-CVg"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="FNR-0h-DtW" secondAttribute="trailing" id="1i1-XP-CVg"/>
                 <constraint firstItem="BMi-Ax-7wP" firstAttribute="leading" secondItem="M9c-Ak-HmK" secondAttribute="leading" constant="120" id="1vK-8V-tIc"/>
                 <constraint firstItem="APB-Nm-aTA" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="M9c-Ak-HmK" secondAttribute="leading" constant="120" id="5zd-Vc-WIq"/>
                 <constraint firstItem="APB-Nm-aTA" firstAttribute="top" secondItem="M9c-Ak-HmK" secondAttribute="top" constant="8" id="9dZ-2B-yS8"/>
@@ -1120,10 +1120,10 @@
                 <constraint firstItem="FNR-0h-DtW" firstAttribute="baseline" secondItem="BMi-Ax-7wP" secondAttribute="baseline" id="n4H-Th-LRJ"/>
                 <constraint firstAttribute="bottom" secondItem="BMi-Ax-7wP" secondAttribute="bottom" constant="8" id="wlh-tx-VdQ"/>
             </constraints>
-            <point key="canvasLocation" x="15" y="-266"/>
+            <point key="canvasLocation" x="14" y="-283"/>
         </customView>
-        <customView id="1fz-oP-RhZ">
-            <rect key="frame" x="0.0" y="0.0" width="588" height="124"/>
+        <customView id="1fz-oP-RhZ" userLabel="Prefs &gt; UI &gt; PIP">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="124"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField identifier="SectionTitlePictureInPicture" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ghC-br-cK9">
@@ -1136,8 +1136,8 @@ Picture:</string>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="A7f-Up-23R">
-                    <rect key="frame" x="118" y="7" width="428" height="18"/>
+                <button verticalHuggingPriority="750" horizontalCompressionResistancePriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="A7f-Up-23R">
+                    <rect key="frame" x="118" y="7" width="362" height="18"/>
                     <buttonCell key="cell" type="check" title="Toggle Picture-in-Picture by minimizing/un-minimizing the window" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="baY-O6-fcB">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -1155,9 +1155,9 @@ Picture:</string>
                     </textFieldCell>
                 </textField>
                 <box title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="eTQ-fy-fNJ">
-                    <rect key="frame" x="117" y="36" width="466" height="60"/>
+                    <rect key="frame" x="117" y="36" width="366" height="60"/>
                     <view key="contentView" id="ucO-5V-y9Y">
-                        <rect key="frame" x="4" y="5" width="458" height="52"/>
+                        <rect key="frame" x="4" y="5" width="358" height="52"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <textField identifier="AccessoryLabelWindowAction" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aYB-ub-yxd">
@@ -1169,7 +1169,7 @@ Picture:</string>
                                 </textFieldCell>
                             </textField>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="o7N-Tm-Aly">
-                                <rect key="frame" x="69" y="29.5" width="79" height="15"/>
+                                <rect key="frame" x="69" y="29" width="79" height="16"/>
                                 <buttonCell key="cell" type="radio" title="Do nothing" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="Zc7-sP-Rdp">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="message" size="11"/>
@@ -1179,7 +1179,7 @@ Picture:</string>
                                 </connections>
                             </button>
                             <button verticalHuggingPriority="750" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="BMA-ed-2gf">
-                                <rect key="frame" x="155" y="29.5" width="46" height="15"/>
+                                <rect key="frame" x="155" y="29" width="46" height="16"/>
                                 <buttonCell key="cell" type="radio" title="Hide" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="xtL-XT-xzb">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="message" size="11"/>
@@ -1189,7 +1189,7 @@ Picture:</string>
                                 </connections>
                             </button>
                             <button verticalHuggingPriority="750" tag="2" translatesAutoresizingMaskIntoConstraints="NO" id="YWw-1J-3Gr">
-                                <rect key="frame" x="208" y="29.5" width="68" height="15"/>
+                                <rect key="frame" x="208" y="29" width="68" height="16"/>
                                 <buttonCell key="cell" type="radio" title="Minimize" bezelStyle="regularSquare" imagePosition="left" alignment="left" controlSize="small" inset="2" id="H1F-mm-Saq">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="message" size="11"/>
@@ -1233,7 +1233,7 @@ Picture:</string>
                 <constraint firstItem="ghC-br-cK9" firstAttribute="leading" secondItem="1fz-oP-RhZ" secondAttribute="leading" id="A1p-op-Aj1"/>
                 <constraint firstItem="eTQ-fy-fNJ" firstAttribute="top" secondItem="l21-mq-zWd" secondAttribute="bottom" constant="6" id="IVY-I6-WXc"/>
                 <constraint firstAttribute="bottom" secondItem="A7f-Up-23R" secondAttribute="bottom" constant="8" id="KI3-bx-05m"/>
-                <constraint firstAttribute="trailing" secondItem="eTQ-fy-fNJ" secondAttribute="trailing" constant="8" id="KZx-Lw-Sfh"/>
+                <constraint firstAttribute="trailing" secondItem="eTQ-fy-fNJ" secondAttribute="trailing" id="KZx-Lw-Sfh"/>
                 <constraint firstItem="l21-mq-zWd" firstAttribute="top" secondItem="ghC-br-cK9" secondAttribute="top" id="N7b-nm-9lF"/>
                 <constraint firstItem="l21-mq-zWd" firstAttribute="leading" secondItem="1fz-oP-RhZ" secondAttribute="leading" constant="120" id="Soe-cB-SYk"/>
                 <constraint firstItem="A7f-Up-23R" firstAttribute="leading" secondItem="eTQ-fy-fNJ" secondAttribute="leading" id="XVe-n6-qzG"/>
@@ -1242,7 +1242,7 @@ Picture:</string>
                 <constraint firstItem="ghC-br-cK9" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="1fz-oP-RhZ" secondAttribute="leading" constant="120" id="pTG-PR-Adh"/>
                 <constraint firstItem="eTQ-fy-fNJ" firstAttribute="leading" secondItem="l21-mq-zWd" secondAttribute="leading" id="xog-r6-yIL"/>
             </constraints>
-            <point key="canvasLocation" x="6" y="977"/>
+            <point key="canvasLocation" x="14" y="907"/>
         </customView>
     </objects>
     <resources>

--- a/iina/Base.lproj/PrefUIViewController.xib
+++ b/iina/Base.lproj/PrefUIViewController.xib
@@ -918,7 +918,7 @@
                 </button>
             </subviews>
             <constraints>
-                <constraint firstItem="MU2-yF-bjd" firstAttribute="top" secondItem="zyi-J3-lSp" secondAttribute="top" id="2eq-3z-2lT"/>
+                <constraint firstItem="MU2-yF-bjd" firstAttribute="firstBaseline" secondItem="zyi-J3-lSp" secondAttribute="firstBaseline" constant="1" id="2eq-3z-2lT"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="2xg-kt-Cz4" secondAttribute="trailing" id="3Pn-CJ-ep7"/>
                 <constraint firstItem="wDT-XM-dyY" firstAttribute="baseline" secondItem="63o-gu-DxA" secondAttribute="baseline" id="4Eq-8k-nZJ"/>
                 <constraint firstItem="63o-gu-DxA" firstAttribute="top" secondItem="bGH-kO-7Rd" secondAttribute="bottom" constant="8" id="5yo-ce-1gz"/>
@@ -968,8 +968,66 @@
                         <binding destination="lH7-Vv-0M1" name="value" keyPath="values.enableThumbnailPreview" id="hw8-mb-tD1"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bWp-lc-kLe">
-                    <rect key="frame" x="258" y="5" width="58" height="21"/>
+                <button translatesAutoresizingMaskIntoConstraints="NO" id="5Om-Um-kQ4" userLabel="Enable for remote files also Checkbox">
+                    <rect key="frame" x="138" y="31" width="191" height="18"/>
+                    <buttonCell key="cell" type="check" title="Enable for remote files also" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="1NF-4u-sGn">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="lH7-Vv-0M1" name="value" keyPath="values.enableThumbnailForRemoteFiles" id="gje-G2-RzV"/>
+                        <binding destination="lH7-Vv-0M1" name="enabled" keyPath="values.enableThumbnailPreview" id="QnO-oW-DaG"/>
+                    </connections>
+                </button>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VqQ-ue-KEO" userLabel="Width: Label">
+                    <rect key="frame" x="118" y="8" width="44" height="16"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Width:" id="f0s-sH-rz8">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QSd-B9-68V" userLabel="ThumbnailWidth-Entry Text Field">
+                    <rect key="frame" x="168" y="5" width="50" height="21"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="50" id="173-i4-0c1"/>
+                    </constraints>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="7dK-R3-myd">
+                        <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" formatWidth="-1" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="j4q-On-bD7">
+                            <real key="minimum" value="16"/>
+                            <real key="maximum" value="9999"/>
+                        </numberFormatter>
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                    <connections>
+                        <binding destination="lH7-Vv-0M1" name="value" keyPath="values.thumbnailWidth" id="eM0-rN-1bl">
+                            <dictionary key="options">
+                                <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                            </dictionary>
+                        </binding>
+                        <binding destination="lH7-Vv-0M1" name="enabled" keyPath="values.enableThumbnailPreview" id="tbL-hW-LEk"/>
+                    </connections>
+                </textField>
+                <textField identifier="MaximumCacheWidthPx" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3kE-zA-EH8" userLabel="px Label">
+                    <rect key="frame" x="224" y="8" width="19" height="16"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="px" id="F9N-Mm-Fvd">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xqx-cU-0OC">
+                    <rect key="frame" x="259" y="8" width="134" height="16"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Maximum cache size:" id="GYe-Y3-bOR">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bWp-lc-kLe" userLabel="MaxThumbnailCacheSize-Entry Text Field">
+                    <rect key="frame" x="399" y="5" width="58" height="21"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="58" id="WV2-4O-FJK"/>
                     </constraints>
@@ -988,53 +1046,9 @@
                         </binding>
                     </connections>
                 </textField>
-                <textField identifier="MaximumCacheSizeMb" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Oba-nc-n1C">
-                    <rect key="frame" x="322" y="8" width="24" height="16"/>
+                <textField identifier="MaximumCacheSizeMb" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Oba-nc-n1C" userLabel="MB Label">
+                    <rect key="frame" x="463" y="8" width="24" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="MB" id="3jK-z5-NDH">
-                        <font key="font" metaFont="system"/>
-                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xqx-cU-0OC">
-                    <rect key="frame" x="118" y="8" width="134" height="16"/>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Maximum cache size:" id="GYe-Y3-bOR">
-                        <font key="font" metaFont="system"/>
-                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
-                <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VqQ-ue-KEO">
-                    <rect key="frame" x="362" y="8" width="44" height="16"/>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Width:" id="f0s-sH-rz8">
-                        <font key="font" metaFont="system"/>
-                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
-                <textField hidden="YES" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QSd-B9-68V">
-                    <rect key="frame" x="412" y="6" width="58" height="21"/>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="58" id="173-i4-0c1"/>
-                    </constraints>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="7dK-R3-myd">
-                        <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="j4q-On-bD7"/>
-                        <font key="font" metaFont="system"/>
-                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                    <connections>
-                        <binding destination="lH7-Vv-0M1" name="enabled" keyPath="values.enableThumbnailPreview" id="tbL-hW-LEk"/>
-                        <binding destination="lH7-Vv-0M1" name="value" keyPath="values.thumbnailWidth" id="aLp-SR-8fZ">
-                            <dictionary key="options">
-                                <bool key="NSContinuouslyUpdatesValue" value="YES"/>
-                            </dictionary>
-                        </binding>
-                    </connections>
-                </textField>
-                <textField identifier="MaximumCacheWidthPx" hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3kE-zA-EH8">
-                    <rect key="frame" x="476" y="8" width="19" height="16"/>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="px" id="F9N-Mm-Fvd">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -1042,27 +1056,33 @@
                 </textField>
             </subviews>
             <constraints>
-                <constraint firstItem="Oba-nc-n1C" firstAttribute="baseline" secondItem="bWp-lc-kLe" secondAttribute="baseline" id="2fJ-Tc-1Da"/>
-                <constraint firstItem="bWp-lc-kLe" firstAttribute="leading" secondItem="xqx-cU-0OC" secondAttribute="trailing" constant="8" id="5gx-ii-N0Y"/>
-                <constraint firstItem="xqx-cU-0OC" firstAttribute="leading" secondItem="mvX-qm-iUh" secondAttribute="leading" id="A34-EA-ctI"/>
-                <constraint firstItem="VqQ-ue-KEO" firstAttribute="centerY" secondItem="Oba-nc-n1C" secondAttribute="centerY" id="Aqt-vS-wbk"/>
-                <constraint firstItem="maZ-e8-1vw" firstAttribute="top" secondItem="3uJ-UU-1zw" secondAttribute="top" constant="8" id="CZG-V2-oQu"/>
-                <constraint firstItem="bWp-lc-kLe" firstAttribute="baseline" secondItem="xqx-cU-0OC" secondAttribute="baseline" id="G2Y-xj-UUl"/>
-                <constraint firstItem="3kE-zA-EH8" firstAttribute="centerY" secondItem="VqQ-ue-KEO" secondAttribute="centerY" id="Inj-VW-V2v"/>
+                <constraint firstItem="QSd-B9-68V" firstAttribute="leading" secondItem="VqQ-ue-KEO" secondAttribute="trailing" constant="8" id="5gx-ii-N0Y"/>
+                <constraint firstItem="5Om-Um-kQ4" firstAttribute="height" secondItem="mvX-qm-iUh" secondAttribute="height" id="9m2-rW-nzZ"/>
+                <constraint firstItem="VqQ-ue-KEO" firstAttribute="leading" secondItem="mvX-qm-iUh" secondAttribute="leading" id="A34-EA-ctI"/>
+                <constraint firstItem="mvX-qm-iUh" firstAttribute="top" secondItem="3uJ-UU-1zw" secondAttribute="top" constant="8" id="FOE-yG-6DH"/>
+                <constraint firstItem="QSd-B9-68V" firstAttribute="firstBaseline" secondItem="VqQ-ue-KEO" secondAttribute="firstBaseline" id="G2Y-xj-UUl"/>
+                <constraint firstItem="5Om-Um-kQ4" firstAttribute="leading" secondItem="mvX-qm-iUh" secondAttribute="leading" constant="20" id="GJR-Mv-XPg"/>
+                <constraint firstItem="3kE-zA-EH8" firstAttribute="firstBaseline" secondItem="VqQ-ue-KEO" secondAttribute="firstBaseline" id="Iyj-cp-vDl"/>
+                <constraint firstItem="Oba-nc-n1C" firstAttribute="firstBaseline" secondItem="3kE-zA-EH8" secondAttribute="firstBaseline" id="JWn-wh-ANq"/>
+                <constraint firstItem="xqx-cU-0OC" firstAttribute="firstBaseline" secondItem="VqQ-ue-KEO" secondAttribute="firstBaseline" id="O9U-6o-xTc"/>
                 <constraint firstItem="maZ-e8-1vw" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="3uJ-UU-1zw" secondAttribute="leading" constant="120" id="Pwz-CG-l82"/>
                 <constraint firstItem="mvX-qm-iUh" firstAttribute="leading" secondItem="3uJ-UU-1zw" secondAttribute="leading" constant="120" id="TeW-h0-jeX"/>
                 <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="maZ-e8-1vw" secondAttribute="bottom" constant="8" id="Ty1-mR-i3A"/>
                 <constraint firstItem="maZ-e8-1vw" firstAttribute="leading" secondItem="3uJ-UU-1zw" secondAttribute="leading" id="VMF-e9-dcW"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="3kE-zA-EH8" secondAttribute="trailing" id="fgQ-os-aSK"/>
-                <constraint firstItem="VqQ-ue-KEO" firstAttribute="leading" secondItem="Oba-nc-n1C" secondAttribute="trailing" constant="20" id="gzY-vY-vB8"/>
-                <constraint firstItem="Oba-nc-n1C" firstAttribute="leading" secondItem="bWp-lc-kLe" secondAttribute="trailing" constant="8" id="j47-cM-6lS"/>
-                <constraint firstItem="QSd-B9-68V" firstAttribute="centerY" secondItem="VqQ-ue-KEO" secondAttribute="centerY" id="kNj-eJ-gn0"/>
-                <constraint firstItem="mvX-qm-iUh" firstAttribute="top" secondItem="maZ-e8-1vw" secondAttribute="top" id="sWO-ib-fQQ"/>
-                <constraint firstItem="QSd-B9-68V" firstAttribute="leading" secondItem="VqQ-ue-KEO" secondAttribute="trailing" constant="8" id="skQ-xf-Glx"/>
-                <constraint firstItem="xqx-cU-0OC" firstAttribute="top" secondItem="mvX-qm-iUh" secondAttribute="bottom" constant="8" id="wJr-Nj-3pz"/>
-                <constraint firstAttribute="bottom" secondItem="xqx-cU-0OC" secondAttribute="bottom" constant="8" id="wSc-cB-mLr"/>
+                <constraint firstItem="VqQ-ue-KEO" firstAttribute="height" secondItem="mvX-qm-iUh" secondAttribute="height" id="ail-jw-Ccj"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="5Om-Um-kQ4" secondAttribute="trailing" id="fbg-qN-z5f"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Oba-nc-n1C" secondAttribute="trailing" id="fgQ-os-aSK"/>
+                <constraint firstItem="xqx-cU-0OC" firstAttribute="leading" secondItem="3kE-zA-EH8" secondAttribute="trailing" constant="20" id="gzY-vY-vB8"/>
+                <constraint firstItem="3kE-zA-EH8" firstAttribute="leading" secondItem="QSd-B9-68V" secondAttribute="trailing" constant="8" id="j47-cM-6lS"/>
+                <constraint firstItem="bWp-lc-kLe" firstAttribute="firstBaseline" secondItem="QSd-B9-68V" secondAttribute="firstBaseline" id="kEy-6q-fem"/>
+                <constraint firstItem="xqx-cU-0OC" firstAttribute="height" secondItem="VqQ-ue-KEO" secondAttribute="height" id="p2m-7q-nMj"/>
+                <constraint firstItem="mvX-qm-iUh" firstAttribute="firstBaseline" secondItem="maZ-e8-1vw" secondAttribute="firstBaseline" constant="1" id="sWO-ib-fQQ"/>
+                <constraint firstItem="bWp-lc-kLe" firstAttribute="leading" secondItem="xqx-cU-0OC" secondAttribute="trailing" constant="8" id="skQ-xf-Glx"/>
+                <constraint firstItem="VqQ-ue-KEO" firstAttribute="top" secondItem="5Om-Um-kQ4" secondAttribute="bottom" constant="8" id="tNg-wV-7RR"/>
+                <constraint firstItem="5Om-Um-kQ4" firstAttribute="top" secondItem="mvX-qm-iUh" secondAttribute="bottom" constant="8" id="wJr-Nj-3pz"/>
+                <constraint firstAttribute="bottom" secondItem="VqQ-ue-KEO" secondAttribute="bottom" constant="8" id="wSc-cB-mLr"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="mvX-qm-iUh" secondAttribute="trailing" id="zVT-gB-Pix"/>
-                <constraint firstItem="3kE-zA-EH8" firstAttribute="leading" secondItem="QSd-B9-68V" secondAttribute="trailing" constant="8" id="zpr-Wi-BPS"/>
+                <constraint firstItem="Oba-nc-n1C" firstAttribute="leading" secondItem="bWp-lc-kLe" secondAttribute="trailing" constant="8" id="zpr-Wi-BPS"/>
             </constraints>
             <point key="canvasLocation" x="14" y="771"/>
         </customView>

--- a/iina/Base.lproj/PrefUIViewController.xib
+++ b/iina/Base.lproj/PrefUIViewController.xib
@@ -979,15 +979,15 @@
                         <binding destination="lH7-Vv-0M1" name="enabled" keyPath="values.enableThumbnailPreview" id="QnO-oW-DaG"/>
                     </connections>
                 </button>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VqQ-ue-KEO" userLabel="Width: Label">
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VqQ-ue-KEO" userLabel="Size: Label">
                     <rect key="frame" x="118" y="8" width="44" height="16"/>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Width:" id="f0s-sH-rz8">
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Size:" id="f0s-sH-rz8">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QSd-B9-68V" userLabel="ThumbnailWidth-Entry Text Field">
+                <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QSd-B9-68V" userLabel="ThumbnailLength-Entry Text Field">
                     <rect key="frame" x="168" y="5" width="50" height="21"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="50" id="173-i4-0c1"/>
@@ -1002,7 +1002,7 @@
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                     <connections>
-                        <binding destination="lH7-Vv-0M1" name="value" keyPath="values.thumbnailWidth" id="eM0-rN-1bl">
+                        <binding destination="lH7-Vv-0M1" name="value" keyPath="values.thumbnailLength" id="eM0-rN-1bl">
                             <dictionary key="options">
                                 <bool key="NSContinuouslyUpdatesValue" value="YES"/>
                             </dictionary>

--- a/iina/Base.lproj/PrefUtilsViewController.xib
+++ b/iina/Base.lproj/PrefUtilsViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -25,16 +25,15 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="480" height="272"/>
-            <point key="canvasLocation" x="139" y="240"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY" userLabel="Prefs &gt; Utils View">
+            <rect key="frame" x="0.0" y="0.0" width="420" height="400"/>
+            <point key="canvasLocation" x="676" y="630"/>
         </customView>
-        <customView id="qu5-4u-ozP">
-            <rect key="frame" x="0.0" y="0.0" width="480" height="70"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="qu5-4u-ozP" userLabel="Prefs &gt; Utils &gt; Default Application">
+            <rect key="frame" x="0.0" y="0.0" width="420" height="68"/>
             <subviews>
                 <textField identifier="SectionTitleDefaultApp" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jnk-en-c84">
-                    <rect key="frame" x="-2" y="45" width="129" height="17"/>
+                    <rect key="frame" x="-2" y="44" width="129" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Default Application" id="ORO-lK-yK5">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -42,7 +41,7 @@
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9bz-Mj-bPf">
-                    <rect key="frame" x="-6" y="1" width="259" height="32"/>
+                    <rect key="frame" x="-6" y="1" width="254" height="32"/>
                     <buttonCell key="cell" type="push" title="Set IINA as the Default Application…" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="e1p-Aa-WFG">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -58,17 +57,16 @@
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="9bz-Mj-bPf" secondAttribute="trailing" id="KWd-CH-8kp"/>
                 <constraint firstAttribute="bottom" secondItem="9bz-Mj-bPf" secondAttribute="bottom" constant="8" id="NtU-eb-GEd"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="jnk-en-c84" secondAttribute="trailing" id="OEH-vJ-iDa"/>
-                <constraint firstItem="9bz-Mj-bPf" firstAttribute="leading" secondItem="jnk-en-c84" secondAttribute="leading" id="kfR-lE-YdU"/>
+                <constraint firstItem="9bz-Mj-bPf" firstAttribute="leading" secondItem="jnk-en-c84" secondAttribute="leading" constant="1" id="kfR-lE-YdU"/>
                 <constraint firstItem="9bz-Mj-bPf" firstAttribute="top" secondItem="jnk-en-c84" secondAttribute="bottom" constant="16" id="vuJ-Zp-jDb"/>
             </constraints>
             <point key="canvasLocation" x="139" y="464"/>
         </customView>
-        <customView id="ve7-5i-dg4">
-            <rect key="frame" x="0.0" y="0.0" width="480" height="248"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="ve7-5i-dg4" userLabel="Prefs &gt; Utils &gt; Cache">
+            <rect key="frame" x="0.0" y="0.0" width="419" height="244"/>
             <subviews>
                 <textField identifier="SectionTitleClearCache" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ggb-jX-7Sf">
-                    <rect key="frame" x="-2" y="223" width="83" height="17"/>
+                    <rect key="frame" x="-2" y="220" width="83" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Clear Cache" id="QHA-tO-oSn">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -76,7 +74,7 @@
                     </textFieldCell>
                 </textField>
                 <button identifier="FunctionalButtonClearProg" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bHj-vX-uFl">
-                    <rect key="frame" x="-6" y="143" width="238" height="32"/>
+                    <rect key="frame" x="-6" y="141" width="234" height="32"/>
                     <buttonCell key="cell" type="push" title="Clear Saved Playback Progress…" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="4nM-C4-9oM">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -85,8 +83,8 @@
                         <action selector="clearWatchLaterBtnAction:" target="-2" id="oL3-bX-caO"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="2Kf-ce-zj1">
-                    <rect key="frame" x="-2" y="179" width="484" height="28"/>
+                <textField horizontalHuggingPriority="750" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="2Kf-ce-zj1">
+                    <rect key="frame" x="-2" y="176" width="423" height="28"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" id="pPC-q2-9Gh">
                         <font key="font" metaFont="smallSystem"/>
                         <string key="title">The button below will delete all files in the "watch later" folder. These files contain all saved playback progress and settings applied during playback.</string>
@@ -94,8 +92,8 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Eby-fI-erw">
-                    <rect key="frame" x="-2" y="120" width="484" height="14"/>
+                <textField horizontalHuggingPriority="750" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Eby-fI-erw">
+                    <rect key="frame" x="-2" y="118" width="423" height="14"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="The button below will delete all playback histories and entries in &quot;Open Recent&quot;." id="9uP-I0-tdX">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -103,7 +101,7 @@
                     </textFieldCell>
                 </textField>
                 <button identifier="FunctionalButtonClearHistory" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SSk-Rd-BxH">
-                    <rect key="frame" x="-6" y="84" width="187" height="32"/>
+                    <rect key="frame" x="-6" y="83" width="182" height="32"/>
                     <buttonCell key="cell" type="push" title="Clear Playback History…" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="MP6-Em-Lp4">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -113,7 +111,7 @@
                     </connections>
                 </button>
                 <button identifier="FunctionalButtonClearThumb" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aCe-0n-uch">
-                    <rect key="frame" x="-6" y="1" width="192" height="32"/>
+                    <rect key="frame" x="-6" y="1" width="186" height="32"/>
                     <buttonCell key="cell" type="push" title="Clear Thumbnail Cache…" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="hsG-JB-TT9">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -123,7 +121,7 @@
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="oBG-5o-wZ1">
-                    <rect key="frame" x="-2" y="59" width="484" height="14"/>
+                    <rect key="frame" x="-2" y="58" width="273" height="14"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="The button below will delete all cached thumbnails." id="Bag-TV-Stp">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -131,7 +129,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2nt-Ax-K1T">
-                    <rect key="frame" x="-2" y="37" width="137" height="14"/>
+                    <rect key="frame" x="-2" y="36" width="137" height="14"/>
                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Current thumbnail cache:" id="uV3-aF-UB7">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -139,7 +137,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="H1t-lX-s9l">
-                    <rect key="frame" x="139" y="37" width="72" height="14"/>
+                    <rect key="frame" x="139" y="36" width="72" height="14"/>
                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Calculating…" id="tRq-eU-AV3">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -147,7 +145,7 @@
                     </textFieldCell>
                 </textField>
                 <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sI2-xW-v1S">
-                    <rect key="frame" x="181" y="94" width="48" height="14"/>
+                    <rect key="frame" x="175" y="93" width="48" height="14"/>
                     <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" title="Cleared." id="Fb4-dy-CXX">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -155,7 +153,7 @@
                     </textFieldCell>
                 </textField>
                 <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="btv-7s-L8M">
-                    <rect key="frame" x="232" y="153" width="48" height="14"/>
+                    <rect key="frame" x="227" y="151" width="48" height="14"/>
                     <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" title="Cleared." id="Efe-8C-4eV">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -165,9 +163,9 @@
             </subviews>
             <constraints>
                 <constraint firstItem="btv-7s-L8M" firstAttribute="firstBaseline" secondItem="bHj-vX-uFl" secondAttribute="firstBaseline" id="0S9-c6-mAK"/>
-                <constraint firstItem="bHj-vX-uFl" firstAttribute="leading" secondItem="ve7-5i-dg4" secondAttribute="leading" id="0gW-1v-lvU"/>
+                <constraint firstItem="bHj-vX-uFl" firstAttribute="leading" secondItem="ve7-5i-dg4" secondAttribute="leading" constant="1" id="0gW-1v-lvU"/>
                 <constraint firstItem="H1t-lX-s9l" firstAttribute="leading" secondItem="2nt-Ax-K1T" secondAttribute="trailing" constant="8" id="0wR-aS-I1K"/>
-                <constraint firstAttribute="trailing" secondItem="2Kf-ce-zj1" secondAttribute="trailing" id="2OO-2C-XuI"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="2Kf-ce-zj1" secondAttribute="trailing" id="2OO-2C-XuI"/>
                 <constraint firstItem="2Kf-ce-zj1" firstAttribute="top" secondItem="ggb-jX-7Sf" secondAttribute="bottom" constant="16" id="4wd-3x-V1k"/>
                 <constraint firstItem="aCe-0n-uch" firstAttribute="top" secondItem="2nt-Ax-K1T" secondAttribute="bottom" constant="8" id="5MO-Ws-kl9"/>
                 <constraint firstItem="Eby-fI-erw" firstAttribute="top" secondItem="bHj-vX-uFl" secondAttribute="bottom" constant="16" id="5ss-60-YfH"/>
@@ -182,16 +180,16 @@
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="aCe-0n-uch" secondAttribute="trailing" id="O8f-oq-G8C"/>
                 <constraint firstItem="Eby-fI-erw" firstAttribute="leading" secondItem="ve7-5i-dg4" secondAttribute="leading" id="ONf-sb-lXx"/>
                 <constraint firstItem="sI2-xW-v1S" firstAttribute="firstBaseline" secondItem="SSk-Rd-BxH" secondAttribute="firstBaseline" id="Pjn-Os-dCj"/>
-                <constraint firstItem="SSk-Rd-BxH" firstAttribute="leading" secondItem="ve7-5i-dg4" secondAttribute="leading" id="QO1-85-aWx"/>
+                <constraint firstItem="SSk-Rd-BxH" firstAttribute="leading" secondItem="ve7-5i-dg4" secondAttribute="leading" constant="1" id="QO1-85-aWx"/>
                 <constraint firstItem="SSk-Rd-BxH" firstAttribute="top" secondItem="Eby-fI-erw" secondAttribute="bottom" constant="8" id="R0O-Rh-rSa"/>
                 <constraint firstItem="btv-7s-L8M" firstAttribute="leading" secondItem="bHj-vX-uFl" secondAttribute="trailing" constant="8" id="WJg-zh-JMa"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="bHj-vX-uFl" secondAttribute="trailing" id="WuM-dI-sLS"/>
                 <constraint firstItem="sI2-xW-v1S" firstAttribute="leading" secondItem="SSk-Rd-BxH" secondAttribute="trailing" constant="8" id="Y4R-V1-TZS"/>
-                <constraint firstAttribute="trailing" secondItem="Eby-fI-erw" secondAttribute="trailing" id="Yd3-8f-tuC"/>
-                <constraint firstAttribute="trailing" secondItem="oBG-5o-wZ1" secondAttribute="trailing" id="b2I-RE-KhA"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Eby-fI-erw" secondAttribute="trailing" id="Yd3-8f-tuC"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="oBG-5o-wZ1" secondAttribute="trailing" id="b2I-RE-KhA"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ggb-jX-7Sf" secondAttribute="trailing" id="bmh-Ky-JTi"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="sI2-xW-v1S" secondAttribute="trailing" id="cXZ-6r-orn"/>
-                <constraint firstItem="aCe-0n-uch" firstAttribute="leading" secondItem="ve7-5i-dg4" secondAttribute="leading" id="dWb-Ts-MLj"/>
+                <constraint firstItem="aCe-0n-uch" firstAttribute="leading" secondItem="ve7-5i-dg4" secondAttribute="leading" constant="1" id="dWb-Ts-MLj"/>
                 <constraint firstItem="2Kf-ce-zj1" firstAttribute="leading" secondItem="ve7-5i-dg4" secondAttribute="leading" id="iZX-Wh-11C"/>
                 <constraint firstItem="2nt-Ax-K1T" firstAttribute="leading" secondItem="oBG-5o-wZ1" secondAttribute="leading" id="sWZ-Vh-V9U"/>
                 <constraint firstItem="ggb-jX-7Sf" firstAttribute="top" secondItem="ve7-5i-dg4" secondAttribute="top" constant="8" id="t2W-Wg-LbY"/>
@@ -199,9 +197,8 @@
             </constraints>
             <point key="canvasLocation" x="139" y="828"/>
         </customView>
-        <customView id="Bem-Ss-PQZ">
-            <rect key="frame" x="0.0" y="0.0" width="480" height="104"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Bem-Ss-PQZ" userLabel="Prefs &gt; Utils &gt; Alerts">
+            <rect key="frame" x="0.0" y="0.0" width="420" height="104"/>
             <subviews>
                 <textField identifier="SectionTitleRestoreAlert" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2lD-HN-fmS">
                     <rect key="frame" x="-2" y="80" width="97" height="16"/>
@@ -212,7 +209,7 @@
                     </textFieldCell>
                 </textField>
                 <button identifier="FunctionalButtonRestoreAlerts" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="y5P-5X-X4x">
-                    <rect key="frame" x="-7" y="1" width="206" height="32"/>
+                    <rect key="frame" x="-6" y="1" width="206" height="32"/>
                     <buttonCell key="cell" type="push" title="Restore Suppressed Alerts…" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="XAz-xa-LVo">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -221,8 +218,8 @@
                         </connections>
                     </buttonCell>
                 </button>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="xmX-IR-h5j">
-                    <rect key="frame" x="-2" y="36" width="484" height="28"/>
+                <textField horizontalHuggingPriority="750" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="xmX-IR-h5j">
+                    <rect key="frame" x="-2" y="36" width="424" height="28"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="The button below will restore all alerts that have been suppressed using the &quot;Do not show this message again&quot; checkbox." id="F5i-KF-2SW">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -230,7 +227,7 @@
                     </textFieldCell>
                 </textField>
                 <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KAc-Jd-4LW">
-                    <rect key="frame" x="198" y="11" width="55" height="14"/>
+                    <rect key="frame" x="199" y="11" width="55" height="14"/>
                     <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" title="Restored." id="Wdh-me-hdC">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -246,21 +243,20 @@
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="y5P-5X-X4x" secondAttribute="trailing" id="CIV-gs-kNa"/>
                 <constraint firstItem="KAc-Jd-4LW" firstAttribute="leading" secondItem="y5P-5X-X4x" secondAttribute="trailing" constant="8" id="EHh-wZ-laO"/>
                 <constraint firstItem="KAc-Jd-4LW" firstAttribute="firstBaseline" secondItem="y5P-5X-X4x" secondAttribute="firstBaseline" id="Lgn-Sk-E3m"/>
-                <constraint firstAttribute="trailing" secondItem="xmX-IR-h5j" secondAttribute="trailing" id="NLT-RO-rS1"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="xmX-IR-h5j" secondAttribute="trailing" id="NLT-RO-rS1"/>
                 <constraint firstAttribute="bottom" secondItem="y5P-5X-X4x" secondAttribute="bottom" constant="8" id="ODa-Bv-ffy"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="KAc-Jd-4LW" secondAttribute="trailing" id="Vlk-9p-5DO"/>
                 <constraint firstItem="y5P-5X-X4x" firstAttribute="top" secondItem="xmX-IR-h5j" secondAttribute="bottom" constant="8" id="jSk-J3-DdX"/>
-                <constraint firstItem="y5P-5X-X4x" firstAttribute="leading" secondItem="Bem-Ss-PQZ" secondAttribute="leading" id="lCU-Pd-QhR"/>
+                <constraint firstItem="y5P-5X-X4x" firstAttribute="leading" secondItem="Bem-Ss-PQZ" secondAttribute="leading" constant="1" id="lCU-Pd-QhR"/>
                 <constraint firstItem="2lD-HN-fmS" firstAttribute="leading" secondItem="Bem-Ss-PQZ" secondAttribute="leading" id="wMJ-ay-p77"/>
             </constraints>
             <point key="canvasLocation" x="139" y="600"/>
         </customView>
-        <customView id="lOp-07-Z6M">
-            <rect key="frame" x="0.0" y="0.0" width="480" height="101"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="lOp-07-Z6M" userLabel="Prefs &gt; Utils &gt; Browser Extension">
+            <rect key="frame" x="0.0" y="0.0" width="420" height="102"/>
             <subviews>
                 <textField identifier="SectionTitleBrowserExt" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Al6-1d-mCg">
-                    <rect key="frame" x="-2" y="76" width="211" height="17"/>
+                    <rect key="frame" x="-2" y="78" width="211" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Get Browser Extensions for IINA" id="zCe-1f-tkF">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -268,7 +264,7 @@
                     </textFieldCell>
                 </textField>
                 <button identifier="FunctionalButtonChrome" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="HRq-fs-0uo">
-                    <rect key="frame" x="0.0" y="7" width="76" height="17"/>
+                    <rect key="frame" x="0.0" y="8" width="73" height="18"/>
                     <buttonCell key="cell" type="inline" title="Chrome" bezelStyle="inline" image="NSFollowLinkFreestandingTemplate" imagePosition="left" alignment="center" borderStyle="border" inset="2" id="yuw-2i-ICd">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="smallSystemBold"/>
@@ -278,7 +274,7 @@
                     </connections>
                 </button>
                 <button identifier="FunctionalButtonFirefox" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="G58-js-HgZ">
-                    <rect key="frame" x="88" y="7" width="71" height="17"/>
+                    <rect key="frame" x="85" y="8" width="68" height="18"/>
                     <buttonCell key="cell" type="inline" title="Firefox" bezelStyle="inline" image="NSFollowLinkFreestandingTemplate" imagePosition="left" alignment="center" borderStyle="border" inset="2" id="f9i-sS-MJN">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="smallSystemBold"/>
@@ -288,7 +284,7 @@
                     </connections>
                 </button>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="DZn-sK-pTY">
-                    <rect key="frame" x="-2" y="32" width="484" height="28"/>
+                    <rect key="frame" x="-2" y="34" width="424" height="28"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Open links or current webpage in IINA with one click. The website must be supported by youtube-dl." id="GAo-fx-NG0">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -307,22 +303,22 @@
                 <constraint firstItem="HRq-fs-0uo" firstAttribute="leading" secondItem="lOp-07-Z6M" secondAttribute="leading" id="jhd-yd-lnA"/>
                 <constraint firstAttribute="bottom" secondItem="HRq-fs-0uo" secondAttribute="bottom" constant="8" id="rd0-xS-Ehg"/>
                 <constraint firstItem="HRq-fs-0uo" firstAttribute="top" secondItem="DZn-sK-pTY" secondAttribute="bottom" constant="8" id="tN3-Bb-JbP"/>
-                <constraint firstAttribute="trailing" secondItem="DZn-sK-pTY" secondAttribute="trailing" id="uEn-NP-ZYa"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="DZn-sK-pTY" secondAttribute="trailing" id="uEn-NP-ZYa"/>
                 <constraint firstItem="Al6-1d-mCg" firstAttribute="top" secondItem="lOp-07-Z6M" secondAttribute="top" constant="8" id="vMZ-SW-pO3"/>
             </constraints>
             <point key="canvasLocation" x="139" y="1059"/>
         </customView>
-        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="gck-1e-Yi7">
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="gck-1e-Yi7" userLabel="&quot;Set as Default&quot; Window">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="163" y="199" width="448" height="192"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1057"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="3440" height="1415"/>
             <view key="contentView" id="HNy-Eo-3UU">
                 <rect key="frame" x="0.0" y="0.0" width="448" height="192"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="2JS-Ar-lM8">
-                        <rect key="frame" x="18" y="135" width="412" height="34"/>
+                        <rect key="frame" x="18" y="140" width="412" height="32"/>
                         <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Please select the media types that you want to make IINA as the default Application for." id="uvK-Y1-dZr">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -330,28 +326,28 @@
                         </textFieldCell>
                     </textField>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dhO-nq-Edx">
-                        <rect key="frame" x="26" y="103" width="57" height="18"/>
+                        <rect key="frame" x="26" y="107" width="61" height="18"/>
                         <buttonCell key="cell" type="check" title="Video" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="8wH-Gi-mRV">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bjj-u6-vYB">
-                        <rect key="frame" x="26" y="81" width="57" height="18"/>
+                        <rect key="frame" x="26" y="83" width="61" height="18"/>
                         <buttonCell key="cell" type="check" title="Audio" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="jFt-2a-nmc">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="MC6-FT-IVG">
-                        <rect key="frame" x="26" y="59" width="65" height="18"/>
+                        <rect key="frame" x="26" y="59" width="69" height="18"/>
                         <buttonCell key="cell" type="check" title="Playlist" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="MGo-J8-zWE">
                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Lh7-1a-rsH">
-                        <rect key="frame" x="352" y="13" width="82" height="32"/>
+                        <rect key="frame" x="359" y="13" width="76" height="32"/>
                         <buttonCell key="cell" type="push" title="OK" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="IkF-qG-s4j">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -364,7 +360,7 @@ DQ
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ak8-rh-mxC">
-                        <rect key="frame" x="274" y="13" width="82" height="32"/>
+                        <rect key="frame" x="289" y="13" width="76" height="32"/>
                         <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="kbP-VI-dmT">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -399,10 +395,10 @@ Gw
                     <constraint firstItem="MC6-FT-IVG" firstAttribute="leading" secondItem="bjj-u6-vYB" secondAttribute="leading" id="zaq-Rb-2fW"/>
                 </constraints>
             </view>
-            <point key="canvasLocation" x="-493" y="582.5"/>
+            <point key="canvasLocation" x="-388" y="657"/>
         </window>
     </objects>
     <resources>
-        <image name="NSFollowLinkFreestandingTemplate" width="14" height="14"/>
+        <image name="NSFollowLinkFreestandingTemplate" width="20" height="20"/>
     </resources>
 </document>

--- a/iina/Base.lproj/PreferenceWindowController.xib
+++ b/iina/Base.lproj/PreferenceWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17156" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17156"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -10,10 +10,12 @@
             <connections>
                 <outlet property="completionPopover" destination="p0p-bU-ap2" id="CDT-9L-7cL"/>
                 <outlet property="completionTableView" destination="MUI-pR-u00" id="0hW-JH-Bsp"/>
-                <outlet property="contentView" destination="5R5-77-bmq" id="hTm-zX-BBk"/>
                 <outlet property="maskView" destination="mpW-1b-ztU" id="1IU-tZ-HzF"/>
+                <outlet property="navTableSearchFieldSpacingConstraint" destination="nOO-7o-aOI" id="zeq-Jq-9Ma"/>
                 <outlet property="noResultLabel" destination="0yO-bT-GQW" id="9Yr-Yb-yWw"/>
-                <outlet property="scrollView" destination="VYU-tb-v3l" id="n0b-YV-otV"/>
+                <outlet property="prefDetailContentView" destination="5R5-77-bmq" id="om5-Bx-6J5"/>
+                <outlet property="prefDetailScrollView" destination="VYU-tb-v3l" id="vrz-s4-dn8"/>
+                <outlet property="prefSectionsStackView" destination="evY-SZ-c3s" id="N2h-NS-yNH"/>
                 <outlet property="searchField" destination="rKj-eM-MTH" id="h5z-XD-hFu"/>
                 <outlet property="tableView" destination="vde-uJ-0ge" id="ezK-1d-1Px"/>
                 <outlet property="window" destination="F0z-JX-Cv5" id="gIp-Ho-8D9"/>
@@ -21,22 +23,22 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" frameAutosaveName="IINAPreferenceWindow" animationBehavior="default" titlebarAppearsTransparent="YES" titleVisibility="hidden" id="F0z-JX-Cv5">
+        <window title="Preferences" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" frameAutosaveName="IINAPreferenceWindow" animationBehavior="default" titlebarAppearsTransparent="YES" titleVisibility="hidden" id="F0z-JX-Cv5" userLabel="Preferences Window">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="196" y="240" width="700" height="480"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1920" height="1055"/>
-            <value key="minSize" type="size" width="480" height="360"/>
-            <view key="contentView" wantsLayer="YES" id="se5-gp-TjO">
-                <rect key="frame" x="0.0" y="0.0" width="700" height="479"/>
-                <autoresizingMask key="autoresizingMask"/>
+            <rect key="contentRect" x="196" y="240" width="820" height="480"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="3440" height="1415"/>
+            <value key="minSize" type="size" width="820" height="320"/>
+            <view key="contentView" wantsLayer="YES" id="se5-gp-TjO" userLabel="PrefWindow Content View">
+                <rect key="frame" x="0.0" y="0.0" width="820" height="480"/>
+                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
-                    <visualEffectView blendingMode="behindWindow" material="sidebar" state="followsWindowActiveState" translatesAutoresizingMaskIntoConstraints="NO" id="AO2-1e-7F6">
-                        <rect key="frame" x="0.0" y="0.0" width="220" height="479"/>
+                    <visualEffectView blendingMode="behindWindow" material="sidebar" state="followsWindowActiveState" translatesAutoresizingMaskIntoConstraints="NO" id="AO2-1e-7F6" userLabel="PrefNavPanel Visual Effect View">
+                        <rect key="frame" x="0.0" y="0.0" width="220" height="480"/>
                         <subviews>
                             <searchField wantsLayer="YES" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rKj-eM-MTH">
-                                <rect key="frame" x="20" y="421" width="180" height="22"/>
-                                <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" refusesFirstResponder="YES" borderStyle="bezel" usesSingleLineMode="YES" bezelStyle="round" id="ZLM-z2-CyT">
+                                <rect key="frame" x="9" y="420" width="202" height="30"/>
+                                <searchFieldCell key="cell" controlSize="large" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" refusesFirstResponder="YES" borderStyle="bezel" usesSingleLineMode="YES" bezelStyle="round" id="ZLM-z2-CyT">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -45,20 +47,19 @@
                                     <action selector="searchFieldAction:" target="-2" id="0qH-ZT-A7p"/>
                                 </connections>
                             </searchField>
-                            <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="38" horizontalPageScroll="10" verticalLineScroll="38" verticalPageScroll="10" usesPredominantAxisScrolling="NO" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="Isy-K8-od9">
-                                <rect key="frame" x="0.0" y="0.0" width="220" height="401"/>
-                                <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="H3G-ed-YHx">
-                                    <rect key="frame" x="0.0" y="0.0" width="220" height="401"/>
+                            <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="38" horizontalPageScroll="10" verticalLineScroll="38" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="Isy-K8-od9" userLabel="PrefNavPanelTable Scroll View">
+                                <rect key="frame" x="0.0" y="0.0" width="220" height="420"/>
+                                <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="H3G-ed-YHx" userLabel="PrefNavPanel Clip View">
+                                    <rect key="frame" x="0.0" y="0.0" width="220" height="420"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" selectionHighlightStyle="sourceList" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="36" rowSizeStyle="automatic" viewBased="YES" id="vde-uJ-0ge">
-                                            <rect key="frame" x="0.0" y="0.0" width="220" height="401"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                            <size key="intercellSpacing" width="3" height="2"/>
+                                        <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="sourceList" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" autosaveName="" rowHeight="36" rowSizeStyle="automatic" viewBased="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vde-uJ-0ge" userLabel="PrefNavPanel Table View">
+                                            <rect key="frame" x="0.0" y="0.0" width="220" height="420"/>
+                                            <size key="intercellSpacing" width="0.0" height="2"/>
                                             <color key="backgroundColor" name="_sourceListBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                             <tableColumns>
-                                                <tableColumn width="188" minWidth="40" maxWidth="1000" id="s8e-nX-tcx">
+                                                <tableColumn width="188" minWidth="100" maxWidth="1000" id="s8e-nX-tcx">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
@@ -71,20 +72,9 @@
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
                                                         <tableCellView id="Cky-oa-sEY">
-                                                            <rect key="frame" x="11" y="1" width="197" height="36"/>
+                                                            <rect key="frame" x="10" y="1" width="200" height="36"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
-                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="XDU-ud-pYc">
-                                                                    <rect key="frame" x="44" y="10" width="135" height="16"/>
-                                                                    <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="Ukj-Vg-wHf" customClass="PrefTabTitleLabelCell" customModule="IINA" customModuleProvider="target">
-                                                                        <font key="font" metaFont="systemBold"/>
-                                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" white="1" alpha="0.0" colorSpace="deviceWhite"/>
-                                                                    </textFieldCell>
-                                                                    <connections>
-                                                                        <binding destination="Cky-oa-sEY" name="value" keyPath="objectValue.title" id="pdj-Rl-qDR"/>
-                                                                    </connections>
-                                                                </textField>
                                                                 <imageView wantsLayer="YES" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="5Yr-Dy-tXq">
                                                                     <rect key="frame" x="20" y="9" width="18" height="18"/>
                                                                     <constraints>
@@ -96,6 +86,17 @@
                                                                         <binding destination="Cky-oa-sEY" name="value" keyPath="objectValue.image" id="C2q-6f-8qZ"/>
                                                                     </connections>
                                                                 </imageView>
+                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="XDU-ud-pYc">
+                                                                    <rect key="frame" x="44" y="10" width="138" height="16"/>
+                                                                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Table View Cell" id="Ukj-Vg-wHf" customClass="PrefTabTitleLabelCell" customModule="IINA" customModuleProvider="target">
+                                                                        <font key="font" metaFont="systemBold"/>
+                                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" white="1" alpha="0.0" colorSpace="deviceWhite"/>
+                                                                    </textFieldCell>
+                                                                    <connections>
+                                                                        <binding destination="Cky-oa-sEY" name="value" keyPath="objectValue.title" id="pdj-Rl-qDR"/>
+                                                                    </connections>
+                                                                </textField>
                                                             </subviews>
                                                             <constraints>
                                                                 <constraint firstAttribute="trailing" secondItem="XDU-ud-pYc" secondAttribute="trailing" constant="20" id="GBQ-e5-LaX"/>
@@ -114,10 +115,16 @@
                                             </tableColumns>
                                         </tableView>
                                     </subviews>
+                                    <constraints>
+                                        <constraint firstItem="vde-uJ-0ge" firstAttribute="leading" secondItem="H3G-ed-YHx" secondAttribute="leading" id="Cxz-CR-kdA"/>
+                                        <constraint firstAttribute="trailing" secondItem="vde-uJ-0ge" secondAttribute="trailing" id="goR-gh-yRz"/>
+                                        <constraint firstItem="vde-uJ-0ge" firstAttribute="top" secondItem="H3G-ed-YHx" secondAttribute="top" id="tZn-Id-7Ac"/>
+                                    </constraints>
                                     <nil key="backgroundColor"/>
+                                    <edgeInsets key="contentInsets" left="0.0" right="0.0" top="0.0" bottom="0.0"/>
                                 </clipView>
                                 <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="DkZ-6e-xVc">
-                                    <rect key="frame" x="0.0" y="385" width="220" height="16"/>
+                                    <rect key="frame" x="-100" y="-100" width="220" height="16"/>
                                     <autoresizingMask key="autoresizingMask"/>
                                 </scroller>
                                 <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="ZJl-L4-rRV">
@@ -129,39 +136,48 @@
                         <constraints>
                             <constraint firstAttribute="trailing" secondItem="Isy-K8-od9" secondAttribute="trailing" id="J3l-Oa-DHc"/>
                             <constraint firstAttribute="bottom" secondItem="Isy-K8-od9" secondAttribute="bottom" id="RC5-qu-3AY"/>
-                            <constraint firstItem="rKj-eM-MTH" firstAttribute="top" secondItem="AO2-1e-7F6" secondAttribute="top" constant="36" id="h6P-ZA-Btd"/>
+                            <constraint firstItem="rKj-eM-MTH" firstAttribute="top" secondItem="AO2-1e-7F6" secondAttribute="top" constant="30" id="h6P-ZA-Btd"/>
                             <constraint firstAttribute="width" constant="220" id="kCX-dz-r0u"/>
-                            <constraint firstItem="Isy-K8-od9" firstAttribute="top" secondItem="rKj-eM-MTH" secondAttribute="bottom" constant="20" id="nOO-7o-aOI"/>
-                            <constraint firstItem="rKj-eM-MTH" firstAttribute="leading" secondItem="AO2-1e-7F6" secondAttribute="leading" constant="20" id="szD-ja-pwz"/>
-                            <constraint firstAttribute="trailing" secondItem="rKj-eM-MTH" secondAttribute="trailing" constant="20" id="uph-Ge-Lqq"/>
+                            <constraint firstItem="Isy-K8-od9" firstAttribute="top" secondItem="rKj-eM-MTH" secondAttribute="bottom" identifier="navTableSearchFieldSpacingConstraint" id="nOO-7o-aOI"/>
+                            <constraint firstItem="rKj-eM-MTH" firstAttribute="leading" secondItem="AO2-1e-7F6" secondAttribute="leading" constant="9" id="szD-ja-pwz"/>
+                            <constraint firstAttribute="trailing" secondItem="rKj-eM-MTH" secondAttribute="trailing" constant="9" id="uph-Ge-Lqq"/>
                             <constraint firstItem="Isy-K8-od9" firstAttribute="leading" secondItem="AO2-1e-7F6" secondAttribute="leading" id="vb0-7P-sn7"/>
                         </constraints>
                     </visualEffectView>
-                    <box horizontalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="anY-kd-ix3">
-                        <rect key="frame" x="217" y="0.0" width="5" height="479"/>
+                    <box horizontalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="anY-kd-ix3" userLabel="Vertical Divider Line">
+                        <rect key="frame" x="217" y="0.0" width="5" height="480"/>
                     </box>
-                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="mpW-1b-ztU" customClass="PrefSearchResultMaskView" customModule="IINA" customModuleProvider="target">
-                        <rect key="frame" x="220" y="0.0" width="480" height="479"/>
+                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="mpW-1b-ztU" userLabel="PrefSearchResult Mask View" customClass="PrefSearchResultMaskView" customModule="IINA" customModuleProvider="target">
+                        <rect key="frame" x="220" y="0.0" width="600" height="480"/>
                     </customView>
-                    <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="VYU-tb-v3l">
-                        <rect key="frame" x="220" y="0.0" width="480" height="479"/>
-                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="fAk-o1-RBn">
-                            <rect key="frame" x="0.0" y="0.0" width="480" height="479"/>
+                    <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="VYU-tb-v3l" userLabel="PrefDetailPanel Scroll View">
+                        <rect key="frame" x="220" y="0.0" width="600" height="480"/>
+                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="fAk-o1-RBn" userLabel="PrefDetailPanel Clip View">
+                            <rect key="frame" x="0.0" y="0.0" width="600" height="480"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
-                                <view translatesAutoresizingMaskIntoConstraints="NO" id="5R5-77-bmq" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="459" width="480" height="20"/>
+                                <view translatesAutoresizingMaskIntoConstraints="NO" id="5R5-77-bmq" userLabel="PrefDetailPanel Flipped Content View" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
+                                    <rect key="frame" x="0.0" y="424" width="600" height="56"/>
+                                    <subviews>
+                                        <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="16" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="250" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="evY-SZ-c3s" userLabel="PrefSections Vertical Stack View">
+                                            <rect key="frame" x="28" y="28" width="544" height="0.0"/>
+                                        </stackView>
+                                    </subviews>
                                     <constraints>
-                                        <constraint firstAttribute="height" constant="20" placeholder="YES" id="zVF-kp-HmN"/>
+                                        <constraint firstItem="evY-SZ-c3s" firstAttribute="leading" secondItem="5R5-77-bmq" secondAttribute="leading" constant="28" id="0Wy-7g-i7p"/>
+                                        <constraint firstItem="evY-SZ-c3s" firstAttribute="trailing" secondItem="5R5-77-bmq" secondAttribute="trailing" constant="-28" id="JKT-WF-qC2"/>
+                                        <constraint firstItem="evY-SZ-c3s" firstAttribute="top" secondItem="5R5-77-bmq" secondAttribute="top" constant="28" id="eir-Fy-Biy"/>
+                                        <constraint firstItem="evY-SZ-c3s" firstAttribute="bottom" secondItem="5R5-77-bmq" secondAttribute="bottom" constant="-28" id="ghX-KC-SZb"/>
                                     </constraints>
                                 </view>
                             </subviews>
                             <constraints>
                                 <constraint firstItem="5R5-77-bmq" firstAttribute="leading" secondItem="fAk-o1-RBn" secondAttribute="leading" id="GDH-y8-wlw"/>
-                                <constraint firstAttribute="trailing" secondItem="5R5-77-bmq" secondAttribute="trailing" id="dpQ-k3-zSF"/>
+                                <constraint firstItem="5R5-77-bmq" firstAttribute="trailing" secondItem="fAk-o1-RBn" secondAttribute="trailing" id="dpQ-k3-zSF"/>
                                 <constraint firstItem="5R5-77-bmq" firstAttribute="top" secondItem="fAk-o1-RBn" secondAttribute="top" id="xXS-T3-Lsu"/>
                             </constraints>
                         </clipView>
+                        <edgeInsets key="contentInsets" left="0.0" right="0.0" top="0.0" bottom="0.0"/>
                         <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="R3A-4z-Qcq">
                             <rect key="frame" x="-100" y="-100" width="480" height="16"/>
                             <autoresizingMask key="autoresizingMask"/>
@@ -204,11 +220,11 @@
                 <outlet property="contentViewController" destination="gzI-hP-SIO" id="7jB-jn-EuX"/>
             </connections>
         </popover>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="XXu-SH-FYF">
-            <rect key="frame" x="0.0" y="0.0" width="340" height="200"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="XXu-SH-FYF" userLabel="Completion Popover">
+            <rect key="frame" x="0.0" y="0.0" width="340" height="180"/>
             <subviews>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0yO-bT-GQW">
-                    <rect key="frame" x="137" y="92" width="67" height="16"/>
+                    <rect key="frame" x="137" y="82" width="67" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="No Result" id="jUU-3A-jLW">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -216,13 +232,13 @@
                     </textFieldCell>
                 </textField>
                 <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="42" horizontalPageScroll="10" verticalLineScroll="42" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="hxH-E2-abg">
-                    <rect key="frame" x="0.0" y="0.0" width="340" height="200"/>
+                    <rect key="frame" x="0.0" y="0.0" width="340" height="180"/>
                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="oMs-Q9-XbP">
-                        <rect key="frame" x="0.0" y="0.0" width="340" height="200"/>
+                        <rect key="frame" x="0.0" y="0.0" width="340" height="180"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="40" rowSizeStyle="automatic" viewBased="YES" id="MUI-pR-u00">
-                                <rect key="frame" x="0.0" y="0.0" width="340" height="200"/>
+                                <rect key="frame" x="0.0" y="0.0" width="340" height="180"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <size key="intercellSpacing" width="3" height="2"/>
                                 <color key="backgroundColor" white="1" alpha="0.0" colorSpace="deviceWhite"/>

--- a/iina/CacheManager.swift
+++ b/iina/CacheManager.swift
@@ -19,9 +19,11 @@ class CacheManager {
 
   private func cacheFolderContents() -> [URL]? {
     if needsRefresh {
+      Logger.log("Refreshing cached thumbnails index", level: .verbose, subsystem: ThumbnailCache.subsystem)
       cachedContents = try? FileManager.default.contentsOfDirectory(at: Utility.thumbnailCacheURL,
                                                                     includingPropertiesForKeys: [.fileSizeKey, .contentAccessDateKey],
                                                                     options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants])
+      needsRefresh = false
     }
     return cachedContents
   }
@@ -59,6 +61,7 @@ class CacheManager {
         break
       }
     }
+    Logger.log("Cleared \(clearedCacheSize) bytes from thumbnail cache", subsystem: ThumbnailCache.subsystem)
   }
 
 }

--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -422,6 +422,10 @@ extension String {
     return localizedCompare(other) == .orderedSame
   }
 
+  var quoted: String {
+    return "\"\(self)\""
+  }
+
   mutating func deleteLast(_ num: Int) {
     removeLast(Swift.min(num, count))
   }

--- a/iina/FFmpegController.h
+++ b/iina/FFmpegController.h
@@ -22,12 +22,12 @@
 /**
  A notification being sent
  */
-- (void)didUpdateThumbnails:(nullable NSArray<FFThumbnail *> *)thumbnails forFile:(nonnull NSString *)filename withProgress:(NSInteger)progress;
+- (void)didUpdateThumbnails:(nullable NSArray<FFThumbnail *> *)thumbnails forFile:(nonnull NSString *)filename thumbWidth:(int)thumbWidth withProgress:(NSInteger)progress;
 
 /**
- Did generated thumbnails for the video.
+ Did generate thumbnails for the video.
  */
-- (void)didGenerateThumbnails:(nonnull NSArray<FFThumbnail *> *)thumbnails forFile:(nonnull NSString *)filename succeeded:(BOOL)succeeded;
+- (void)didGenerateThumbnails:(nonnull NSArray<FFThumbnail *> *)thumbnails forFile:(nonnull NSString *)filename thumbWidth:(int)width succeeded:(BOOL)succeeded;
 
 @end
 

--- a/iina/FFmpegController.m
+++ b/iina/FFmpegController.m
@@ -48,7 +48,7 @@ return -1;\
   double _timestamp;
 }
 
-- (int)getPeeksForFile:(NSString *)file thumbnailsWidth:(int)thumbnailsWidth;
+- (int)getPeeksForFile:(NSString *)file thumbnailWidth:(int)thumbnailWidth;
 - (void)saveThumbnail:(AVFrame *)pFrame width:(int)width height:(int)height index:(int)index realTime:(int)second forFile:(NSString *)file;
 
 @end
@@ -82,10 +82,11 @@ return -1;\
       return;
     }
     self->_timestamp = CACurrentMediaTime();
-    int success = [self getPeeksForFile:file thumbnailsWidth:thumbWidth];
+    int success = [self getPeeksForFile:file thumbnailWidth:thumbWidth];
     if (self.delegate) {
       [self.delegate didGenerateThumbnails:[NSArray arrayWithArray:self->_thumbnails]
                                    forFile: file
+                                thumbWidth: thumbWidth
                                  succeeded:(success < 0 ? NO : YES)];
     }
   }];
@@ -93,7 +94,7 @@ return -1;\
 }
 
 - (int)getPeeksForFile:(NSString *)file
-       thumbnailsWidth:(int)thumbnailsWidth
+        thumbnailWidth:(int)thumbnailWidth
 {
   int i, ret;
 
@@ -162,7 +163,7 @@ return -1;\
 
   // Allocate the output frame
   // We need to convert the video frame to RGBA to satisfy CGImage's data format
-  int thumbWidth = thumbnailsWidth;
+  int thumbWidth = thumbnailWidth;
   int thumbHeight = (float)thumbWidth / ((float)pCodecCtx->width / pCodecCtx->height);
 
   AVFrame *pFrameRGB = av_frame_alloc();
@@ -235,7 +236,7 @@ return -1;\
             double currentTime = CACurrentMediaTime();
             if (currentTime - _timestamp > 1) {
               if (self.delegate) {
-                [self.delegate didUpdateThumbnails:NULL forFile: file withProgress: i];
+                [self.delegate didUpdateThumbnails:NULL forFile: file thumbWidth: thumbWidth withProgress: i];
                 _timestamp = currentTime;
               }
             }
@@ -327,6 +328,7 @@ return -1;\
       if (self.delegate) {
         [self.delegate didUpdateThumbnails:[NSArray arrayWithArray:_thumbnailPartialResult]
                                    forFile: file
+                                thumbWidth: width
                               withProgress: index];
       }
       [_thumbnailPartialResult removeAllObjects];

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -312,6 +312,7 @@ class MainWindowController: PlayerWindowController {
 
   private let localObservedPrefKeys: [Preference.Key] = [
     .oscPosition,
+    .thumbnailWidth,
     .showChapterPos,
     .arrowButtonAction,
     .pinchAction,
@@ -330,6 +331,16 @@ class MainWindowController: PlayerWindowController {
     case PK.oscPosition.rawValue:
       if let newValue = change[.newKey] as? Int {
         setupOnScreenController(withPosition: Preference.OSCPosition(rawValue: newValue) ?? .floating)
+      }
+    case PK.thumbnailWidth.rawValue:
+      if let newValue = change[.newKey] as? Int {
+        DispatchQueue.main.asyncAfter(deadline: .now() + AppData.thumbnailRegenerationDelay) {
+          if newValue == Preference.integer(for: .thumbnailWidth) && newValue != self.player.info.thumbnailWidth {
+            Logger.log("Pref \(Preference.Key.thumbnailWidth.rawValue.quoted) changed to \(newValue)px: requesting thumbs regen",
+                       subsystem: self.player.subsystem)
+            self.player.generateThumbnails()
+          }
+        }
       }
     case PK.showChapterPos.rawValue:
       if let newValue = change[.newKey] as? Bool {
@@ -2142,11 +2153,12 @@ class MainWindowController: PlayerWindowController {
       if player.info.thumbnailsReady, let image = player.info.getThumbnail(forSecond: previewTime.second)?.image {
         thumbnailPeekView.imageView.image = image.rotate(rotation)
         thumbnailPeekView.isHidden = false
-        let height = round(120 / thumbnailPeekView.imageView.image!.size.aspect)
+        let width = CGFloat(player.info.thumbnailWidth)
+        let height = round(width / thumbnailPeekView.imageView.image!.size.aspect)
         let timePreviewFrameInWindow = timePreviewWhenSeek.superview!.convert(timePreviewWhenSeek.frame.origin, to: nil)
         let showAbove = canShowThumbnailAbove(timnePreviewYPos: timePreviewFrameInWindow.y, thumbnailHeight: height)
         let yPos = showAbove ? timePreviewFrameInWindow.y + timePreviewWhenSeek.frame.height : sliderFrameInWindow.y - height
-        thumbnailPeekView.frame.size = NSSize(width: 120, height: height)
+        thumbnailPeekView.frame.size = NSSize(width: width, height: height)
         thumbnailPeekView.frame.origin = NSPoint(x: round(originalPos.x - thumbnailPeekView.frame.width / 2), y: yPos)
       } else {
         thumbnailPeekView.isHidden = true

--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -257,6 +257,7 @@ class PlaybackInfo {
   var thumbnailsReady = false
   var thumbnailsProgress: Double = 0
   var thumbnails: [FFThumbnail] = []
+  var thumbnailWidth: Int = 0
 
   func getThumbnail(forSecond sec: Double) -> FFThumbnail? {
     guard !thumbnails.isEmpty else { return nil }

--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -257,6 +257,7 @@ class PlaybackInfo {
   var thumbnailsReady = false
   var thumbnailsProgress: Double = 0
   var thumbnails: [FFThumbnail] = []
+  var thumbnailLength: Int = 0
   var thumbnailWidth: Int = 0
 
   func getThumbnail(forSecond sec: Double) -> FFThumbnail? {

--- a/iina/PrefPluginViewController.xib
+++ b/iina/PrefPluginViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21225" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21225"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -41,11 +41,11 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY">
-            <rect key="frame" x="0.0" y="0.0" width="725" height="531"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY" userLabel="Prefs &gt; Plugins View">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="545"/>
             <subviews>
                 <scrollView autohidesScrollers="YES" horizontalLineScroll="38" horizontalPageScroll="10" verticalLineScroll="38" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZZO-wR-pQN">
-                    <rect key="frame" x="8" y="8" width="160" height="400"/>
+                    <rect key="frame" x="0.0" y="8" width="160" height="400"/>
                     <clipView key="contentView" id="MLE-fd-V2n">
                         <rect key="frame" x="1" y="1" width="158" height="398"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -122,13 +122,13 @@
                     </scroller>
                 </scrollView>
                 <scrollView horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="aCG-6E-fwa">
-                    <rect key="frame" x="176" y="8" width="541" height="400"/>
+                    <rect key="frame" x="168" y="8" width="312" height="400"/>
                     <clipView key="contentView" id="qAI-Vk-KZx">
-                        <rect key="frame" x="1" y="1" width="539" height="398"/>
+                        <rect key="frame" x="1" y="1" width="310" height="398"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <view translatesAutoresizingMaskIntoConstraints="NO" id="dBW-JH-AvA" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="0.0" width="539" height="398"/>
+                                <rect key="frame" x="0.0" y="0.0" width="310" height="398"/>
                                 <subviews>
                                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="RQj-8e-E8x">
                                         <rect key="frame" x="10" y="370" width="40" height="16"/>
@@ -150,7 +150,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="8U3-yT-6HJ">
-                                        <rect key="frame" x="10" y="352" width="519" height="14"/>
+                                        <rect key="frame" x="10" y="352" width="290" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" selectable="YES" title="Multiline Label" id="T11-Rl-GHV">
                                             <font key="font" metaFont="controlContent" size="11"/>
                                             <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -158,7 +158,7 @@
                                         </textFieldCell>
                                     </textField>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kmI-AD-0GL">
-                                        <rect key="frame" x="467" y="368" width="60" height="17"/>
+                                        <rect key="frame" x="238" y="368" width="60" height="17"/>
                                         <buttonCell key="cell" type="roundRect" title="Uninstall" bezelStyle="roundedRect" alignment="center" controlSize="small" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ue8-hU-kLm">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="controlContent" size="11"/>
@@ -168,16 +168,16 @@
                                         </connections>
                                     </button>
                                     <tabView drawsBackground="NO" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="Cly-9N-1cz">
-                                        <rect key="frame" x="0.0" y="0.0" width="539" height="316"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="310" height="316"/>
                                         <font key="font" metaFont="system"/>
                                         <tabViewItems>
                                             <tabViewItem label="Permissions" identifier="" id="ALD-n6-A0r">
                                                 <view key="view" id="vcw-rr-7hi">
-                                                    <rect key="frame" x="0.0" y="0.0" width="539" height="316"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="310" height="316"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
                                                         <stackView distribution="fill" orientation="vertical" alignment="leading" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="PzT-T3-f8b" customClass="PrefPluginPermissionListView" customModule="IINA" customModuleProvider="target">
-                                                            <rect key="frame" x="8" y="8" width="523" height="300"/>
+                                                            <rect key="frame" x="8" y="8" width="294" height="300"/>
                                                         </stackView>
                                                     </subviews>
                                                     <constraints>
@@ -429,10 +429,10 @@
                                         </tabViewItems>
                                     </tabView>
                                     <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="O3h-Pq-T36">
-                                        <rect key="frame" x="0.0" y="326" width="539" height="5"/>
+                                        <rect key="frame" x="0.0" y="326" width="310" height="5"/>
                                     </box>
                                     <box boxType="custom" cornerRadius="4" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="27z-7F-oLV">
-                                        <rect key="frame" x="174" y="320" width="191" height="18"/>
+                                        <rect key="frame" x="60" y="320" width="191" height="18"/>
                                         <view key="contentView" id="wwE-Ri-E27">
                                             <rect key="frame" x="1" y="1" width="189" height="16"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -441,7 +441,7 @@
                                         <color key="fillColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     </box>
                                     <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="304-WM-rM6">
-                                        <rect key="frame" x="172" y="318" width="195" height="21"/>
+                                        <rect key="frame" x="58" y="318" width="195" height="21"/>
                                         <segmentedCell key="cell" controlSize="small" borderStyle="border" alignment="left" style="rounded" trackingMode="selectOne" id="KTN-5r-mMm">
                                             <font key="font" metaFont="controlContent" size="11"/>
                                             <segments>
@@ -455,7 +455,7 @@
                                         </connections>
                                     </segmentedControl>
                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sl8-zI-7f5">
-                                        <rect key="frame" x="367" y="368" width="92" height="17"/>
+                                        <rect key="frame" x="138" y="368" width="92" height="17"/>
                                         <buttonCell key="cell" type="roundRect" title="Show in Finder" bezelStyle="roundedRect" alignment="center" controlSize="small" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="drh-6w-3z1">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                             <font key="font" metaFont="controlContent" size="11"/>
@@ -505,19 +505,19 @@
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="300" id="Eud-HL-zMW"/>
                     </constraints>
                     <scroller key="horizontalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="jco-u7-SJs">
-                        <rect key="frame" x="1" y="383" width="539" height="16"/>
+                        <rect key="frame" x="1" y="383" width="310" height="16"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                     <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="eSh-BD-Twe">
-                        <rect key="frame" x="524" y="1" width="16" height="398"/>
+                        <rect key="frame" x="295" y="1" width="16" height="398"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                 </scrollView>
                 <progressIndicator wantsLayer="YES" maxValue="100" displayedWhenStopped="NO" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="SBI-Gr-Vhq">
-                    <rect key="frame" x="188" y="20" width="16" height="16"/>
+                    <rect key="frame" x="180" y="20" width="16" height="16"/>
                 </progressIndicator>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="aJi-Tg-tph">
-                    <rect key="frame" x="6" y="489" width="713" height="14"/>
+                    <rect key="frame" x="-2" y="489" width="484" height="28"/>
                     <textFieldCell key="cell" controlSize="small" id="fnl-uA-X7r">
                         <font key="font" metaFont="controlContent" size="11"/>
                         <string key="title">You can install a new plugin from GitHub or a local .iinaplgz package. Plugins installed from GitHub can be updated automatically.</string>
@@ -526,15 +526,15 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="XzQ-9h-Ysp">
-                    <rect key="frame" x="6" y="416" width="107" height="16"/>
+                    <rect key="frame" x="-2" y="416" width="116" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="Installed plugins:" id="Ztn-MG-D7D">
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DbD-Cu-uoz">
-                    <rect key="frame" x="1" y="454" width="160" height="32"/>
+                    <rect key="frame" x="-7" y="454" width="159" height="32"/>
                     <buttonCell key="cell" type="push" title="Install from GitHub..." bezelStyle="rounded" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="enP-C1-4vu">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -544,18 +544,18 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EIM-00-eRR">
-                    <rect key="frame" x="6" y="507" width="49" height="16"/>
+                    <rect key="frame" x="-2" y="521" width="52" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="Plugins" id="tfn-0I-n6p">
-                        <font key="font" usesAppearanceFont="YES"/>
+                        <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
                 <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="q8W-0n-Rem">
-                    <rect key="frame" x="8" y="442" width="709" height="5"/>
+                    <rect key="frame" x="0.0" y="442" width="480" height="5"/>
                 </box>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="K9h-qs-0tJ">
-                    <rect key="frame" x="159" y="454" width="210" height="32"/>
+                    <rect key="frame" x="150" y="454" width="210" height="32"/>
                     <buttonCell key="cell" type="push" title="Install from a local package…" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="sdU-FG-dTO">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -569,35 +569,35 @@
                 <constraint firstAttribute="bottom" secondItem="aCG-6E-fwa" secondAttribute="bottom" constant="8" id="6ek-GI-19D"/>
                 <constraint firstItem="aCG-6E-fwa" firstAttribute="top" secondItem="ZZO-wR-pQN" secondAttribute="top" id="8I3-LV-cJH"/>
                 <constraint firstItem="aJi-Tg-tph" firstAttribute="top" secondItem="EIM-00-eRR" secondAttribute="bottom" constant="4" id="Adr-Np-183"/>
-                <constraint firstAttribute="trailing" secondItem="aCG-6E-fwa" secondAttribute="trailing" constant="8" id="AkC-O1-FPG"/>
-                <constraint firstItem="DbD-Cu-uoz" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="8" id="Ed3-UK-Mwn"/>
+                <constraint firstAttribute="trailing" secondItem="aCG-6E-fwa" secondAttribute="trailing" id="AkC-O1-FPG"/>
+                <constraint firstItem="DbD-Cu-uoz" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="Ed3-UK-Mwn"/>
                 <constraint firstItem="aCG-6E-fwa" firstAttribute="leading" secondItem="ZZO-wR-pQN" secondAttribute="trailing" constant="8" id="L64-lM-Sni"/>
                 <constraint firstItem="EIM-00-eRR" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="8" id="Mzv-Rj-8yA"/>
-                <constraint firstItem="EIM-00-eRR" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="8" id="RpA-gZ-Mbg"/>
-                <constraint firstItem="ZZO-wR-pQN" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="8" id="WfH-VA-QY7"/>
+                <constraint firstItem="EIM-00-eRR" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="RpA-gZ-Mbg"/>
+                <constraint firstItem="ZZO-wR-pQN" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="WfH-VA-QY7"/>
                 <constraint firstItem="aCG-6E-fwa" firstAttribute="bottom" secondItem="SBI-Gr-Vhq" secondAttribute="bottom" constant="12" id="Wr7-fg-Gwt"/>
-                <constraint firstAttribute="trailing" secondItem="q8W-0n-Rem" secondAttribute="trailing" constant="8" id="YZO-c1-sbD"/>
+                <constraint firstAttribute="trailing" secondItem="q8W-0n-Rem" secondAttribute="trailing" id="YZO-c1-sbD"/>
                 <constraint firstItem="K9h-qs-0tJ" firstAttribute="leading" secondItem="DbD-Cu-uoz" secondAttribute="trailing" constant="12" id="b6h-z0-ZbE"/>
                 <constraint firstItem="ZZO-wR-pQN" firstAttribute="top" secondItem="XzQ-9h-Ysp" secondAttribute="bottom" constant="8" id="cgv-zc-Bkt"/>
                 <constraint firstItem="q8W-0n-Rem" firstAttribute="top" secondItem="DbD-Cu-uoz" secondAttribute="bottom" constant="16" id="eqE-KG-PB9"/>
                 <constraint firstItem="XzQ-9h-Ysp" firstAttribute="top" secondItem="q8W-0n-Rem" secondAttribute="bottom" constant="12" id="ezm-Ff-eb5"/>
-                <constraint firstItem="XzQ-9h-Ysp" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="8" id="g2C-6L-a6P"/>
-                <constraint firstItem="aJi-Tg-tph" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="8" id="gg0-nG-EDs"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="EIM-00-eRR" secondAttribute="trailing" constant="8" id="jf8-5x-czE"/>
+                <constraint firstItem="XzQ-9h-Ysp" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="g2C-6L-a6P"/>
+                <constraint firstItem="aJi-Tg-tph" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="gg0-nG-EDs"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="EIM-00-eRR" secondAttribute="trailing" id="jf8-5x-czE"/>
                 <constraint firstItem="K9h-qs-0tJ" firstAttribute="firstBaseline" secondItem="DbD-Cu-uoz" secondAttribute="firstBaseline" id="kBc-Uj-sLw"/>
                 <constraint firstItem="DbD-Cu-uoz" firstAttribute="top" secondItem="aJi-Tg-tph" secondAttribute="bottom" constant="8" id="o72-U9-3Gn"/>
-                <constraint firstItem="q8W-0n-Rem" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="8" id="qKI-kR-HzB"/>
-                <constraint firstAttribute="trailing" secondItem="aJi-Tg-tph" secondAttribute="trailing" constant="8" id="qbO-aO-pa9"/>
+                <constraint firstItem="q8W-0n-Rem" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="qKI-kR-HzB"/>
+                <constraint firstAttribute="trailing" secondItem="aJi-Tg-tph" secondAttribute="trailing" id="qbO-aO-pa9"/>
                 <constraint firstItem="ZZO-wR-pQN" firstAttribute="bottom" secondItem="aCG-6E-fwa" secondAttribute="bottom" id="ri6-Xe-X9M"/>
                 <constraint firstItem="SBI-Gr-Vhq" firstAttribute="leading" secondItem="aCG-6E-fwa" secondAttribute="leading" constant="12" id="v3r-iA-thr"/>
             </constraints>
             <point key="canvasLocation" x="56.5" y="287.5"/>
         </customView>
-        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="Lbk-y3-8Oe">
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="Lbk-y3-8Oe" userLabel="New Plugin Window">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="283" y="305" width="480" height="297"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="3440" height="1415"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1792" height="1095"/>
             <view key="contentView" id="iQg-1N-GyM">
                 <rect key="frame" x="0.0" y="0.0" width="480" height="297"/>
                 <autoresizingMask key="autoresizingMask"/>
@@ -668,7 +668,7 @@ DQ
                         <rect key="frame" x="20" y="60" width="438" height="101"/>
                         <clipView key="contentView" id="aFk-H7-59O">
                             <rect key="frame" x="1" y="1" width="436" height="99"/>
-                            <autoresizingMask key="autoresizingMask"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="bRx-bz-pZ0">
                                     <rect key="frame" x="0.0" y="0.0" width="436" height="99"/>
@@ -690,7 +690,7 @@ DQ
                                             <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                             <prototypeCellViews>
                                                 <tableCellView identifier="URLCell" id="pQh-Sg-FDH">
-                                                    <rect key="frame" x="11" y="1" width="336" height="17"/>
+                                                    <rect key="frame" x="1" y="1" width="336" height="17"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
                                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Kyj-2t-Kff">
@@ -726,7 +726,7 @@ DQ
                                             <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                             <prototypeCellViews>
                                                 <tableCellView identifier="InstalledCell" id="MLN-xs-VvQ">
-                                                    <rect key="frame" x="350" y="1" width="65" height="17"/>
+                                                    <rect key="frame" x="340" y="1" width="65" height="17"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
                                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8Gc-LL-LXO">
@@ -791,6 +791,6 @@ DQ
         </window>
     </objects>
     <resources>
-        <image name="NSFollowLinkFreestandingTemplate" width="15" height="15"/>
+        <image name="NSFollowLinkFreestandingTemplate" width="20" height="20"/>
     </resources>
 </document>

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -132,7 +132,7 @@ struct Preference {
     static let enableThumbnailPreview = Key("enableThumbnailPreview")
     static let maxThumbnailPreviewCacheSize = Key("maxThumbnailPreviewCacheSize")
     static let enableThumbnailForRemoteFiles = Key("enableThumbnailForRemoteFiles")
-    static let thumbnailWidth = Key("thumbnailWidth")
+    static let thumbnailLength = Key("thumbnailLength")
 
     static let autoSwitchToMusicMode = Key("autoSwitchToMusicMode")
     static let musicModeShowPlaylist = Key("musicModeShowPlaylist")
@@ -722,7 +722,7 @@ struct Preference {
     .enableThumbnailPreview: true,
     .maxThumbnailPreviewCacheSize: 500,
     .enableThumbnailForRemoteFiles: false,
-    .thumbnailWidth: 240,
+    .thumbnailLength: 240,
     .autoSwitchToMusicMode: true,
     .musicModeShowPlaylist: false,
     .musicModeShowAlbumArt: true,

--- a/iina/ThumbnailCache.swift
+++ b/iina/ThumbnailCache.swift
@@ -8,12 +8,12 @@
 
 import Cocoa
 
-fileprivate let subsystem = Logger.Subsystem(rawValue: "thumbcache")
-
 class ThumbnailCache {
   private typealias CacheVersion = UInt8
   private typealias FileSize = UInt64
   private typealias FileTimestamp = Int64
+
+  static let subsystem = Logger.Subsystem(rawValue: "thumbcache")
 
   private static let version: CacheVersion = 2
   
@@ -23,11 +23,11 @@ class ThumbnailCache {
     .compressionFactor: 0.75
   ]
 
-  static func fileExists(forName name: String) -> Bool {
-    return FileManager.default.fileExists(atPath: urlFor(name).path)
+  private static func fileExists(forName name: String, forWidth width: Int) -> Bool {
+    return FileManager.default.fileExists(atPath: urlFor(name, width: width).path)
   }
 
-  static func fileIsCached(forName name: String, forVideo videoPath: URL?) -> Bool {
+  static func fileIsCached(forName name: String, forVideo videoPath: URL?, forWidth width: Int) -> Bool {
     guard let fileAttr = try? FileManager.default.attributesOfItem(atPath: videoPath!.path) else {
       Logger.log("Cannot get video file attributes", level: .error, subsystem: subsystem)
       return false
@@ -47,8 +47,8 @@ class ThumbnailCache {
     let fileTimestamp = FileTimestamp(fileModifiedDate.timeIntervalSince1970)
 
     // Check metadate in the cache
-    if self.fileExists(forName: name) {
-      guard let file = try? FileHandle(forReadingFrom: urlFor(name)) else {
+    if self.fileExists(forName: name, forWidth: width) {
+      guard let file = try? FileHandle(forReadingFrom: urlFor(name, width: width)) else {
         Logger.log("Cannot open cache file.", level: .error, subsystem: subsystem)
         return false
       }
@@ -65,23 +65,30 @@ class ThumbnailCache {
 
   /// Write thumbnail cache to file.
   /// This method is expected to be called when the file doesn't exist.
-  static func write(_ thumbnails: [FFThumbnail], forName name: String, forVideo videoPath: URL?) {
-    Logger.log("Writing thumbnail cache...", subsystem: subsystem)
+  static func write(_ thumbnails: [FFThumbnail], forName name: String, forVideo videoPath: URL?, forWidth width: Int) {
+    Logger.log("Writing \(thumbnails.count) thumbnails with width \(width) to cache file", subsystem: subsystem)
 
     let maxCacheSize = Preference.integer(for: .maxThumbnailPreviewCacheSize) * FloatingPointByteCountFormatter.PrefixFactor.mi.rawValue
     if maxCacheSize == 0 {
       return
-    } else if CacheManager.shared.getCacheSize() > maxCacheSize {
+    }
+    let cacheSize = CacheManager.shared.getCacheSize()
+    if cacheSize > maxCacheSize {
+      Logger.log("Thumbnail cache size (\(cacheSize)) is larger than max allowed (\(maxCacheSize)) and will be cleared", subsystem: subsystem)
       CacheManager.shared.clearOldCache()
     }
 
-    let pathURL = urlFor(name)
+    let pathURL = urlFor(name, width: width)
+
+    Utility.createDirIfNotExist(url: pathURL.deletingLastPathComponent())
+
+    let path = pathURL.path
     guard FileManager.default.createFile(atPath: pathURL.path, contents: nil, attributes: nil) else {
-      Logger.log("Cannot create file.", level: .error, subsystem: subsystem)
+      Logger.log("Cannot create thumbnail cache file: \(path)", level: .error, subsystem: subsystem)
       return
     }
     guard let file = try? FileHandle(forWritingTo: pathURL) else {
-      Logger.log("Cannot write to file.", level: .error, subsystem: subsystem)
+      Logger.log("Cannot write to thumbnail cache file: \(path)", level: .error, subsystem: subsystem)
       return
     }
 
@@ -90,13 +97,13 @@ class ThumbnailCache {
     file.write(versionData)
 
     guard let fileAttr = try? FileManager.default.attributesOfItem(atPath: videoPath!.path) else {
-      Logger.log("Cannot get video file attributes", level: .error, subsystem: subsystem)
+      Logger.log("Cannot get video file attributes (path: \(videoPath!.path))", level: .error, subsystem: subsystem)
       return
     }
 
     // file size
     guard let fileSize = fileAttr[.size] as? FileSize else {
-      Logger.log("Cannot get video file size", level: .error, subsystem: subsystem)
+      Logger.log("Cannot get video file size from attributes", level: .error, subsystem: subsystem)
       return
     }
     let fileSizeData = Data(bytesOf: fileSize)
@@ -104,7 +111,7 @@ class ThumbnailCache {
 
     // modified date
     guard let fileModifiedDate = fileAttr[.modificationDate] as? Date else {
-      Logger.log("Cannot get video file modification date", level: .error, subsystem: subsystem)
+      Logger.log("Cannot get video file modification date from attributes", level: .error, subsystem: subsystem)
       return
     }
     let fileTimestamp = FileTimestamp(fileModifiedDate.timeIntervalSince1970)
@@ -129,21 +136,27 @@ class ThumbnailCache {
       file.write(jpegData)
     }
 
+    if #available(macOS 10.15, *) {
+      do {
+        try file.close()
+      } catch {
+        Logger.log("Failed to close file: \(path)", level: .error, subsystem: subsystem)
+      }
+    }
+
     CacheManager.shared.needsRefresh = true
-    Logger.log("Finished writing thumbnail cache.", subsystem: subsystem)
+    Logger.log("Finished writing thumbnail cache: \(path)", subsystem: subsystem)
   }
 
   /// Read thumbnail cache to file.
   /// This method is expected to be called when the file exists.
-  static func read(forName name: String) -> [FFThumbnail]? {
-    Logger.log("Reading thumbnail cache...", subsystem: subsystem)
-
-    let pathURL = urlFor(name)
+  static func read(forName name: String, forWidth width: Int) -> [FFThumbnail]? {
+    let pathURL = urlFor(name, width: width)
     guard let file = try? FileHandle(forReadingFrom: pathURL) else {
-      Logger.log("Cannot open file.", level: .error, subsystem: subsystem)
+      Logger.log("Cannot open thumbnail cache file: \(pathURL.path)", level: .error, subsystem: subsystem)
       return nil
     }
-    Logger.log("Reading from \(pathURL.path)", subsystem: subsystem)
+    Logger.log("Reading thumbnail cache: \(pathURL.path)", subsystem: subsystem)
 
     var result: [FFThumbnail] = []
 
@@ -159,7 +172,7 @@ class ThumbnailCache {
       // length and timestamp
       guard let blockLength = file.read(type: Int64.self),
             let timestamp = file.read(type: Double.self) else {
-        Logger.log("Cannot read image header. Cache file will be deleted.", level: .warning, subsystem: subsystem)
+        Logger.log("Cannot read image header. Cache file will be deleted: \(pathURL)", level: .warning, subsystem: subsystem)
         file.closeFile()
         deleteCacheFile(at: pathURL)
         return nil
@@ -167,7 +180,7 @@ class ThumbnailCache {
       // jpeg
       let jpegData = file.readData(ofLength: Int(blockLength) - MemoryLayout.size(ofValue: timestamp))
       guard let image = NSImage(data: jpegData) else {
-        Logger.log("Cannot read image. Cache file will be deleted.", level: .warning, subsystem: subsystem)
+        Logger.log("Cannot read image. Cache file will be deleted: \(pathURL)", level: .warning, subsystem: subsystem)
         file.closeFile()
         deleteCacheFile(at: pathURL)
         return nil
@@ -189,12 +202,13 @@ class ThumbnailCache {
     do {
       try FileManager.default.removeItem(at: pathURL)
     } catch {
-      Logger.log("Cannot delete corrupted cache.", level: .error, subsystem: subsystem)
+      Logger.log("Cannot delete corrupted cache: \(pathURL)", level: .error, subsystem: subsystem)
     }
   }
 
-  private static func urlFor(_ name: String) -> URL {
-    return Utility.thumbnailCacheURL.appendingPathComponent(name)
+  // Thumbnail cache URL
+  private static func urlFor(_ name: String, width: Int) -> URL {
+    return Utility.thumbnailCacheURL.appendingPathComponent("\(width)").appendingPathComponent(name)
   }
 
 }

--- a/iina/en.lproj/PrefSubViewController.strings
+++ b/iina/en.lproj/PrefSubViewController.strings
@@ -71,7 +71,7 @@
 "OcF-0z-7qe.title" = "If enabled, all ASS subtitles will be drawn using the styles below.";
 
 /* Class = "NSTextFieldCell"; title = "Text subtitles:"; ObjectID = "Qda-dp-nhg"; */
-"Qda-dp-nhg.title" = "Text subtitles:";
+"Qda-dp-nhg.title" = "Text Subtitles:";
 
 /* Class = "NSTextFieldCell"; title = "Also search subtitles in following directories:"; ObjectID = "QsS-wD-2hY"; */
 "QsS-wD-2hY.title" = "Also search subtitles in following directories:";
@@ -134,7 +134,7 @@
 "l7l-ZO-W79.title" = " X:";
 
 /* Class = "NSTextFieldCell"; title = "ASS subtitles:"; ObjectID = "mFm-Q6-aja"; */
-"mFm-Q6-aja.title" = "ASS subtitles:";
+"mFm-Q6-aja.title" = "ASS Subtitles:";
 
 /* Class = "NSButtonCell"; title = "Choose…"; ObjectID = "nH7-kO-S15"; */
 "nH7-kO-S15.title" = "Choose…";
@@ -149,7 +149,7 @@
 "rZf-bj-qbV.title" = "Ignore ASS styles";
 
 /* Class = "NSTextFieldCell"; title = "Auto load:"; ObjectID = "raf-Yu-ck0"; */
-"raf-Yu-ck0.title" = "Auto load:";
+"raf-Yu-ck0.title" = "Auto Load:";
 
 /* Class = "NSMenuItem"; title = "Center"; ObjectID = "slU-Ox-aeF"; */
 "slU-Ox-aeF.title" = "Center";


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #885 / #3972
- Also fixes #3408. Sorry, didn't want to waste time breaking this into a separate PR.

---

**Description:**

Note: PR #4107 is a prerequisite for this because it builds on its layout.

<img width="511" alt="SCR-20230126-f4" src="https://user-images.githubusercontent.com/2213815/214787973-336a0e10-7e93-4a04-8bdd-97174e12496a.png">

![SCR-20230126-15l](https://user-images.githubusercontent.com/2213815/214795409-4d5ba760-e1a7-4cb1-80bf-60658819b627.jpeg)

I was mucking around in the `Settings` > `UI` tab for unrelated things, but went into a rabbit hole after I saw commented-out stuff and here's the result :)

Looks PR #3289 (although still open) was fully merged into develop, but more work was needed. This commit:
- Adds a level to the thumbnail cache directory structure so that instead of "`thumbnailCacheURL`/`MD5`", the thumbs go in "`thumbnailCacheURL`/`width`/`MD5`"
- Makes the width setting visible in the UI, but swapped its place with the cache size setting, because it seemed funny the way it was.
- Adds code to `PlayerCore` so that it detects when the pref setting is changed, and will regenerate its thumbnails. But saw that it gets notified immediately for each character the user types! So I added a timer mechanism to it, so that it will only regenerate if the new value doesn't change for 2 seconds.
- Replaces hard-coded widths with `width` variable (previously, thumbs were generated with 240px width, then displayed with 120px width).

I was surprised how fast the thumbnails generate and display! Now I don't know how I ever lived with sub-500-pixel thumbnails!

One more change, because it would be hard to separate the code for each; and I already spend too much of my time on these write-ups. I added a new checkbox, `Enable for remote files also`, which toggles enablement of thumbnails for remote video files. This pref already existed but is disabled by default (see #3408). I really agonized over the name, but am open to changes. Or maybe would be good to add a further explanation below it, like "Not recommended for slow network connections" or "May slow down playback if bandwidth is limited". Of course on my NAS it was still very fast and I wouldn't have noticed the difference. Probably a more ideal solution would be to try to check the state of the playback buffer (if possible) and only generate thumbnails when the buffer is close to full.