### PR TITLE
Fix resizing issue in interactive mode when the crop box width or height is negative

### DIFF
--- a/iina/CropBoxView.swift
+++ b/iina/CropBoxView.swift
@@ -185,6 +185,7 @@ class CropBoxView: NSView {
   override func mouseUp(with event: NSEvent) {
     if isDragging {
       isDragging = false
+      boxRect = boxRect.standardized
     } else if isFreeSelecting {
       isFreeSelecting = false
       updateCursorRects()
@@ -218,8 +219,8 @@ class CropBoxView: NSView {
   }
 
   func updateCursorRects() {
-    let x = boxRect.origin.x
-    let y = boxRect.origin.y
+    let x = boxRect.minX
+    let y = boxRect.minY
     let w = boxRect.width
     let h = boxRect.height
 


### PR DESCRIPTION
Standardize crop box upon `mouseUp`. Use `minX` and `minY` instead of `origin` when updating cursor rects to correct the behavior.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4299.