### PR TITLE
Fix black window switching from music to video, #4055

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		49542982216C34950058F680 /* ToolbarItemIcon.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 49542981216C34950058F680 /* ToolbarItemIcon.pdf */; };
 		49542986216C34950058F680 /* OpenInIINA.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 49542973216C34950058F680 /* OpenInIINA.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		496B19921E2968530035AF10 /* PIP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 496B19911E2968530035AF10 /* PIP.framework */; settings = {ATTRIBUTES = (Weak, ); }; };
+		513A4FFA29B53F8100A8EA7D /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513A4FF929B53F8100A8EA7D /* Atomic.swift */; };
 		519872FF26879B9B00F84BCC /* AccessibilityPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519872FE26879B9B00F84BCC /* AccessibilityPreferences.swift */; };
 		51F7974728C7E00200812D0D /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F7974628C7E00200812D0D /* Lock.swift */; };
 		6100FF2B1EDF9806002CF0FB /* dsa_pub.pem in Resources */ = {isa = PBXBuildFile; fileRef = 6100FF2A1EDF9806002CF0FB /* dsa_pub.pem */; };
@@ -773,6 +774,7 @@
 		4964988E2919E47900CD61A5 /* OpenInIINA.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = OpenInIINA.xcconfig; sourceTree = "<group>"; };
 		496B19911E2968530035AF10 /* PIP.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PIP.framework; path = ../../../../System/Library/PrivateFrameworks/PIP.framework; sourceTree = "<group>"; };
 		49F7E3BF2920D65C002DA28E /* Availability.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Availability.xcconfig; sourceTree = "<group>"; };
+		513A4FF929B53F8100A8EA7D /* Atomic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
 		519872FE26879B9B00F84BCC /* AccessibilityPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPreferences.swift; sourceTree = "<group>"; };
 		51F7974628C7E00200812D0D /* Lock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
 		5879479521A87DD700757A6F /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/MiniPlayerWindowController.strings; sourceTree = "<group>"; };
@@ -2075,6 +2077,7 @@
 			children = (
 				84A886E21E24F2D3008755BB /* Sub */,
 				8497A4831D2FF573005F504F /* iina-Bridging-Header.h */,
+				513A4FF929B53F8100A8EA7D /* Atomic.swift */,
 				84A0BA9A1D2FAB4100BC8DA1 /* Parameter.swift */,
 				84EB1F061D2F5E76004FA5A1 /* Utility.swift */,
 				8461C52F1D462488006E91FF /* VideoTime.swift */,
@@ -2874,6 +2877,7 @@
 				E35306EF2147A8CE008FE492 /* JavascriptPlugin.swift in Sources */,
 				84795C371E0825AD0059A648 /* GifGenerator.swift in Sources */,
 				845ABEAC1D4D19C000BFB15B /* MPVTrack.swift in Sources */,
+				513A4FFA29B53F8100A8EA7D /* Atomic.swift in Sources */,
 				84AABE981DBFB62F00D138FD /* FixedFontManager.m in Sources */,
 				84EB1EDA1D2F51D3004FA5A1 /* AppDelegate.swift in Sources */,
 				84CFC92623F8DDE000381E5B /* PlayerWindowController.swift in Sources */,

--- a/iina/Atomic.swift
+++ b/iina/Atomic.swift
@@ -1,0 +1,35 @@
+//
+//  Atomic.swift
+//  iina
+//
+//  Created by low-batt on 11/27/22.
+//  Copyright © 2022 lhc. All rights reserved.
+//
+
+import Foundation
+
+@propertyWrapper class Atomic<Value> {
+
+  private let lock = Lock()
+
+  var projectedValue: Atomic<Value> {
+      return self
+  }
+
+  private var value: Value
+
+  var wrappedValue: Value {
+    get { lock.withLock { value } }
+    set { lock.withLock { value = newValue } }
+  }
+
+  init(wrappedValue: Value) {
+    self.value = wrappedValue
+  }
+
+  func withLock<R>(_ body: (inout Value) throws -> R) rethrows -> R {
+    return try lock.withLock {
+      return try body(&value)
+    }
+  }
+}

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -1434,5 +1434,8 @@ fileprivate func mpvGetOpenGLFunc(_ ctx: UnsafeMutableRawPointer?, _ name: Unsaf
 fileprivate func mpvUpdateCallback(_ ctx: UnsafeMutableRawPointer?) {
   let layer = bridge(ptr: ctx!) as ViewLayer
   guard !layer.blocked else { return }
-  layer.draw()
+
+  layer.mpvGLQueue.async {
+    layer.draw()
+  }
 }

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2008,7 +2008,11 @@ class MainWindowController: PlayerWindowController {
       videoView.needsLayout = true
       videoView.layoutSubtreeIfNeeded()
       // force rerender a frame
-      videoView.videoLayer.draw(forced: true)
+      videoView.videoLayer.mpvGLQueue.async {
+        DispatchQueue.main.sync {
+          self.videoView.videoLayer.draw()
+        }
+      }
     }
 
     let controlView = mode.viewController()

--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -14,13 +14,13 @@ class ViewLayer: CAOpenGLLayer {
 
   weak var videoView: VideoView!
 
-  private let mpvGLQueue = DispatchQueue(label: "com.colliderli.iina.mpvgl", qos: .userInteractive)
-  var blocked = false
+  let mpvGLQueue = DispatchQueue(label: "com.colliderli.iina.mpvgl", qos: .userInteractive)
+  @Atomic var blocked = false
 
   private var fbo: GLint = 1
 
-  private var needsMPVRender = false
-  private var forceRender = false
+  @Atomic private var needsMPVRender = false
+  @Atomic private var forceRender = false
 
   override init() {
     super.init()
@@ -143,30 +143,28 @@ class ViewLayer: CAOpenGLLayer {
   }
 
   func draw(forced: Bool = false) {
-    mpvGLQueue.async { [self] in
-      needsMPVRender = true
-      if forced { forceRender = true }
-      display()
-      if forced {
-        forceRender = false
-        return
-      }
-      if needsMPVRender {
-        videoView.player.mpv.lockAndSetOpenGLContext()
-        defer { videoView.player.mpv.unlockOpenGLContext() }
-        // draw(inCGLContext:) is not called, needs a skip render
-        if !videoView.isUninited, let renderContext = videoView.player.mpv.mpvRenderContext {
-          var skip: CInt = 1
-          withUnsafeMutablePointer(to: &skip) { skip in
-            var params: [mpv_render_param] = [
-              mpv_render_param(type: MPV_RENDER_PARAM_SKIP_RENDERING, data: .init(skip)),
-              mpv_render_param()
-            ]
-            mpv_render_context_render(renderContext, &params);
-          }
+    needsMPVRender = true
+    if forced { forceRender = true }
+    display()
+    if forced {
+      forceRender = false
+      return
+    }
+    if needsMPVRender {
+      videoView.player.mpv.lockAndSetOpenGLContext()
+      defer { videoView.player.mpv.unlockOpenGLContext() }
+      // draw(inCGLContext:) is not called, needs a skip render
+      if !videoView.isUninited, let renderContext = videoView.player.mpv.mpvRenderContext {
+        var skip: CInt = 1
+        withUnsafeMutablePointer(to: &skip) { skip in
+          var params: [mpv_render_param] = [
+            mpv_render_param(type: MPV_RENDER_PARAM_SKIP_RENDERING, data: .init(skip)),
+            mpv_render_param()
+          ]
+          mpv_render_context_render(renderContext, &params);
         }
-        needsMPVRender = false
       }
+      needsMPVRender = false
     }
   }
 


### PR DESCRIPTION
This commit will:

- Effectively revert the changes made in commit f8811b6 that attempted to always draw using the mpvGLQueue queue
- Add an Atomic property wrapper to protect a property with a lock
- Add locking to the VideoLayer properties blocked, forceRender and needsMPVRender

The commit f8811b6 attempted to standardize drawing to always use the mpvGLQueue queue to resolve TSan detected data races reported in issue #3827 without using locks. However as discussed in issue #4055 drawing can still occur on the main thread. This commit resolves the TSan data races using locks.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4055.

---

**Description:**
