### PR TITLE
Fix PlayerCore.active not accessed from main thread, #4251

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -17,6 +17,8 @@ class PlayerCore: NSObject {
 
   static private weak var _lastActive: PlayerCore?
 
+  /// - Important: Code referencing this property **must** be run on the main thread as getting the value of this property _may_
+  ///              result in a reference the `active` property and that requires use of the main thread.
   static var lastActive: PlayerCore {
     get {
       return _lastActive ?? active
@@ -26,6 +28,8 @@ class PlayerCore: NSObject {
     }
   }
 
+  /// - Important: Code referencing this property **must** be run on the main thread because it references
+  ///              [NSApplication.mainWindow`](https://developer.apple.com/documentation/appkit/nsapplication/1428723-mainwindow)
   static var active: PlayerCore {
     if let wc = NSApp.mainWindow?.windowController as? MainWindowController {
       return wc.player
@@ -1451,10 +1455,10 @@ class PlayerCore: NSObject {
     mainWindow.videoView.videoLayer.draw(forced: true)
 
     if #available(macOS 10.13, *), RemoteCommandController.useSystemMediaControl {
-      NowPlayingInfoManager.updateInfo()
+      DispatchQueue.main.sync {
+        NowPlayingInfoManager.updateInfo()
+      }
     }
-
-
     DispatchQueue.main.async {
       Timer.scheduledTimer(timeInterval: TimeInterval(0.2), target: self, selector: #selector(self.reEnableOSDAfterFileLoading), userInfo: nil, repeats: false)
     }
@@ -2064,14 +2068,20 @@ extension PlayerCore: FFmpegControllerDelegate {
 
 @available (macOS 10.13, *)
 class NowPlayingInfoManager {
-  static private let lock = NSLock()
 
+  /// Update the information shown by macOS in `Now Playing`.
+  ///
+  /// The macOS [Control Center](https://support.apple.com/guide/mac-help/quickly-change-settings-mchl50f94f8f/mac)
+  /// contains a `Now Playing` module. This module can also be configured to be directly accessible from the menu bar.
+  /// `Now Playing` displays the title of the media currently  playing and other information about the state of playback. It also can be
+  /// used to control playback. IINA is fully integrated with the macOS `Now Playing` module.
+  ///
+  /// - Note: See [Becoming a Now Playable App](https://developer.apple.com/documentation/mediaplayer/becoming_a_now_playable_app)
+  ///         and [MPNowPlayingInfoCenter](https://developer.apple.com/documentation/mediaplayer/mpnowplayinginfocenter)
+  ///         for more information.
+  ///
+  /// - Important: This method **must** be run on the main thread because it references `PlayerCore.lastActive`.
   static func updateInfo(state: MPNowPlayingPlaybackState? = nil, withTitle: Bool = false) {
-    // This method is called from the main thread and from background threads. Must single thread access.
-    lock.lock()
-    defer {
-      lock.unlock()
-    }
     let center = MPNowPlayingInfoCenter.default()
     var info = center.nowPlayingInfo ?? [String: Any]()
 


### PR DESCRIPTION
This commit will:
- Change `PlayerCore.playbackRestarted` to use the main thread to call `NowPlayingInfoManager.updateInfo`
- Remove locking from `NowPlayingInfoManager.updateInfo` since there is no longer a need to coordinate access from multiple threads
- Add comments pointing out the requirement to use the main thread

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4251.

---

**Description:**
