### PR TITLE
Don't disable the subtitle scale slider for image subs

### DIFF
--- a/iina/QuickSettingViewController.swift
+++ b/iina/QuickSettingViewController.swift
@@ -289,7 +289,6 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
 
   private func updateSubTabControl() {
     if let currSub = player.info.currentTrack(.sub) {
-      subScaleSlider.isEnabled = !currSub.isImageSub
       // FIXME: CollorWells cannot be disable?
       let enableTextSettings = !(currSub.isAssSub || currSub.isImageSub)
       [subTextColorWell, subTextSizePopUp, subTextBgColorWell, subTextBorderColorWell, subTextBorderWidthPopUp, subTextFontBtn].forEach { $0.isEnabled = enableTextSettings }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4225 .

---

**Description:**
mpv can handle scale change for image subtitles without problem now. It might be a legacy problem for mpv.