### PR TITLE
Use `addAttributes` instead of `setAttribute`

### DIFF
--- a/iina/Base.lproj/InitialWindowController.xib
+++ b/iina/Base.lproj/InitialWindowController.xib
@@ -377,7 +377,7 @@
                     <rect key="frame" x="10" y="96" width="298" height="42"/>
                     <textFieldCell key="cell" controlSize="small" selectable="YES" sendsActionOnEndEditing="YES" allowsEditingTextAttributes="YES" id="3aN-Hg-GkT">
                         <font key="font" metaFont="menu" size="11"/>
-                        <string key="title">Uncheck "receive beta updates" from Preferences - General, and install a stable release from our &lt;a href="https://iina.io"&gt;official website&lt;/a&gt;.</string>
+                        <string key="title">Uncheck "receive beta updates" from Settings &gt; General, and install a stable release from our &lt;a href="https://iina.io"&gt;official website&lt;/a&gt;.</string>
                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>

--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -483,14 +483,9 @@ extension NSTextField {
   func setHTMLValue(_ html: String) {
     let font = self.font ?? NSFont.systemFont(ofSize: NSFont.systemFontSize)
     let color = self.textColor ?? NSColor.labelColor
-    let style = String(format: "<style>body{font-family: '%@'; font-size:%fpx;}</style>", font.fontName, font.pointSize)
-    if let data = (style + html).data(using: .utf8), let string = NSMutableAttributedString(html: data, options: [.textEncodingName: "utf8"], documentAttributes: nil) {
-      string.enumerateAttributes(in: NSMakeRange(0, string.length) , options: []) { attrs, range, _ in
-        if attrs[.link] == nil {
-          string.setAttributes([.foregroundColor: color], range: range)
-        }
-      }
-      self.attributedStringValue = string
+    if let data = html.data(using: .utf8), let str = NSMutableAttributedString(html: data, documentAttributes: nil) {
+      str.addAttributes([.font: font, .foregroundColor: color], range: NSMakeRange(0, str.length))
+      self.attributedStringValue = str
     }
   }
 

--- a/iina/en.lproj/InitialWindowController.strings
+++ b/iina/en.lproj/InitialWindowController.strings
@@ -1,5 +1,5 @@
-/* Class = "NSTextFieldCell"; title = "Uncheck \"receive beta updates\" from Preferences - General, and install a stable release from our <a href=\"https://iina.io\">official website</a>."; ObjectID = "3aN-Hg-GkT"; */
-"3aN-Hg-GkT.title" = "Uncheck \"receive beta updates\" from Preferences - General, and install a stable release from our <a href=\"https://iina.io\">official website</a>.";
+/* Class = "NSTextFieldCell"; title = "Uncheck \"receive beta updates\" from Settings > General, and install a stable release from our <a href=\"https://iina.io\">official website</a>."; ObjectID = "3aN-Hg-GkT"; */
+"3aN-Hg-GkT.title" = "Uncheck \"receive beta updates\" from Settings > General, and install a stable release from our <a href=\"https://iina.io\">official website</a>.";
 
 /* Class = "NSTextFieldCell"; title = "Report to us via <a href=\"mailto:developers@iina.io\">email</a> or <a href=\"https://github.com/iina/iina/issues\">GitHub issue</a>."; ObjectID = "BIz-NQ-0qD"; */
 "BIz-NQ-0qD.title" = "Report to us via <a href=\"mailto:developers@iina.io\">email</a> or <a href=\"https://github.com/iina/iina/issues\">GitHub issue</a>.";


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)

---

**Description:**
This commit:
- Removes CSS used to set attributes for `NSAttributedString`
- Sets the font and color all together
- Fixes an issue where the font becomes incorrect when trying to select the text using mouse

Before:
![image](https://user-images.githubusercontent.com/20237141/229262697-9a0be7d5-b68d-486b-8131-9d2243fc2bc6.png)


After:
![image](https://user-images.githubusercontent.com/20237141/229262664-bc835beb-1182-4467-bfdd-bfe19164753c.png)

You can try this by commenting out this line:
https://github.com/iina/iina/blob/763700dea8afcff89af02868a0621f6d0097cb4e/iina/InitialWindowController.swift#L176