### PR TITLE
Fix data race in Logger.makeSubsystem, #4352

### DIFF
--- a/iina/LogWindowController.swift
+++ b/iina/LogWindowController.swift
@@ -75,10 +75,12 @@ class LogWindowController: NSWindowController, NSMenuDelegate {
   func menuNeedsUpdate(_ menu: NSMenu) {
     // The first menu item is "All"
     let offset = 1
-    for (index, subsystem) in Logger.subsystems.enumerated() {
-      guard !subsystem.added else { continue }
-      subsystem.added = true
-      menu.insertItem(withTitle: subsystem.rawValue, action: nil, keyEquivalent: "", at: index + offset)
+    Logger.$subsystems.withLock() { subsystems in
+      for (index, subsystem) in subsystems.enumerated() {
+        guard !subsystem.added else { continue }
+        subsystem.added = true
+        menu.insertItem(withTitle: subsystem.rawValue, action: nil, keyEquivalent: "", at: index + offset)
+      }
     }
   }
 

--- a/iina/Logger.swift
+++ b/iina/Logger.swift
@@ -52,23 +52,25 @@ class Logger: NSObject {
     }
   }
 
-  static var subsystems: [Subsystem] = [.general]
+  @Atomic static var subsystems: [Subsystem] = [.general]
 
   static func makeSubsystem(_ rawValue: String) -> Subsystem {
-    for (index, subsystem) in subsystems.enumerated() {
-      // The first subsystem will always be "iina"
-      if index == 0 { continue }
-      if rawValue < subsystem.rawValue {
-        let newSubsystem = Subsystem(rawValue: rawValue)
-        subsystems.insert(newSubsystem, at: index)
-        return newSubsystem
-      } else if rawValue == subsystem.rawValue {
-        return subsystem
+    $subsystems.withLock() { subsystems in
+      for (index, subsystem) in subsystems.enumerated() {
+        // The first subsystem will always be "iina"
+        if index == 0 { continue }
+        if rawValue < subsystem.rawValue {
+          let newSubsystem = Subsystem(rawValue: rawValue)
+          subsystems.insert(newSubsystem, at: index)
+          return newSubsystem
+        } else if rawValue == subsystem.rawValue {
+          return subsystem
+        }
       }
+      let newSubsystem = Subsystem(rawValue: rawValue)
+      subsystems.append(newSubsystem)
+      return newSubsystem
     }
-    let newSubsystem = Subsystem(rawValue: rawValue)
-    subsystems.append(newSubsystem)
-    return newSubsystem
   }
 
   enum Level: Int, Comparable, CustomStringConvertible {


### PR DESCRIPTION
This commit will:
- Add the `Atomic` property wrapper to `Logger.subsystems`
- Change `Logger.makeSubsystem` to hold a lock while changing `subsystems`
- Change `LogWindowController.menuNeedsUpdate` to hold a lock while iterating over `subsystems`

Access to mutable Swift arrays by multiple threads must be coordinated. These changes use a lock to single thread access to the subsystems array correcting a rare data race detected by the thread sanitizer.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4352.

---

**Description:**
