### PR TITLE
Fix new Xcode 14.3 compiler warnings

### DIFF
--- a/iina/InitialWindowController.swift
+++ b/iina/InitialWindowController.swift
@@ -289,7 +289,7 @@ extension InitialWindowController: NSTableViewDelegate, NSTableViewDataSource {
     return [
       "filename": url.lastPathComponent,
       "docIcon": NSWorkspace.shared.icon(forFile: url.path)
-    ]
+    ] as [String: Any]
   }
 
   // facilitates highlight on hover

--- a/iina/JavascriptAPICore.swift
+++ b/iina/JavascriptAPICore.swift
@@ -112,7 +112,7 @@ class JavascriptAPICore: JavascriptAPI, JavascriptAPICoreExportable {
         "date": $0.addedDate,
         "progress": $0.mpvProgress?.second ?? NSNull(),
         "duration": $0.duration.second
-      ]
+      ] as [String: Any]
     }
   }
 

--- a/iina/JavascriptAPIHttp.swift
+++ b/iina/JavascriptAPIHttp.swift
@@ -149,7 +149,7 @@ class JavascriptAPIXmlrpc: JavascriptAPI, JavascriptAPIXmlrpcExportable {
             "httpCode": err.httpCode,
             "reason": err.reason,
             "description": err.readableDescription,
-          ]])
+          ] as [String: Any]])
         }
       }
     }

--- a/iina/PrefKeyBindingViewController.swift
+++ b/iina/PrefKeyBindingViewController.swift
@@ -400,7 +400,7 @@ extension PrefKeyBindingViewController: NSTableViewDelegate, NSTableViewDataSour
     return [
       "name": name,
       "isHidden": !isDefaultConfig(name)
-    ]
+    ] as [String: Any]
   }
 
   // NSTableViewDelegate

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -792,7 +792,7 @@ struct Preference {
     .ytdlRawOptions: "",
     .httpProxy: "",
 
-    .inputConfigs: [:],
+    .inputConfigs: [String: Any](),
     .currentInputConfigName: "IINA Default",
 
     .enableAdvancedSettings: false,
@@ -800,7 +800,7 @@ struct Preference {
     .enableLogging: false,
     .logLevel: Logger.Level.debug.rawValue,
     .displayKeyBindingRawValues: false,
-    .userOptions: [],
+    .userOptions: [[String]](),
     .useUserDefinedConfDir: false,
     .userDefinedConfDir: "~/.config/mpv/",
     .iinaEnablePluginSystem: false,
@@ -829,9 +829,9 @@ struct Preference {
     .screenshotTemplate: "%F-%n",
     .screenshotShowPreview: true,
 
-    .watchProperties: [],
-    .savedVideoFilters: [],
-    .savedAudioFilters: [],
+    .watchProperties: [String](),
+    .savedVideoFilters: [SavedFilter](),
+    .savedAudioFilters: [SavedFilter](),
 
     .suppressCannotPreventDisplaySleep: false
   ]

--- a/iina/PreferenceWindowController.swift
+++ b/iina/PreferenceWindowController.swift
@@ -376,7 +376,7 @@ extension PreferenceWindowController: NSTableViewDelegate, NSTableViewDataSource
         "noSection": noLabel,
         "section": result.strippedSection,
         "label": result.strippedLabel ?? result.strippedSection,
-      ]
+      ] as [String: Any?]
     }
   }
 


### PR DESCRIPTION
This commit will update code to specify the types of collection literals to address these new warnings being reported by Xcode 14.3:
- Empty collection literal requires an explicit type
- Heterogeneous collection literal could only be inferred

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
