### PR TITLE
Migrate color prefs away from NSArchiver

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -172,6 +172,7 @@
 		B4E446F725CB54EF0069F06E /* Mustache in Frameworks */ = {isa = PBXBuildFile; productRef = B4E446F625CB54EF0069F06E /* Mustache */; };
 		B4E4470125CE3F930069F06E /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = B4E4470025CE3F930069F06E /* Sparkle */; };
 		C789872F1E34EF170005769F /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = C78987311E34EF170005769F /* InfoPlist.strings */; };
+		D1A4D98A2B1495270009AB4E /* LegacyMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A4D9892B1495270009AB4E /* LegacyMigration.swift */; };
 		D1B4E24E2A3AFC9100E36F1D /* MiniPlayerWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B4E24D2A3AFC9100E36F1D /* MiniPlayerWindow.swift */; };
 		E301EFDA21312AB300BC8588 /* KeychainAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = E301EFD921312AB300BC8588 /* KeychainAccess.swift */; };
 		E30D2EBD21F5FD2600E1FF0D /* PluginOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30D2EBC21F5FD2600E1FF0D /* PluginOverlayView.swift */; };
@@ -1556,6 +1557,7 @@
 		C7DBA5EB1F07C5FD00C2B416 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/InitialWindowController.strings; sourceTree = "<group>"; };
 		C7DC79CE1EC63821002DE23B /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/HistoryWindowController.strings; sourceTree = "<group>"; };
 		C7E90B522087EC5700A58B6B /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/SubChooseViewController.strings; sourceTree = "<group>"; };
+		D1A4D9892B1495270009AB4E /* LegacyMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyMigration.swift; sourceTree = "<group>"; };
 		D1B4E24D2A3AFC9100E36F1D /* MiniPlayerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerWindow.swift; sourceTree = "<group>"; };
 		D27556FC1EC6E1C300CAB2A4 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/HistoryWindowController.strings"; sourceTree = "<group>"; };
 		D27E35CE1E379B6D0064BE57 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/MainMenu.strings"; sourceTree = "<group>"; };
@@ -2058,6 +2060,7 @@
 				E3513AFA20F120F600F8C347 /* PreferenceViewController.swift */,
 				E374160B20F138A900B4F7F9 /* CollapseView.swift */,
 				519872FE26879B9B00F84BCC /* AccessibilityPreferences.swift */,
+				D1A4D9892B1495270009AB4E /* LegacyMigration.swift */,
 			);
 			name = Preference;
 			sourceTree = "<group>";
@@ -2896,6 +2899,7 @@
 				846352581EEEE11A0043F0CC /* ThumbnailPeekView.swift in Sources */,
 				84E745D61DFDD4FD00588DED /* KeyCodeHelper.swift in Sources */,
 				840D479B1DFEF649000D9A64 /* KeyRecordViewController.swift in Sources */,
+				D1A4D98A2B1495270009AB4E /* LegacyMigration.swift in Sources */,
 				E3965E1A2487C99900607EB4 /* JavascriptPluginSubtitle.swift in Sources */,
 				84F5D4951E44D5230060A838 /* KeyBindingCriterion.swift in Sources */,
 				846121BD1F35FCA500ABB39C /* DraggingDetect.swift in Sources */,

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -215,6 +215,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     // register for url event
     NSAppleEventManager.shared().setEventHandler(self, andSelector: #selector(self.handleURLEvent(event:withReplyEvent:)), forEventClass: AEEventClass(kInternetEventClass), andEventID: AEEventID(kAEGetURL))
 
+    // Check for legacy pref entries and migrate them to their modern equivalents
+    LegacyMigration.shared.migrateLegacyPreferences()
+
     // guide window
     if FirstRunManager.isFirstRun(for: .init("firstLaunchAfter\(version)")) {
       guideWindow.show(pages: [.highlights])

--- a/iina/Base.lproj/PrefSubViewController.xib
+++ b/iina/Base.lproj/PrefSubViewController.xib
@@ -509,9 +509,9 @@
                                 </constraints>
                                 <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 <connections>
-                                    <binding destination="5Up-Ab-aAm" name="value" keyPath="values.subTextColor" id="57K-5E-1e6">
+                                    <binding destination="5Up-Ab-aAm" name="value" keyPath="values.subTextColorString" id="add-O6-WUQ">
                                         <dictionary key="options">
-                                            <string key="NSValueTransformerName">NSUnarchiveFromData</string>
+                                            <string key="NSValueTransformerName">MPVColorStringTransformer</string>
                                         </dictionary>
                                     </binding>
                                 </connections>
@@ -538,9 +538,9 @@
                                 <rect key="frame" x="189" y="8" width="44" height="23"/>
                                 <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 <connections>
-                                    <binding destination="5Up-Ab-aAm" name="value" keyPath="values.subBgColor" id="BDd-oz-ARs">
+                                    <binding destination="5Up-Ab-aAm" name="value" keyPath="values.subBgColorString" id="2V9-yF-uLN">
                                         <dictionary key="options">
-                                            <string key="NSValueTransformerName">NSUnarchiveFromData</string>
+                                            <string key="NSValueTransformerName">MPVColorStringTransformer</string>
                                         </dictionary>
                                     </binding>
                                 </connections>
@@ -668,9 +668,9 @@
                                 <rect key="frame" x="133" y="8" width="44" height="23"/>
                                 <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                 <connections>
-                                    <binding destination="5Up-Ab-aAm" name="value" keyPath="values.subBorderColor" id="K3Q-tt-UYU">
+                                    <binding destination="5Up-Ab-aAm" name="value" keyPath="values.subBorderColorString" id="AOH-6Z-CCF">
                                         <dictionary key="options">
-                                            <string key="NSValueTransformerName">NSUnarchiveFromData</string>
+                                            <string key="NSValueTransformerName">MPVColorStringTransformer</string>
                                         </dictionary>
                                     </binding>
                                 </connections>
@@ -744,9 +744,9 @@
                                                 <rect key="frame" x="143" y="8" width="44" height="24"/>
                                                 <color key="color" red="0.05813049898" green="0.055541899059999997" blue="1" alpha="1" colorSpace="calibratedRGB"/>
                                                 <connections>
-                                                    <binding destination="5Up-Ab-aAm" name="value" keyPath="values.subShadowColor" id="jjh-lk-EJJ">
+                                                    <binding destination="5Up-Ab-aAm" name="value" keyPath="values.subShadowColorString" id="wvE-s6-v6l">
                                                         <dictionary key="options">
-                                                            <string key="NSValueTransformerName">NSUnarchiveFromData</string>
+                                                            <string key="NSValueTransformerName">MPVColorStringTransformer</string>
                                                         </dictionary>
                                                     </binding>
                                                 </connections>

--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -332,16 +332,6 @@ extension NSMutableAttributedString {
 }
 
 
-extension UserDefaults {
-
-  func mpvColor(forKey key: String) -> String? {
-    guard let data = self.data(forKey: key) else { return nil }
-    guard let color = NSUnarchiver.unarchiveObject(with: data) as? NSColor else { return nil }
-    return color.usingColorSpace(.deviceRGB)?.mpvColorString
-  }
-}
-
-
 extension NSData {
   func md5() -> NSString {
     let digestLength = Int(CC_MD5_DIGEST_LENGTH)

--- a/iina/LegacyMigration.swift
+++ b/iina/LegacyMigration.swift
@@ -1,0 +1,81 @@
+//
+//  LegacyMigration.swift
+//  iina
+//
+//  Created by Matt Svoboda on 11/27/23.
+//  Copyright © 2023 lhc. All rights reserved.
+//
+
+import Foundation
+
+class LegacyMigration {
+
+  /// Map of [modern pref key → legacy key].
+  ///
+  /// - Important: Do not reference legacy keys outside this file.
+  fileprivate static let legacyColorPrefKeyMap: [Preference.Key: Preference.Key] = [
+    Preference.Key.subTextColorString: Preference.Key("subTextColor"),
+    Preference.Key.subBgColorString: Preference.Key("subBgColor"),
+    Preference.Key.subBorderColorString: Preference.Key("subBorderColor"),
+    Preference.Key.subShadowColorString: Preference.Key("subShadowColor"),
+  ]
+
+  /// The `LegacyMigration` singleton object.
+  static var shared = LegacyMigration()
+
+  /**
+   Loops over the set of legacy preference keys. If a value is found for a given legacy key, but no value is found for its modern equivalent key,
+   the legacy value is migrated & stored under the modern key.
+
+   Older versions of IINA serialized mpv color data into NSObject binary using the now-deprecated `NSUnarchiver` class.
+   This method will transition to the new format which consists of the color components written to a `String`.
+   To do this in a way which does not corrupt the values for older versions of IINA, we'll store the new format under a new `Preference.Key`,
+   and leave the legacy pref entry as-is.
+
+   This method will be executed on each of the affected prefs when IINA starts up. It will first check if there is already an entry for the new
+   pref key. If it finds one, then it will assume that the migration has already occurred, and will just return that.
+   Otherwise it will look for an entry for the legacy pref key. If it finds that, if will convert its value into the new format and store it under
+   the new pref key, and then return that.
+
+   This will have the effect of automatically migrating older versions of IINA into the new format with no loss of data.
+   However, it is worth noting that this migration will only happen once, and afterwards newer versions of IINA will not look at the old pref entry.
+   And since older versions of IINA will only use the old pref entry, users who mix old and new versions of IINA may experience different values
+   for these keys.
+   */
+  func migrateLegacyPreferences() {
+    Logger.log("Looking for legacy color prefs to migrate")
+
+    let appID = InfoDictionary.shared.bundleIdentifier
+    guard let persistedPrefKeys = UserDefaults.standard.persistentDomain(forName: appID)?.keys else {
+      Logger.log("Aborting legacy color prefs migration: failed to find prefs domain for \"\(appID)\"!", level: .error)
+      return
+    }
+
+    var unmigratedEntriesFoundCount: Int = 0
+    var entriesMigratedCount: Int = 0
+    for (modernKey, legacyKey) in LegacyMigration.legacyColorPrefKeyMap {
+      // Migrate pref only if there is a legacy entry with but no corresponding modern entry
+      guard persistedPrefKeys.contains(legacyKey.rawValue),
+            !persistedPrefKeys.contains(modernKey.rawValue) else { continue }
+      unmigratedEntriesFoundCount += 1
+
+      // Deserialize & convert legacy pref value to modern string format:
+      guard let legacyData = Preference.data(for: legacyKey) else { continue }
+      guard let color = NSUnarchiver.unarchiveObject(with: legacyData) as? NSColor,
+            let mpvColorString = color.usingColorSpace(.deviceRGB)?.mpvColorString else {
+        Logger.log("Failed to convert color value from legacy pref \(legacyKey.rawValue)", level: .error)
+        continue
+      }
+      // Store string under modern pref key:
+      Preference.set(mpvColorString, for: modernKey)
+      Logger.log("Converted color value from legacy pref \(legacyKey.rawValue) and stored in pref \(modernKey.rawValue)")
+      entriesMigratedCount += 1
+    }
+    if unmigratedEntriesFoundCount == 0 {
+      Logger.log("No unmigrated legacy color prefs found")
+    } else {
+      Logger.log("Migrated \(entriesMigratedCount) of \(unmigratedEntriesFoundCount) legacy color prefs")
+    }
+  }
+
+}

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -345,8 +345,8 @@ not applying FFmpeg 9599 workaround
     setUserOption(PK.subTextFont, type: .string, forName: MPVOption.Subtitles.subFont)
     setUserOption(PK.subTextSize, type: .float, forName: MPVOption.Subtitles.subFontSize)
 
-    setUserOption(PK.subTextColor, type: .color, forName: MPVOption.Subtitles.subColor)
-    setUserOption(PK.subBgColor, type: .color, forName: MPVOption.Subtitles.subBackColor)
+    setUserOption(PK.subTextColorString, type: .color, forName: MPVOption.Subtitles.subColor)
+    setUserOption(PK.subBgColorString, type: .color, forName: MPVOption.Subtitles.subBackColor)
 
     setUserOption(PK.subBold, type: .bool, forName: MPVOption.Subtitles.subBold)
     setUserOption(PK.subItalic, type: .bool, forName: MPVOption.Subtitles.subItalic)
@@ -355,10 +355,10 @@ not applying FFmpeg 9599 workaround
     setUserOption(PK.subSpacing, type: .float, forName: MPVOption.Subtitles.subSpacing)
 
     setUserOption(PK.subBorderSize, type: .float, forName: MPVOption.Subtitles.subBorderSize)
-    setUserOption(PK.subBorderColor, type: .color, forName: MPVOption.Subtitles.subBorderColor)
+    setUserOption(PK.subBorderColorString, type: .color, forName: MPVOption.Subtitles.subBorderColor)
 
     setUserOption(PK.subShadowSize, type: .float, forName: MPVOption.Subtitles.subShadowOffset)
-    setUserOption(PK.subShadowColor, type: .color, forName: MPVOption.Subtitles.subShadowColor)
+    setUserOption(PK.subShadowColorString, type: .color, forName: MPVOption.Subtitles.subShadowColor)
 
     setUserOption(PK.subAlignX, type: .other, forName: MPVOption.Subtitles.subAlignX) { key in
       let v = Preference.integer(for: key)
@@ -1413,7 +1413,7 @@ not applying FFmpeg 9599 workaround
       code = setOptionalOptionString(name, Preference.string(for: key))
 
     case .color:
-      let value = Preference.mpvColor(for: key)
+      let value = Preference.string(for: key)
       code = setOptionalOptionString(name, value)
       // Random error here (perhaps a Swift or mpv one), so set it twice
       // 「没有什么是 set 不了的；如果有，那就 set 两次」
@@ -1472,7 +1472,7 @@ not applying FFmpeg 9599 workaround
         }
 
       case .color:
-        if let value = Preference.mpvColor(for: info.prefKey) {
+        if let value = Preference.string(for: info.prefKey) {
           setString(info.optionName, value)
         }
 

--- a/iina/PrefSubViewController.swift
+++ b/iina/PrefSubViewController.swift
@@ -236,3 +236,26 @@ class PrefSubViewController: PreferenceViewController, PreferenceWindowEmbeddabl
   }
 
 }
+
+@objc(MPVColorStringTransformer) class MPVColorStringTransformer: ValueTransformer {
+
+  static override func allowsReverseTransformation() -> Bool {
+    return true
+  }
+
+  static override func transformedValueClass() -> AnyClass {
+    return NSString.self
+  }
+
+  // Serializes an NSColor to an mpv-recognized string
+  override func transformedValue(_ value: Any?) -> Any? {
+    guard let mpvColorString = value as? NSString else { return nil }
+    return NSColor(mpvColorString: String(mpvColorString))
+  }
+
+  override func reverseTransformedValue(_ value: Any?) -> Any? {
+    guard let color = value as? NSColor else { return nil }
+    return color.usingColorSpace(.deviceRGB)!.mpvColorString
+  }
+}
+

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -180,16 +180,16 @@ struct Preference {
     static let subOverrideLevel = Key("subOverrideLevel")
     static let subTextFont = Key("subTextFont")
     static let subTextSize = Key("subTextSize")
-    static let subTextColor = Key("subTextColor")
-    static let subBgColor = Key("subBgColor")
+    static let subTextColorString = Key("subTextColorString")
+    static let subBgColorString = Key("subBgColorString")
     static let subBold = Key("subBold")
     static let subItalic = Key("subItalic")
     static let subBlur = Key("subBlur")
     static let subSpacing = Key("subSpacing")
     static let subBorderSize = Key("subBorderSize")
-    static let subBorderColor = Key("subBorderColor")
+    static let subBorderColorString = Key("subBorderColorString")
     static let subShadowSize = Key("subShadowSize")
-    static let subShadowColor = Key("subShadowColor")
+    static let subShadowColorString = Key("subShadowColorString")
     static let subAlignX = Key("subAlignX")
     static let subAlignY = Key("subAlignY")
     static let subMarginX = Key("subMarginX")
@@ -800,16 +800,16 @@ struct Preference {
     .subOverrideLevel: SubOverrideLevel.strip.rawValue,
     .subTextFont: "sans-serif",
     .subTextSize: Float(55),
-    .subTextColor: NSArchiver.archivedData(withRootObject: NSColor.white),
-    .subBgColor: NSArchiver.archivedData(withRootObject: NSColor.clear),
+    .subTextColorString: NSColor.white.usingColorSpace(.deviceRGB)!.mpvColorString,
+    .subBgColorString: NSColor.clear.usingColorSpace(.deviceRGB)!.mpvColorString,
     .subBold: false,
     .subItalic: false,
     .subBlur: Float(0),
     .subSpacing: Float(0),
     .subBorderSize: Float(3),
-    .subBorderColor: NSArchiver.archivedData(withRootObject: NSColor.black),
+    .subBorderColorString: NSColor.black.usingColorSpace(.deviceRGB)!.mpvColorString,
     .subShadowSize: Float(0),
-    .subShadowColor: NSArchiver.archivedData(withRootObject: NSColor.clear),
+    .subShadowColorString: NSColor.clear.usingColorSpace(.deviceRGB)!.mpvColorString,
     .subAlignX: SubAlign.center.rawValue,
     .subAlignY: SubAlign.bottom.rawValue,
     .subMarginX: Float(25),
@@ -932,10 +932,6 @@ struct Preference {
 
   static func value(for key: Key) -> Any? {
     return ud.value(forKey: key.rawValue)
-  }
-
-  static func mpvColor(for key: Key) -> String? {
-    return ud.mpvColor(forKey: key.rawValue)
   }
 
   static func set(_ value: Bool, for key: Key) {


### PR DESCRIPTION
- [X] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**

`NSArchiver` & `NSUnarchiver` are deprecated, and XCode is showing warnings. But currently IINA relies on them to serialize `NSColor` to binary format when storing the following prefs:

1. `subTextColor`
2. `subBgColor`
3. `subBorderColor`
4. `subShadowColor`

But if storing these in binary format was ever necessary, it's not now. There is already code to write the color into a string, in the format that mpv expects (search the existing code for `mpvColorString`). It wasn't too hard to change the code to store a `String` in the prefs. I did have to write a new `ValueTransformer` for it to make the XIB happy but it wasn't hard.

But changing the datatype of the 4 prefs is probably not the best idea, because doing that will cause legacy versions of IINA to show error messages when they try to read the prefs and don't get the type they were expecting.

So the code here will create 4 new pref entries with the same names but ending in `String`:
1. `subTextColorString`
2. `subBgColorString`
3. `subBorderColorString`
4. `subShadowColorString`

And all references in code are changed to use these values.

It also adds some logic at the start of IINA when the prefs are loaded:

- For the 4 prefs, it first checks to see if there is a new-style `String`-format entry.
- If `String` entry found, returns it.
- If `String` entry not found, it looks for an legacy-style `NSArchiver`-style entry.
  - If that is found, it infers that the user has just upgraded their version of IINA. So it:
    - Reads in the legacy entry,
    - Copies it into the new entry in the new `String` format
    - Returns it.
   
See `convertFromLegacyColor()` for more details.

This way, older versions of IINA will not be affected by the change to the new format, but users will be given a path away from `NSArchiver` without losing any data. Maybe after a couple versions of IINA (or when `NSArchiver` is killed by Apple), all references to the legacy entries can be dropped.  Unfortunately, until then, there will still be 1 `NSArchiver` warning (down from 4), but this seems unavoidable unless we are willing to drop the users' existing prefs for these 4 colors.