### PR TITLE
Fix crash in PlayerCore.fileStarted, #3822

### DIFF
--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -185,7 +185,10 @@ class PlaybackInfo {
   var chapters: [MPVChapter] = []
   var chapter = 0
 
-  var matchedSubs: [String: [URL]] = [:]
+  @Atomic var matchedSubs: [String: [URL]] = [:]
+
+  func getMatchedSubs(_ file: String) -> [URL]? { $matchedSubs.withLock { $0[file] } }
+
   var currentSubsInfo: [FileInfo] = []
   var currentVideosInfo: [FileInfo] = []
 


### PR DESCRIPTION
This commit will:
- Add `Atomic` to `PlaybackInfo.matchedSubs`
- Add a `getMatchedSubs` method to `PlaybackInfo`
- Change `AutoFileMatcher`, `PlayerCore` and `PlaylistViewController` to hold a lock while accessing `matchedSubs`
- Add `Atomic` to `PlayerCore.backgroundQueueTicket`
- Change `PlayerCore.fileStarted` to hold a lock while incrementing `backgroundQueueTicket`
- Add code to `PlayerCore.stop` that increments `backgroundQueueTicket`

These changes insure the mutable Swift dictionary `matchedSubs` is only accessed by one thread at a time. Accessing a mutable dictionary from multiple threads without such coordination can result in a crash as seen in issue #3822.

These changes also attempt to insure the background task that finds and loads subtitle files stops its work if playback is stopped before that process completes.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #3822.

---

**Description:**
