### PR TITLE
Fix order of filter parameters is random, #4262

### DIFF
--- a/iina/FilterWindowController.swift
+++ b/iina/FilterWindowController.swift
@@ -411,10 +411,10 @@ class NewFilterSheetViewController: NSViewController, NSTableViewDelegate, NSTab
     }
     if let paramOrder = preset.paramOrder {
       for name in paramOrder {
-        generateInputs(name, preset.params[name]!)
+        generateInputs(name, preset.params.get(name)!)
       }
     } else {
-      for (name, param) in preset.params {
+      preset.params.forEach { (name, param) in
         generateInputs(name, param)
       }
     }
@@ -490,7 +490,7 @@ class NewFilterSheetViewController: NSViewController, NSTableViewDelegate, NSTab
     // create instance
     let instance = FilterPresetInstance(from: preset)
     for (name, control) in currentBindings {
-      switch preset.params[name]!.type {
+      switch preset.params.get(name)!.type {
       case .text:
         instance.params[name] = FilterParameterValue(string: control.stringValue)
       case .int:
@@ -498,7 +498,7 @@ class NewFilterSheetViewController: NSViewController, NSTableViewDelegate, NSTab
       case .float:
         instance.params[name] = FilterParameterValue(float: control.floatValue)
       case .choose:
-        instance.params[name] = FilterParameterValue(string: preset.params[name]!.choices[Int(control.intValue)])
+        instance.params[name] = FilterParameterValue(string: preset.params.get(name)!.choices[Int(control.intValue)])
       }
     }
     // create filter


### PR DESCRIPTION
This commit will:
- Add a new struct FilterParameters that holds parameters in a KeyValuePairs object
- Change FilterPreset to use the new struct to preserve the order of parameters specified in the filter definition

This insures the order of the UI controls displayed to the user representing the filter parameters remains consistent.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4262.

---

**Description:**
