### PR TITLE
Fix IINA sometimes takes a few seconds to quit #4227

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1723,12 +1723,14 @@ class PlayerCore: NSObject {
   func errorOpeningFileAndCloseMainWindow() {
     DispatchQueue.main.async {
       Utility.showAlert("error_open")
+      self.isStopped = true
       self.mainWindow.close()
     }
   }
 
   func closeMainWindow() {
     DispatchQueue.main.async {
+      self.isStopped = true
       self.mainWindow.close()
     }
   }


### PR DESCRIPTION
This commit will change the PlayerCore methods closeMainWindow and errorOpeningFileAndCloseMainWindow to set the isStopped property to true. These methods are called by MPVController when the mpv property idle-active changes to true. This marks idle payers as stopped so that the applicationShouldTerminate method in AppDelegate will detect they are stopped and can be shutdown.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4227.

---

**Description:**
