### PR TITLE
Fix crash in mpv_render_context_report_swap, #4315

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -445,6 +445,11 @@ class PlayerCore: NSObject {
     isShuttingDown = true
     Logger.log("Shutting down", subsystem: subsystem)
     savePlayerState()
+    // Once mpv has been instructed to quit accessing the mpv core can result in a crash. Must not
+    // allow the display link thread or the mpvGLQueue dispatch queue to continue processing because
+    // these entities will call mpv.
+    mainWindow.videoView.videoLayer.suspend()
+    mainWindow.videoView.stopDisplayLink()
     mpv.mpvQuit()
   }
 


### PR DESCRIPTION
This commit will change PlayerCore.shutdown to suspend the video layer mpvGLQueue dispatch queue and stop the display link before sending a quit command to mpv.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4315.

---

**Description:**
