### PR TITLE
Fix crop animation does not respect reduce motion, #4301

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2079,7 +2079,7 @@ class MainWindowController: PlayerWindowController {
 
     // show crop settings view
     NSAnimationContext.runAnimationGroup({ (context) in
-      context.duration = CropAnimationDuration
+      context.duration = AccessibilityPreferences.adjustedDuration(CropAnimationDuration)
       context.timingFunction = CAMediaTimingFunction(name: .easeIn)
       bottomBarBottomConstraint.animator().constant = 0
       ([.top, .bottom, .left, .right] as [NSLayoutConstraint.Attribute]).forEach { attr in
@@ -2118,7 +2118,7 @@ class MainWindowController: PlayerWindowController {
 
     // if with animation
     NSAnimationContext.runAnimationGroup({ (context) in
-      context.duration = CropAnimationDuration
+      context.duration = AccessibilityPreferences.adjustedDuration(CropAnimationDuration)
       context.timingFunction = CAMediaTimingFunction(name: .easeIn)
       bottomBarBottomConstraint.animator().constant = -InteractiveModeBottomViewHeight
       ([.top, .bottom, .left, .right] as [NSLayoutConstraint.Attribute]).forEach { attr in


### PR DESCRIPTION
The commit will change the `MainWindowController` methods `enterInteractiveMode` and `exitInteractiveMode` to use the method `AccessibilityPreferences.adjustedDuration` to suppress the zooming animation if reduce motion is enabled.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4301.

---

**Description:**
Minor change that makes use of the code added for issue #3437.