### PR TITLE
Fix `setHTMLValue` encoding issue

### DIFF
--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -483,7 +483,9 @@ extension NSTextField {
   func setHTMLValue(_ html: String) {
     let font = self.font ?? NSFont.systemFont(ofSize: NSFont.systemFontSize)
     let color = self.textColor ?? NSColor.labelColor
-    if let data = html.data(using: .utf8), let str = NSMutableAttributedString(html: data, documentAttributes: nil) {
+    if let data = html.data(using: .utf8), let str = NSMutableAttributedString(html: data,
+                                                                               options: [.textEncodingName: "utf8"],
+                                                                               documentAttributes: nil) {
       str.addAttributes([.font: font, .foregroundColor: color], range: NSMakeRange(0, str.length))
       self.attributedStringValue = str
     }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**

PR #4311 updates `setHTMLValue` extension method but seems it caused an encoding issue in "About - Translators" text field.

IINA nightly build [79345ab](https://github.com/iina/iina/commit/79345ab):

<img width="752" alt="image" src="https://user-images.githubusercontent.com/34335406/230556871-011c7a32-af0e-4740-a0a7-16ed6cf09efd.png">


Adding `.textEncodingName` option when constructing `NSMutableAttributedString` should fix this.