### PR TITLE
Set `pendingRedraws` after exiting

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2786,7 +2786,7 @@ extension MainWindowController: PIPViewControllerDelegate {
     if player.info.isPaused || currentTrackIsAlbumArt {
       // It takes two `layout` before finishing entering PIP (tested on macOS 12, but
       // could be earlier). Force redraw for the first two `layout`s.
-      videoView.pendingRedrawsAfterEnteringPIP = 2
+      videoView.pendingRedraws = 1
     }
 
     if let window = self.window {
@@ -2839,7 +2839,7 @@ extension MainWindowController: PIPViewControllerDelegate {
     // noticeable, we only redraw if we are paused.
     let currentTrackIsAlbumArt = player.info.currentTrack(.video)?.isAlbumart ?? false
     if player.info.isPaused || currentTrackIsAlbumArt {
-      videoView.videoLayer.draw(forced: true)
+      videoView.pendingRedraws = 1
     }
 
     updateTimer()

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -37,7 +37,7 @@ class VideoView: NSView {
   // cached indicator to prevent unnecessary updates of DisplayLink
   var currentDisplay: UInt32?
 
-  var pendingRedrawsAfterEnteringPIP = 0;
+  var pendingRedraws = 0;
 
   lazy var hdrSubsystem = Logger.Subsystem(rawValue: "hdr")
 
@@ -95,8 +95,8 @@ class VideoView: NSView {
 
   override func layout() {
     super.layout()
-    if pendingRedrawsAfterEnteringPIP != 0 && superview != nil {
-      pendingRedrawsAfterEnteringPIP -= 1
+    if pendingRedraws != 0 && superview != nil {
+      pendingRedraws -= 1
       videoLayer.draw(forced: true)
     }
   }

--- a/iina/iina-Bridging-Header.h
+++ b/iina/iina-Bridging-Header.h
@@ -44,9 +44,8 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol PIPViewControllerDelegate <NSObject>
 
 @optional
-// it seems the system doesn't call this function since macOS 10.15
+// the system might only call `pipShouldClose` or only call `pipWillClose` or both, depending on the system version
 - (BOOL)pipShouldClose:(PIPViewController *)pip __OSX_AVAILABLE_STARTING(__MAC_10_12,__IPHONE_NA);
-// instead this is added in macOS 10.15
 - (void)pipWillClose:(PIPViewController *)pip __OSX_AVAILABLE_STARTING(__MAC_10_12,__IPHONE_NA);
 - (void)pipDidClose:(PIPViewController *)pip __OSX_AVAILABLE_STARTING(__MAC_10_12,__IPHONE_NA);
 - (void)pipActionPlay:(PIPViewController *)pip __OSX_AVAILABLE_STARTING(__MAC_10_12,__IPHONE_NA);


### PR DESCRIPTION
trying to fix #4268

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4268.

---

**Description:**
Previous PR about a similar issue: https://github.com/iina/iina/pull/3973

It seems now we not only need 2 forced redraws after entering PIP,  but also exiting PIP. This commit should temporarily fix the issue.