### PR TITLE
Fix inspector displays "Error" for filename, #4289

### DIFF
--- a/iina/InspectorWindowController.swift
+++ b/iina/InspectorWindowController.swift
@@ -260,7 +260,7 @@ class InspectorWindowController: NSWindowController, NSTableViewDelegate, NSTabl
     if identifier == .key {
       return property
     } else if identifier == .value {
-      return PlayerCore.active.mpv.getString(property) ?? "<Error>"
+      return PlayerCore.lastActive.mpv.getString(property) ?? "<Error>"
     }
     return ""
   }


### PR DESCRIPTION
This commit will change InspectorWindowController.tableView to use PlayerCore.lastActive to match up with the rest of the code in the class.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4289.

---

**Description:**
