### PR TITLE
Fix cannot apply filters to multiple windows, #4273

### DIFF
--- a/iina/Base.lproj/FilterWindowController.xib
+++ b/iina/Base.lproj/FilterWindowController.xib
@@ -8,6 +8,7 @@
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="FilterWindowController" customModule="IINA" customModuleProvider="target">
             <connections>
+                <outlet property="addButton" destination="La1-eJ-8B2" id="R96-ah-Qy4"/>
                 <outlet property="currentFiltersTableView" destination="iTp-t4-bao" id="kgR-wA-2qY"/>
                 <outlet property="editFilterKeyRecordView" destination="dAY-w3-zCx" id="45M-ij-r6G"/>
                 <outlet property="editFilterKeyRecordViewLabel" destination="B5v-za-vBd" id="8JH-aQ-LQH"/>

--- a/iina/FilterWindowController.swift
+++ b/iina/FilterWindowController.swift
@@ -104,9 +104,13 @@ class FilterWindowController: NSWindowController, NSWindowDelegate {
     }
     currentFiltersTableView.reloadData()
     savedFiltersTableView.reloadData()
-    // Once a player window is being closed the user must not be allowed to add a filter to the
-    // active player core if it is being stopped and about to be added to the player core cache.
-    addButton.isEnabled = !pc.isStopping && !pc.isStopped
+    // If the preference "Always open media in a new window" is enabled then once a player window is
+    // being closed the user must not be allowed to add a filter to the active player core if it is
+    // being stopped and about to be added to the player core cache. With that preference enabled
+    // there can be multiple player/mpv cores cached which would result in random behavior as to
+    // what filters would be applied to the next video.
+    addButton.isEnabled = !Preference.bool(for: .alwaysOpenInNewWindow)
+                          || !pc.isStopping && !pc.isStopped
   }
 
   func setFilters() {


### PR DESCRIPTION
This commit will:
- Change `FilterWindowController` to use the active `PlayerCore`
- Change `FilterWindowController.reloadTable` to check if the active `PlayerCore` is shutting down
- Disable the ability to add a filter if the active core is stopping
- Change `PlayerCore.playbackStopped` to clear all audio and video filters

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4273.

---

**Description:**
