### PR TITLE
Make shuffle toggleable

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -888,8 +888,10 @@ class RemoteCommandController {
       PlayerCore.lastActive.togglePlaylistLoop()
       return .success
     }
-    remoteCommand.changeShuffleModeCommand.isEnabled = false
-    // remoteCommand.changeShuffleModeCommand.addTarget {})
+    remoteCommand.changeShuffleModeCommand.addTarget { _ in
+      PlayerCore.lastActive.toggleShuffle()
+      return .success
+    }
     remoteCommand.changePlaybackRateCommand.supportedPlaybackRates = [0.5, 1, 1.5, 2]
     remoteCommand.changePlaybackRateCommand.addTarget { event in
       PlayerCore.lastActive.setSpeed(Double((event as! MPChangePlaybackRateCommandEvent).playbackRate))

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -86,6 +86,7 @@
 "osd.filter_removed" = "Removed Filter";
 "osd.file_loop" = "File Loop: %@";
 "osd.playlist_loop" = "Playlist Loop: %@";
+"osd.shuffle" = "Shuffle: %@";
 
 "preference.title" = "Preferences";
 "preference.general" = "General";

--- a/iina/Base.lproj/MainMenu.xib
+++ b/iina/Base.lproj/MainMenu.xib
@@ -306,6 +306,9 @@ CA
                             <menuItem title="Playlist Loop" id="aSc-P6-fiZ">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                             </menuItem>
+                            <menuItem title="Shuffle" id="Mcf-JR-YVs">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                            </menuItem>
                             <menuItem title="Playlist" id="Gi5-1S-RQB">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                                 <menu key="submenu" title="Playlist" systemMenu="font" id="aXa-aM-Jaq"/>
@@ -764,6 +767,7 @@ CA
                 <outlet property="savedVideoFiltersMenu" destination="xhY-fF-oio" id="MDx-8r-ENg"/>
                 <outlet property="screenshot" destination="AoP-K6-Kb5" id="dhl-4W-7yS"/>
                 <outlet property="secondSubTrackMenu" destination="UwY-P2-Xdb" id="D3B-WW-bAk"/>
+                <outlet property="shufflePlaylist" destination="Mcf-JR-YVs" id="CbQ-WX-IbI"/>
                 <outlet property="smallerSize" destination="ZOF-MG-6II" id="0jA-m5-Qy7"/>
                 <outlet property="speedDown" destination="HsE-LN-Nd6" id="0ZB-lc-ngV"/>
                 <outlet property="speedDownSlightly" destination="DUP-nm-BJt" id="Ym7-LJ-eQp"/>

--- a/iina/Base.lproj/PlaylistViewController.xib
+++ b/iina/Base.lproj/PlaylistViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -32,22 +32,22 @@
             <rect key="frame" x="0.0" y="0.0" width="241" height="334"/>
             <subviews>
                 <tabView drawsBackground="NO" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="Yym-Zw-Hd8">
-                    <rect key="frame" x="0.0" y="0.0" width="241" height="294"/>
+                    <rect key="frame" x="0.0" y="0.0" width="241" height="279"/>
                     <font key="font" metaFont="system"/>
                     <tabViewItems>
                         <tabViewItem label="Playlist" identifier="1" id="rjs-Qf-mT6">
-                            <view key="view" ambiguous="YES" id="BXH-zz-cse">
-                                <rect key="frame" x="0.0" y="0.0" width="241" height="282"/>
+                            <view key="view" id="BXH-zz-cse">
+                                <rect key="frame" x="0.0" y="0.0" width="241" height="279"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
-                                    <scrollView ambiguous="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="28" horizontalPageScroll="10" verticalLineScroll="28" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n5h-uy-hbd">
-                                        <rect key="frame" x="0.0" y="24" width="236" height="258"/>
-                                        <clipView key="contentView" ambiguous="YES" drawsBackground="NO" copiesOnScroll="NO" id="2M9-8L-veI">
-                                            <rect key="frame" x="0.0" y="0.0" width="236" height="258"/>
+                                    <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="28" horizontalPageScroll="10" verticalLineScroll="28" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n5h-uy-hbd">
+                                        <rect key="frame" x="0.0" y="24" width="236" height="255"/>
+                                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="2M9-8L-veI">
+                                            <rect key="frame" x="0.0" y="0.0" width="236" height="255"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
-                                                <tableView focusRingType="none" verticalHuggingPriority="750" ambiguous="YES" allowsExpansionToolTips="YES" tableStyle="fullWidth" columnResizing="NO" autosaveColumns="NO" rowHeight="26" viewBased="YES" id="xIa-sI-0Xn">
-                                                    <rect key="frame" x="0.0" y="0.0" width="236" height="258"/>
+                                                <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" tableStyle="fullWidth" columnResizing="NO" autosaveColumns="NO" rowHeight="26" viewBased="YES" id="xIa-sI-0Xn">
+                                                    <rect key="frame" x="0.0" y="0.0" width="236" height="255"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <size key="intercellSpacing" width="3" height="2"/>
                                                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.080000000000000002" colorSpace="calibratedRGB"/>
@@ -216,10 +216,10 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                     </scrollView>
-                                    <customView ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="X2W-MY-vYB" userLabel="ToolBar">
+                                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="X2W-MY-vYB" userLabel="ToolBar">
                                         <rect key="frame" x="0.0" y="0.0" width="236" height="24"/>
                                         <subviews>
-                                            <button verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xKm-J1-NZs" userLabel="Remove Button">
+                                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xKm-J1-NZs" userLabel="Remove Button">
                                                 <rect key="frame" x="186" y="0.0" width="24" height="24"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="24" id="V4F-VM-w6F"/>
@@ -232,7 +232,7 @@
                                                     <action selector="removeBtnAction:" target="-2" id="Ihy-Ga-m0c"/>
                                                 </connections>
                                             </button>
-                                            <button verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7my-AM-8Ts">
+                                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="7my-AM-8Ts">
                                                 <rect key="frame" x="210" y="0.0" width="24" height="24"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="24" id="6gk-wr-fJW"/>
@@ -258,20 +258,20 @@
                                                     <action selector="loopBtnAction:" target="-2" id="nF4-D4-7dC"/>
                                                 </connections>
                                             </button>
-                                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xhU-qn-3aa">
+                                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xhU-qn-3aa" userLabel="Shuffle Button">
                                                 <rect key="frame" x="26" y="0.0" width="24" height="24"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="24" id="rpj-hJ-3Y9"/>
                                                 </constraints>
                                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="shuffle" imagePosition="only" alignment="center" alternateImage="shuffle-dark" lineBreakMode="truncatingTail" imageScaling="proportionallyDown" inset="2" id="Xx9-xM-Avl">
-                                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                    <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
                                                     <font key="font" metaFont="system"/>
                                                 </buttonCell>
                                                 <connections>
                                                     <action selector="shuffleBtnAction:" target="-2" id="ZiC-jw-zzz"/>
                                                 </connections>
                                             </button>
-                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="icQ-T6-fV9">
+                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="icQ-T6-fV9">
                                                 <rect key="frame" x="102" y="5" width="33" height="14"/>
                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" title="Label" id="6J7-iM-V5h">
                                                     <font key="font" metaFont="controlContent" size="11"/>
@@ -279,7 +279,7 @@
                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 </textFieldCell>
                                             </textField>
-                                            <button verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="W9C-Z7-hiI" userLabel="Add Button">
+                                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="W9C-Z7-hiI" userLabel="Add Button">
                                                 <rect key="frame" x="162" y="0.0" width="24" height="24"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="24" id="Wbf-h5-7Gb"/>
@@ -337,7 +337,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="241" height="294"/>
                                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="6tr-hz-bdD">
                                             <rect key="frame" x="0.0" y="0.0" width="241" height="294"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="31" rowSizeStyle="automatic" viewBased="YES" id="BvG-MR-6LX">
                                                     <rect key="frame" x="0.0" y="0.0" width="241" height="294"/>
@@ -459,7 +459,7 @@
                     </tabViewItems>
                 </tabView>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SOR-3l-PFj">
-                    <rect key="frame" x="121" y="294" width="120" height="48"/>
+                    <rect key="frame" x="121" y="279" width="120" height="48"/>
                     <buttonCell key="cell" type="square" title="CHAPTERS" bezelStyle="shadowlessSquare" alignment="center" imageScaling="proportionallyDown" inset="2" id="jUF-xa-uRI">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -469,7 +469,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5Zq-JQ-XO4">
-                    <rect key="frame" x="0.0" y="294" width="121" height="48"/>
+                    <rect key="frame" x="0.0" y="279" width="121" height="48"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="48" id="aPN-VC-eZR"/>
                     </constraints>
@@ -482,7 +482,7 @@
                     </connections>
                 </button>
                 <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="glW-5x-LJr">
-                    <rect key="frame" x="0.0" y="291" width="241" height="5"/>
+                    <rect key="frame" x="0.0" y="276" width="241" height="5"/>
                 </box>
             </subviews>
             <constraints>
@@ -529,7 +529,7 @@
                     <rect key="frame" x="8" y="28" width="224" height="42"/>
                     <clipView key="contentView" drawsBackground="NO" id="6rI-3b-JZo">
                         <rect key="frame" x="0.0" y="0.0" width="224" height="42"/>
-                        <autoresizingMask key="autoresizingMask"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="none" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="16" id="puj-Kl-qOI">
                                 <rect key="frame" x="0.0" y="0.0" width="432" height="42"/>

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -111,6 +111,7 @@ class MPVController: NSObject {
     MPVOption.Subtitles.secondarySid: MPV_FORMAT_INT64,
     MPVOption.PlaybackControl.pause: MPV_FORMAT_FLAG,
     MPVOption.PlaybackControl.loopPlaylist: MPV_FORMAT_STRING,
+    MPVOption.PlaybackControl.shuffle: MPV_FORMAT_FLAG,
     MPVProperty.chapter: MPV_FORMAT_INT64,
     MPVOption.Video.deinterlace: MPV_FORMAT_FLAG,
     MPVOption.Video.hwdec: MPV_FORMAT_STRING,
@@ -1081,6 +1082,9 @@ class MPVController: NSObject {
 
     case MPVOption.PlaybackControl.loopPlaylist:
       player.syncUI(.playlistLoop)
+    
+    case MPVOption.PlaybackControl.shuffle:
+      player.syncUI(.shuffle)
 
     case MPVOption.Video.deinterlace:
       needReloadQuickSettingsView = true

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -146,6 +146,10 @@ extension MainMenuActionHandler {
   @objc func menuPlaylistLoop(_ sender: NSMenuItem) {
     player.togglePlaylistLoop()
   }
+  
+  @objc func menuShufflePlaylist(_ sender: NSMenuItem) {
+    player.toggleShuffle()
+  }
 
   @objc func menuPlaylistItem(_ sender: NSMenuItem) {
     let index = sender.tag

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -84,6 +84,7 @@ class MenuController: NSObject, NSMenuDelegate {
   @IBOutlet weak var playlistPanel: NSMenuItem!
   @IBOutlet weak var playlist: NSMenuItem!
   @IBOutlet weak var playlistLoop: NSMenuItem!
+  @IBOutlet weak var shufflePlaylist: NSMenuItem!
   @IBOutlet weak var playlistMenu: NSMenu!
   @IBOutlet weak var nextMedia: NSMenuItem!
   @IBOutlet weak var previousMedia: NSMenuItem!
@@ -230,6 +231,7 @@ class MenuController: NSObject, NSMenuDelegate {
     playlistMenu.delegate = self
     chapterMenu.delegate = self
     playlistLoop.action = #selector(MainMenuActionHandler.menuPlaylistLoop(_:))
+    shufflePlaylist.action = #selector(MainMenuActionHandler.menuShufflePlaylist(_:))
     playlistPanel.action = #selector(MainWindowController.menuShowPlaylistPanel(_:))
     chapterPanel.action = #selector(MainWindowController.menuShowChaptersPanel(_:))
 
@@ -463,6 +465,8 @@ class MenuController: NSObject, NSMenuDelegate {
     fileLoop.state = isLoop ? .on : .off
     let isPlaylistLoop = player.mpv.getString(MPVOption.PlaybackControl.loopPlaylist)
     playlistLoop.state = (isPlaylistLoop == "inf" || isPlaylistLoop == "force") ? .on : .off
+    let isShuffled = player.mpv.getFlag(MPVOption.PlaybackControl.shuffle)
+    shufflePlaylist.state = isShuffled ? .on : .off
     speedIndicator.title = String(format: NSLocalizedString("menu.speed", comment: "Speed:"), player.info.playSpeed)
   }
 

--- a/iina/OSDMessage.swift
+++ b/iina/OSDMessage.swift
@@ -77,6 +77,7 @@ enum OSDMessage {
 
   case fileLoop(Bool)
   case playlistLoop(Bool)
+  case shuffle(Bool)
 
   case custom(String)
   case customWithDetail(String, String)
@@ -336,6 +337,14 @@ enum OSDMessage {
       return (
         String(format: NSLocalizedString("osd.playlist_loop", comment: "Playlist Loop: %@"),
                enabled ? NSLocalizedString("general.on", comment: "On") : NSLocalizedString("general.off", comment: "Off")),
+        .normal
+      )
+
+    case .shuffle(let enabled):
+      return (
+        String(format: NSLocalizedString("osd.shuffle", comment: "Shuffle: %@"),
+               enabled ? NSLocalizedString("general.on", comment: "On") :
+                   NSLocalizedString("general.off", comment: "Off")),
         .normal
       )
     case .custom(let message):

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -742,8 +742,14 @@ class PlayerCore: NSObject {
     sendOSD(.playlistLoop(!isLoop))
   }
 
-  func toggleShuffle() {
-    mpv.command(.playlistShuffle)
+  func toggleShuffle() {  // TODO add OSD message
+    let isShuffled = mpv.getFlag(MPVOption.PlaybackControl.shuffle)
+    if isShuffled {
+      mpv.command(.playlistUnshuffle)
+    } else {
+      mpv.command(.playlistShuffle)
+    }
+    mpv.setFlag(MPVOption.PlaybackControl.shuffle, !isShuffled)
     postNotification(.iinaPlaylistChanged)
   }
 
@@ -1584,6 +1590,7 @@ class PlayerCore: NSObject {
     case playlist
     case playlistLoop
 //    case fileLoop
+    case shuffle
     case additionalInfo
   }
 
@@ -1688,6 +1695,11 @@ class PlayerCore: NSObject {
     case .playlistLoop:
       DispatchQueue.main.async {
         self.mainWindow.playlistView.updateLoopBtnStatus()
+      }
+    
+    case .shuffle:
+      DispatchQueue.main.async {
+        self.mainWindow.playlistView.updateShuffleBtnStatus()
       }
 
     case .additionalInfo:

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -742,7 +742,7 @@ class PlayerCore: NSObject {
     sendOSD(.playlistLoop(!isLoop))
   }
 
-  func toggleShuffle() {  // TODO add OSD message
+  func toggleShuffle() {
     let isShuffled = mpv.getFlag(MPVOption.PlaybackControl.shuffle)
     if isShuffled {
       mpv.command(.playlistUnshuffle)
@@ -750,6 +750,7 @@ class PlayerCore: NSObject {
       mpv.command(.playlistShuffle)
     }
     mpv.setFlag(MPVOption.PlaybackControl.shuffle, !isShuffled)
+    sendOSD(.shuffle(!isShuffled))
     postNotification(.iinaPlaylistChanged)
   }
 

--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -150,6 +150,9 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
 
     let loopStatus = player.mpv.getString(MPVOption.PlaybackControl.loopPlaylist)
     loopBtn.state = (loopStatus == "inf" || loopStatus == "force") ? .on : .off
+    
+    let shuffleStatus = player.mpv.getFlag(MPVOption.PlaybackControl.shuffle)
+    shuffleBtn.state = shuffleStatus ? .on : .off
   }
 
   deinit {
@@ -205,6 +208,12 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
     guard isViewLoaded else { return }
     let loopStatus = player.mpv.getString(MPVOption.PlaybackControl.loopPlaylist)
     loopBtn.state = (loopStatus == "inf" || loopStatus == "force") ? .on : .off
+  }
+  
+  func updateShuffleBtnStatus() {
+    guard isViewLoaded else { return }
+    let shuffleStatus = player.mpv.getFlag(MPVOption.PlaybackControl.shuffle)
+    shuffleBtn.state = shuffleStatus ? .on : .off
   }
     
   // MARK: - Tab switching

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -84,6 +84,7 @@
 "osd.filter_removed" = "Removed Filter";
 "osd.file_loop" = "File Loop: %@";
 "osd.playlist_loop" = "Playlist Loop: %@";
+"osd.shuffle" = "Shuffle: %@";
 
 "preference.title" = "Preferences";
 "preference.general" = "General";


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #718 .

---

**Description:**

The shuffle button now shuffles the playlist when toggled on, and unshuffles the playlist using mpv's `playlist-unshuffle` when toggled off.

I've also added a menu bar item and an OSD message. I've put the new shuffle UI elements (& code) next to playlist-loop, to match where it is in the playlist view.