### PR TITLE
Suppress warning from Sparkle 2.4.0

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -96,6 +96,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 
   // MARK: - SPUUpdaterDelegate
 
+  @IBOutlet weak var updaterController: SPUStandardUpdaterController!
+
   func feedURLString(for updater: SPUUpdater) -> String? {
     return Preference.bool(for: .receiveBetaUpdate) ? AppData.appcastBetaLink : AppData.appcastLink
   }
@@ -219,6 +221,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     if !isReady {
       getReady()
     }
+
+    // see https://sparkle-project.org/documentation/api-reference/Classes/SPUUpdater.html#/c:objc(cs)SPUUpdater(im)clearFeedURLFromUserDefaults
+    updaterController.updater.clearFeedURLFromUserDefaults()
 
     // show alpha in color panels
     NSColorPanel.shared.showsAlpha = true

--- a/iina/Base.lproj/MainMenu.xib
+++ b/iina/Base.lproj/MainMenu.xib
@@ -16,6 +16,7 @@
             <connections>
                 <outlet property="dockMenu" destination="fxS-xv-Jb2" id="YdT-kw-qmk"/>
                 <outlet property="menuController" destination="cyK-tE-xgA" id="6U6-oJ-g0G"/>
+                <outlet property="updaterController" destination="wTK-gz-aTs" id="pWT-ES-mjo"/>
             </connections>
         </customObject>
         <customObject id="YLy-65-1bz" customClass="NSFontManager"/>


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)

---

**Description:**
- See https://sparkle-project.org/documentation/api-reference/Classes/SPUUpdater.html#/c:objc(cs)SPUUpdater(im)clearFeedURLFromUserDefaults
- And previous update from Sparkle 1.x to 2.x: #4047

@low-batt Also I was shocked that SwiftPM's `Package.resolved` is not tracked by git (since it deeply resides in the `xcodeproj` `xcworkspace` and `xcshareddata` folders). That's why I didn't get the warning, and since you start from git clone, all packages are checked out to the latest version. I think we should consider adding `Package.resolved` into the version control. Discussion about this: https://forums.swift.org/t/package-resolved-should-go-in-the-gitignore/14699