### PR TITLE
Improve reliability of click detection in player window by adding minimum threshold for drag

### DIFF
--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -35,15 +35,9 @@ func - (lhs: NSPoint, rhs: NSPoint) -> NSPoint {
 }
 
 extension CGPoint {
-  // This is Pythagoras's theorem to calculate the distance between two points,
-  // but omitting the square root at the end, which is an expensive operation.
-  // If doing a comparison with another number, it's more efficient to just square the other number.
-  func distanceSquared(to: CGPoint) -> CGFloat {
-    return (self.x - to.x) * (self.x - to.x) + (self.y - to.y) * (self.y - to.y)
-  }
-
-  func isWithinRadius(radius: CGFloat, ofPoint otherPoint: CGPoint) -> Bool {
-    return self.distanceSquared(to: otherPoint) <= (radius * radius)
+  // Uses Pythagorean theorem to calculate the distance between two points
+  func distance(to: CGPoint) -> CGFloat {
+    return sqrt(pow(self.x - to.x, 2) + pow(self.y - to.y, 2))
   }
 }
 

--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -34,6 +34,19 @@ func - (lhs: NSPoint, rhs: NSPoint) -> NSPoint {
   return NSMakePoint(lhs.x - rhs.x, lhs.y - rhs.y)
 }
 
+extension CGPoint {
+  // This is Pythagoras's theorem to calculate the distance between two points,
+  // but omitting the square root at the end, which is an expensive operation.
+  // If doing a comparison with another number, it's more efficient to just square the other number.
+  func distanceSquared(to: CGPoint) -> CGFloat {
+    return (self.x - to.x) * (self.x - to.x) + (self.y - to.y) * (self.y - to.y)
+  }
+
+  func isWithinRadius(radius: CGFloat, ofPoint otherPoint: CGPoint) -> Bool {
+    return self.distanceSquared(to: otherPoint) < (radius * radius)
+  }
+}
+
 extension NSSize {
 
   var aspect: CGFloat {

--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -43,7 +43,7 @@ extension CGPoint {
   }
 
   func isWithinRadius(radius: CGFloat, ofPoint otherPoint: CGPoint) -> Bool {
-    return self.distanceSquared(to: otherPoint) < (radius * radius)
+    return self.distanceSquared(to: otherPoint) <= (radius * radius)
   }
 }
 

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -50,7 +50,7 @@ fileprivate extension NSStackView.VisibilityPriority {
 }
 
 // The minimum distance that the user must drag before their click or tap gesture is interpreted as a drag gesture:
-fileprivate let minimumInitialDragDistance: CGFloat = 4.0
+fileprivate let minimumInitialDragDistance: CGFloat = 3.0
 
 class MainWindowController: PlayerWindowController {
 
@@ -843,7 +843,7 @@ class MainWindowController: PlayerWindowController {
 
   override func mouseDown(with event: NSEvent) {
     if Logger.enabled && Logger.Level.preferred >= .verbose {
-      Logger.log("MainWindow mouseDown \(event.locationInWindow)", level: .verbose, subsystem: player.subsystem)
+      Logger.log("MainWindow mouseDown @ \(event.locationInWindow)", level: .verbose, subsystem: player.subsystem)
     }
     // do nothing if it's related to floating OSC
     guard !controlBarFloating.isDragging else { return }
@@ -859,9 +859,6 @@ class MainWindowController: PlayerWindowController {
   }
 
   override func mouseDragged(with event: NSEvent) {
-    if Logger.enabled && Logger.Level.preferred >= .verbose {
-      Logger.log("MainWindow mouseDrag \(event.locationInWindow)", level: .verbose, subsystem: player.subsystem)
-    }
     if isResizingSidebar {
       // resize sidebar
       let currentLocation = event.locationInWindow
@@ -872,16 +869,15 @@ class MainWindowController: PlayerWindowController {
 
       if let mousePosRelatedToWindow = mousePosRelatedToWindow {
         if !isDragging {
-          // Require that the user must drag the cursor at least a small distance for it to start a "drag" (`isDragging==true`)
-          // The user's action will only be counted as a click if `isDragging==false` when `mouseUp` is called.
-          // (Apple's trackpad in particular is very sensitive and tends to call `mouseDragged()` if there is even the slightest
-          // roll of the finger during a click, and the distance of the "drag" may be less than 1 pixel)
-          if mousePosRelatedToWindow.isWithinRadius(radius: minimumInitialDragDistance,
-                                                    ofPoint: event.locationInWindow) {
+          /// Require that the user must drag the cursor at least a small distance for it to start a "drag" (`isDragging==true`)
+          /// The user's action will only be counted as a click if `isDragging==false` when `mouseUp` is called.
+          /// (Apple's trackpad in particular is very sensitive and tends to call `mouseDragged()` if there is even the slightest
+          /// roll of the finger during a click, and the distance of the "drag" may be less than `minimumInitialDragDistance`)
+          if mousePosRelatedToWindow.distance(to: event.locationInWindow) <= minimumInitialDragDistance {
             return
           }
           if Logger.enabled && Logger.Level.preferred >= .verbose {
-            Logger.log("MainWindow mouseDrag: minimum dragging distance was met!", level: .verbose, subsystem: player.subsystem)
+            Logger.log("MainWindow mouseDrag: minimum dragging distance was met", level: .verbose, subsystem: player.subsystem)
           }
           isDragging = true
         }
@@ -892,7 +888,8 @@ class MainWindowController: PlayerWindowController {
 
   override func mouseUp(with event: NSEvent) {
     if Logger.enabled && Logger.Level.preferred >= .verbose {
-      Logger.log("MainWindow mouseUp! isDragging: \(isDragging), isResizingSidebar: \(isResizingSidebar), clickCount: \(event.clickCount)", level: .verbose, subsystem: player.subsystem)
+      Logger.log("MainWindow mouseUp @ \(event.locationInWindow), isDragging: \(isDragging), isResizingSidebar: \(isResizingSidebar), clickCount: \(event.clickCount)",
+                 level: .verbose, subsystem: player.subsystem)
     }
 
     mousePosRelatedToWindow = nil

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -50,7 +50,7 @@ fileprivate extension NSStackView.VisibilityPriority {
 }
 
 // The minimum distance that the user must drag before their click or tap gesture is interpreted as a drag gesture:
-fileprivate let minimumInitialDragDistance: CGFloat = 2.0
+fileprivate let minimumInitialDragDistance: CGFloat = 4.0
 
 class MainWindowController: PlayerWindowController {
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4231.

---

**Description:**

This updates the click detection in `MainWindowController` and adds a requirement that after mouseDown the user must drag the cursor at least 2pts distance for drag to start.

A given `mouseDown`/`mouseUp` pair is processed as either a click or a drag, but not both. The out-of-the-box behavior in Cocoa is unfortunately not very useful to take on its own: the `mouseDragged` callback is called with very high sensitivity (particularly with trackpad actions); `mouseDragged` will get called for drag distances of just a fraction of a pixel. This is both not very useful as a an actual drag distance, and actively harmful because it results in clicks/taps appearing to be ignored from the user's standpoint.

After some testing and tweaking, I concluded that a drag start threshold requirement of 2pts is all that's needed to ensure that clicks are registered reliably *and* there is no noticeable burden on actual drag attempts. Note that 2pts is all that's needed to *start* the drag, so if the user's goal is to move their player window by only 1pt, they will have to first drag it by 2 pts to register the drag, then drag it back by 1 pt to position it. I believe this behavior is similar to how CAD & layout software usually works, but as a video player it's expected to be very rare that any user will be making such fine adjustments anyway.