### PR TITLE
Layout miniplyer window after setting the initial constraints

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -506,6 +506,7 @@ class PlayerCore: NSObject {
     let (width, height) = originalVideoSize
     let aspect = (width == 0 || height == 0) ? 1 : CGFloat(width) / CGFloat(height)
     miniPlayer.updateVideoViewAspectConstraint(withAspect: aspect)
+    miniPlayer.window?.layoutIfNeeded()
 
     // if received video size before switching to music mode, hide default album art
     if info.vid != 0 {


### PR DESCRIPTION
Otherwise `window.frame.height` will always be 72, which is the height without the video view. This incorrect height will affect later calucations.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This probably implements/fixes issue #4088.

---

## Analysis

When I was tracking down the issue #4088, I found that in `PlayerCore.switchToMiniPlayer`, the `videoView` is removed from the main window and added into the mini player. However, even through constraints are set correctly, the window frame is not updated immediately, and the window height will be 72 throughout the function `PlayerCore.switchToMiniPlayer`.

When trying to restore the layout of the mini player, `.musicModeShowAlbumArt` is firstly tested, but `miniPlayer.toggleVideoView()` is not called, in which we manually set the window frame. This is because the default behavior is album art being shown (`var isVideoVisible = true`). So the window frame height is still 72.

After that, if `.musicModeShowPlaylist` is true, we will call `miniPlayer.togglePlaylist()`. When it wants to show the playlist, it uses `window.frame` to get the current window size (in our case it is still 72) and then calculate the new height, which is the height with the playlist. After setting the frame with the calculated new height and done the window resizing animation, the system will call `windowDidEndLiveResize()`.

`if window.frame.height < normalWindowHeight() + AutoHidePlaylistThreshold`

In here, the left hand size is `72 + DefaultPlaylistHeight = 372`.

``` swift
private func normalWindowHeight() -> CGFloat {
  return 72 + (isVideoVisible ? videoWrapperView.frame.height : 0)
}
```
On the right hand side, the `normalWindowHeight()` is calculated based on `isVideoVisible`, which is always true by default, even if the window frame is not updated with `videoWrapperView.frame.height`, `normalWindowHeight()` incorrectly includes the height of the video. This will cause our window height not exceeding the threshold and make it automatically collapse the playlist.

## Solution

After setting up the constraints for video in the mini player, I manually layout the mini player, so that the window frame got updated immediately (should be 72 + height of the video), so that in `windowDidEndLiveResize()` the window height is correct, which will pass the threshold thus will not trigger a collapse.

I'm not sure whether this will fix #4088 but it at least fix some part of that issue.