### PR TITLE
Fix: cursor lost when dragging clip view edges

### DIFF
--- a/iina/CropBoxView.swift
+++ b/iina/CropBoxView.swift
@@ -220,8 +220,8 @@ class CropBoxView: NSView {
   func updateCursorRects() {
     let x = boxRect.origin.x
     let y = boxRect.origin.y
-    let w = boxRect.width
-    let h = boxRect.height
+    let w = boxRect.size.width
+    let h = boxRect.size.height
 
     rectTop = NSMakeRect(x, y-2, w, 4)
     rectBottom = NSMakeRect(x, y+h-2, w, 4)

--- a/iina/CropBoxView.swift
+++ b/iina/CropBoxView.swift
@@ -205,7 +205,6 @@ class CropBoxView: NSView {
     path.lineWidth = 2
     path.fill()
     path.stroke()
-
   }
 
   // MARK: - Cursor rects
@@ -222,11 +221,25 @@ class CropBoxView: NSView {
     let y = boxRect.origin.y
     let w = boxRect.size.width
     let h = boxRect.size.height
-
-    rectTop = NSMakeRect(x, y-2, w, 4)
-    rectBottom = NSMakeRect(x, y+h-2, w, 4)
-    rectLeft = NSMakeRect(x-2, y+2, 4, h-4)
-    rectRight = NSMakeRect(x+w-2, y+2, 4, h-4)
+    
+    // call NSMakeRect with non-negative width and heights
+    func makeRect(_ x: CGFloat, _ y: CGFloat, _ w: CGFloat, _ h: CGFloat) -> NSRect {
+      var (x, y, w, h) = (x, y, w, h)
+      if w < 0 {
+        w = -w
+        x -= w
+      }
+      if h < 0 {
+        h = -h
+        y -= h
+      }
+      return NSMakeRect(x, y, w, h)
+    }
+    
+    rectTop = makeRect(x, y-2, w, 4)
+    rectBottom = makeRect(x, y+h-2, w, 4)
+    rectLeft = makeRect(x-2, y+2, 4, h-4)
+    rectRight = makeRect(x+w-2, y+2, 4, h-4)
 
     window?.invalidateCursorRects(for: self)
   }

--- a/iina/CropBoxView.swift
+++ b/iina/CropBoxView.swift
@@ -222,24 +222,10 @@ class CropBoxView: NSView {
     let w = boxRect.size.width
     let h = boxRect.size.height
     
-    // call NSMakeRect with non-negative width and heights
-    func makeRect(_ x: CGFloat, _ y: CGFloat, _ w: CGFloat, _ h: CGFloat) -> NSRect {
-      var (x, y, w, h) = (x, y, w, h)
-      if w < 0 {
-        w = -w
-        x -= w
-      }
-      if h < 0 {
-        h = -h
-        y -= h
-      }
-      return NSMakeRect(x, y, w, h)
-    }
-    
-    rectTop = makeRect(x, y-2, w, 4)
-    rectBottom = makeRect(x, y+h-2, w, 4)
-    rectLeft = makeRect(x-2, y+2, 4, h-4)
-    rectRight = makeRect(x+w-2, y+2, 4, h-4)
+    rectTop = NSMakeRect(x, y-2, w, 4).standardized
+    rectBottom = NSMakeRect(x, y+h-2, w, 4).standardized
+    rectLeft = NSMakeRect(x-2, y+2, 4, h-4).standardized
+    rectRight = NSMakeRect(x+w-2, y+2, 4, h-4).standardized
 
     window?.invalidateCursorRects(for: self)
   }

--- a/iina/CropBoxView.swift
+++ b/iina/CropBoxView.swift
@@ -221,7 +221,6 @@ class CropBoxView: NSView {
     let y = boxRect.origin.y
     let w = boxRect.size.width
     let h = boxRect.size.height
-    
     rectTop = NSMakeRect(x, y-2, w, 4).standardized
     rectBottom = NSMakeRect(x, y+h-2, w, 4).standardized
     rectLeft = NSMakeRect(x-2, y+2, 4, h-4).standardized


### PR DESCRIPTION
Start IINA and play a video, open "Quick Settings" panel and select Crop - "Custom...". Drag the right edge over the left boundary and release. The cursor that should appear on the left edge will be lost.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4299 .

---

**Description:**

In `CropBoxView.swift`, it uses a `boxRect: NSRect` to store currently selected clip region, and drew cursor rects around it to capture dragging events. `boxRect.size` can be negative, indicating that it expands southwest from its origin point.

However, `NSRect.width` and `NSRect.height` are always positive, so the cursor rects (colored in red) are misplaced.

<img width="1192" alt="A screenshot of misplaced cursor rects" src="https://user-images.githubusercontent.com/34335406/228108200-d344e041-ccc6-4c15-b24c-819357b1dd79.png">

Using `NSRect.size.width` and `NSRect.size.height` should fix this problem.
