### PR TITLE
Fix regression/crash in PlaySliderCell.knobRect

### DIFF
--- a/iina/PlaySliderCell.swift
+++ b/iina/PlaySliderCell.swift
@@ -133,9 +133,9 @@ class PlaySliderCell: NSSliderCell {
   }
 
   override func knobRect(flipped: Bool) -> NSRect {
-    let slider = self.controlView as! PlaySlider
+    let slider = self.controlView as! NSSlider
     let barRect = barRect(flipped: flipped)
-    let percentage = slider.doubleValue / slider.span
+    let percentage = slider.doubleValue / (slider.maxValue - slider.minValue)
     // The usable width of the bar is reduced by the width of the knob.
     let effectiveBarWidth = barRect.width - knobWidth
     let pos = barRect.origin.x + CGFloat(percentage) * effectiveBarWidth


### PR DESCRIPTION
This commit will change `PlaySliderCell.knobRect` to not cast controlView to `PlaySlider`.

`PlaySliderCell` must not assume it is being used by `PlaySlider` as that is not the case when the slider is in the mini-player.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
A small fix to correct a regression added by PR #3700.