### PR TITLE
Include muted status in Audio menu

### DIFF
--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -109,6 +109,7 @@
 "preference.enable_adv_settings" = "Enable advanced settings";
 
 "menu.volume" = "Volume: %d";
+"menu.volume_muted" = "Volume: %d (Muted)";
 "menu.audio_delay" = "Audio Delay: %.2fs";
 "menu.sub_delay" = "Subtitle Delay: %.2fs";
 "menu.fullscreen" = "Enter Full Screen";

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -489,7 +489,15 @@ class MenuController: NSObject, NSMenuDelegate {
           player.mainWindow.quickSettingView.currentTab == .audio
     quickSettingsAudio?.title = isDisplayingSettings ? Constants.String.hideAudioPanel :
         Constants.String.audioPanel
-    volumeIndicator.title = String(format: NSLocalizedString("menu.volume", comment: "Volume:"), Int(player.info.volume))
+    let volFmtString: String
+    if player.info.isMuted {
+      volFmtString = NSLocalizedString("menu.volume_muted", comment: "Volume: (Muted)")
+      mute.state = .on
+    } else {
+      volFmtString = NSLocalizedString("menu.volume", comment: "Volume:")
+      mute.state = .off
+    }
+    volumeIndicator.title = String(format: volFmtString, Int(player.info.volume))
     audioDelayIndicator.title = String(format: NSLocalizedString("menu.audio_delay", comment: "Audio Delay:"), player.info.audioDelay)
   }
 

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -107,6 +107,7 @@
 "preference.enable_adv_settings" = "Enable advanced settings";
 
 "menu.volume" = "Volume: %d";
+"menu.volume_muted" = "Volume: %d (Muted)";
 "menu.audio_delay" = "Audio Delay: %.2fs";
 "menu.sub_delay" = "Subtitle Delay: %.2fs";
 "menu.fullscreen" = "Enter Full Screen";


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4201.

---

**Description:**

Adds checkmark to `Muted` menu item, and includes "(Muted)" in the volume indicator menu item, when the audio is muted, as discussed in the above issue.