### PR TITLE
Fix fullscreen only works for first video, #4202

### DIFF
--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -79,7 +79,6 @@ class PlaybackInfo {
     }
   }
 
-  var justLaunched: Bool = true
   var justStartedFile: Bool = false
   var justOpenedFile: Bool = false
   var shouldAutoLoadFiles: Bool = false

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1423,12 +1423,8 @@ class PlayerCore: NSObject {
         miniPlayer.defaultAlbumArt.isHidden = self.info.vid != 0
       }
     }
-    // set initial properties for the first file
-    if info.justLaunched {
-      if Preference.bool(for: .fullScreenWhenOpen) && !mainWindow.fsState.isFullscreen && !isInMiniPlayer {
-        DispatchQueue.main.async(execute: self.mainWindow.toggleWindowFullScreen)
-      }
-      info.justLaunched = false
+    if Preference.bool(for: .fullScreenWhenOpen) && !mainWindow.fsState.isFullscreen && !isInMiniPlayer {
+      DispatchQueue.main.async(execute: self.mainWindow.toggleWindowFullScreen)
     }
     // add to history
     if let url = info.currentURL {


### PR DESCRIPTION
This commit will:
- Remove a check in `PlayerCore.fileLoaded` that only put the player into full screen mode for the first file
- Remove the property `justLaunched` from `PlaybackInfo`

This causes the "Enter fullscreen" setting under the "When media is opened" settings to when enabled put the player into full screen mode for all videos, not just the first video played.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4202.

---

**Description:**
