### PR TITLE
Playback History window: modernize look & improve window functionality

### DIFF
--- a/iina/Base.lproj/HistoryWindowController.xib
+++ b/iina/Base.lproj/HistoryWindowController.xib
@@ -19,13 +19,13 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="600" height="400"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="3440" height="1415"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1728" height="1079"/>
             <value key="minSize" type="size" width="400" height="200"/>
             <view key="contentView" wantsLayer="YES" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="se5-gp-TjO" userLabel="PlaybackHistoryWindow Content View">
-                <rect key="frame" x="0.0" y="0.0" width="600" height="400"/>
+                <rect key="frame" x="0.0" y="0.0" width="600" height="300"/>
                 <subviews>
                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="OQZ-Pk-zUa" userLabel="Top Panel">
-                        <rect key="frame" x="0.0" y="368" width="600" height="32"/>
+                        <rect key="frame" x="0.0" y="268" width="600" height="32"/>
                         <subviews>
                             <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ob0-Up-S1q" userLabel="GroupBy Label">
                                 <rect key="frame" x="6" y="7" width="64" height="18"/>
@@ -54,9 +54,7 @@
                                     </menu>
                                 </popUpButtonCell>
                                 <connections>
-                                    <connections>
-                                        <action selector="groupByChangedAction:" target="-2" id="YOC-15-2CZ"/>
-                                    </connections>
+                                    <action selector="groupByChangedAction:" target="-2" id="YOC-15-2CZ"/>
                                 </connections>
                             </popUpButton>
                             <searchField wantsLayer="YES" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nfA-G1-DVj">
@@ -90,20 +88,20 @@
                         </constraints>
                     </customView>
                     <scrollView horizontalHuggingPriority="249" verticalHuggingPriority="249" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" autohidesScrollers="YES" horizontalLineScroll="24" horizontalPageScroll="10" verticalLineScroll="24" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="II4-dF-AGa" userLabel="PlaybackHistoryTable Scroll View">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="368"/>
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="268"/>
                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="IB5-0J-8sn" userLabel="PlaybackHistoryTable Clip View">
-                            <rect key="frame" x="1" y="1" width="598" height="366"/>
+                            <rect key="frame" x="1" y="1" width="598" height="266"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
-                                <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" tableStyle="fullWidth" autosaveName="PlaybackHistoryTable" rowHeight="22" headerView="MiB-ow-W6T" viewBased="YES" indentationPerLevel="12" autoresizesOutlineColumn="YES" outlineTableColumn="DIC-tR-R2F" id="6jR-CS-fgx" userLabel="PlaybackHistoryTable Outline View">
-                                    <rect key="frame" x="0.0" y="0.0" width="598" height="343"/>
+                                <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" tableStyle="fullWidth" columnReordering="NO" autosaveName="HistoryWindowTable" rowHeight="22" headerView="MiB-ow-W6T" viewBased="YES" indentationPerLevel="12" indentationMarkerFollowsCell="NO" outlineTableColumn="DIC-tR-R2F" id="6jR-CS-fgx" userLabel="PlaybackHistoryTable Outline View">
+                                    <rect key="frame" x="0.0" y="0.0" width="606" height="243"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                    <size key="intercellSpacing" width="4" height="2"/>
+                                    <size key="intercellSpacing" width="8" height="2"/>
                                     <color key="backgroundColor" white="1" alpha="0.0" colorSpace="deviceWhite"/>
                                     <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                     <tableColumns>
-                                        <tableColumn identifier="Filename" editable="NO" width="408" minWidth="200" maxWidth="1000" id="DIC-tR-R2F" userLabel="File Column">
-                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="File">
+                                        <tableColumn identifier="Filename" editable="NO" width="408" minWidth="200" maxWidth="5000" id="DIC-tR-R2F" userLabel="File Column">
+                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="File">
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
@@ -115,7 +113,7 @@
                                             <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                             <prototypeCellViews>
                                                 <tableCellView identifier="Filename" id="wYh-IS-KLy" customClass="HistoryFilenameCellView" customModule="IINA" customModuleProvider="target">
-                                                    <rect key="frame" x="2" y="1" width="412" height="17"/>
+                                                    <rect key="frame" x="4" y="1" width="410" height="17"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
                                                         <imageView translatesAutoresizingMaskIntoConstraints="NO" id="iVY-ZI-AZI">
@@ -127,8 +125,8 @@
                                                             <imageCell key="cell" controlSize="large" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" id="VSC-Pt-fuS"/>
                                                         </imageView>
                                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Fqk-Qo-Mj5" userLabel="History Filename Table View Cell">
-                                                            <rect key="frame" x="20" y="1" width="394" height="16"/>
-                                                            <textFieldCell key="cell" controlSize="large" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="hAx-fJ-3rD">
+                                                            <rect key="frame" x="20" y="1" width="392" height="16"/>
+                                                            <textFieldCell key="cell" controlSize="large" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="left" title="Table View Cell" id="hAx-fJ-3rD">
                                                                 <font key="font" metaFont="system"/>
                                                                 <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -148,12 +146,12 @@
                                                     </connections>
                                                 </tableCellView>
                                                 <tableCellView identifier="Group" id="RoJ-be-42E" userLabel="Group Table Cell View">
-                                                    <rect key="frame" x="2" y="20" width="412" height="17"/>
+                                                    <rect key="frame" x="4" y="20" width="410" height="17"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
                                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Nf6-hw-AKB" userLabel="Group Table View Cell">
-                                                            <rect key="frame" x="-2" y="1" width="416" height="16"/>
-                                                            <textFieldCell key="cell" controlSize="large" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Group Table View Cell" id="vDR-ax-UJb">
+                                                            <rect key="frame" x="2" y="1" width="410" height="16"/>
+                                                            <textFieldCell key="cell" controlSize="large" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="left" title="Group Table View Cell" id="vDR-ax-UJb">
                                                                 <font key="font" metaFont="system"/>
                                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -164,7 +162,7 @@
                                                         </textField>
                                                     </subviews>
                                                     <constraints>
-                                                        <constraint firstItem="Nf6-hw-AKB" firstAttribute="leading" secondItem="RoJ-be-42E" secondAttribute="leading" id="KkS-gh-eI6"/>
+                                                        <constraint firstItem="Nf6-hw-AKB" firstAttribute="leading" secondItem="RoJ-be-42E" secondAttribute="leading" constant="4" id="KkS-gh-eI6"/>
                                                         <constraint firstAttribute="trailing" secondItem="Nf6-hw-AKB" secondAttribute="trailing" id="g4u-zI-tC6"/>
                                                         <constraint firstItem="Nf6-hw-AKB" firstAttribute="centerY" secondItem="RoJ-be-42E" secondAttribute="centerY" id="oDv-9f-Eo1"/>
                                                     </constraints>
@@ -187,11 +185,11 @@
                                             <tableColumnResizingMask key="resizingMask" userResizable="YES"/>
                                             <prototypeCellViews>
                                                 <tableCellView id="pqd-3v-fYy" customClass="HistoryProgressCellView" customModule="IINA" customModuleProvider="target">
-                                                    <rect key="frame" x="418" y="1" width="110" height="17"/>
+                                                    <rect key="frame" x="422" y="1" width="110" height="17"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
                                                         <progressIndicator wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="1" bezeled="NO" controlSize="small" style="bar" translatesAutoresizingMaskIntoConstraints="NO" id="MG3-Zj-U3c">
-                                                            <rect key="frame" x="3" y="3" width="50" height="12"/>
+                                                            <rect key="frame" x="4" y="3" width="49" height="12"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="30" id="f9e-xF-cPT"/>
                                                             </constraints>
@@ -209,7 +207,7 @@
                                                         <constraint firstAttribute="trailing" secondItem="UIs-Aj-nFe" secondAttribute="trailing" id="4hJ-zz-4Ud"/>
                                                         <constraint firstItem="UIs-Aj-nFe" firstAttribute="centerY" secondItem="pqd-3v-fYy" secondAttribute="centerY" id="9e9-vF-BVn"/>
                                                         <constraint firstItem="UIs-Aj-nFe" firstAttribute="leading" secondItem="MG3-Zj-U3c" secondAttribute="trailing" constant="8" id="Adl-4O-Gzf"/>
-                                                        <constraint firstItem="MG3-Zj-U3c" firstAttribute="leading" secondItem="pqd-3v-fYy" secondAttribute="leading" constant="3" id="VAL-K4-ovJ"/>
+                                                        <constraint firstItem="MG3-Zj-U3c" firstAttribute="leading" secondItem="pqd-3v-fYy" secondAttribute="leading" constant="4" id="VAL-K4-ovJ"/>
                                                         <constraint firstItem="UIs-Aj-nFe" firstAttribute="centerY" secondItem="MG3-Zj-U3c" secondAttribute="centerY" id="fqe-YB-vaN"/>
                                                     </constraints>
                                                     <connections>
@@ -219,7 +217,7 @@
                                                 </tableCellView>
                                             </prototypeCellViews>
                                         </tableColumn>
-                                        <tableColumn identifier="Time" editable="NO" width="60" minWidth="60" maxWidth="400" id="M7K-6H-OPw" userLabel="Played at Column">
+                                        <tableColumn identifier="Time" editable="NO" width="60" minWidth="60" maxWidth="300" id="M7K-6H-OPw" userLabel="Played at Column">
                                             <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Played at">
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
@@ -232,12 +230,12 @@
                                             <tableColumnResizingMask key="resizingMask" userResizable="YES"/>
                                             <prototypeCellViews>
                                                 <tableCellView identifier="Time" id="1Qm-L8-ZC5">
-                                                    <rect key="frame" x="532" y="1" width="64" height="17"/>
+                                                    <rect key="frame" x="540" y="1" width="62" height="17"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
                                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Esj-ym-AE9">
-                                                            <rect key="frame" x="-2" y="1" width="64" height="16"/>
-                                                            <textFieldCell key="cell" controlSize="large" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="right" title="00:00 AM" id="z9u-td-fQW">
+                                                            <rect key="frame" x="2" y="1" width="62" height="16"/>
+                                                            <textFieldCell key="cell" controlSize="large" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="left" title="00:00 AM" id="z9u-td-fQW">
                                                                 <font key="font" metaFont="system"/>
                                                                 <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -248,8 +246,8 @@
                                                         </textField>
                                                     </subviews>
                                                     <constraints>
-                                                        <constraint firstItem="Esj-ym-AE9" firstAttribute="leading" secondItem="1Qm-L8-ZC5" secondAttribute="leading" id="2ti-fC-ySL"/>
-                                                        <constraint firstAttribute="trailing" secondItem="Esj-ym-AE9" secondAttribute="trailing" constant="4" id="PTv-O2-9gu"/>
+                                                        <constraint firstItem="Esj-ym-AE9" firstAttribute="leading" secondItem="1Qm-L8-ZC5" secondAttribute="leading" constant="4" id="2ti-fC-ySL"/>
+                                                        <constraint firstAttribute="trailing" secondItem="Esj-ym-AE9" secondAttribute="trailing" id="PTv-O2-9gu"/>
                                                         <constraint firstItem="Esj-ym-AE9" firstAttribute="centerY" secondItem="1Qm-L8-ZC5" secondAttribute="centerY" id="egq-j1-maM"/>
                                                     </constraints>
                                                     <connections>
@@ -265,8 +263,8 @@
                                 </outlineView>
                             </subviews>
                         </clipView>
-                        <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="Hfw-fb-gd5">
-                            <rect key="frame" x="1" y="31" width="214" height="16"/>
+                        <scroller key="horizontalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="Hfw-fb-gd5">
+                            <rect key="frame" x="1" y="251" width="598" height="16"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
                         <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="dwA-h7-ch3">
@@ -274,7 +272,7 @@
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
                         <tableHeaderView key="headerView" wantsLayer="YES" id="MiB-ow-W6T" userLabel="PlaybackHistoryTable Table Header View">
-                            <rect key="frame" x="0.0" y="0.0" width="598" height="23"/>
+                            <rect key="frame" x="0.0" y="0.0" width="606" height="23"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </tableHeaderView>
                     </scrollView>
@@ -282,7 +280,7 @@
                 <constraints>
                     <constraint firstItem="OQZ-Pk-zUa" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" id="04h-qy-HPu"/>
                     <constraint firstAttribute="trailing" secondItem="II4-dF-AGa" secondAttribute="trailing" id="2el-lQ-ebS"/>
-                    <constraint firstAttribute="height" constant="400" placeholder="YES" id="Dqr-GP-aT1"/>
+                    <constraint firstAttribute="height" constant="300" placeholder="YES" id="Dqr-GP-aT1"/>
                     <constraint firstItem="OQZ-Pk-zUa" firstAttribute="top" secondItem="se5-gp-TjO" secondAttribute="top" id="GGJ-cK-v1o"/>
                     <constraint firstItem="II4-dF-AGa" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" id="He6-cF-muG"/>
                     <constraint firstItem="OQZ-Pk-zUa" firstAttribute="bottom" secondItem="II4-dF-AGa" secondAttribute="top" id="bAK-Ww-Ds4"/>

--- a/iina/Base.lproj/HistoryWindowController.xib
+++ b/iina/Base.lproj/HistoryWindowController.xib
@@ -236,7 +236,7 @@
                                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Esj-ym-AE9">
                                                             <rect key="frame" x="2" y="1" width="62" height="16"/>
                                                             <textFieldCell key="cell" controlSize="large" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="left" title="00:00 AM" id="z9u-td-fQW">
-                                                                <font key="font" metaFont="system"/>
+                                                                <font key="font" size="13" name="Menlo-Regular"/>
                                                                 <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                             </textFieldCell>

--- a/iina/Base.lproj/HistoryWindowController.xib
+++ b/iina/Base.lproj/HistoryWindowController.xib
@@ -15,11 +15,11 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Playback History" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="F0z-JX-Cv5" userLabel="Playback History Window">
+        <window title="Playback History" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" frameAutosaveName="PlaybackHistoryWindow" animationBehavior="default" id="F0z-JX-Cv5" userLabel="Playback History Window">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="600" height="400"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1728" height="1079"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="3440" height="1415"/>
             <value key="minSize" type="size" width="400" height="200"/>
             <view key="contentView" wantsLayer="YES" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="se5-gp-TjO" userLabel="PlaybackHistoryWindow Content View">
                 <rect key="frame" x="0.0" y="0.0" width="600" height="300"/>
@@ -63,7 +63,7 @@
                                     <constraint firstAttribute="width" constant="200" id="8T5-1l-PW8"/>
                                     <constraint firstAttribute="height" constant="24" id="i1e-zn-ahj"/>
                                 </constraints>
-                                <searchFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" recentsAutosaveName="IINAHistorySearchField" id="k5B-TS-AUl">
+                                <searchFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" alignment="left" usesSingleLineMode="YES" bezelStyle="round" recentsAutosaveName="IINAHistorySearchField" id="k5B-TS-AUl">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -234,7 +234,7 @@
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
                                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Esj-ym-AE9">
-                                                            <rect key="frame" x="2" y="1" width="62" height="16"/>
+                                                            <rect key="frame" x="2" y="1" width="62" height="15"/>
                                                             <textFieldCell key="cell" controlSize="large" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="left" title="00:00 AM" id="z9u-td-fQW">
                                                                 <font key="font" size="13" name="Menlo-Regular"/>
                                                                 <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>

--- a/iina/Base.lproj/HistoryWindowController.xib
+++ b/iina/Base.lproj/HistoryWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21225" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21225"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,87 +15,146 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Playback History" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="F0z-JX-Cv5">
+        <window title="Playback History" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="F0z-JX-Cv5" userLabel="Playback History Window">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="196" y="240" width="563" height="342"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1680" height="1025"/>
-            <view key="contentView" wantsLayer="YES" id="se5-gp-TjO">
-                <rect key="frame" x="0.0" y="0.0" width="563" height="342"/>
-                <autoresizingMask key="autoresizingMask"/>
+            <rect key="contentRect" x="196" y="240" width="600" height="400"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="3440" height="1415"/>
+            <value key="minSize" type="size" width="400" height="200"/>
+            <view key="contentView" wantsLayer="YES" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="se5-gp-TjO" userLabel="PlaybackHistoryWindow Content View">
+                <rect key="frame" x="0.0" y="0.0" width="600" height="400"/>
                 <subviews>
-                    <searchField wantsLayer="YES" focusRingType="none" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nfA-G1-DVj">
-                        <rect key="frame" x="355" y="320" width="200" height="19"/>
+                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="OQZ-Pk-zUa" userLabel="Top Panel">
+                        <rect key="frame" x="0.0" y="368" width="600" height="32"/>
+                        <subviews>
+                            <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ob0-Up-S1q" userLabel="GroupBy Label">
+                                <rect key="frame" x="6" y="7" width="64" height="18"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="18" id="ZCV-1y-g3N"/>
+                                </constraints>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Group by:" id="z6c-c4-dgd">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dcE-VR-Vxk" userLabel="GroupBy Popup">
+                                <rect key="frame" x="73" y="0.0" width="78" height="29"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="24" id="Xmm-F8-gsu"/>
+                                </constraints>
+                                <popUpButtonCell key="cell" type="push" title="Date" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" selectedItem="QBO-JS-dNV" id="geF-qk-cXT">
+                                    <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="menu"/>
+                                    <menu key="menu" id="IlO-8S-UTZ">
+                                        <items>
+                                            <menuItem title="Date" state="on" id="QBO-JS-dNV"/>
+                                            <menuItem title="Folder" tag="1" id="VH5-en-8FR"/>
+                                        </items>
+                                    </menu>
+                                </popUpButtonCell>
+                                <connections>
+                                    <connections>
+                                        <action selector="groupByChangedAction:" target="-2" id="YOC-15-2CZ"/>
+                                    </connections>
+                                </connections>
+                            </popUpButton>
+                            <searchField wantsLayer="YES" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="nfA-G1-DVj">
+                                <rect key="frame" x="392" y="4" width="200" height="24"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" constant="200" id="8T5-1l-PW8"/>
+                                    <constraint firstAttribute="height" constant="24" id="i1e-zn-ahj"/>
+                                </constraints>
+                                <searchFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" recentsAutosaveName="IINAHistorySearchField" id="k5B-TS-AUl">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </searchFieldCell>
+                                <connections>
+                                    <action selector="searchFieldAction:" target="-2" id="GHt-cO-ckm"/>
+                                    <outlet property="searchMenuTemplate" destination="u6g-IF-TSS" id="y2i-UM-V7o"/>
+                                </connections>
+                            </searchField>
+                        </subviews>
                         <constraints>
-                            <constraint firstAttribute="width" constant="200" id="8T5-1l-PW8"/>
+                            <constraint firstAttribute="trailing" secondItem="nfA-G1-DVj" secondAttribute="trailing" constant="8" id="Jnt-On-mRa"/>
+                            <constraint firstAttribute="bottom" secondItem="nfA-G1-DVj" secondAttribute="bottom" constant="4" id="PTb-Ja-7nk"/>
+                            <constraint firstItem="dcE-VR-Vxk" firstAttribute="leading" secondItem="ob0-Up-S1q" secondAttribute="trailing" constant="8" id="ULk-Yl-s8T"/>
+                            <constraint firstAttribute="height" constant="32" id="Udk-tI-Mtj"/>
+                            <constraint firstItem="nfA-G1-DVj" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="dcE-VR-Vxk" secondAttribute="trailing" constant="8" id="YJw-Fw-ho7"/>
+                            <constraint firstItem="dcE-VR-Vxk" firstAttribute="top" secondItem="OQZ-Pk-zUa" secondAttribute="top" constant="4" id="eSu-zd-4Xc"/>
+                            <constraint firstAttribute="bottom" secondItem="dcE-VR-Vxk" secondAttribute="bottom" constant="4" id="frW-fu-n5L"/>
+                            <constraint firstItem="nfA-G1-DVj" firstAttribute="top" secondItem="OQZ-Pk-zUa" secondAttribute="top" constant="4" id="gS5-zF-KhI"/>
+                            <constraint firstItem="ob0-Up-S1q" firstAttribute="centerY" secondItem="OQZ-Pk-zUa" secondAttribute="centerY" id="kDk-F2-skc"/>
+                            <constraint firstItem="ob0-Up-S1q" firstAttribute="leading" secondItem="OQZ-Pk-zUa" secondAttribute="leading" constant="8" id="stx-Ea-iMr"/>
                         </constraints>
-                        <searchFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" borderStyle="bezel" focusRingType="none" usesSingleLineMode="YES" bezelStyle="round" recentsAutosaveName="IINAHistorySearchField" id="k5B-TS-AUl">
-                            <font key="font" metaFont="smallSystem"/>
-                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                        </searchFieldCell>
-                        <connections>
-                            <action selector="searchFieldAction:" target="-2" id="GHt-cO-ckm"/>
-                            <outlet property="searchMenuTemplate" destination="u6g-IF-TSS" id="y2i-UM-V7o"/>
-                        </connections>
-                    </searchField>
-                    <scrollView autohidesScrollers="YES" horizontalLineScroll="22" horizontalPageScroll="10" verticalLineScroll="22" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="II4-dF-AGa">
-                        <rect key="frame" x="-1" y="-1" width="565" height="319"/>
-                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="IB5-0J-8sn">
-                            <rect key="frame" x="1" y="1" width="563" height="317"/>
+                    </customView>
+                    <scrollView horizontalHuggingPriority="249" verticalHuggingPriority="249" horizontalCompressionResistancePriority="751" verticalCompressionResistancePriority="751" autohidesScrollers="YES" horizontalLineScroll="24" horizontalPageScroll="10" verticalLineScroll="24" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="II4-dF-AGa" userLabel="PlaybackHistoryTable Scroll View">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="368"/>
+                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="IB5-0J-8sn" userLabel="PlaybackHistoryTable Clip View">
+                            <rect key="frame" x="1" y="1" width="598" height="366"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
-                                <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" autosaveColumns="NO" rowHeight="20" headerView="MiB-ow-W6T" viewBased="YES" indentationPerLevel="16" outlineTableColumn="DIC-tR-R2F" id="6jR-CS-fgx">
-                                    <rect key="frame" x="0.0" y="0.0" width="563" height="294"/>
+                                <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" tableStyle="fullWidth" autosaveName="PlaybackHistoryTable" rowHeight="22" headerView="MiB-ow-W6T" viewBased="YES" indentationPerLevel="12" autoresizesOutlineColumn="YES" outlineTableColumn="DIC-tR-R2F" id="6jR-CS-fgx" userLabel="PlaybackHistoryTable Outline View">
+                                    <rect key="frame" x="0.0" y="0.0" width="598" height="343"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                    <size key="intercellSpacing" width="3" height="2"/>
+                                    <size key="intercellSpacing" width="4" height="2"/>
                                     <color key="backgroundColor" white="1" alpha="0.0" colorSpace="deviceWhite"/>
                                     <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                     <tableColumns>
-                                        <tableColumn identifier="Filename" width="367" minWidth="40" maxWidth="1000" id="DIC-tR-R2F">
+                                        <tableColumn identifier="Filename" editable="NO" width="408" minWidth="200" maxWidth="1000" id="DIC-tR-R2F" userLabel="File Column">
                                             <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="File">
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <textFieldCell key="dataCell" controlSize="small" lineBreakMode="truncatingTail" selectable="YES" editable="YES" title="Text Cell" id="lyw-91-dHG">
-                                                <font key="font" metaFont="smallSystem"/>
+                                            <textFieldCell key="dataCell" controlSize="large" lineBreakMode="truncatingTail" selectable="YES" editable="YES" title="Text Cell" id="lyw-91-dHG">
+                                                <font key="font" metaFont="system"/>
                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                             <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                             <prototypeCellViews>
                                                 <tableCellView identifier="Filename" id="wYh-IS-KLy" customClass="HistoryFilenameCellView" customModule="IINA" customModuleProvider="target">
-                                                    <rect key="frame" x="11" y="1" width="372" height="17"/>
+                                                    <rect key="frame" x="2" y="1" width="412" height="17"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
-                                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Fqk-Qo-Mj5">
-                                                            <rect key="frame" x="19" y="1" width="353" height="14"/>
-                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
-                                                            <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="hAx-fJ-3rD">
-                                                                <font key="font" metaFont="smallSystem"/>
+                                                        <imageView translatesAutoresizingMaskIntoConstraints="NO" id="iVY-ZI-AZI">
+                                                            <rect key="frame" x="0.0" y="0.0" width="18" height="18"/>
+                                                            <constraints>
+                                                                <constraint firstAttribute="height" constant="18" id="h01-Ah-8wf"/>
+                                                                <constraint firstAttribute="width" secondItem="iVY-ZI-AZI" secondAttribute="height" multiplier="1:1" id="h9p-To-Kr4"/>
+                                                            </constraints>
+                                                            <imageCell key="cell" controlSize="large" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" id="VSC-Pt-fuS"/>
+                                                        </imageView>
+                                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Fqk-Qo-Mj5" userLabel="History Filename Table View Cell">
+                                                            <rect key="frame" x="20" y="1" width="394" height="16"/>
+                                                            <textFieldCell key="cell" controlSize="large" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="hAx-fJ-3rD">
+                                                                <font key="font" metaFont="system"/>
                                                                 <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                             </textFieldCell>
                                                         </textField>
-                                                        <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="iVY-ZI-AZI">
-                                                            <rect key="frame" x="3" y="0.0" width="16" height="16"/>
-                                                            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                            <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" id="VSC-Pt-fuS"/>
-                                                        </imageView>
                                                     </subviews>
+                                                    <constraints>
+                                                        <constraint firstItem="Fqk-Qo-Mj5" firstAttribute="leading" secondItem="iVY-ZI-AZI" secondAttribute="trailing" constant="4" id="7T6-sw-PXi"/>
+                                                        <constraint firstItem="iVY-ZI-AZI" firstAttribute="leading" secondItem="wYh-IS-KLy" secondAttribute="leading" id="DEq-CO-hls"/>
+                                                        <constraint firstItem="Fqk-Qo-Mj5" firstAttribute="centerY" secondItem="wYh-IS-KLy" secondAttribute="centerY" id="DQr-97-kWS"/>
+                                                        <constraint firstAttribute="trailing" secondItem="Fqk-Qo-Mj5" secondAttribute="trailing" id="iaF-de-ThD"/>
+                                                        <constraint firstItem="Fqk-Qo-Mj5" firstAttribute="centerY" secondItem="iVY-ZI-AZI" secondAttribute="centerY" id="sJf-Q4-RxW"/>
+                                                    </constraints>
                                                     <connections>
                                                         <outlet property="docImage" destination="iVY-ZI-AZI" id="X2U-Lu-WiH"/>
                                                         <outlet property="textField" destination="Fqk-Qo-Mj5" id="Rr3-hY-lEW"/>
                                                     </connections>
                                                 </tableCellView>
-                                                <tableCellView identifier="Group" id="RoJ-be-42E">
-                                                    <rect key="frame" x="11" y="20" width="372" height="17"/>
+                                                <tableCellView identifier="Group" id="RoJ-be-42E" userLabel="Group Table Cell View">
+                                                    <rect key="frame" x="2" y="20" width="412" height="17"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
-                                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Nf6-hw-AKB">
-                                                            <rect key="frame" x="0.0" y="2" width="372" height="14"/>
-                                                            <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="vDR-ax-UJb">
-                                                                <font key="font" metaFont="smallSystemBold"/>
+                                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Nf6-hw-AKB" userLabel="Group Table View Cell">
+                                                            <rect key="frame" x="-2" y="1" width="416" height="16"/>
+                                                            <textFieldCell key="cell" controlSize="large" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Group Table View Cell" id="vDR-ax-UJb">
+                                                                <font key="font" metaFont="system"/>
                                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                             </textFieldCell>
@@ -105,9 +164,9 @@
                                                         </textField>
                                                     </subviews>
                                                     <constraints>
-                                                        <constraint firstItem="Nf6-hw-AKB" firstAttribute="centerY" secondItem="RoJ-be-42E" secondAttribute="centerY" id="F6U-B3-X5u"/>
-                                                        <constraint firstItem="Nf6-hw-AKB" firstAttribute="leading" secondItem="RoJ-be-42E" secondAttribute="leading" constant="2" id="KkS-gh-eI6"/>
-                                                        <constraint firstAttribute="trailing" secondItem="Nf6-hw-AKB" secondAttribute="trailing" constant="2" id="g4u-zI-tC6"/>
+                                                        <constraint firstItem="Nf6-hw-AKB" firstAttribute="leading" secondItem="RoJ-be-42E" secondAttribute="leading" id="KkS-gh-eI6"/>
+                                                        <constraint firstAttribute="trailing" secondItem="Nf6-hw-AKB" secondAttribute="trailing" id="g4u-zI-tC6"/>
+                                                        <constraint firstItem="Nf6-hw-AKB" firstAttribute="centerY" secondItem="RoJ-be-42E" secondAttribute="centerY" id="oDv-9f-Eo1"/>
                                                     </constraints>
                                                     <connections>
                                                         <outlet property="textField" destination="Nf6-hw-AKB" id="VAv-Wr-ufd"/>
@@ -115,46 +174,43 @@
                                                 </tableCellView>
                                             </prototypeCellViews>
                                         </tableColumn>
-                                        <tableColumn identifier="Progress" width="107" minWidth="107" maxWidth="3.4028234663852886e+38" id="MJU-JY-7fx">
+                                        <tableColumn identifier="Progress" editable="NO" width="110" minWidth="110" maxWidth="1000" id="MJU-JY-7fx" userLabel="Progress Column">
                                             <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Progress">
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
                                             </tableHeaderCell>
-                                            <textFieldCell key="dataCell" controlSize="small" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="kHb-nh-KTm">
-                                                <font key="font" metaFont="smallSystem"/>
+                                            <textFieldCell key="dataCell" controlSize="large" lineBreakMode="truncatingTail" selectable="YES" editable="YES" alignment="left" title="Text Cell" id="kHb-nh-KTm">
+                                                <font key="font" metaFont="system"/>
                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
-                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                            <tableColumnResizingMask key="resizingMask" userResizable="YES"/>
                                             <prototypeCellViews>
                                                 <tableCellView id="pqd-3v-fYy" customClass="HistoryProgressCellView" customModule="IINA" customModuleProvider="target">
-                                                    <rect key="frame" x="386" y="1" width="107" height="17"/>
+                                                    <rect key="frame" x="418" y="1" width="110" height="17"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
                                                         <progressIndicator wantsLayer="YES" horizontalHuggingPriority="750" verticalHuggingPriority="750" maxValue="1" bezeled="NO" controlSize="small" style="bar" translatesAutoresizingMaskIntoConstraints="NO" id="MG3-Zj-U3c">
-                                                            <rect key="frame" x="3" y="2" width="51" height="12"/>
+                                                            <rect key="frame" x="3" y="3" width="50" height="12"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="30" id="f9e-xF-cPT"/>
                                                             </constraints>
                                                         </progressIndicator>
                                                         <textField identifier="Progress" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="UIs-Aj-nFe">
-                                                            <rect key="frame" x="60" y="1" width="46" height="14"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="42" id="NmX-g8-rAb"/>
-                                                            </constraints>
-                                                            <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="left" title="0:00:00" id="cu8-Oe-yca">
-                                                                <font key="font" metaFont="smallSystem"/>
+                                                            <rect key="frame" x="59" y="1" width="53" height="16"/>
+                                                            <textFieldCell key="cell" controlSize="large" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="left" title="0:00:00" id="cu8-Oe-yca">
+                                                                <font key="font" metaFont="system"/>
                                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                             </textFieldCell>
                                                         </textField>
                                                     </subviews>
                                                     <constraints>
-                                                        <constraint firstAttribute="trailing" secondItem="UIs-Aj-nFe" secondAttribute="trailing" constant="3" id="4hJ-zz-4Ud"/>
+                                                        <constraint firstAttribute="trailing" secondItem="UIs-Aj-nFe" secondAttribute="trailing" id="4hJ-zz-4Ud"/>
+                                                        <constraint firstItem="UIs-Aj-nFe" firstAttribute="centerY" secondItem="pqd-3v-fYy" secondAttribute="centerY" id="9e9-vF-BVn"/>
                                                         <constraint firstItem="UIs-Aj-nFe" firstAttribute="leading" secondItem="MG3-Zj-U3c" secondAttribute="trailing" constant="8" id="Adl-4O-Gzf"/>
                                                         <constraint firstItem="MG3-Zj-U3c" firstAttribute="leading" secondItem="pqd-3v-fYy" secondAttribute="leading" constant="3" id="VAL-K4-ovJ"/>
-                                                        <constraint firstItem="UIs-Aj-nFe" firstAttribute="centerY" secondItem="MG3-Zj-U3c" secondAttribute="centerY" id="b4k-rE-hv3"/>
-                                                        <constraint firstItem="MG3-Zj-U3c" firstAttribute="top" secondItem="pqd-3v-fYy" secondAttribute="top" constant="3" id="vZl-MW-PU5"/>
+                                                        <constraint firstItem="UIs-Aj-nFe" firstAttribute="centerY" secondItem="MG3-Zj-U3c" secondAttribute="centerY" id="fqe-YB-vaN"/>
                                                     </constraints>
                                                     <connections>
                                                         <outlet property="indicator" destination="MG3-Zj-U3c" id="RZu-DK-R6o"/>
@@ -163,27 +219,26 @@
                                                 </tableCellView>
                                             </prototypeCellViews>
                                         </tableColumn>
-                                        <tableColumn identifier="Time" width="44" minWidth="40" maxWidth="1000" id="M7K-6H-OPw">
-                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Played at">
+                                        <tableColumn identifier="Time" editable="NO" width="60" minWidth="60" maxWidth="400" id="M7K-6H-OPw" userLabel="Played at Column">
+                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Played at">
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
-                                            <textFieldCell key="dataCell" controlSize="small" lineBreakMode="truncatingTail" selectable="YES" title="Text Cell" id="amS-Lf-wNT">
-                                                <font key="font" metaFont="smallSystem"/>
+                                            <textFieldCell key="dataCell" controlSize="large" lineBreakMode="truncatingTail" selectable="YES" title="Text Cell" id="amS-Lf-wNT">
+                                                <font key="font" metaFont="system"/>
                                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
-                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                            <tableColumnResizingMask key="resizingMask" userResizable="YES"/>
                                             <prototypeCellViews>
                                                 <tableCellView identifier="Time" id="1Qm-L8-ZC5">
-                                                    <rect key="frame" x="496" y="1" width="48" height="17"/>
+                                                    <rect key="frame" x="532" y="1" width="64" height="17"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
-                                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Esj-ym-AE9">
-                                                            <rect key="frame" x="0.0" y="1" width="55" height="14"/>
-                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
-                                                            <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="00:00 AM" id="z9u-td-fQW">
-                                                                <font key="font" metaFont="smallSystem"/>
+                                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Esj-ym-AE9">
+                                                            <rect key="frame" x="-2" y="1" width="64" height="16"/>
+                                                            <textFieldCell key="cell" controlSize="large" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="right" title="00:00 AM" id="z9u-td-fQW">
+                                                                <font key="font" metaFont="system"/>
                                                                 <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
                                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                             </textFieldCell>
@@ -192,6 +247,11 @@
                                                             </connections>
                                                         </textField>
                                                     </subviews>
+                                                    <constraints>
+                                                        <constraint firstItem="Esj-ym-AE9" firstAttribute="leading" secondItem="1Qm-L8-ZC5" secondAttribute="leading" id="2ti-fC-ySL"/>
+                                                        <constraint firstAttribute="trailing" secondItem="Esj-ym-AE9" secondAttribute="trailing" constant="4" id="PTv-O2-9gu"/>
+                                                        <constraint firstItem="Esj-ym-AE9" firstAttribute="centerY" secondItem="1Qm-L8-ZC5" secondAttribute="centerY" id="egq-j1-maM"/>
+                                                    </constraints>
                                                     <connections>
                                                         <outlet property="textField" destination="Esj-ym-AE9" id="sVD-ty-jwk"/>
                                                     </connections>
@@ -206,64 +266,35 @@
                             </subviews>
                         </clipView>
                         <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="Hfw-fb-gd5">
-                            <rect key="frame" x="1" y="302" width="542" height="16"/>
+                            <rect key="frame" x="1" y="31" width="214" height="16"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
                         <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="dwA-h7-ch3">
                             <rect key="frame" x="224" y="17" width="15" height="102"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
-                        <tableHeaderView key="headerView" wantsLayer="YES" id="MiB-ow-W6T">
-                            <rect key="frame" x="0.0" y="0.0" width="563" height="23"/>
+                        <tableHeaderView key="headerView" wantsLayer="YES" id="MiB-ow-W6T" userLabel="PlaybackHistoryTable Table Header View">
+                            <rect key="frame" x="0.0" y="0.0" width="598" height="23"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </tableHeaderView>
                     </scrollView>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ob0-Up-S1q">
-                        <rect key="frame" x="6" y="323" width="56" height="14"/>
-                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Group by:" id="z6c-c4-dgd">
-                            <font key="font" metaFont="smallSystem"/>
-                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                        </textFieldCell>
-                    </textField>
-                    <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dcE-VR-Vxk">
-                        <rect key="frame" x="69" y="321" width="80" height="17"/>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="80" id="fYD-4W-8ut"/>
-                        </constraints>
-                        <popUpButtonCell key="cell" type="roundRect" title="Date" bezelStyle="roundedRect" alignment="left" controlSize="small" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" selectedItem="QBO-JS-dNV" id="geF-qk-cXT">
-                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                            <font key="font" metaFont="smallSystem"/>
-                            <menu key="menu" id="IlO-8S-UTZ">
-                                <items>
-                                    <menuItem title="Date" state="on" id="QBO-JS-dNV"/>
-                                    <menuItem title="Folder" tag="1" id="VH5-en-8FR"/>
-                                </items>
-                            </menu>
-                        </popUpButtonCell>
-                        <connections>
-                            <action selector="groupByChangedAction:" target="-2" id="YOC-15-2CZ"/>
-                        </connections>
-                    </popUpButton>
                 </subviews>
                 <constraints>
-                    <constraint firstAttribute="trailing" secondItem="II4-dF-AGa" secondAttribute="trailing" constant="-1" id="2el-lQ-ebS"/>
-                    <constraint firstItem="ob0-Up-S1q" firstAttribute="centerY" secondItem="nfA-G1-DVj" secondAttribute="centerY" id="4Sq-HG-7ea"/>
-                    <constraint firstItem="dcE-VR-Vxk" firstAttribute="leading" secondItem="ob0-Up-S1q" secondAttribute="trailing" constant="9" id="7dv-Eh-lkU"/>
-                    <constraint firstItem="II4-dF-AGa" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" constant="-1" id="He6-cF-muG"/>
-                    <constraint firstItem="nfA-G1-DVj" firstAttribute="top" secondItem="se5-gp-TjO" secondAttribute="top" constant="3" id="Mi6-SQ-f1j"/>
-                    <constraint firstAttribute="trailing" secondItem="nfA-G1-DVj" secondAttribute="trailing" constant="8" id="SpX-3c-5W7"/>
-                    <constraint firstItem="nfA-G1-DVj" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="dcE-VR-Vxk" secondAttribute="trailing" constant="8" id="Srg-PF-efH"/>
-                    <constraint firstItem="dcE-VR-Vxk" firstAttribute="baseline" secondItem="ob0-Up-S1q" secondAttribute="baseline" id="ZRj-0I-lre"/>
-                    <constraint firstItem="II4-dF-AGa" firstAttribute="top" secondItem="nfA-G1-DVj" secondAttribute="bottom" constant="2" id="gs2-8g-scW"/>
-                    <constraint firstItem="ob0-Up-S1q" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" constant="8" id="oAG-A0-JZA"/>
-                    <constraint firstAttribute="bottom" secondItem="II4-dF-AGa" secondAttribute="bottom" constant="-1" id="yDA-3c-2eZ"/>
+                    <constraint firstItem="OQZ-Pk-zUa" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" id="04h-qy-HPu"/>
+                    <constraint firstAttribute="trailing" secondItem="II4-dF-AGa" secondAttribute="trailing" id="2el-lQ-ebS"/>
+                    <constraint firstAttribute="height" constant="400" placeholder="YES" id="Dqr-GP-aT1"/>
+                    <constraint firstItem="OQZ-Pk-zUa" firstAttribute="top" secondItem="se5-gp-TjO" secondAttribute="top" id="GGJ-cK-v1o"/>
+                    <constraint firstItem="II4-dF-AGa" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" id="He6-cF-muG"/>
+                    <constraint firstItem="OQZ-Pk-zUa" firstAttribute="bottom" secondItem="II4-dF-AGa" secondAttribute="top" id="bAK-Ww-Ds4"/>
+                    <constraint firstAttribute="trailing" secondItem="OQZ-Pk-zUa" secondAttribute="trailing" id="cs8-27-Jue"/>
+                    <constraint firstAttribute="width" constant="600" placeholder="YES" id="j6I-3G-1Fu"/>
+                    <constraint firstItem="II4-dF-AGa" firstAttribute="bottom" secondItem="se5-gp-TjO" secondAttribute="bottom" id="yDA-3c-2eZ"/>
                 </constraints>
             </view>
             <connections>
                 <outlet property="delegate" destination="-2" id="0bl-1N-AYu"/>
             </connections>
-            <point key="canvasLocation" x="181.5" y="200"/>
+            <point key="canvasLocation" x="181.5" y="264"/>
         </window>
         <menu title="Context Menu" identifier="ContextMenu" id="lR3-1E-Rwr" userLabel="Context Menu">
             <items>
@@ -304,13 +335,13 @@
                 <menuItem title="Filename" tag="200" indentationLevel="1" id="Wkp-Vn-JoJ">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
-                        <action selector="searchOptionFilenameAction:" target="-2" id="ojh-2T-Drj"/>
+                        <action selector="searchOptionFilenameAction:" target="-2" id="9VP-rB-pIg"/>
                     </connections>
                 </menuItem>
                 <menuItem title="Full path" tag="201" indentationLevel="1" id="AZL-gY-Tob">
                     <modifierMask key="keyEquivalentModifierMask"/>
                     <connections>
-                        <action selector="searchOptionFullPathAction:" target="-2" id="51W-C3-T6u"/>
+                        <action selector="searchOptionFullPathAction:" target="-2" id="M6n-38-1py"/>
                     </connections>
                 </menuItem>
                 <menuItem isSeparatorItem="YES" id="Uvl-9Y-Q1e"/>
@@ -330,5 +361,6 @@
             </items>
             <point key="canvasLocation" x="84" y="549"/>
         </menu>
+        <userDefaultsController representsSharedInstance="YES" id="Pxd-7n-Ym5"/>
     </objects>
 </document>

--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -322,6 +322,11 @@ extension NSMutableAttributedString {
     self.addAttribute(.font, value: font, range: range)
     self.endEditing()
   }
+
+  // Adds the given attribute for the entire string
+  func addAttrib(_ key: NSAttributedString.Key, _ value: Any) {
+    self.addAttributes([key: value], range: NSRange(location: 0, length: self.length))
+  }
 }
 
 

--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -322,11 +322,6 @@ extension NSMutableAttributedString {
     self.addAttribute(.font, value: font, range: range)
     self.endEditing()
   }
-
-  // Adds the given attribute for the entire string
-  func addAttrib(_ key: NSAttributedString.Key, _ value: Any) {
-    self.addAttributes([key: value], range: NSRange(location: 0, length: self.length))
-  }
 }
 
 

--- a/iina/HistoryWindowController.swift
+++ b/iina/HistoryWindowController.swift
@@ -59,7 +59,6 @@ class HistoryWindowController: NSWindowController, NSOutlineViewDelegate, NSOutl
 
   override func windowDidLoad() {
     super.windowDidLoad()
-    self.windowFrameAutosaveName = "PlaybackHistoryWindow"
 
     NotificationCenter.default.addObserver(forName: .iinaHistoryUpdated, object: nil, queue: .main) { [unowned self] _ in
       self.reloadData()

--- a/iina/HistoryWindowController.swift
+++ b/iina/HistoryWindowController.swift
@@ -55,6 +55,7 @@ class HistoryWindowController: NSWindowController, NSOutlineViewDelegate, NSOutl
 
   override func windowDidLoad() {
     super.windowDidLoad()
+    self.windowFrameAutosaveName = "PlaybackHistoryWindow"
 
     NotificationCenter.default.addObserver(forName: .iinaHistoryUpdated, object: nil, queue: .main) { [unowned self] _ in
       self.reloadData()

--- a/iina/HistoryWindowController.swift
+++ b/iina/HistoryWindowController.swift
@@ -36,7 +36,7 @@ class HistoryWindowController: NSWindowController, NSOutlineViewDelegate, NSOutl
 
   private static let timeColMinWidths: [SortOption: CGFloat] = [
     .lastPlayed: 60,
-    .fileLocation: 130
+    .fileLocation: 145
   ]
 
   private let getKey: [SortOption: (PlaybackHistory) -> String] = [
@@ -220,9 +220,6 @@ class HistoryWindowController: NSWindowController, NSOutlineViewDelegate, NSOutl
           progressView.textField?.stringValue = ""
           progressView.indicator.isHidden = true
         }
-      } else if identifier == .time {
-        let timeString = getTimeString(from: entry)
-        setMonospacedText(cell, timeString)
       }
       return cell
     } else {
@@ -237,22 +234,6 @@ class HistoryWindowController: NSWindowController, NSOutlineViewDelegate, NSOutl
     } else {
       return DateFormatter.localizedString(from: entry.addedDate, dateStyle: .short, timeStyle: .short)
     }
-  }
-
-  private func setMonospacedText(_ cell: NSTableCellView, _ stringValue: String) {
-    guard let textField = cell.textField else { return }
-
-    let font: NSFont
-    if #available(macOS 10.15, *) {
-      font = NSFont.monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .regular)
-    } else if let fixedPitchFont = NSFont.userFixedPitchFont(ofSize: NSFont.systemFontSize) {
-      font = fixedPitchFont
-    } else {
-      return
-    }
-    let attrString = NSMutableAttributedString(string: stringValue)
-    attrString.addAttrib(.font, font)
-    textField.attributedStringValue = attrString
   }
 
   // MARK: - Searching


### PR DESCRIPTION
Before:
![Screenshot 2023-03-09 at 21 20 04](https://user-images.githubusercontent.com/2213815/224230241-6fad33b3-cecc-4aef-83ac-ab6afa769f48.png)
After:
![Screenshot 2023-03-09 at 21 00 05](https://user-images.githubusercontent.com/2213815/224230130-f0b6305e-9eb4-4e2a-93c6-bc29b518cf13.png)

- [X] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**

Submitting this in case there is interest.

- Seeing as the smaller "HUD" type of window is going out of style (the "round rect" style of of the "Group By" box is very antiquated), this upgrades most of the elements to full-size.
- The `File` column now expands/shrinks when the window size changes.
- Column sizes are saved across launches.
- Increased minimum size of `Played at` column so that its title is not cut off.
  - Min size expands to a larger value when grouping by `Folder`, to help fit the longer content.
- Fixed all warnings and added missing constraint in the XIB.
- Disabled the "filling up" animations in the progress bars. Doubtful anyone even noticed them, and they slowed down scrolling a lot.