### PR TITLE
Only load once when showing the PrefKeyBindingView

### DIFF
--- a/iina/PrefKeyBindingViewController.swift
+++ b/iina/PrefKeyBindingViewController.swift
@@ -102,7 +102,6 @@ class PrefKeyBindingViewController: NSViewController, PreferenceWindowEmbeddable
     currentConfName = currentConf
     guard let path = getFilePath(forConfig: currentConf) else { return }
     currentConfFilePath = path
-    loadConfigFile()
     
     NotificationCenter.default.addObserver(forName: .iinaKeyBindingChanged, object: nil, queue: .main, using: saveToConfFile)
   }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)

---

**Description:**
https://github.com/iina/iina/blob/b17fa5d12549be910d9ace9a63852aeacce7275b/iina/PrefKeyBindingViewController.swift#L101
This line already triggers `loadConfigFile()`, so there's no need to load it again. Slightly improve performance.