### PR TITLE
Fix Quit after welcome window triggers crash, #4343

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -862,7 +862,7 @@ class MPVController: NSObject {
     case MPV_EVENT_AUDIO_RECONFIG: break
 
     case MPV_EVENT_VIDEO_RECONFIG:
-      onVideoReconfig()
+      player.onVideoReconfig()
 
     case MPV_EVENT_START_FILE:
       player.info.isIdle = false
@@ -988,28 +988,6 @@ class MPVController: NSObject {
       setFlag(MPVOption.PlaybackControl.pause, false)
     }
     player.syncUI(.playlist)
-  }
-
-  private func onVideoReconfig() {
-    // If loading file, video reconfig can return 0 width and height
-    if player.info.fileLoading {
-      return
-    }
-    var dwidth = getInt(MPVProperty.dwidth)
-    var dheight = getInt(MPVProperty.dheight)
-    if player.info.rotation == 90 || player.info.rotation == 270 {
-      swap(&dwidth, &dheight)
-    }
-    if dwidth != player.info.displayWidth! || dheight != player.info.displayHeight! {
-      // filter the last video-reconfig event before quit
-      if dwidth == 0 && dheight == 0 && getFlag(MPVProperty.coreIdle) { return }
-      // video size changed
-      player.info.displayWidth = dwidth
-      player.info.displayHeight = dheight
-      DispatchQueue.main.sync {
-        player.notifyMainWindowVideoSizeChanged()
-      }
-    }
   }
 
   // MARK: - Property listeners

--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -181,7 +181,7 @@ class ViewLayer: CAOpenGLLayer {
   }
 
   override func display() {
-    let needsFlush = videoView.$isUninited.withLock() { isUninited in
+    let needsFlush: Bool = videoView.$isUninited.withLock() { isUninited in
       guard !isUninited else { return false }
 
       super.display()


### PR DESCRIPTION
This commit will:
- Remove the incorrect fix added to `PlayerCore.shutdown` for issue #4315
- Add the `Atomic` property wrapper to the `VideoView.isUninited` property
- Change `VideoView.uninit` to hold a lock on `isUninited` when executing
- Change `VideoView.displayLinkCallback` to hold a lock on `isUninited` when executing
- Change `ViewLayer.draw` to to hold a lock on `isUninited` as needed
- Change `ViewLayer.display` to to hold a lock on `isUninited` as needd
- Remove the `Atomic` property wrapper from the `ViewLayer` properties `forceRender` and `needsMPVRender`
- Move the method `onVideoReconfig` from `MPVController` to `PlayerCore`
- Change the `onVideoReconfig` method to check for shutdown

These changes:
- Correct issue #4343 by removing the faulty fix for issue #4315
- Correct issue #4315 by coordinating threads during the shutdown of `VideoView`
- Correct a crash due to `onVideoReconfig` accessing the mpv core during shutdown

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4343.

---

**Description:**
