### PR TITLE
Fix bug: menu items with variable titles and values failed to reset to their defaults after their key bindings were removed

### DIFF
--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -211,10 +211,6 @@ class MenuController: NSObject, NSMenuDelegate {
     jumpTo.action = #selector(MainMenuActionHandler.menuJumpTo(_:))
 
     // -- speed
-    (speedUp.representedObject,
-     speedUpSlightly.representedObject,
-     speedDown.representedObject,
-     speedDownSlightly.representedObject) = (2.0, 1.1, 0.5, 0.9)
     [speedUp, speedDown, speedUpSlightly, speedDownSlightly, speedReset].forEach { item in
       item?.action = #selector(MainMenuActionHandler.menuChangeSpeed(_:))
     }
@@ -317,20 +313,12 @@ class MenuController: NSObject, NSMenuDelegate {
     audioTrackMenu.delegate = self
 
     // - volume
-    (increaseVolume.representedObject,
-     decreaseVolume.representedObject,
-     increaseVolumeSlightly.representedObject,
-     decreaseVolumeSlightly.representedObject) = (5, -5, 1, -1)
     [increaseVolume, decreaseVolume, increaseVolumeSlightly, decreaseVolumeSlightly].forEach { item in
       item?.action = #selector(MainMenuActionHandler.menuChangeVolume(_:))
     }
     mute.action = #selector(MainMenuActionHandler.menuToggleMute(_:))
 
     // - audio delay
-    (increaseAudioDelay.representedObject,
-     increaseAudioDelaySlightly.representedObject,
-     decreaseAudioDelay.representedObject,
-     decreaseAudioDelaySlightly.representedObject) = (0.5, 0.1, -0.5, -0.1)
     [increaseAudioDelay, decreaseAudioDelay, increaseAudioDelaySlightly, decreaseAudioDelaySlightly].forEach { item in
       item?.action = #selector(MainMenuActionHandler.menuChangeAudioDelay(_:))
     }
@@ -365,10 +353,6 @@ class MenuController: NSObject, NSMenuDelegate {
     }
 
     // - delay
-    (increaseSubDelay.representedObject,
-     increaseSubDelaySlightly.representedObject,
-     decreaseSubDelay.representedObject,
-     decreaseSubDelaySlightly.representedObject) = (0.5, 0.1, -0.5, -0.1)
     [increaseSubDelay, decreaseSubDelay, increaseSubDelaySlightly, decreaseSubDelaySlightly].forEach { item in
       item?.action = #selector(MainMenuActionHandler.menuChangeSubDelay(_:))
     }
@@ -842,9 +826,19 @@ class MenuController: NSObject, NSMenuDelegate {
           break
         }
       }
+
       if !bound {
         menuItem.keyEquivalent = ""
         menuItem.keyEquivalentModifierMask = []
+
+        // Need to regenerate `title` and `representedObject` from their default values.
+        // This is needed for the case where the menu item previously matched to a key binding, but now there is no match.
+        // Obviously this is a little kludgey, but it avoids having to do a big refactor and/or writing a bunch of new code.
+        let (_, value) = sameKeyAction(actions, actions, normalizeLastNum, numRange)
+        if let value = value, let l10nKey = l10nKey {
+          menuItem.title = String(format: NSLocalizedString("menu." + l10nKey, comment: ""), abs(value))
+          menuItem.representedObject = value
+        }
       }
     }
   }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4221.

---

**Description:**
If technical debt could be measured, `MenuController` should be declaring bankruptcy. Had to fight my natural tendency to try to go beyond and try to refactor it. But I think I found a solution which works fairly well, even though it's also kind of ugly.

There are 16 menu items (which I found at least) in which `MenuController` will change the their title and associated data based on their value parameter. IINA has been deriving these based on their defaults in `bindMenuItems()` at program start. It has also been deriving these from the user's active key bindings in `updateKeyEquivalentsFrom()` - but only if they matched one of the user's bindings.

Unfortunately, `bindMenuItems()` doesn't cache the default values it generates, and there's no easy way to modify that method without it being a lot of work. However, the `settings` array inside the `updateKeyEquivalentsFrom()` method contains all the information needed in order to re-derive those default values. It's just necessary to supply the default values twice in order to be able to derive it via the existing code:

```Swift
let (_, value) = sameKeyAction(actions, actions, normalizeLastNum, numRange)
```

Finally, this PR removes some code in `bindMenuItems()` which sets the `representedObject` for those 16 fields at program load. They are completely unnecessary, because the updated code will get the same result when it calls `updateKeyEquivalentsFrom()` at program start. Following the DRY principle, it's important to remove them as a potential source of error, in case their values ever needed to be changed in the future.