### PR TITLE
Close support subtitle visibility, #4235

### DIFF
--- a/iina/AppData.swift
+++ b/iina/AppData.swift
@@ -145,4 +145,6 @@ extension Notification.Name {
   static let iinaPlayerShutdown = Notification.Name("iinaPlayerShutdown")
   static let iinaPlaySliderLoopKnobChanged = Notification.Name("iinaPlaySliderLoopKnobChanged")
   static let iinaLogoutCompleted = Notification.Name("iinaLoggedOutOfSubtitleProvider")
+  static let iinaSecondSubVisibilityChanged = Notification.Name("iinaSecondSubVisibilityChanged")
+  static let iinaSubVisibilityChanged = Notification.Name("iinaSubVisibilityChanged")
 }

--- a/iina/AppData.swift
+++ b/iina/AppData.swift
@@ -103,6 +103,10 @@ struct Constants {
     static let hideAudioPanel = NSLocalizedString("menu.hide_audio", comment: "Hide Audio Panel")
     static let subtitlesPanel = NSLocalizedString("menu.subtitles", comment: "Show Subtitles Panel")
     static let hideSubtitlesPanel = NSLocalizedString("menu.hide_subtitles", comment: "Hide Subtitles Panel")
+    static let hideSubtitles = NSLocalizedString("menu.sub_hide", comment: "Hide Subtitles")
+    static let showSubtitles = NSLocalizedString("menu.sub_show", comment: "Show Subtitles")
+    static let hideSecondSubtitles = NSLocalizedString("menu.sub_second_hide", comment: "Hide Second Subtitles")
+    static let showSecondSubtitles = NSLocalizedString("menu.sub_second_show", comment: "Show Second Subtitles")
   }
   struct Time {
     static let infinite = VideoTime(999, 0, 0)

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -64,6 +64,8 @@
 "osd.sub_delay.later" = "Subtitle Delay: %.2fs Later";
 "osd.sub_delay.earlier" = "Subtitle Delay: %.2fs Earlier";
 "osd.subtitle_pos" = "Subtitle Position: %.1f";
+"osd.sub_visibility" = "Subtitle Visibility: %@";
+"osd.sub_second_visibility" = "Second Subtitle Visibility: %@";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
 "osd.screenshot" = "Screenshot Captured";
@@ -127,6 +129,10 @@
 "menu.volume_muted" = "Volume: %d (Muted)";
 "menu.audio_delay" = "Audio Delay: %.2fs";
 "menu.sub_delay" = "Subtitle Delay: %.2fs";
+"menu.sub_hide" = "Hide Subtitles";
+"menu.sub_show" = "Show Subtitles";
+"menu.sub_second_hide" = "Hide Second Subtitles";
+"menu.sub_second_show" = "Show Second Subtitles";
 "menu.fullscreen" = "Enter Full Screen";
 "menu.exit_fullscreen" = "Exit Full Screen";
 "menu.pip" = "Enter Picture-in-Picture";

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -64,8 +64,10 @@
 "osd.sub_delay.later" = "Subtitle Delay: %.2fs Later";
 "osd.sub_delay.earlier" = "Subtitle Delay: %.2fs Earlier";
 "osd.subtitle_pos" = "Subtitle Position: %.1f";
-"osd.sub_visibility" = "Subtitle Visibility: %@";
-"osd.sub_second_visibility" = "Second Subtitle Visibility: %@";
+"osd.sub_hidden" = "Subtitles Hidden";
+"osd.sub_visible" = "Subtitles Visible";
+"osd.sub_second_hidden" = "Second Subtitles Hidden";
+"osd.sub_second_visible" = "Second Subtitles Visible";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
 "osd.screenshot" = "Screenshot Captured";

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -46,6 +46,7 @@
 "quicksetting.hwdec" = "Hardware Decoding";
 "quicksetting.deinterlace" = "Deinterlace";
 "quicksetting.hdr" = "HDR";
+"quicksetting.hide" = "Hide";
 
 // OSDMessage.swift
 "osd.pause" = "Pause";

--- a/iina/Base.lproj/MainMenu.xib
+++ b/iina/Base.lproj/MainMenu.xib
@@ -531,6 +531,9 @@ CA
                                     </items>
                                 </menu>
                             </menuItem>
+                            <menuItem title="Hide Subtitles" id="smo-rw-rg7" userLabel="Hide Subtitles">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                            </menuItem>
                             <menuItem title="Second Subtitle" id="mGw-jm-5x2">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Second Subtitle" systemMenu="font" id="UwY-P2-Xdb">
@@ -543,6 +546,9 @@ CA
                                         </menuItem>
                                     </items>
                                 </menu>
+                            </menuItem>
+                            <menuItem title="Hide Second Subtitles" id="BOm-ia-wOV">
+                                <modifierMask key="keyEquivalentModifierMask"/>
                             </menuItem>
                             <menuItem title="Load External Subtitle…" id="k6x-hf-ATi">
                                 <modifierMask key="keyEquivalentModifierMask"/>
@@ -727,6 +733,8 @@ CA
                 <outlet property="fullScreen" destination="6Eq-ni-6hG" id="y11-Q1-drn"/>
                 <outlet property="gotoScreenshotFolder" destination="lj0-Oo-7nB" id="Jlj-kX-fv0"/>
                 <outlet property="halfSize" destination="snW-S8-Cw5" id="PDi-lV-6HL"/>
+                <outlet property="hideSecondSubtitles" destination="BOm-ia-wOV" id="iKO-xG-GWA"/>
+                <outlet property="hideSubtitles" destination="smo-rw-rg7" id="LQB-s7-8Yy"/>
                 <outlet property="increaseAudioDelay" destination="4ae-MT-2L1" id="nsv-LC-B9o"/>
                 <outlet property="increaseAudioDelaySlightly" destination="lew-3S-oGY" id="Fo9-t3-WFI"/>
                 <outlet property="increaseSubDelay" destination="pAo-L5-qTO" id="55m-ex-for"/>

--- a/iina/Base.lproj/QuickSettingViewController.xib
+++ b/iina/Base.lproj/QuickSettingViewController.xib
@@ -37,6 +37,7 @@
                 <outlet property="gammaSlider" destination="fLl-8b-pj0" id="jEi-R0-6G0"/>
                 <outlet property="hardwareDecodingSwitch" destination="7z5-cT-Huj" id="lHA-DF-UM7"/>
                 <outlet property="hdrSwitch" destination="U8P-fW-N3q" id="VUC-bd-g4X"/>
+                <outlet property="hideSwitch" destination="9f0-0q-rg2" id="tTx-Gl-HNL"/>
                 <outlet property="hueSlider" destination="mKB-Mu-l5Y" id="vy8-lj-ko8"/>
                 <outlet property="pluginContentContainerView" destination="GeS-T1-vtB" id="a96-Mh-BMb"/>
                 <outlet property="pluginTabsScrollView" destination="dfw-cq-GHm" id="3z0-CB-HKn"/>
@@ -44,6 +45,7 @@
                 <outlet property="pluginTabsViewHeightConstraint" destination="ZRN-u2-VBd" id="wWC-3x-wNe"/>
                 <outlet property="rotateSegment" destination="bza-SA-tXE" id="Sdw-vn-MUV"/>
                 <outlet property="saturationSlider" destination="VlS-Jo-4C0" id="rJV-p9-OVz"/>
+                <outlet property="secHideSwitch" destination="Ji9-kR-VBA" id="YnG-5d-WVd"/>
                 <outlet property="secSubTableView" destination="Jve-qX-Agy" id="0ia-bh-sbu"/>
                 <outlet property="speedSlider" destination="UWh-M9-5Nw" id="UXr-dD-8K1"/>
                 <outlet property="speedSlider0_25xLabel" destination="Nhb-Co-xbZ" id="16j-wm-Ajt"/>
@@ -84,13 +86,13 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY" customClass="QuickSettingView" customModule="IINA" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="367" height="912"/>
+            <rect key="frame" x="0.0" y="0.0" width="360" height="912"/>
             <subviews>
                 <stackView distribution="fillEqually" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="200" verticalStackHuggingPriority="250" horizontalHuggingPriority="200" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dNi-Ib-2vd" userLabel="TabButtons Stack View">
-                    <rect key="frame" x="20" y="864" width="327" height="48"/>
+                    <rect key="frame" x="20" y="864" width="320" height="48"/>
                     <subviews>
                         <button imageHugsTitle="YES" horizontalHuggingPriority="252" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ma8-6g-tVw" userLabel="VideoTab Button">
-                            <rect key="frame" x="0.0" y="0.0" width="104" height="48"/>
+                            <rect key="frame" x="0.0" y="0.0" width="101" height="48"/>
                             <buttonCell key="cell" type="square" title="VIDEO" bezelStyle="shadowlessSquare" image="tab_video" imagePosition="leading" alignment="center" imageScaling="proportionallyDown" inset="2" id="lQt-I0-jHO">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="systemBold"/>
@@ -100,7 +102,7 @@
                             </connections>
                         </button>
                         <button tag="1" imageHugsTitle="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3Fk-ey-FhK" userLabel="AudioTab Buttom">
-                            <rect key="frame" x="112" y="0.0" width="103" height="48"/>
+                            <rect key="frame" x="109" y="0.0" width="100" height="48"/>
                             <buttonCell key="cell" type="square" title="AUDIO" bezelStyle="shadowlessSquare" image="tab_audio" imagePosition="leading" alignment="center" imageScaling="proportionallyDown" inset="2" id="cpm-5o-a2c">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="systemBold"/>
@@ -110,7 +112,7 @@
                             </connections>
                         </button>
                         <button tag="2" imageHugsTitle="YES" horizontalHuggingPriority="253" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="rH3-pU-mFc" userLabel="SubtitlesTab Button">
-                            <rect key="frame" x="223" y="0.0" width="104" height="48"/>
+                            <rect key="frame" x="217" y="0.0" width="103" height="48"/>
                             <buttonCell key="cell" type="square" title="SUBTITLES" bezelStyle="shadowlessSquare" image="tab_sub" imagePosition="leading" alignment="center" imageScaling="proportionallyDown" inset="2" id="NxO-to-jcI">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="systemBold"/>
@@ -141,19 +143,19 @@
                     </customSpacing>
                 </stackView>
                 <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="L78-cf-BxB" userLabel="BelowTabButtons Horizontal Line">
-                    <rect key="frame" x="0.0" y="861" width="367" height="5"/>
+                    <rect key="frame" x="0.0" y="861" width="360" height="5"/>
                 </box>
                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="iNg-R1-bXw" userLabel="PluginTabs View">
-                    <rect key="frame" x="0.0" y="827" width="367" height="36"/>
+                    <rect key="frame" x="0.0" y="827" width="360" height="36"/>
                     <subviews>
                         <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="dfw-cq-GHm" userLabel="PluginsTabs Scroll View">
-                            <rect key="frame" x="0.0" y="1" width="367" height="35"/>
+                            <rect key="frame" x="0.0" y="1" width="360" height="35"/>
                             <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="Q9c-dH-CRI" userLabel="PluginsTabs Clip View">
-                                <rect key="frame" x="0.0" y="0.0" width="367" height="35"/>
+                                <rect key="frame" x="0.0" y="0.0" width="360" height="35"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <view id="PF8-CN-LtV">
-                                        <rect key="frame" x="0.0" y="0.0" width="352" height="20"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="345" height="20"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     </view>
                                 </subviews>
@@ -169,7 +171,7 @@
                             </scroller>
                         </scrollView>
                         <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="Uvg-kn-ZiM" userLabel="BelowPluginsTabs Horizontal Line">
-                            <rect key="frame" x="0.0" y="-2" width="367" height="5"/>
+                            <rect key="frame" x="0.0" y="-2" width="360" height="5"/>
                         </box>
                     </subviews>
                     <constraints>
@@ -184,7 +186,7 @@
                     </constraints>
                 </customView>
                 <tabView drawsBackground="NO" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="udA-m2-eJb" userLabel="AllTabs Tab View">
-                    <rect key="frame" x="0.0" y="0.0" width="367" height="827"/>
+                    <rect key="frame" x="0.0" y="0.0" width="360" height="827"/>
                     <font key="font" metaFont="system"/>
                     <tabViewItems>
                         <tabViewItem label="Video" identifier="1" id="CYP-el-A6A" userLabel="VideoTab Tab View Item">
@@ -1584,32 +1586,32 @@
                         </tabViewItem>
                         <tabViewItem label="Subtitle" identifier="" id="jND-MZ-sKB" userLabel="SubtitlesTab Tab View Item">
                             <view key="view" id="MrM-2b-7ob" userLabel="SubtitlesTab View">
-                                <rect key="frame" x="0.0" y="0.0" width="360" height="829"/>
+                                <rect key="frame" x="0.0" y="0.0" width="360" height="827"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3kA-IY-poi" userLabel="SubtitlesTab Scroll View">
-                                        <rect key="frame" x="0.0" y="0.0" width="360" height="829"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="360" height="827"/>
                                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="epy-wp-Ja5" userLabel="SubtitlesTab Clip View">
-                                            <rect key="frame" x="0.0" y="0.0" width="360" height="829"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="360" height="827"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="pm4-x9-WJ5" userLabel="SubtitlesTab Flipped CONTENT VIEW" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="-1" width="360" height="830"/>
+                                                    <rect key="frame" x="0.0" y="-11" width="360" height="838"/>
                                                     <subviews>
                                                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="PJb-5N-8QM" userLabel="PANEL EDGE INSETS">
-                                                            <rect key="frame" x="20" y="830" width="320" height="0.0"/>
+                                                            <rect key="frame" x="20" y="838" width="320" height="0.0"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" id="jai-Pg-hCw"/>
                                                             </constraints>
                                                         </customView>
                                                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Wuf-PX-OYd" userLabel="SubBasicSection Container View">
-                                                            <rect key="frame" x="0.0" y="426" width="360" height="404"/>
+                                                            <rect key="frame" x="0.0" y="426" width="360" height="412"/>
                                                             <subviews>
                                                                 <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Fq-4o-8Hh" userLabel="SubTable Scroll View">
-                                                                    <rect key="frame" x="0.0" y="285" width="360" height="75"/>
+                                                                    <rect key="frame" x="0.0" y="289" width="360" height="75"/>
                                                                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="dJV-R0-O3M" userLabel="SubTable Clip View">
                                                                         <rect key="frame" x="0.0" y="0.0" width="360" height="75"/>
-                                                                        <autoresizingMask key="autoresizingMask"/>
+                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
                                                                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="2vU-hm-gGB" userLabel="SubTable Table View">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="360" height="75"/>
@@ -1765,7 +1767,7 @@
                                                                     <rect key="frame" x="0.0" y="166" width="360" height="75"/>
                                                                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="EKn-MX-Fao" userLabel="SecondarySub Clip View">
                                                                         <rect key="frame" x="0.0" y="0.0" width="360" height="75"/>
-                                                                        <autoresizingMask key="autoresizingMask"/>
+                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
                                                                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="Jve-qX-Agy" userLabel="SecondarySub Table View">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="360" height="75"/>
@@ -1918,7 +1920,7 @@
                                                                     </scroller>
                                                                 </scrollView>
                                                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mYH-DV-e4F" userLabel="Subtitle">
-                                                                    <rect key="frame" x="18" y="368" width="324" height="16"/>
+                                                                    <rect key="frame" x="18" y="376" width="60" height="16"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Subtitle:" id="eXZ-HN-qL4">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1926,7 +1928,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3xe-mv-ORw" userLabel="Secondary subtitle">
-                                                                    <rect key="frame" x="18" y="249" width="324" height="16"/>
+                                                                    <rect key="frame" x="18" y="253" width="131" height="16"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Secondary subtitle:" id="bKb-pW-HnS">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -2044,12 +2046,25 @@
                                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                                     </textFieldCell>
                                                                 </textField>
+                                                                <switch horizontalHuggingPriority="750" verticalHuggingPriority="750" baseWritingDirection="leftToRight" alignment="left" translatesAutoresizingMaskIntoConstraints="NO" id="9f0-0q-rg2">
+                                                                    <rect key="frame" x="300" y="371" width="42" height="25"/>
+                                                                    <connections>
+                                                                        <action selector="hideSubAction:" target="-2" id="I9P-h7-1Vv"/>
+                                                                    </connections>
+                                                                </switch>
+                                                                <switch horizontalHuggingPriority="750" verticalHuggingPriority="750" baseWritingDirection="leftToRight" alignment="left" translatesAutoresizingMaskIntoConstraints="NO" id="Ji9-kR-VBA">
+                                                                    <rect key="frame" x="300" y="248" width="42" height="25"/>
+                                                                    <connections>
+                                                                        <action selector="hideSecSubAction:" target="-2" id="QOg-07-Szj"/>
+                                                                    </connections>
+                                                                </switch>
                                                             </subviews>
                                                             <constraints>
                                                                 <constraint firstAttribute="trailing" secondItem="LMp-7Y-Rxg" secondAttribute="trailing" id="0Gl-lc-Bm7"/>
                                                                 <constraint firstAttribute="trailing" secondItem="1Fq-4o-8Hh" secondAttribute="trailing" id="1hL-1o-nGN"/>
                                                                 <constraint firstItem="zQu-u6-goi" firstAttribute="top" secondItem="M2U-rq-X2L" secondAttribute="bottom" constant="8" id="26L-W9-3iG"/>
                                                                 <constraint firstItem="kzp-GR-Sy4" firstAttribute="centerX" secondItem="dXz-x4-sm5" secondAttribute="centerX" id="33J-Xb-Xbh"/>
+                                                                <constraint firstItem="9f0-0q-rg2" firstAttribute="centerY" secondItem="mYH-DV-e4F" secondAttribute="centerY" id="6px-Sx-9dj"/>
                                                                 <constraint firstItem="VdJ-nq-zaM" firstAttribute="centerX" secondItem="dXz-x4-sm5" secondAttribute="leading" priority="800" constant="120" id="7t1-v0-J55"/>
                                                                 <constraint firstItem="r77-VA-Z1b" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="kzp-GR-Sy4" secondAttribute="trailing" id="8Vz-fK-wJu"/>
                                                                 <constraint firstItem="kzp-GR-Sy4" firstAttribute="top" secondItem="dXz-x4-sm5" secondAttribute="bottom" constant="1" id="9mp-6s-MHB"/>
@@ -2060,7 +2075,9 @@
                                                                 <constraint firstItem="dXz-x4-sm5" firstAttribute="top" secondItem="VdJ-nq-zaM" secondAttribute="bottom" constant="1" id="Fdp-D4-VPU"/>
                                                                 <constraint firstItem="3xe-mv-ORw" firstAttribute="top" secondItem="1Fq-4o-8Hh" secondAttribute="bottom" constant="20" id="I4y-iB-fWM"/>
                                                                 <constraint firstItem="mYH-DV-e4F" firstAttribute="top" secondItem="Wuf-PX-OYd" secondAttribute="top" constant="20" id="Izb-ki-XeU"/>
+                                                                <constraint firstItem="Ji9-kR-VBA" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="3xe-mv-ORw" secondAttribute="trailing" constant="8" id="L0n-h9-nNd"/>
                                                                 <constraint firstItem="eOz-bB-vzM" firstAttribute="leading" secondItem="dXz-x4-sm5" secondAttribute="trailing" constant="8" id="LTf-pu-8fz"/>
+                                                                <constraint firstItem="Ji9-kR-VBA" firstAttribute="centerY" secondItem="3xe-mv-ORw" secondAttribute="centerY" id="MFX-GK-WcM"/>
                                                                 <constraint firstItem="LMp-7Y-Rxg" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" id="O1s-aJ-7eK"/>
                                                                 <constraint firstItem="VbE-TV-lb5" firstAttribute="leading" secondItem="dXz-x4-sm5" secondAttribute="leading" id="Q0F-ty-AhB"/>
                                                                 <constraint firstAttribute="bottom" secondItem="kzp-GR-Sy4" secondAttribute="bottom" constant="20" id="Thn-5Q-9b9"/>
@@ -2068,14 +2085,15 @@
                                                                 <constraint firstItem="kzp-GR-Sy4" firstAttribute="firstBaseline" secondItem="VbE-TV-lb5" secondAttribute="firstBaseline" id="ZeT-rD-nRd"/>
                                                                 <constraint firstItem="1Fq-4o-8Hh" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" id="eCR-6x-gEL"/>
                                                                 <constraint firstItem="r77-VA-Z1b" firstAttribute="firstBaseline" secondItem="VbE-TV-lb5" secondAttribute="firstBaseline" id="fRc-yO-K49"/>
-                                                                <constraint firstItem="1Fq-4o-8Hh" firstAttribute="top" secondItem="mYH-DV-e4F" secondAttribute="bottom" constant="8" id="hl3-X4-nod"/>
+                                                                <constraint firstItem="9f0-0q-rg2" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="mYH-DV-e4F" secondAttribute="trailing" constant="8" id="hl1-vl-yic"/>
+                                                                <constraint firstItem="1Fq-4o-8Hh" firstAttribute="top" secondItem="mYH-DV-e4F" secondAttribute="bottom" constant="12" id="hl3-X4-nod"/>
                                                                 <constraint firstItem="cOv-Yl-KdH" firstAttribute="top" secondItem="zQu-u6-goi" secondAttribute="bottom" constant="20" id="jYB-bh-14P"/>
                                                                 <constraint firstItem="r77-VA-Z1b" firstAttribute="trailing" secondItem="dXz-x4-sm5" secondAttribute="trailing" id="kSN-80-IMR"/>
                                                                 <constraint firstItem="YIE-pv-gCK" firstAttribute="centerY" secondItem="zQu-u6-goi" secondAttribute="centerY" id="lUf-kQ-zMz"/>
                                                                 <constraint firstItem="kzp-GR-Sy4" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="VbE-TV-lb5" secondAttribute="trailing" id="llG-p4-ckS"/>
                                                                 <constraint firstItem="eOz-bB-vzM" firstAttribute="centerY" secondItem="dXz-x4-sm5" secondAttribute="centerY" id="rgl-9k-oY7"/>
                                                                 <constraint firstItem="4U2-kT-76O" firstAttribute="leading" secondItem="eOz-bB-vzM" secondAttribute="trailing" id="rnJ-T0-g1e"/>
-                                                                <constraint firstItem="LMp-7Y-Rxg" firstAttribute="top" secondItem="3xe-mv-ORw" secondAttribute="bottom" constant="8" id="uj7-Lc-oLk"/>
+                                                                <constraint firstItem="LMp-7Y-Rxg" firstAttribute="top" secondItem="3xe-mv-ORw" secondAttribute="bottom" constant="12" id="uj7-Lc-oLk"/>
                                                             </constraints>
                                                         </customView>
                                                         <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="jRc-VZ-Vv2">
@@ -2324,7 +2342,7 @@
                                                                     </constraints>
                                                                 </customView>
                                                                 <button translatesAutoresizingMaskIntoConstraints="NO" id="8ZC-Wx-nt7">
-                                                                    <rect key="frame" x="324" y="338.5" width="16" height="21"/>
+                                                                    <rect key="frame" x="324" y="338" width="16" height="21"/>
                                                                     <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRefreshFreestandingTemplate" imagePosition="only" alignment="center" controlSize="small" imageScaling="proportionallyUpOrDown" inset="2" id="ojj-5V-n3t">
                                                                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                                         <font key="font" metaFont="message" size="11"/>
@@ -2375,6 +2393,7 @@
                                                         <constraint firstItem="Wuf-PX-OYd" firstAttribute="top" secondItem="pm4-x9-WJ5" secondAttribute="top" id="Asb-va-Eiv"/>
                                                         <constraint firstItem="PJb-5N-8QM" firstAttribute="leading" secondItem="pm4-x9-WJ5" secondAttribute="leading" constant="20" id="BQV-10-Aft"/>
                                                         <constraint firstAttribute="trailing" secondItem="jRc-VZ-Vv2" secondAttribute="trailing" id="Bgp-ag-XCb"/>
+                                                        <constraint firstItem="9f0-0q-rg2" firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="E3K-iB-zmF"/>
                                                         <constraint firstItem="XwE-7y-DXJ" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="E6E-nw-l3T"/>
                                                         <constraint firstItem="3xe-mv-ORw" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="EM8-9Q-Yhw"/>
                                                         <constraint firstItem="Lkf-Yn-nsR" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="FiQ-Xm-8Ps"/>
@@ -2382,15 +2401,14 @@
                                                         <constraint firstItem="M2U-rq-X2L" firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="H2R-H8-0CG"/>
                                                         <constraint firstItem="lzW-d6-Asr" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="HCm-yU-vu2"/>
                                                         <constraint firstItem="Wuf-PX-OYd" firstAttribute="leading" secondItem="pm4-x9-WJ5" secondAttribute="leading" id="Hee-mM-GuU"/>
-                                                        <constraint firstItem="mYH-DV-e4F" firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="Iqu-ZF-4f5"/>
                                                         <constraint firstAttribute="bottom" secondItem="gSw-NK-ZU6" secondAttribute="bottom" id="Jmq-0f-8aF"/>
                                                         <constraint firstAttribute="trailing" secondItem="gSw-NK-ZU6" secondAttribute="trailing" id="K60-XN-ktT"/>
                                                         <constraint firstItem="9xm-5m-Q7G" firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="Kib-uN-23k"/>
                                                         <constraint firstAttribute="trailing" secondItem="Wuf-PX-OYd" secondAttribute="trailing" id="NTd-uf-my8"/>
+                                                        <constraint firstItem="Ji9-kR-VBA" firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="RAY-i7-3Pp"/>
                                                         <constraint firstItem="ipr-WR-eax" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="STy-a7-NgJ"/>
                                                         <constraint firstItem="YIE-pv-gCK" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="SXw-h1-5CU"/>
                                                         <constraint firstItem="4U2-kT-76O" firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="Ve3-JU-eQO"/>
-                                                        <constraint firstItem="3xe-mv-ORw" firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="WC8-9a-fa5"/>
                                                         <constraint firstItem="jRc-VZ-Vv2" firstAttribute="leading" secondItem="pm4-x9-WJ5" secondAttribute="leading" id="XLU-g4-EAb"/>
                                                         <constraint firstItem="mYH-DV-e4F" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="aMT-hN-hi6"/>
                                                         <constraint firstItem="dXz-x4-sm5" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="ant-fM-6lp"/>
@@ -2422,8 +2440,8 @@
                                             <rect key="frame" x="-100" y="-100" width="360" height="16"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
-                                        <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="3ZS-ug-kkq">
-                                            <rect key="frame" x="344" y="0.0" width="16" height="829"/>
+                                        <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="0.090909090909090939" horizontal="NO" id="3ZS-ug-kkq">
+                                            <rect key="frame" x="344" y="0.0" width="16" height="827"/>
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                     </scrollView>

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -1233,17 +1233,15 @@ not applying FFmpeg 9599 workaround
 
     case MPVOption.Subtitles.subVisibility:
       if let visible = UnsafePointer<Bool>(OpaquePointer(property.data))?.pointee {
-        if player.info.isSubVisible != visible {
-          player.info.isSubVisible = visible
-          player.sendOSD(visible ? .subVisible : .subHidden)
+        DispatchQueue.main.async {
+          self.player.subVisibilityChanged(visible)
         }
       }
 
     case MPVOption.Subtitles.secondarySubVisibility:
       if let visible = UnsafePointer<Bool>(OpaquePointer(property.data))?.pointee {
-        if player.info.isSecondSubVisible != visible {
-          player.info.isSecondSubVisible = visible
-          player.sendOSD(visible ? .secondSubVisible : .secondSubHidden)
+        DispatchQueue.main.async {
+          self.player.secondSubVisibilityChanged(visible)
         }
       }
 

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -1235,7 +1235,7 @@ not applying FFmpeg 9599 workaround
       if let visible = UnsafePointer<Bool>(OpaquePointer(property.data))?.pointee {
         if player.info.isSubVisible != visible {
           player.info.isSubVisible = visible
-          player.sendOSD(.subVisible(visible))
+          player.sendOSD(visible ? .subVisible : .subHidden)
         }
       }
 
@@ -1243,7 +1243,7 @@ not applying FFmpeg 9599 workaround
       if let visible = UnsafePointer<Bool>(OpaquePointer(property.data))?.pointee {
         if player.info.isSecondSubVisible != visible {
           player.info.isSecondSubVisible = visible
-          player.sendOSD(.secondSubVisible(visible))
+          player.sendOSD(visible ? .secondSubVisible : .secondSubHidden)
         }
       }
 

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -340,6 +340,14 @@ extension MainMenuActionHandler {
     }
   }
 
+  @objc func menuToggleSubVisibility(_ sender: NSMenuItem) {
+    player.toggleSubVisibility()
+  }
+
+  @objc func menuToggleSecondSubVisibility(_ sender: NSMenuItem) {
+    player.toggleSecondSubVisibility()
+  }
+
   @objc func menuChangeSubDelay(_ sender: NSMenuItem) {
     if let delayDelta = sender.representedObject as? Double {
       let newDelay = player.info.subDelay + delayDelta

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -172,6 +172,8 @@ class MenuController: NSObject, NSMenuDelegate {
   // Subtitle
   @IBOutlet weak var subMenu: NSMenu!
   @IBOutlet weak var quickSettingsSub: NSMenuItem!
+  @IBOutlet weak var hideSubtitles: NSMenuItem!
+  @IBOutlet weak var hideSecondSubtitles: NSMenuItem!
   @IBOutlet weak var cycleSubtitles: NSMenuItem!
   @IBOutlet weak var subTrackMenu: NSMenu!
   @IBOutlet weak var secondSubTrackMenu: NSMenu!
@@ -374,6 +376,8 @@ class MenuController: NSObject, NSMenuDelegate {
     quickSettingsSub.action = #selector(MainWindowController.menuShowSubQuickSettings(_:))
     loadExternalSub.action = #selector(MainMenuActionHandler.menuLoadExternalSub(_:))
     subTrackMenu.delegate = self
+    hideSubtitles.action = #selector(MainMenuActionHandler.menuToggleSubVisibility(_:))
+    hideSecondSubtitles.action = #selector(MainMenuActionHandler.menuToggleSecondSubVisibility(_:))
     secondSubTrackMenu.delegate = self
 
     findOnlineSub.action = #selector(MainMenuActionHandler.menuFindOnlineSub(_:))
@@ -551,6 +555,10 @@ class MenuController: NSObject, NSMenuDelegate {
           player.mainWindow.quickSettingView.currentTab == .sub
     quickSettingsSub?.title = isDisplayingSettings ? Constants.String.hideSubtitlesPanel :
         Constants.String.subtitlesPanel
+    hideSubtitles.title = player.info.isSubVisible ? Constants.String.hideSubtitles :
+        Constants.String.showSubtitles
+    hideSecondSubtitles.title = player.info.isSecondSubVisible ? Constants.String.hideSecondSubtitles :
+        Constants.String.showSecondSubtitles
     subDelayIndicator.title = String(format: NSLocalizedString("menu.sub_delay", comment: "Subtitle Delay:"), player.info.subDelay)
 
     let encodingCode = player.info.subEncoding ?? "auto"
@@ -867,6 +875,8 @@ class MenuController: NSObject, NSMenuDelegate {
       (increaseAudioDelay, false, ["add", "audio-delay", "0.5"], true, nil, "audio_delay_up"),
       (increaseAudioDelaySlightly, false, ["add", "audio-delay", "0.1"], true, nil, "audio_delay_up"),
       (resetAudioDelay, false, ["set", "audio-delay", "0"], true, nil, nil),
+      (hideSubtitles, false, ["cycle", "sub-visibility"], false, nil, nil),
+      (hideSecondSubtitles, false, ["cycle", "secondary-sub-visibility"], false, nil, nil),
       (decreaseSubDelay, false, ["add", "sub-delay", "-0.5"], true, nil, "sub_delay_down"),
       (decreaseSubDelaySlightly, false, ["add", "sub-delay", "-0.1"], true, nil, "sub_delay_down"),
       (increaseSubDelay, false, ["add", "sub-delay", "0.5"], true, nil, "sub_delay_up"),

--- a/iina/OSDMessage.swift
+++ b/iina/OSDMessage.swift
@@ -46,6 +46,8 @@ enum OSDMessage {
   case audioDelay(Double)
   case subDelay(Double)
   case subScale(Double)
+  case subVisible(Bool)
+  case secondSubVisible(Bool)
   case subPos(Double)
   case mute
   case unMute
@@ -175,6 +177,18 @@ enum OSDMessage {
       return (
         String(format: NSLocalizedString("osd.subtitle_pos", comment: "Subtitle Position: %f"), value),
         .withProgress(value / 100)
+      )
+
+    case .subVisible(let enabled):
+      return (
+        String(format: NSLocalizedString("osd.sub_visibility", comment: "Subtitle Visibility: %@"), enabled ? NSLocalizedString("general.on", comment: "On") : NSLocalizedString("general.off", comment: "Off")),
+        .normal
+      )
+
+    case .secondSubVisible(let enabled):
+      return (
+        String(format: NSLocalizedString("osd.sub_second_visibility", comment: "Second Subtitle Visibility: %@"), enabled ? NSLocalizedString("general.on", comment: "On") : NSLocalizedString("general.off", comment: "Off")),
+        .normal
       )
 
     case .mute:

--- a/iina/OSDMessage.swift
+++ b/iina/OSDMessage.swift
@@ -46,8 +46,10 @@ enum OSDMessage {
   case audioDelay(Double)
   case subDelay(Double)
   case subScale(Double)
-  case subVisible(Bool)
-  case secondSubVisible(Bool)
+  case subHidden
+  case subVisible
+  case secondSubHidden
+  case secondSubVisible
   case subPos(Double)
   case mute
   case unMute
@@ -179,17 +181,17 @@ enum OSDMessage {
         .withProgress(value / 100)
       )
 
-    case .subVisible(let enabled):
-      return (
-        String(format: NSLocalizedString("osd.sub_visibility", comment: "Subtitle Visibility: %@"), enabled ? NSLocalizedString("general.on", comment: "On") : NSLocalizedString("general.off", comment: "Off")),
-        .normal
-      )
+    case .subHidden:
+      return (NSLocalizedString("osd.sub_hidden", comment: "Subtitles Hidden"), .normal)
 
-    case .secondSubVisible(let enabled):
-      return (
-        String(format: NSLocalizedString("osd.sub_second_visibility", comment: "Second Subtitle Visibility: %@"), enabled ? NSLocalizedString("general.on", comment: "On") : NSLocalizedString("general.off", comment: "Off")),
-        .normal
-      )
+    case .subVisible:
+      return (NSLocalizedString("osd.sub_visible", comment: "Subtitles Visible"), .normal)
+
+    case .secondSubHidden:
+      return (NSLocalizedString("osd.sub_second_hidden", comment: "Second Subtitles Hidden"), .normal)
+
+    case .secondSubVisible:
+      return (NSLocalizedString("osd.sub_second_visible", comment: "Second Subtitles Visible"), .normal)
 
     case .mute:
       return (NSLocalizedString("osd.mute", comment: "Mute"), .normal)

--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -149,6 +149,9 @@ class PlaybackInfo {
   var vid: Int?
   var secondSid: Int?
 
+  var isSubVisible = true
+  var isSecondSubVisible = true
+
   var subEncoding: String?
 
   var haveDownloadedSub: Bool = false

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1130,6 +1130,14 @@ class PlayerCore: NSObject {
     }
   }
 
+  func toggleSubVisibility() {
+    mpv.setFlag(MPVOption.Subtitles.subVisibility, !info.isSubVisible)
+  }
+
+  func toggleSecondSubVisibility() {
+    mpv.setFlag(MPVOption.Subtitles.secondarySubVisibility, !info.isSecondSubVisible)
+  }
+
   func loadExternalSubFile(_ url: URL, delay: Bool = false) {
     if let track = info.subTracks.first(where: { $0.externalFilename == url.path }) {
       mpv.command(.subReload, args: [String(track.id)], checkError: false)

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1130,12 +1130,14 @@ class PlayerCore: NSObject {
     }
   }
 
-  func toggleSubVisibility() {
-    mpv.setFlag(MPVOption.Subtitles.subVisibility, !info.isSubVisible)
+  func toggleSubVisibility(_ set: Bool? = nil) {
+    let newState = set ?? !info.isSubVisible
+    mpv.setFlag(MPVOption.Subtitles.subVisibility, newState)
   }
 
-  func toggleSecondSubVisibility() {
-    mpv.setFlag(MPVOption.Subtitles.secondarySubVisibility, !info.isSecondSubVisible)
+  func toggleSecondSubVisibility(_ set: Bool? = nil) {
+    let newState = set ?? !info.isSecondSubVisible
+    mpv.setFlag(MPVOption.Subtitles.secondarySubVisibility, newState)
   }
 
   func loadExternalSubFile(_ url: URL, delay: Bool = false) {
@@ -1821,11 +1823,25 @@ class PlayerCore: NSObject {
     postNotification(.iinaSIDChanged)
   }
 
+  func secondSubVisibilityChanged(_ visible: Bool) {
+    guard info.isSecondSubVisible != visible else { return }
+    info.isSecondSubVisible = visible
+    sendOSD(visible ? .secondSubVisible : .secondSubHidden)
+    postNotification(.iinaSecondSubVisibilityChanged)
+  }
+
   func sidChanged() {
     guard !isShuttingDown, !isShutdown else { return }
     info.sid = Int(mpv.getInt(MPVOption.TrackSelection.sid))
     postNotification(.iinaSIDChanged)
     sendOSD(.track(info.currentTrack(.sub) ?? .noneSubTrack))
+  }
+
+  func subVisibilityChanged(_ visible: Bool) {
+    guard info.isSubVisible != visible else { return }
+    info.isSubVisible = visible
+    sendOSD(visible ? .subVisible : .subHidden)
+    postNotification(.iinaSubVisibilityChanged)
   }
 
   func trackListChanged() {

--- a/iina/QuickSettingViewController.swift
+++ b/iina/QuickSettingViewController.swift
@@ -140,7 +140,8 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
   @IBOutlet weak var audioDelaySliderConstraint: NSLayoutConstraint!
   @IBOutlet weak var customAudioDelayTextField: NSTextField!
 
-
+  @IBOutlet weak var hideSwitch: NSSwitch!
+  @IBOutlet weak var secHideSwitch: NSSwitch!
   @IBOutlet weak var subLoadSementedControl: NSSegmentedControl!
   @IBOutlet weak var subDelaySlider: NSSlider!
   @IBOutlet weak var subDelaySliderIndicator: NSTextField!
@@ -223,6 +224,8 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
       self.subTableView.reloadData()
       self.secSubTableView.reloadData()
     }
+    observe(.iinaSecondSubVisibilityChanged) { [unowned self] _ in secHideSwitch.state = player.info.isSecondSubVisible ? .on : .off }
+    observe(.iinaSubVisibilityChanged) { [unowned self] _ in hideSwitch.state = player.info.isSubVisible ? .on : .off }
   }
 
   // MARK: - Right to Left Constraints
@@ -384,6 +387,9 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
   }
 
   private func updateSubTabControl() {
+    hideSwitch.state = player.info.isSubVisible ? .on : .off
+    secHideSwitch.state = player.info.isSecondSubVisible ? .on : .off
+
     if let currSub = player.info.currentTrack(.sub) {
       // FIXME: CollorWells cannot be disable?
       let enableTextSettings = !(currSub.isAssSub || currSub.isImageSub)
@@ -825,6 +831,14 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
 
 
   // MARK: Sub tab
+
+  @IBAction func hideSubAction(_ sender: NSSwitch) {
+    player.toggleSubVisibility()
+  }
+
+  @IBAction func hideSecSubAction(_ sender: NSSwitch) {
+    player.toggleSecondSubVisibility()
+  }
 
   @IBAction func loadExternalSubAction(_ sender: NSSegmentedControl) {
     if sender.selectedSegment == 0 {

--- a/iina/config/iina-default-input.conf
+++ b/iina/config/iina-default-input.conf
@@ -98,6 +98,8 @@ F add sub-scale -0.1                   # decrease the subtitle font size
 r add sub-pos -1
 R add sub-pos +1
 t add sub-pos +1
+v cycle sub-visibility                 # hide or show the subtitles
+Alt+v cycle secondary-sub-visibility   # hide or show the secondary subtitles
 
 f cycle fullscreen                     # toggle fullscreen
 

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -64,6 +64,8 @@
 "osd.sub_delay.later" = "Subtitle Delay: %.2fs Later";
 "osd.sub_delay.earlier" = "Subtitle Delay: %.2fs Earlier";
 "osd.subtitle_pos" = "Subtitle Position: %.1f";
+"osd.sub_visibility" = "Subtitle Visibility: %@";
+"osd.sub_second_visibility" = "Second Subtitle Visibility: %@";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
 "osd.screenshot" = "Screenshot Captured";
@@ -127,6 +129,10 @@
 "menu.volume_muted" = "Volume: %d (Muted)";
 "menu.audio_delay" = "Audio Delay: %.2fs";
 "menu.sub_delay" = "Subtitle Delay: %.2fs";
+"menu.sub_hide" = "Hide Subtitles";
+"menu.sub_show" = "Show Subtitles";
+"menu.sub_second_hide" = "Hide Second Subtitles";
+"menu.sub_second_show" = "Show Second Subtitles";
 "menu.fullscreen" = "Enter Full Screen";
 "menu.exit_fullscreen" = "Exit Full Screen";
 "menu.pip" = "Enter Picture-in-Picture";

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -64,8 +64,10 @@
 "osd.sub_delay.later" = "Subtitle Delay: %.2fs Later";
 "osd.sub_delay.earlier" = "Subtitle Delay: %.2fs Earlier";
 "osd.subtitle_pos" = "Subtitle Position: %.1f";
-"osd.sub_visibility" = "Subtitle Visibility: %@";
-"osd.sub_second_visibility" = "Second Subtitle Visibility: %@";
+"osd.sub_hidden" = "Subtitles Hidden";
+"osd.sub_visible" = "Subtitles Visible";
+"osd.sub_second_hidden" = "Second Subtitles Hidden";
+"osd.sub_second_visible" = "Second Subtitles Visible";"osd.mute" = "Mute";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
 "osd.screenshot" = "Screenshot Captured";

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -46,6 +46,7 @@
 "quicksetting.hwdec" = "Hardware Decoding";
 "quicksetting.deinterlace" = "Deinterlace";
 "quicksetting.hdr" = "HDR";
+"quicksetting.hide" = "Hide";
 
 // OSDMessage.swift
 "osd.pause" = "Pause";


### PR DESCRIPTION
This commit will:
- Add a Hide Subtitles/Show Subtitles item to the Subtitles menu
- Add a Hide Second Subtitles/Show Second Subtitles item to the Subtitles menu
- Add a key binding mapping v to cycle sub-visibility
- Add a key binding mapping Alt-v to cycle secondary-sub-visibility
- Add a new OSD message Subtitle Visibility: On/Off
- Add a new OSD message Second Subtitle Visibility: On/Off
- Add secondary-sub-visibility to watch-later-options
- Add logging of watch-later-options

These changes add a graphical user interface for the mpv features that control subtitle visibility.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4235.

---

**Description:**
