### PR TITLE
Close add HDR tone mapping settings, #4358

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -87,6 +87,7 @@
 		49542986216C34950058F680 /* OpenInIINA.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 49542973216C34950058F680 /* OpenInIINA.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		496B19921E2968530035AF10 /* PIP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 496B19911E2968530035AF10 /* PIP.framework */; };
 		513A4FFA29B53F8100A8EA7D /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513A4FF929B53F8100A8EA7D /* Atomic.swift */; };
+		5196819A29EC963F00B05D55 /* CoreDisplay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5196819929EC963F00B05D55 /* CoreDisplay.framework */; };
 		519872FF26879B9B00F84BCC /* AccessibilityPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519872FE26879B9B00F84BCC /* AccessibilityPreferences.swift */; };
 		51C1BA3A291CA76700C1208A /* InfoDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C1BA39291CA76700C1208A /* InfoDictionary.swift */; };
 		51CACB9529D500290034CEE5 /* VideoPIPViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51CACB9429D500290034CEE5 /* VideoPIPViewController.swift */; };
@@ -881,9 +882,10 @@
 		4964988C2919E47900CD61A5 /* Debug.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Debug.xcconfig; sourceTree = "<group>"; };
 		4964988D2919E47900CD61A5 /* Release.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		4964988E2919E47900CD61A5 /* OpenInIINA.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = OpenInIINA.xcconfig; sourceTree = "<group>"; };
-		496B19911E2968530035AF10 /* PIP.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PIP.framework; path = ../../../../System/Library/PrivateFrameworks/PIP.framework; sourceTree = "<group>"; };
+		496B19911E2968530035AF10 /* PIP.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PIP.framework; path = /System/Library/PrivateFrameworks/PIP.framework; sourceTree = "<group>"; };
 		49F7E3BF2920D65C002DA28E /* Availability.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Availability.xcconfig; sourceTree = "<group>"; };
 		513A4FF929B53F8100A8EA7D /* Atomic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
+		5196819929EC963F00B05D55 /* CoreDisplay.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreDisplay.framework; path = /System/Library/Frameworks/CoreDisplay.framework; sourceTree = "<group>"; };
 		519872FE26879B9B00F84BCC /* AccessibilityPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPreferences.swift; sourceTree = "<group>"; };
 		51C1BA39291CA76700C1208A /* InfoDictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InfoDictionary.swift; sourceTree = "<group>"; };
 		51CACB9429D500290034CEE5 /* VideoPIPViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPIPViewController.swift; sourceTree = "<group>"; };
@@ -1850,6 +1852,7 @@
 				8403CEA72007CBD400645516 /* MediaPlayer.framework in Frameworks */,
 				B4E4470125CE3F930069F06E /* Sparkle in Frameworks */,
 				8451E6D92604AEFC009A15D7 /* Just in Frameworks */,
+				5196819A29EC963F00B05D55 /* CoreDisplay.framework in Frameworks */,
 				B4E446F225CB53FF0069F06E /* Gzip in Frameworks */,
 				B4E446E825CB53920069F06E /* PromiseKit in Frameworks */,
 				B4E446F725CB54EF0069F06E /* Mustache in Frameworks */,
@@ -2054,8 +2057,10 @@
 				34AE82A329EE78DF005B8B7F /* libzstd.1.dylib */,
 				8403CEA62007CBD300645516 /* MediaPlayer.framework */,
 				845E2F491E76CFC2002C6588 /* libz.tbd */,
-				496B19911E2968530035AF10 /* PIP.framework */,
 				49542974216C34950058F680 /* Cocoa.framework */,
+				5196819929EC963F00B05D55 /* CoreDisplay.framework */,
+				8403CEA62007CBD300645516 /* MediaPlayer.framework */,
+				496B19911E2968530035AF10 /* PIP.framework */,
 			);
 			name = Frameworks;
 			sourceTree = "<group>";

--- a/iina/AppData.swift
+++ b/iina/AppData.swift
@@ -58,6 +58,9 @@ struct AppData {
   static let assrtRegisterLink = "https://secure.assrt.net/user/register.xml?redir=http%3A%2F%2Fassrt.net%2Fusercp.php"
   static let chromeExtensionLink = "https://chrome.google.com/webstore/detail/open-in-iina/pdnojahnhpgmdhjdhgphgdcecehkbhfo"
   static let firefoxExtensionLink = "https://addons.mozilla.org/addon/open-in-iina-x"
+  static let toneMappingHelpLink = "https://en.wikipedia.org/wiki/Tone_mapping"
+  static let targetPeakHelpLink = "https://mpv.io/manual/stable/#options-target-peak"
+  static let algorithmHelpLink = "https://mpv.io/manual/stable/#options-tone-mapping"
 
   static let widthWhenNoVideo = 640
   static let heightWhenNoVideo = 360

--- a/iina/Base.lproj/InspectorWindowController.xib
+++ b/iina/Base.lproj/InspectorWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19455" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19455"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -43,6 +43,7 @@
                 <outlet property="trackSelectedField" destination="lU2-XA-lgf" id="njA-cV-4hO"/>
                 <outlet property="trackSourceIdField" destination="n48-Ey-Kcr" id="08s-DD-bX8"/>
                 <outlet property="trackTitleField" destination="gNk-wZ-LBX" id="AZX-FZ-poh"/>
+                <outlet property="vPixelFormat" destination="WWd-BJ-GxF" id="3hZ-EU-KOT"/>
                 <outlet property="vbitrateField" destination="4PF-1d-gZO" id="Db5-5Q-lUm"/>
                 <outlet property="vcodecField" destination="6sj-bN-LIv" id="fxo-G8-ka1"/>
                 <outlet property="vcolorspaceField" destination="wxy-f3-FrW" id="vvv-An-cnQ"/>
@@ -64,19 +65,19 @@
             <rect key="contentRect" x="1539" y="436" width="350" height="430"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1728" height="1079"/>
             <view key="contentView" id="se5-gp-TjO">
-                <rect key="frame" x="0.0" y="0.0" width="350" height="454"/>
+                <rect key="frame" x="0.0" y="0.0" width="350" height="476"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <tabView drawsBackground="NO" controlSize="small" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="wHY-jo-uW0">
-                        <rect key="frame" x="12" y="12" width="326" height="406"/>
+                        <rect key="frame" x="12" y="12" width="326" height="428"/>
                         <tabViewItems>
                             <tabViewItem label="General" identifier="1" id="f7a-XG-NCc">
                                 <view key="view" id="mRY-yK-FeT">
-                                    <rect key="frame" x="0.0" y="0.0" width="326" height="406"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="326" height="428"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="I9X-Rp-scA">
-                                            <rect key="frame" x="10" y="382" width="44" height="16"/>
+                                            <rect key="frame" x="10" y="404" width="44" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="VIDEO" id="gDG-Eq-1Bc">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -84,7 +85,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hBf-Sx-lbf">
-                                            <rect key="frame" x="92" y="354" width="224" height="16"/>
+                                            <rect key="frame" x="92" y="376" width="224" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Format Label" id="c6m-YO-xqZ">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -140,7 +141,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aGE-iz-M2h">
-                                            <rect key="frame" x="10" y="356" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="378" width="78" height="14"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="74" id="ciu-up-5ds"/>
                                             </constraints>
@@ -159,7 +160,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FwA-X7-Alr">
-                                            <rect key="frame" x="10" y="334" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="356" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Codec:" id="bki-sE-xCA">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -207,7 +208,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ira-RI-5kc">
-                                            <rect key="frame" x="92" y="311" width="224" height="16"/>
+                                            <rect key="frame" x="92" y="333" width="224" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="HwD Label" id="iMk-qU-kVv">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -215,7 +216,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="z1d-SG-OZB">
-                                            <rect key="frame" x="10" y="312" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="334" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Hw Decoder:" id="DHh-ne-10f">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -282,7 +283,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Xol-2r-g7u">
-                                            <rect key="frame" x="10" y="290" width="75" height="14"/>
+                                            <rect key="frame" x="10" y="312" width="75" height="14"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" constant="71" id="ULh-mH-glh"/>
                                             </constraints>
@@ -301,7 +302,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Hm9-gI-9j7">
-                                            <rect key="frame" x="10" y="268" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="290" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Colorspace:" id="mLo-Wc-BoO">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -309,7 +310,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wxy-f3-FrW">
-                                            <rect key="frame" x="92" y="267" width="228" height="16"/>
+                                            <rect key="frame" x="92" y="289" width="228" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Colorspace Label" id="iMO-Ze-egg">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -325,7 +326,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="6sj-bN-LIv">
-                                            <rect key="frame" x="92" y="333" width="224" height="16"/>
+                                            <rect key="frame" x="92" y="355" width="224" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Codec Label" id="SzU-uF-10g">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -333,8 +334,24 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="s9S-zN-lwA">
-                                            <rect key="frame" x="92" y="289" width="224" height="16"/>
+                                            <rect key="frame" x="92" y="311" width="224" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Primaries Label" id="b34-md-3Dx">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dyh-2O-q0Y">
+                                            <rect key="frame" x="10" y="268" width="78" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Pixel Format:" id="UrR-u2-hFz">
+                                                <font key="font" metaFont="smallSystemBold"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WWd-BJ-GxF">
+                                            <rect key="frame" x="92" y="267" width="228" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Pixel Format Label" id="BsT-Yz-AgP">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -355,6 +372,7 @@
                                         <constraint firstAttribute="trailing" secondItem="v4j-fa-olc" secondAttribute="trailing" constant="12" id="8Tf-Ky-7WP"/>
                                         <constraint firstItem="6sj-bN-LIv" firstAttribute="centerY" secondItem="FwA-X7-Alr" secondAttribute="centerY" id="8ax-Nq-2MU"/>
                                         <constraint firstItem="GSF-Y5-FGJ" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="leading" id="9UE-9C-GAq"/>
+                                        <constraint firstItem="dyh-2O-q0Y" firstAttribute="top" secondItem="Hm9-gI-9j7" secondAttribute="bottom" constant="8" id="9en-Dh-zLJ"/>
                                         <constraint firstItem="Hm9-gI-9j7" firstAttribute="top" secondItem="Xol-2r-g7u" secondAttribute="bottom" constant="8" id="AWt-7R-ZTa"/>
                                         <constraint firstItem="EiP-Mu-9cf" firstAttribute="width" secondItem="6EL-aj-Hjq" secondAttribute="width" id="B7U-fB-UtT"/>
                                         <constraint firstItem="aGE-iz-M2h" firstAttribute="top" secondItem="I9X-Rp-scA" secondAttribute="bottom" constant="12" id="BeU-Ai-D6V"/>
@@ -386,6 +404,7 @@
                                         <constraint firstItem="EiP-Mu-9cf" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="O08-wB-hSa"/>
                                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="I9X-Rp-scA" secondAttribute="trailing" constant="20" symbolic="YES" id="PSJ-nK-rFv"/>
                                         <constraint firstItem="Xol-2r-g7u" firstAttribute="top" secondItem="z1d-SG-OZB" secondAttribute="bottom" constant="8" id="Q7j-tD-FPY"/>
+                                        <constraint firstAttribute="trailing" secondItem="WWd-BJ-GxF" secondAttribute="trailing" constant="8" id="QXi-hD-VTS"/>
                                         <constraint firstItem="Nn4-TP-Hpd" firstAttribute="leading" secondItem="apr-sq-JIb" secondAttribute="leading" id="QYI-0x-rCQ"/>
                                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="hGO-dV-reB" secondAttribute="trailing" constant="20" symbolic="YES" id="QwD-zL-Ztq"/>
                                         <constraint firstItem="6EL-aj-Hjq" firstAttribute="top" secondItem="hGO-dV-reB" secondAttribute="bottom" constant="12" id="RSl-a2-Yuc"/>
@@ -393,12 +412,14 @@
                                         <constraint firstAttribute="trailing" secondItem="S6Z-fT-kcG" secondAttribute="trailing" constant="12" id="Ryg-im-8s1"/>
                                         <constraint firstItem="GaY-iG-tAy" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="Sj5-Vc-ro8"/>
                                         <constraint firstItem="Hm9-gI-9j7" firstAttribute="leading" secondItem="Ldf-jT-tdl" secondAttribute="leading" id="UBG-1H-tXQ"/>
+                                        <constraint firstItem="WWd-BJ-GxF" firstAttribute="centerY" secondItem="dyh-2O-q0Y" secondAttribute="centerY" id="UMW-Lu-GG7"/>
                                         <constraint firstItem="GaY-iG-tAy" firstAttribute="leading" secondItem="Zp5-es-UTa" secondAttribute="trailing" constant="8" id="Vaf-by-Sni"/>
                                         <constraint firstItem="IXe-pS-a3x" firstAttribute="top" secondItem="dOE-eM-QQi" secondAttribute="bottom" constant="15" id="VoV-xO-OWt"/>
                                         <constraint firstItem="Hm9-gI-9j7" firstAttribute="leading" secondItem="Xol-2r-g7u" secondAttribute="leading" id="VvP-S8-Obo"/>
                                         <constraint firstItem="6EL-aj-Hjq" firstAttribute="width" secondItem="aGE-iz-M2h" secondAttribute="width" id="WYv-xd-gGz"/>
                                         <constraint firstItem="a3w-YC-7oN" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="Wb3-tr-ceH"/>
                                         <constraint firstItem="gxW-1z-Af9" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="WgR-Zu-MYa"/>
+                                        <constraint firstItem="WWd-BJ-GxF" firstAttribute="leading" secondItem="dyh-2O-q0Y" secondAttribute="trailing" constant="8" symbolic="YES" id="Wik-Qn-a7H"/>
                                         <constraint firstItem="GSF-Y5-FGJ" firstAttribute="width" secondItem="6EL-aj-Hjq" secondAttribute="width" id="Wl4-bL-h7a"/>
                                         <constraint firstItem="Zp5-es-UTa" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="Wu6-X4-E6P"/>
                                         <constraint firstItem="FwA-X7-Alr" firstAttribute="width" secondItem="aGE-iz-M2h" secondAttribute="width" id="WwN-iG-RWR"/>
@@ -417,6 +438,7 @@
                                         <constraint firstItem="z1d-SG-OZB" firstAttribute="width" secondItem="aGE-iz-M2h" secondAttribute="width" id="cKL-vM-mwO"/>
                                         <constraint firstItem="Hmg-bS-UMv" firstAttribute="leading" secondItem="gxW-1z-Af9" secondAttribute="trailing" constant="8" id="cfg-sm-rHH"/>
                                         <constraint firstItem="z1d-SG-OZB" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="leading" id="dYK-Xc-OZs"/>
+                                        <constraint firstItem="WWd-BJ-GxF" firstAttribute="leading" secondItem="wxy-f3-FrW" secondAttribute="leading" id="db1-bQ-fR4"/>
                                         <constraint firstItem="c90-dT-hDG" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="df8-rX-9EY"/>
                                         <constraint firstItem="5yU-sy-R0n" firstAttribute="top" secondItem="Ldf-jT-tdl" secondAttribute="top" id="dro-jH-hsY"/>
                                         <constraint firstItem="Hmg-bS-UMv" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="eAg-yb-hsG"/>
@@ -441,6 +463,7 @@
                                         <constraint firstItem="wxy-f3-FrW" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="lOe-BJ-1nS"/>
                                         <constraint firstItem="Qke-bh-4oG" firstAttribute="top" secondItem="gxW-1z-Af9" secondAttribute="bottom" constant="8" id="mm4-st-lkq"/>
                                         <constraint firstItem="aGE-iz-M2h" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="mqs-Uu-Fxb"/>
+                                        <constraint firstItem="dyh-2O-q0Y" firstAttribute="leading" secondItem="Hm9-gI-9j7" secondAttribute="leading" id="my4-Mf-EV1"/>
                                         <constraint firstAttribute="trailing" secondItem="c90-dT-hDG" secondAttribute="trailing" constant="12" id="o2v-Jf-HiJ"/>
                                         <constraint firstItem="Qke-bh-4oG" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="odY-rn-vAx"/>
                                         <constraint firstItem="v4j-fa-olc" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="oy0-v4-evT"/>
@@ -451,7 +474,7 @@
                                         <constraint firstItem="hBf-Sx-lbf" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="trailing" constant="8" id="r3N-FI-PJf"/>
                                         <constraint firstItem="5yU-sy-R0n" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="r8i-x9-6Rp"/>
                                         <constraint firstItem="apr-sq-JIb" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="leading" id="rBi-h4-iir"/>
-                                        <constraint firstItem="Ldf-jT-tdl" firstAttribute="top" secondItem="Hm9-gI-9j7" secondAttribute="bottom" constant="8" id="rdm-PD-bK4"/>
+                                        <constraint firstItem="Ldf-jT-tdl" firstAttribute="top" secondItem="dyh-2O-q0Y" secondAttribute="bottom" constant="8" id="rdm-PD-bK4"/>
                                         <constraint firstItem="a3w-YC-7oN" firstAttribute="centerY" secondItem="6EL-aj-Hjq" secondAttribute="centerY" id="sjN-af-eHt"/>
                                         <constraint firstAttribute="bottom" secondItem="Nn4-TP-Hpd" secondAttribute="bottom" id="t6V-ol-Uji"/>
                                         <constraint firstItem="Hm9-gI-9j7" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="leading" id="tmx-fb-lh3"/>
@@ -1196,7 +1219,7 @@
                         </tabViewItems>
                     </tabView>
                     <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0rt-Td-kr8">
-                        <rect key="frame" x="77" y="418" width="196" height="21"/>
+                        <rect key="frame" x="77" y="440" width="196" height="21"/>
                         <segmentedCell key="cell" controlSize="small" borderStyle="border" alignment="left" style="rounded" trackingMode="selectOne" id="Fqo-1c-3L1">
                             <font key="font" usesAppearanceFont="YES"/>
                             <segments>

--- a/iina/Base.lproj/PrefCodecViewController.xib
+++ b/iina/Base.lproj/PrefCodecViewController.xib
@@ -241,7 +241,7 @@
                     <rect key="frame" x="138" y="29" width="308" height="42"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" id="aTt-aZ-rjK">
                         <font key="font" metaFont="label" size="11"/>
-                        <string key="title">Measured peak brightness of the display. If set to 0, IINA detects this value. If detection fails, IINA sets the target peak to 400</string>
+                        <string key="title">Measured peak brightness of the display. If set to 0, IINA detects this value. If detection fails, IINA sets the target peak to 400.</string>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>

--- a/iina/Base.lproj/PrefCodecViewController.xib
+++ b/iina/Base.lproj/PrefCodecViewController.xib
@@ -30,11 +30,11 @@
         </customView>
         <userDefaultsController representsSharedInstance="YES" id="pxc-7C-SGP"/>
         <customView id="gZf-gF-XoY">
-            <rect key="frame" x="0.0" y="0.0" width="444" height="406"/>
+            <rect key="frame" x="0.0" y="0.0" width="444" height="374"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField identifier="SectionTitleVideo" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2BH-mP-kfr">
-                    <rect key="frame" x="-2" y="368" width="46" height="16"/>
+                    <rect key="frame" x="-2" y="336" width="46" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Video:" id="m5P-5f-5uo">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -42,7 +42,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="paR-ax-h5M">
-                    <rect key="frame" x="118" y="368" width="122" height="16"/>
+                    <rect key="frame" x="118" y="336" width="122" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Number of threads:" id="50C-1R-wlJ">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -50,7 +50,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NZA-64-tXh">
-                    <rect key="frame" x="246" y="365" width="58" height="21"/>
+                    <rect key="frame" x="246" y="333" width="58" height="21"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="58" id="GLI-3U-bmm"/>
                     </constraints>
@@ -71,7 +71,7 @@
                     </connections>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kas-7q-TbK">
-                    <rect key="frame" x="312" y="368" width="92" height="14"/>
+                    <rect key="frame" x="312" y="336" width="92" height="14"/>
                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Default: 0 (Auto)" id="bxW-np-SGm">
                         <font key="font" metaFont="label" size="11"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -79,7 +79,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EWs-Ib-pVZ">
-                    <rect key="frame" x="243" y="329" width="127" height="25"/>
+                    <rect key="frame" x="243" y="297" width="127" height="25"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="120" id="P27-F4-Ogg"/>
                     </constraints>
@@ -100,7 +100,7 @@
                     </connections>
                 </popUpButton>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="0Re-PY-hmC">
-                    <rect key="frame" x="118" y="318" width="33" height="14"/>
+                    <rect key="frame" x="118" y="286" width="33" height="14"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Label" id="n3r-mP-f8V">
                         <font key="font" metaFont="label" size="11"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -108,7 +108,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4rB-d2-drE">
-                    <rect key="frame" x="118" y="336" width="122" height="16"/>
+                    <rect key="frame" x="118" y="304" width="122" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Hardware decoder:" id="nwg-2K-G2G">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -116,7 +116,7 @@
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xXS-nP-Chk">
-                    <rect key="frame" x="118" y="289" width="156" height="18"/>
+                    <rect key="frame" x="118" y="257" width="156" height="18"/>
                     <buttonCell key="cell" type="check" title="Force dedicated GPU" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="YUr-aJ-xfC">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -126,7 +126,7 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="40Z-9R-jw0">
-                    <rect key="frame" x="118" y="258" width="328" height="28"/>
+                    <rect key="frame" x="118" y="226" width="328" height="28"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Always use the dedicated GPU for rendering (if it exists). This can improve performance but may reduce battery life." id="gCv-sJ-uQJ">
                         <font key="font" metaFont="label" size="11"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -134,7 +134,7 @@
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="H9a-N4-xDt">
-                    <rect key="frame" x="118" y="233" width="124" height="18"/>
+                    <rect key="frame" x="118" y="201" width="124" height="18"/>
                     <buttonCell key="cell" type="check" title="Load ICC profile" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="3g4-jW-uJd">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -144,7 +144,7 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="IQ8-K4-5CX">
-                    <rect key="frame" x="118" y="202" width="328" height="28"/>
+                    <rect key="frame" x="118" y="170" width="328" height="28"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Load the ICC profile for current display and use it to transform video RGB to screen output. (Only for SDR mode)" id="M2M-of-gjd">
                         <font key="font" metaFont="label" size="11"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -152,7 +152,7 @@
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jf6-xG-UF1">
-                    <rect key="frame" x="118" y="177" width="136" height="18"/>
+                    <rect key="frame" x="118" y="145" width="136" height="18"/>
                     <buttonCell key="cell" type="check" title="Enable HDR mode" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="oMN-7X-c5d">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -162,7 +162,7 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="VBh-HJ-Hsl">
-                    <rect key="frame" x="118" y="160" width="294" height="14"/>
+                    <rect key="frame" x="118" y="128" width="294" height="14"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Enable HDR mode by default when playing HDR videos." id="AF3-Hf-nll">
                         <font key="font" metaFont="label" size="11"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -170,18 +170,17 @@
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ty3-Qg-ysu">
-                    <rect key="frame" x="118" y="135" width="154" height="18"/>
+                    <rect key="frame" x="118" y="103" width="154" height="18"/>
                     <buttonCell key="cell" type="check" title="Enable tone mapping" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="a5Y-gU-JTj">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                     <connections>
-                        <action selector="updateEnableToneMapping:" target="-2" id="MwT-60-rc2"/>
                         <binding destination="pxc-7C-SGP" name="value" keyPath="values.enableToneMapping" id="E81-x5-XQn"/>
                     </connections>
                 </button>
                 <button horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QHq-hw-OHZ" userLabel="Tone Mapping Help Button">
-                    <rect key="frame" x="277" y="130" width="25" height="25"/>
+                    <rect key="frame" x="277" y="98" width="25" height="25"/>
                     <buttonCell key="cell" type="help" bezelStyle="helpButton" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="4DE-fQ-Tbx">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -190,16 +189,8 @@
                         <action selector="toneMappingHelpAction:" target="-2" id="uYA-Ua-kae"/>
                     </connections>
                 </button>
-                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="oPy-hC-O47">
-                    <rect key="frame" x="118" y="118" width="242" height="14"/>
-                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Enable tone mapping images onto the display" id="mNn-cb-IVw">
-                        <font key="font" metaFont="label" size="11"/>
-                        <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nuY-oY-ief">
-                    <rect key="frame" x="138" y="96" width="80" height="16"/>
+                    <rect key="frame" x="138" y="78" width="80" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Target peak:" id="xVk-OA-kOf">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -207,7 +198,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="w2K-eR-xqK">
-                    <rect key="frame" x="224" y="93" width="58" height="21"/>
+                    <rect key="frame" x="224" y="75" width="58" height="21"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="58" id="eGm-nT-ceU"/>
                     </constraints>
@@ -220,6 +211,7 @@
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                     <connections>
+                        <binding destination="pxc-7C-SGP" name="enabled" keyPath="values.enableToneMapping" id="mbf-5t-pSs"/>
                         <binding destination="pxc-7C-SGP" name="value" keyPath="values.toneMappingTargetPeak" id="p2I-ha-v97">
                             <dictionary key="options">
                                 <bool key="NSContinuouslyUpdatesValue" value="YES"/>
@@ -228,7 +220,7 @@
                     </connections>
                 </textField>
                 <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bL4-aH-JLz">
-                    <rect key="frame" x="284" y="96" width="26" height="16"/>
+                    <rect key="frame" x="284" y="78" width="26" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="nits" id="baO-xy-7hD">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -236,7 +228,7 @@
                     </textFieldCell>
                 </textField>
                 <button horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IGa-h9-bKr" userLabel="Target Peak Help Button">
-                    <rect key="frame" x="313" y="90" width="25" height="25"/>
+                    <rect key="frame" x="313" y="72" width="25" height="25"/>
                     <buttonCell key="cell" type="help" bezelStyle="helpButton" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="npo-66-j8t">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -246,15 +238,16 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="6Tu-h1-NQu">
-                    <rect key="frame" x="138" y="61" width="308" height="28"/>
-                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Measured peak brightness of the display. If set to 0, IINA will attempt to detect this value." id="aTt-aZ-rjK">
+                    <rect key="frame" x="138" y="29" width="308" height="42"/>
+                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" id="aTt-aZ-rjK">
                         <font key="font" metaFont="label" size="11"/>
+                        <string key="title">Measured peak brightness of the display. If set to 0, IINA detects this value. If detection fails, IINA sets the target peak to 400</string>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wqd-66-Fxt">
-                    <rect key="frame" x="138" y="40" width="67" height="16"/>
+                    <rect key="frame" x="138" y="8" width="67" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Algorithm:" id="qzI-rq-PqO">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -262,7 +255,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="A2r-Qf-VPp">
-                    <rect key="frame" x="208" y="33" width="127" height="25"/>
+                    <rect key="frame" x="208" y="2" width="127" height="25"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="120" id="Xac-yr-dfJ"/>
                     </constraints>
@@ -283,11 +276,12 @@
                         </menu>
                     </popUpButtonCell>
                     <connections>
+                        <binding destination="pxc-7C-SGP" name="enabled" keyPath="values.enableToneMapping" id="EUW-WZ-o1E"/>
                         <binding destination="pxc-7C-SGP" name="selectedTag" keyPath="values.toneMappingAlgorithm" id="9dO-s5-Juq"/>
                     </connections>
                 </popUpButton>
                 <button horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="AR5-D6-Fjf" userLabel="Algorithm Help Button">
-                    <rect key="frame" x="336" y="33" width="25" height="25"/>
+                    <rect key="frame" x="336" y="2" width="25" height="25"/>
                     <buttonCell key="cell" type="help" bezelStyle="helpButton" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="heO-a7-miP">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -296,20 +290,11 @@
                         <action selector="algorithmHelpAction:" target="-2" id="N3I-Wg-Ca2"/>
                     </connections>
                 </button>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="ZAh-6z-ZS8">
-                    <rect key="frame" x="138" y="5" width="308" height="28"/>
-                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Algorithm to use for tone mapping images onto the display." id="szA-8r-plt">
-                        <font key="font" metaFont="label" size="11"/>
-                        <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
             </subviews>
             <constraints>
                 <constraint firstItem="4rB-d2-drE" firstAttribute="baseline" secondItem="EWs-Ib-pVZ" secondAttribute="baseline" id="0Wl-YU-BME"/>
                 <constraint firstItem="2BH-mP-kfr" firstAttribute="top" secondItem="gZf-gF-XoY" secondAttribute="top" constant="22" id="0jh-iZ-prT"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="IGa-h9-bKr" secondAttribute="trailing" id="0l4-7Z-nJD"/>
-                <constraint firstItem="ZAh-6z-ZS8" firstAttribute="leading" secondItem="wqd-66-Fxt" secondAttribute="leading" id="0r5-J7-HZc"/>
                 <constraint firstItem="40Z-9R-jw0" firstAttribute="leading" secondItem="xXS-nP-Chk" secondAttribute="leading" id="1of-sZ-BN6"/>
                 <constraint firstItem="0Re-PY-hmC" firstAttribute="top" secondItem="4rB-d2-drE" secondAttribute="bottom" constant="4" id="5Mm-wm-VFG"/>
                 <constraint firstItem="VBh-HJ-Hsl" firstAttribute="leading" secondItem="jf6-xG-UF1" secondAttribute="leading" id="6Rg-Ag-e6J"/>
@@ -317,22 +302,19 @@
                 <constraint firstItem="jf6-xG-UF1" firstAttribute="top" secondItem="IQ8-K4-5CX" secondAttribute="bottom" constant="8" id="6dx-e8-7Ck"/>
                 <constraint firstItem="40Z-9R-jw0" firstAttribute="top" secondItem="xXS-nP-Chk" secondAttribute="bottom" constant="4" id="87O-GK-HSl"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="IQ8-K4-5CX" secondAttribute="trailing" id="ASv-Wn-ieW"/>
-                <constraint firstItem="ZAh-6z-ZS8" firstAttribute="top" secondItem="A2r-Qf-VPp" secondAttribute="bottom" constant="4" id="CZr-tb-0zE"/>
                 <constraint firstItem="4rB-d2-drE" firstAttribute="leading" secondItem="paR-ax-h5M" secondAttribute="leading" id="Can-oM-yLm"/>
                 <constraint firstItem="6Tu-h1-NQu" firstAttribute="leading" secondItem="nuY-oY-ief" secondAttribute="leading" id="CtA-P7-Xw1"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="QHq-hw-OHZ" secondAttribute="trailing" id="Cug-5x-Ejs"/>
+                <constraint firstAttribute="bottom" secondItem="wqd-66-Fxt" secondAttribute="bottom" constant="8" id="DDd-xz-f2V"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="6Tu-h1-NQu" secondAttribute="trailing" id="F39-rh-YMW"/>
                 <constraint firstItem="EWs-Ib-pVZ" firstAttribute="leading" secondItem="4rB-d2-drE" secondAttribute="trailing" constant="8" id="Fj7-lr-KGg"/>
                 <constraint firstItem="jf6-xG-UF1" firstAttribute="leading" secondItem="IQ8-K4-5CX" secondAttribute="leading" id="Fs9-LQ-Ic9"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="0Re-PY-hmC" secondAttribute="trailing" id="HJH-5L-Dd4"/>
                 <constraint firstItem="bL4-aH-JLz" firstAttribute="centerY" secondItem="w2K-eR-xqK" secondAttribute="centerY" id="I6G-Fc-L6z"/>
                 <constraint firstItem="AR5-D6-Fjf" firstAttribute="centerY" secondItem="A2r-Qf-VPp" secondAttribute="centerY" id="JDT-Rk-WpL"/>
-                <constraint firstItem="nuY-oY-ief" firstAttribute="top" secondItem="oPy-hC-O47" secondAttribute="bottom" constant="6" id="JQb-WM-GJM"/>
                 <constraint firstItem="2BH-mP-kfr" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="gZf-gF-XoY" secondAttribute="leading" constant="120" id="KBf-6v-pL9"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="oPy-hC-O47" secondAttribute="trailing" id="Ksi-jN-Tmf"/>
                 <constraint firstItem="IGa-h9-bKr" firstAttribute="leading" secondItem="bL4-aH-JLz" secondAttribute="trailing" constant="8" id="LUb-kU-13b"/>
                 <constraint firstItem="Ty3-Qg-ysu" firstAttribute="leading" secondItem="VBh-HJ-Hsl" secondAttribute="leading" id="MBt-xU-dtb"/>
-                <constraint firstAttribute="bottom" secondItem="ZAh-6z-ZS8" secondAttribute="bottom" constant="5" id="OAb-Sq-ATy"/>
                 <constraint firstItem="Ty3-Qg-ysu" firstAttribute="top" secondItem="VBh-HJ-Hsl" secondAttribute="bottom" constant="8" id="Q1a-pU-TK2"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="xXS-nP-Chk" secondAttribute="trailing" constant="12" id="QNu-hr-TdO"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Ty3-Qg-ysu" secondAttribute="trailing" constant="20" symbolic="YES" id="Spa-yf-bXq"/>
@@ -340,28 +322,26 @@
                 <constraint firstItem="VBh-HJ-Hsl" firstAttribute="top" secondItem="jf6-xG-UF1" secondAttribute="bottom" constant="4" id="Unp-3s-Prn"/>
                 <constraint firstItem="IQ8-K4-5CX" firstAttribute="top" secondItem="H9a-N4-xDt" secondAttribute="bottom" constant="4" id="W29-Gj-v7X"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="kas-7q-TbK" secondAttribute="trailing" constant="20" symbolic="YES" id="XnT-jM-uWw"/>
+                <constraint firstItem="A2r-Qf-VPp" firstAttribute="centerY" secondItem="wqd-66-Fxt" secondAttribute="centerY" id="XnT-nL-dYe"/>
                 <constraint firstItem="paR-ax-h5M" firstAttribute="top" secondItem="2BH-mP-kfr" secondAttribute="top" id="ZwF-7T-SvE"/>
                 <constraint firstItem="w2K-eR-xqK" firstAttribute="centerY" secondItem="nuY-oY-ief" secondAttribute="centerY" id="aOx-Nk-jwh"/>
                 <constraint firstItem="xXS-nP-Chk" firstAttribute="leading" secondItem="0Re-PY-hmC" secondAttribute="leading" id="aYZ-dq-yBE"/>
                 <constraint firstItem="kas-7q-TbK" firstAttribute="leading" secondItem="NZA-64-tXh" secondAttribute="trailing" constant="10" id="c73-Gh-U6L"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="A2r-Qf-VPp" secondAttribute="trailing" constant="20" symbolic="YES" id="ccv-z1-Qnu"/>
                 <constraint firstItem="IQ8-K4-5CX" firstAttribute="leading" secondItem="H9a-N4-xDt" secondAttribute="leading" id="cpx-2e-hcB"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ZAh-6z-ZS8" secondAttribute="trailing" id="dUy-Bs-FiR"/>
+                <constraint firstItem="w2K-eR-xqK" firstAttribute="top" secondItem="Ty3-Qg-ysu" secondAttribute="bottom" constant="8" id="eM6-GT-LKh"/>
                 <constraint firstItem="xXS-nP-Chk" firstAttribute="top" secondItem="0Re-PY-hmC" secondAttribute="bottom" constant="12" id="fO3-5j-FCq"/>
                 <constraint firstItem="paR-ax-h5M" firstAttribute="leading" secondItem="gZf-gF-XoY" secondAttribute="leading" constant="120" id="fWo-4I-DAC"/>
-                <constraint firstItem="oPy-hC-O47" firstAttribute="top" secondItem="Ty3-Qg-ysu" secondAttribute="bottom" constant="4" id="fZ8-Oy-EhY"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="jf6-xG-UF1" secondAttribute="trailing" constant="12" id="fvX-Px-0Pz"/>
                 <constraint firstItem="nuY-oY-ief" firstAttribute="leading" secondItem="Ty3-Qg-ysu" secondAttribute="leading" constant="20" id="g4g-Y8-WSC"/>
                 <constraint firstItem="A2r-Qf-VPp" firstAttribute="leading" secondItem="wqd-66-Fxt" secondAttribute="trailing" constant="8" id="h3S-Yh-vwA"/>
                 <constraint firstItem="NZA-64-tXh" firstAttribute="baseline" secondItem="paR-ax-h5M" secondAttribute="baseline" id="hly-ga-NBA"/>
-                <constraint firstItem="oPy-hC-O47" firstAttribute="leading" secondItem="Ty3-Qg-ysu" secondAttribute="leading" id="i0H-qv-HF5"/>
                 <constraint firstItem="EWs-Ib-pVZ" firstAttribute="leading" secondItem="NZA-64-tXh" secondAttribute="leading" id="k0a-vZ-1e2"/>
                 <constraint firstItem="IGa-h9-bKr" firstAttribute="centerY" secondItem="w2K-eR-xqK" secondAttribute="centerY" id="kcY-Dh-sck"/>
                 <constraint firstItem="6Tu-h1-NQu" firstAttribute="top" secondItem="w2K-eR-xqK" secondAttribute="bottom" constant="4" id="kf5-Qd-Thk"/>
                 <constraint firstItem="QHq-hw-OHZ" firstAttribute="leading" secondItem="Ty3-Qg-ysu" secondAttribute="trailing" constant="8" id="kj0-ni-QGC"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="AR5-D6-Fjf" secondAttribute="trailing" id="lUg-TZ-fYB"/>
                 <constraint firstItem="NZA-64-tXh" firstAttribute="leading" secondItem="paR-ax-h5M" secondAttribute="trailing" constant="8" id="mRg-ce-YRy"/>
-                <constraint firstItem="wqd-66-Fxt" firstAttribute="baseline" secondItem="A2r-Qf-VPp" secondAttribute="baseline" id="mkQ-Mf-QSE"/>
                 <constraint firstItem="2BH-mP-kfr" firstAttribute="leading" secondItem="gZf-gF-XoY" secondAttribute="leading" id="pDP-Rm-tDg"/>
                 <constraint firstItem="0Re-PY-hmC" firstAttribute="leading" secondItem="4rB-d2-drE" secondAttribute="leading" id="q9a-bj-3IP"/>
                 <constraint firstItem="wqd-66-Fxt" firstAttribute="top" secondItem="6Tu-h1-NQu" secondAttribute="bottom" constant="5" id="qkF-0G-8EE"/>
@@ -374,7 +354,6 @@
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="40Z-9R-jw0" secondAttribute="trailing" id="u8t-cI-LR5"/>
                 <constraint firstItem="QHq-hw-OHZ" firstAttribute="centerY" secondItem="Ty3-Qg-ysu" secondAttribute="centerY" id="uEa-LQ-zen"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="EWs-Ib-pVZ" secondAttribute="trailing" constant="20" symbolic="YES" id="uSA-lp-egl"/>
-                <constraint firstItem="nuY-oY-ief" firstAttribute="top" secondItem="oPy-hC-O47" secondAttribute="bottom" constant="6" id="uZ0-R8-yfD"/>
                 <constraint firstItem="H9a-N4-xDt" firstAttribute="top" secondItem="40Z-9R-jw0" secondAttribute="bottom" constant="8" id="w3M-iD-Ho3"/>
                 <constraint firstItem="H9a-N4-xDt" firstAttribute="leading" secondItem="40Z-9R-jw0" secondAttribute="leading" id="ybt-SY-BgR"/>
             </constraints>

--- a/iina/Base.lproj/PrefCodecViewController.xib
+++ b/iina/Base.lproj/PrefCodecViewController.xib
@@ -30,7 +30,7 @@
         </customView>
         <userDefaultsController representsSharedInstance="YES" id="pxc-7C-SGP"/>
         <customView id="gZf-gF-XoY">
-            <rect key="frame" x="0.0" y="0.0" width="444" height="392"/>
+            <rect key="frame" x="0.0" y="0.0" width="444" height="406"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField identifier="SectionTitleVideo" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2BH-mP-kfr">
@@ -100,7 +100,7 @@
                     </connections>
                 </popUpButton>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="0Re-PY-hmC">
-                    <rect key="frame" x="118" y="318" width="328" height="14"/>
+                    <rect key="frame" x="118" y="318" width="33" height="14"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Label" id="n3r-mP-f8V">
                         <font key="font" metaFont="label" size="11"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -162,7 +162,7 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="VBh-HJ-Hsl">
-                    <rect key="frame" x="118" y="160" width="328" height="14"/>
+                    <rect key="frame" x="118" y="160" width="294" height="14"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Enable HDR mode by default when playing HDR videos." id="AF3-Hf-nll">
                         <font key="font" metaFont="label" size="11"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -180,8 +180,18 @@
                         <binding destination="pxc-7C-SGP" name="value" keyPath="values.enableToneMapping" id="E81-x5-XQn"/>
                     </connections>
                 </button>
+                <button horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QHq-hw-OHZ" userLabel="Tone Mapping Help Button">
+                    <rect key="frame" x="277" y="130" width="25" height="25"/>
+                    <buttonCell key="cell" type="help" bezelStyle="helpButton" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="4DE-fQ-Tbx">
+                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="toneMappingHelpAction:" target="-2" id="uYA-Ua-kae"/>
+                    </connections>
+                </button>
                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="oPy-hC-O47">
-                    <rect key="frame" x="118" y="118" width="328" height="14"/>
+                    <rect key="frame" x="118" y="118" width="242" height="14"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Enable tone mapping images onto the display" id="mNn-cb-IVw">
                         <font key="font" metaFont="label" size="11"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -217,7 +227,7 @@
                         </binding>
                     </connections>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bL4-aH-JLz">
+                <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bL4-aH-JLz">
                     <rect key="frame" x="284" y="96" width="26" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="nits" id="baO-xy-7hD">
                         <font key="font" metaFont="system"/>
@@ -225,6 +235,16 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
+                <button horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IGa-h9-bKr" userLabel="Target Peak Help Button">
+                    <rect key="frame" x="313" y="90" width="25" height="25"/>
+                    <buttonCell key="cell" type="help" bezelStyle="helpButton" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="npo-66-j8t">
+                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="targetPeakHelpAction:" target="-2" id="5kv-Hz-jn5"/>
+                    </connections>
+                </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="6Tu-h1-NQu">
                     <rect key="frame" x="138" y="61" width="308" height="28"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Measured peak brightness of the display. If set to 0, IINA will attempt to detect this value." id="aTt-aZ-rjK">
@@ -266,6 +286,16 @@
                         <binding destination="pxc-7C-SGP" name="selectedTag" keyPath="values.toneMappingAlgorithm" id="9dO-s5-Juq"/>
                     </connections>
                 </popUpButton>
+                <button horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="AR5-D6-Fjf" userLabel="Algorithm Help Button">
+                    <rect key="frame" x="336" y="33" width="25" height="25"/>
+                    <buttonCell key="cell" type="help" bezelStyle="helpButton" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="heO-a7-miP">
+                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="algorithmHelpAction:" target="-2" id="N3I-Wg-Ca2"/>
+                    </connections>
+                </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="ZAh-6z-ZS8">
                     <rect key="frame" x="138" y="5" width="308" height="28"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Algorithm to use for tone mapping images onto the display." id="szA-8r-plt">
@@ -277,7 +307,8 @@
             </subviews>
             <constraints>
                 <constraint firstItem="4rB-d2-drE" firstAttribute="baseline" secondItem="EWs-Ib-pVZ" secondAttribute="baseline" id="0Wl-YU-BME"/>
-                <constraint firstItem="2BH-mP-kfr" firstAttribute="top" secondItem="gZf-gF-XoY" secondAttribute="top" constant="8" id="0jh-iZ-prT"/>
+                <constraint firstItem="2BH-mP-kfr" firstAttribute="top" secondItem="gZf-gF-XoY" secondAttribute="top" constant="22" id="0jh-iZ-prT"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="IGa-h9-bKr" secondAttribute="trailing" id="0l4-7Z-nJD"/>
                 <constraint firstItem="ZAh-6z-ZS8" firstAttribute="leading" secondItem="wqd-66-Fxt" secondAttribute="leading" id="0r5-J7-HZc"/>
                 <constraint firstItem="40Z-9R-jw0" firstAttribute="leading" secondItem="xXS-nP-Chk" secondAttribute="leading" id="1of-sZ-BN6"/>
                 <constraint firstItem="0Re-PY-hmC" firstAttribute="top" secondItem="4rB-d2-drE" secondAttribute="bottom" constant="4" id="5Mm-wm-VFG"/>
@@ -285,19 +316,21 @@
                 <constraint firstItem="wqd-66-Fxt" firstAttribute="leading" secondItem="6Tu-h1-NQu" secondAttribute="leading" id="6VQ-kl-6Xx"/>
                 <constraint firstItem="jf6-xG-UF1" firstAttribute="top" secondItem="IQ8-K4-5CX" secondAttribute="bottom" constant="8" id="6dx-e8-7Ck"/>
                 <constraint firstItem="40Z-9R-jw0" firstAttribute="top" secondItem="xXS-nP-Chk" secondAttribute="bottom" constant="4" id="87O-GK-HSl"/>
-                <constraint firstAttribute="trailing" secondItem="IQ8-K4-5CX" secondAttribute="trailing" id="ASv-Wn-ieW"/>
-                <constraint firstItem="nuY-oY-ief" firstAttribute="leading" secondItem="VBh-HJ-Hsl" secondAttribute="leading" constant="20" id="Bcn-Nn-Fxq"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="IQ8-K4-5CX" secondAttribute="trailing" id="ASv-Wn-ieW"/>
                 <constraint firstItem="ZAh-6z-ZS8" firstAttribute="top" secondItem="A2r-Qf-VPp" secondAttribute="bottom" constant="4" id="CZr-tb-0zE"/>
                 <constraint firstItem="4rB-d2-drE" firstAttribute="leading" secondItem="paR-ax-h5M" secondAttribute="leading" id="Can-oM-yLm"/>
                 <constraint firstItem="6Tu-h1-NQu" firstAttribute="leading" secondItem="nuY-oY-ief" secondAttribute="leading" id="CtA-P7-Xw1"/>
-                <constraint firstAttribute="trailing" secondItem="6Tu-h1-NQu" secondAttribute="trailing" id="F39-rh-YMW"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="QHq-hw-OHZ" secondAttribute="trailing" id="Cug-5x-Ejs"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="6Tu-h1-NQu" secondAttribute="trailing" id="F39-rh-YMW"/>
                 <constraint firstItem="EWs-Ib-pVZ" firstAttribute="leading" secondItem="4rB-d2-drE" secondAttribute="trailing" constant="8" id="Fj7-lr-KGg"/>
                 <constraint firstItem="jf6-xG-UF1" firstAttribute="leading" secondItem="IQ8-K4-5CX" secondAttribute="leading" id="Fs9-LQ-Ic9"/>
-                <constraint firstAttribute="trailing" secondItem="0Re-PY-hmC" secondAttribute="trailing" id="HJH-5L-Dd4"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="0Re-PY-hmC" secondAttribute="trailing" id="HJH-5L-Dd4"/>
                 <constraint firstItem="bL4-aH-JLz" firstAttribute="centerY" secondItem="w2K-eR-xqK" secondAttribute="centerY" id="I6G-Fc-L6z"/>
+                <constraint firstItem="AR5-D6-Fjf" firstAttribute="centerY" secondItem="A2r-Qf-VPp" secondAttribute="centerY" id="JDT-Rk-WpL"/>
                 <constraint firstItem="nuY-oY-ief" firstAttribute="top" secondItem="oPy-hC-O47" secondAttribute="bottom" constant="6" id="JQb-WM-GJM"/>
                 <constraint firstItem="2BH-mP-kfr" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="gZf-gF-XoY" secondAttribute="leading" constant="120" id="KBf-6v-pL9"/>
-                <constraint firstAttribute="trailing" secondItem="oPy-hC-O47" secondAttribute="trailing" id="Ksi-jN-Tmf"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="oPy-hC-O47" secondAttribute="trailing" id="Ksi-jN-Tmf"/>
+                <constraint firstItem="IGa-h9-bKr" firstAttribute="leading" secondItem="bL4-aH-JLz" secondAttribute="trailing" constant="8" id="LUb-kU-13b"/>
                 <constraint firstItem="Ty3-Qg-ysu" firstAttribute="leading" secondItem="VBh-HJ-Hsl" secondAttribute="leading" id="MBt-xU-dtb"/>
                 <constraint firstAttribute="bottom" secondItem="ZAh-6z-ZS8" secondAttribute="bottom" constant="5" id="OAb-Sq-ATy"/>
                 <constraint firstItem="Ty3-Qg-ysu" firstAttribute="top" secondItem="VBh-HJ-Hsl" secondAttribute="bottom" constant="8" id="Q1a-pU-TK2"/>
@@ -313,28 +346,33 @@
                 <constraint firstItem="kas-7q-TbK" firstAttribute="leading" secondItem="NZA-64-tXh" secondAttribute="trailing" constant="10" id="c73-Gh-U6L"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="A2r-Qf-VPp" secondAttribute="trailing" constant="20" symbolic="YES" id="ccv-z1-Qnu"/>
                 <constraint firstItem="IQ8-K4-5CX" firstAttribute="leading" secondItem="H9a-N4-xDt" secondAttribute="leading" id="cpx-2e-hcB"/>
-                <constraint firstAttribute="trailing" secondItem="ZAh-6z-ZS8" secondAttribute="trailing" id="dUy-Bs-FiR"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ZAh-6z-ZS8" secondAttribute="trailing" id="dUy-Bs-FiR"/>
                 <constraint firstItem="xXS-nP-Chk" firstAttribute="top" secondItem="0Re-PY-hmC" secondAttribute="bottom" constant="12" id="fO3-5j-FCq"/>
                 <constraint firstItem="paR-ax-h5M" firstAttribute="leading" secondItem="gZf-gF-XoY" secondAttribute="leading" constant="120" id="fWo-4I-DAC"/>
                 <constraint firstItem="oPy-hC-O47" firstAttribute="top" secondItem="Ty3-Qg-ysu" secondAttribute="bottom" constant="4" id="fZ8-Oy-EhY"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="jf6-xG-UF1" secondAttribute="trailing" constant="12" id="fvX-Px-0Pz"/>
+                <constraint firstItem="nuY-oY-ief" firstAttribute="leading" secondItem="Ty3-Qg-ysu" secondAttribute="leading" constant="20" id="g4g-Y8-WSC"/>
                 <constraint firstItem="A2r-Qf-VPp" firstAttribute="leading" secondItem="wqd-66-Fxt" secondAttribute="trailing" constant="8" id="h3S-Yh-vwA"/>
                 <constraint firstItem="NZA-64-tXh" firstAttribute="baseline" secondItem="paR-ax-h5M" secondAttribute="baseline" id="hly-ga-NBA"/>
                 <constraint firstItem="oPy-hC-O47" firstAttribute="leading" secondItem="Ty3-Qg-ysu" secondAttribute="leading" id="i0H-qv-HF5"/>
                 <constraint firstItem="EWs-Ib-pVZ" firstAttribute="leading" secondItem="NZA-64-tXh" secondAttribute="leading" id="k0a-vZ-1e2"/>
+                <constraint firstItem="IGa-h9-bKr" firstAttribute="centerY" secondItem="w2K-eR-xqK" secondAttribute="centerY" id="kcY-Dh-sck"/>
                 <constraint firstItem="6Tu-h1-NQu" firstAttribute="top" secondItem="w2K-eR-xqK" secondAttribute="bottom" constant="4" id="kf5-Qd-Thk"/>
+                <constraint firstItem="QHq-hw-OHZ" firstAttribute="leading" secondItem="Ty3-Qg-ysu" secondAttribute="trailing" constant="8" id="kj0-ni-QGC"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="AR5-D6-Fjf" secondAttribute="trailing" id="lUg-TZ-fYB"/>
                 <constraint firstItem="NZA-64-tXh" firstAttribute="leading" secondItem="paR-ax-h5M" secondAttribute="trailing" constant="8" id="mRg-ce-YRy"/>
                 <constraint firstItem="wqd-66-Fxt" firstAttribute="baseline" secondItem="A2r-Qf-VPp" secondAttribute="baseline" id="mkQ-Mf-QSE"/>
                 <constraint firstItem="2BH-mP-kfr" firstAttribute="leading" secondItem="gZf-gF-XoY" secondAttribute="leading" id="pDP-Rm-tDg"/>
                 <constraint firstItem="0Re-PY-hmC" firstAttribute="leading" secondItem="4rB-d2-drE" secondAttribute="leading" id="q9a-bj-3IP"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="bL4-aH-JLz" secondAttribute="trailing" constant="20" symbolic="YES" id="qY1-l2-zm1"/>
                 <constraint firstItem="wqd-66-Fxt" firstAttribute="top" secondItem="6Tu-h1-NQu" secondAttribute="bottom" constant="5" id="qkF-0G-8EE"/>
                 <constraint firstItem="4rB-d2-drE" firstAttribute="top" secondItem="paR-ax-h5M" secondAttribute="bottom" constant="16" id="rCv-37-pHD"/>
                 <constraint firstItem="w2K-eR-xqK" firstAttribute="leading" secondItem="nuY-oY-ief" secondAttribute="trailing" constant="8" id="rQW-oX-C8k"/>
                 <constraint firstItem="kas-7q-TbK" firstAttribute="baseline" secondItem="paR-ax-h5M" secondAttribute="baseline" id="rWF-ZF-Tlb"/>
+                <constraint firstItem="AR5-D6-Fjf" firstAttribute="leading" secondItem="A2r-Qf-VPp" secondAttribute="trailing" constant="8" id="sFS-wN-0yH"/>
                 <constraint firstItem="bL4-aH-JLz" firstAttribute="leading" secondItem="w2K-eR-xqK" secondAttribute="trailing" constant="4" id="sSS-dt-KAq"/>
-                <constraint firstAttribute="trailing" secondItem="VBh-HJ-Hsl" secondAttribute="trailing" id="sqM-h5-Xgo"/>
-                <constraint firstAttribute="trailing" secondItem="40Z-9R-jw0" secondAttribute="trailing" id="u8t-cI-LR5"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="VBh-HJ-Hsl" secondAttribute="trailing" id="sqM-h5-Xgo"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="40Z-9R-jw0" secondAttribute="trailing" id="u8t-cI-LR5"/>
+                <constraint firstItem="QHq-hw-OHZ" firstAttribute="centerY" secondItem="Ty3-Qg-ysu" secondAttribute="centerY" id="uEa-LQ-zen"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="EWs-Ib-pVZ" secondAttribute="trailing" constant="20" symbolic="YES" id="uSA-lp-egl"/>
                 <constraint firstItem="nuY-oY-ief" firstAttribute="top" secondItem="oPy-hC-O47" secondAttribute="bottom" constant="6" id="uZ0-R8-yfD"/>
                 <constraint firstItem="H9a-N4-xDt" firstAttribute="top" secondItem="40Z-9R-jw0" secondAttribute="bottom" constant="8" id="w3M-iD-Ho3"/>

--- a/iina/Base.lproj/PrefCodecViewController.xib
+++ b/iina/Base.lproj/PrefCodecViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -10,28 +10,31 @@
             <connections>
                 <outlet property="audioDevicePopUp" destination="Min-k4-E1V" id="gOa-nX-tNk"/>
                 <outlet property="audioLangTokenField" destination="Mib-1U-RcV" id="r2O-EA-DIJ"/>
+                <outlet property="enableToneMappingBtn" destination="Ty3-Qg-ysu" id="m0d-uT-DYO"/>
                 <outlet property="hwdecDescriptionTextField" destination="0Re-PY-hmC" id="AXN-kV-1hB"/>
                 <outlet property="sectionAudioView" destination="bsP-Kc-xXR" id="1QS-jd-Kg7"/>
                 <outlet property="sectionVideoView" destination="gZf-gF-XoY" id="pg5-8W-sPk"/>
                 <outlet property="spdifAC3Btn" destination="iAK-W4-XCh" id="WqH-nb-dND"/>
                 <outlet property="spdifDTSBtn" destination="FJ2-As-AUm" id="GuI-ys-Mub"/>
                 <outlet property="spdifDTSHDBtn" destination="haq-Mp-LHn" id="WsL-zK-EYy"/>
+                <outlet property="toneMappingAlgorithmPopUpBtn" destination="A2r-Qf-VPp" id="hau-rQ-zS1"/>
+                <outlet property="toneMappingTargetPeakTextField" destination="w2K-eR-xqK" id="UpK-1G-1BI"/>
                 <outlet property="view" destination="Hz6-mo-xeY" id="0bl-1N-x8E"/>
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY" userLabel="Prefs &gt; Codec View">
-            <rect key="frame" x="0.0" y="0.0" width="480" height="288"/>
-            <point key="canvasLocation" x="1331" y="416"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY">
+            <rect key="frame" x="0.0" y="0.0" width="500" height="288"/>
+            <point key="canvasLocation" x="218" y="203.5"/>
         </customView>
         <userDefaultsController representsSharedInstance="YES" id="pxc-7C-SGP"/>
-        <customView id="gZf-gF-XoY" userLabel="Prefs &gt; Codec &gt; Video">
-            <rect key="frame" x="0.0" y="0.0" width="480" height="244"/>
+        <customView id="gZf-gF-XoY">
+            <rect key="frame" x="0.0" y="0.0" width="444" height="392"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField identifier="SectionTitleVideo" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="2BH-mP-kfr">
-                    <rect key="frame" x="-2" y="220" width="46" height="16"/>
+                    <rect key="frame" x="-2" y="368" width="46" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Video:" id="m5P-5f-5uo">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -39,7 +42,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="paR-ax-h5M">
-                    <rect key="frame" x="118" y="220" width="122" height="16"/>
+                    <rect key="frame" x="118" y="368" width="122" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Number of threads:" id="50C-1R-wlJ">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -47,7 +50,7 @@
                     </textFieldCell>
                 </textField>
                 <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NZA-64-tXh">
-                    <rect key="frame" x="246" y="217" width="58" height="21"/>
+                    <rect key="frame" x="246" y="365" width="58" height="21"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="58" id="GLI-3U-bmm"/>
                     </constraints>
@@ -68,7 +71,7 @@
                     </connections>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kas-7q-TbK">
-                    <rect key="frame" x="312" y="220" width="92" height="14"/>
+                    <rect key="frame" x="312" y="368" width="92" height="14"/>
                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Default: 0 (Auto)" id="bxW-np-SGm">
                         <font key="font" metaFont="label" size="11"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -76,7 +79,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EWs-Ib-pVZ">
-                    <rect key="frame" x="243" y="181" width="127" height="25"/>
+                    <rect key="frame" x="243" y="329" width="127" height="25"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="120" id="P27-F4-Ogg"/>
                     </constraints>
@@ -97,7 +100,7 @@
                     </connections>
                 </popUpButton>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="0Re-PY-hmC">
-                    <rect key="frame" x="118" y="170" width="364" height="14"/>
+                    <rect key="frame" x="118" y="318" width="328" height="14"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Label" id="n3r-mP-f8V">
                         <font key="font" metaFont="label" size="11"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -105,7 +108,7 @@
                     </textFieldCell>
                 </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4rB-d2-drE">
-                    <rect key="frame" x="118" y="188" width="122" height="16"/>
+                    <rect key="frame" x="118" y="336" width="122" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Hardware decoder:" id="nwg-2K-G2G">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -113,7 +116,7 @@
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xXS-nP-Chk">
-                    <rect key="frame" x="118" y="141" width="156" height="18"/>
+                    <rect key="frame" x="118" y="289" width="156" height="18"/>
                     <buttonCell key="cell" type="check" title="Force dedicated GPU" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="YUr-aJ-xfC">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -123,7 +126,7 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="40Z-9R-jw0">
-                    <rect key="frame" x="118" y="110" width="364" height="28"/>
+                    <rect key="frame" x="118" y="258" width="328" height="28"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Always use the dedicated GPU for rendering (if it exists). This can improve performance but may reduce battery life." id="gCv-sJ-uQJ">
                         <font key="font" metaFont="label" size="11"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -131,7 +134,7 @@
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="H9a-N4-xDt">
-                    <rect key="frame" x="118" y="85" width="124" height="18"/>
+                    <rect key="frame" x="118" y="233" width="124" height="18"/>
                     <buttonCell key="cell" type="check" title="Load ICC profile" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="3g4-jW-uJd">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -141,75 +144,205 @@
                     </connections>
                 </button>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="IQ8-K4-5CX">
-                    <rect key="frame" x="118" y="54" width="364" height="28"/>
+                    <rect key="frame" x="118" y="202" width="328" height="28"/>
                     <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Load the ICC profile for current display and use it to transform video RGB to screen output. (Only for SDR mode)" id="M2M-of-gjd">
                         <font key="font" metaFont="label" size="11"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9Rd-yY-b8t">
-                    <rect key="frame" x="118" y="29" width="149" height="18"/>
-                    <buttonCell key="cell" type="check" title="Enable HDR support" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="R7Z-9c-vPJ">
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="jf6-xG-UF1">
+                    <rect key="frame" x="118" y="177" width="136" height="18"/>
+                    <buttonCell key="cell" type="check" title="Enable HDR mode" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="oMN-7X-c5d">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                     <connections>
-                        <binding destination="pxc-7C-SGP" name="value" keyPath="values.enableHdrSupport" id="tJt-Yx-2ox"/>
+                        <binding destination="pxc-7C-SGP" name="value" keyPath="values.enableHdrSupport" id="iQO-ea-yOA"/>
                     </connections>
                 </button>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="f1i-M6-eNG">
-                    <rect key="frame" x="118" y="12" width="364" height="14"/>
-                    <textFieldCell key="cell" lineBreakMode="clipping" title="Enable HDR mode by default when playing HDR videos." id="ZgQ-bc-yEE">
-                        <font key="font" metaFont="smallSystem"/>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="VBh-HJ-Hsl">
+                    <rect key="frame" x="118" y="160" width="328" height="14"/>
+                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Enable HDR mode by default when playing HDR videos." id="AF3-Hf-nll">
+                        <font key="font" metaFont="label" size="11"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ty3-Qg-ysu">
+                    <rect key="frame" x="118" y="135" width="154" height="18"/>
+                    <buttonCell key="cell" type="check" title="Enable tone mapping" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="a5Y-gU-JTj">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="updateEnableToneMapping:" target="-2" id="MwT-60-rc2"/>
+                        <binding destination="pxc-7C-SGP" name="value" keyPath="values.enableToneMapping" id="E81-x5-XQn"/>
+                    </connections>
+                </button>
+                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="oPy-hC-O47">
+                    <rect key="frame" x="118" y="118" width="328" height="14"/>
+                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Enable tone mapping images onto the display" id="mNn-cb-IVw">
+                        <font key="font" metaFont="label" size="11"/>
+                        <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nuY-oY-ief">
+                    <rect key="frame" x="138" y="96" width="80" height="16"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Target peak:" id="xVk-OA-kOf">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="w2K-eR-xqK">
+                    <rect key="frame" x="224" y="93" width="58" height="21"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="58" id="eGm-nT-ceU"/>
+                    </constraints>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="Mmj-8V-L5G">
+                        <numberFormatter key="formatter" formatterBehavior="default10_4" usesGroupingSeparator="NO" groupingSize="0" minimumIntegerDigits="0" maximumIntegerDigits="42" id="r3r-oG-MBj">
+                            <real key="minimum" value="0.0"/>
+                        </numberFormatter>
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                    <connections>
+                        <binding destination="pxc-7C-SGP" name="value" keyPath="values.toneMappingTargetPeak" id="p2I-ha-v97">
+                            <dictionary key="options">
+                                <bool key="NSContinuouslyUpdatesValue" value="YES"/>
+                            </dictionary>
+                        </binding>
+                    </connections>
+                </textField>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bL4-aH-JLz">
+                    <rect key="frame" x="284" y="96" width="26" height="16"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="nits" id="baO-xy-7hD">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="6Tu-h1-NQu">
+                    <rect key="frame" x="138" y="61" width="308" height="28"/>
+                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Measured peak brightness of the display. If set to 0, IINA will attempt to detect this value." id="aTt-aZ-rjK">
+                        <font key="font" metaFont="label" size="11"/>
+                        <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wqd-66-Fxt">
+                    <rect key="frame" x="138" y="40" width="67" height="16"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Algorithm:" id="qzI-rq-PqO">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="A2r-Qf-VPp">
+                    <rect key="frame" x="208" y="33" width="127" height="25"/>
+                    <constraints>
+                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="120" id="Xac-yr-dfJ"/>
+                    </constraints>
+                    <popUpButtonCell key="cell" type="push" title="auto" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="uey-Ao-wwZ" id="Z8Y-Nt-nBs">
+                        <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="menu"/>
+                        <menu key="menu" id="q7F-zj-h8e">
+                            <items>
+                                <menuItem title="auto" state="on" id="uey-Ao-wwZ"/>
+                                <menuItem title="clip" tag="1" id="hpU-bf-sNW"/>
+                                <menuItem title="mobius" tag="2" id="8QO-fX-FbS"/>
+                                <menuItem title="reinhard" tag="3" id="1Kp-GN-lWF"/>
+                                <menuItem title="hable" tag="4" id="n6V-Hw-yNt"/>
+                                <menuItem title="bt.2390" tag="5" id="Q01-SJ-M3x"/>
+                                <menuItem title="gamma" tag="6" id="6Iq-cU-A17"/>
+                                <menuItem title="linear" tag="7" id="yd0-W0-bHk"/>
+                            </items>
+                        </menu>
+                    </popUpButtonCell>
+                    <connections>
+                        <binding destination="pxc-7C-SGP" name="selectedTag" keyPath="values.toneMappingAlgorithm" id="9dO-s5-Juq"/>
+                    </connections>
+                </popUpButton>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="ZAh-6z-ZS8">
+                    <rect key="frame" x="138" y="5" width="308" height="28"/>
+                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Algorithm to use for tone mapping images onto the display." id="szA-8r-plt">
+                        <font key="font" metaFont="label" size="11"/>
+                        <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
             </subviews>
             <constraints>
                 <constraint firstItem="4rB-d2-drE" firstAttribute="baseline" secondItem="EWs-Ib-pVZ" secondAttribute="baseline" id="0Wl-YU-BME"/>
                 <constraint firstItem="2BH-mP-kfr" firstAttribute="top" secondItem="gZf-gF-XoY" secondAttribute="top" constant="8" id="0jh-iZ-prT"/>
+                <constraint firstItem="ZAh-6z-ZS8" firstAttribute="leading" secondItem="wqd-66-Fxt" secondAttribute="leading" id="0r5-J7-HZc"/>
                 <constraint firstItem="40Z-9R-jw0" firstAttribute="leading" secondItem="xXS-nP-Chk" secondAttribute="leading" id="1of-sZ-BN6"/>
                 <constraint firstItem="0Re-PY-hmC" firstAttribute="top" secondItem="4rB-d2-drE" secondAttribute="bottom" constant="4" id="5Mm-wm-VFG"/>
-                <constraint firstItem="9Rd-yY-b8t" firstAttribute="top" secondItem="IQ8-K4-5CX" secondAttribute="bottom" constant="8" id="6dx-e8-7Ck"/>
+                <constraint firstItem="VBh-HJ-Hsl" firstAttribute="leading" secondItem="jf6-xG-UF1" secondAttribute="leading" id="6Rg-Ag-e6J"/>
+                <constraint firstItem="wqd-66-Fxt" firstAttribute="leading" secondItem="6Tu-h1-NQu" secondAttribute="leading" id="6VQ-kl-6Xx"/>
+                <constraint firstItem="jf6-xG-UF1" firstAttribute="top" secondItem="IQ8-K4-5CX" secondAttribute="bottom" constant="8" id="6dx-e8-7Ck"/>
                 <constraint firstItem="40Z-9R-jw0" firstAttribute="top" secondItem="xXS-nP-Chk" secondAttribute="bottom" constant="4" id="87O-GK-HSl"/>
-                <constraint firstItem="f1i-M6-eNG" firstAttribute="top" secondItem="9Rd-yY-b8t" secondAttribute="bottom" constant="4" id="9g0-YK-9ZQ"/>
                 <constraint firstAttribute="trailing" secondItem="IQ8-K4-5CX" secondAttribute="trailing" id="ASv-Wn-ieW"/>
+                <constraint firstItem="nuY-oY-ief" firstAttribute="leading" secondItem="VBh-HJ-Hsl" secondAttribute="leading" constant="20" id="Bcn-Nn-Fxq"/>
+                <constraint firstItem="ZAh-6z-ZS8" firstAttribute="top" secondItem="A2r-Qf-VPp" secondAttribute="bottom" constant="4" id="CZr-tb-0zE"/>
                 <constraint firstItem="4rB-d2-drE" firstAttribute="leading" secondItem="paR-ax-h5M" secondAttribute="leading" id="Can-oM-yLm"/>
+                <constraint firstItem="6Tu-h1-NQu" firstAttribute="leading" secondItem="nuY-oY-ief" secondAttribute="leading" id="CtA-P7-Xw1"/>
+                <constraint firstAttribute="trailing" secondItem="6Tu-h1-NQu" secondAttribute="trailing" id="F39-rh-YMW"/>
                 <constraint firstItem="EWs-Ib-pVZ" firstAttribute="leading" secondItem="4rB-d2-drE" secondAttribute="trailing" constant="8" id="Fj7-lr-KGg"/>
+                <constraint firstItem="jf6-xG-UF1" firstAttribute="leading" secondItem="IQ8-K4-5CX" secondAttribute="leading" id="Fs9-LQ-Ic9"/>
                 <constraint firstAttribute="trailing" secondItem="0Re-PY-hmC" secondAttribute="trailing" id="HJH-5L-Dd4"/>
+                <constraint firstItem="bL4-aH-JLz" firstAttribute="centerY" secondItem="w2K-eR-xqK" secondAttribute="centerY" id="I6G-Fc-L6z"/>
+                <constraint firstItem="nuY-oY-ief" firstAttribute="top" secondItem="oPy-hC-O47" secondAttribute="bottom" constant="6" id="JQb-WM-GJM"/>
                 <constraint firstItem="2BH-mP-kfr" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="gZf-gF-XoY" secondAttribute="leading" constant="120" id="KBf-6v-pL9"/>
+                <constraint firstAttribute="trailing" secondItem="oPy-hC-O47" secondAttribute="trailing" id="Ksi-jN-Tmf"/>
+                <constraint firstItem="Ty3-Qg-ysu" firstAttribute="leading" secondItem="VBh-HJ-Hsl" secondAttribute="leading" id="MBt-xU-dtb"/>
+                <constraint firstAttribute="bottom" secondItem="ZAh-6z-ZS8" secondAttribute="bottom" constant="5" id="OAb-Sq-ATy"/>
+                <constraint firstItem="Ty3-Qg-ysu" firstAttribute="top" secondItem="VBh-HJ-Hsl" secondAttribute="bottom" constant="8" id="Q1a-pU-TK2"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="xXS-nP-Chk" secondAttribute="trailing" constant="12" id="QNu-hr-TdO"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Ty3-Qg-ysu" secondAttribute="trailing" constant="20" symbolic="YES" id="Spa-yf-bXq"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="H9a-N4-xDt" secondAttribute="trailing" constant="12" id="TxZ-c7-rVn"/>
-                <constraint firstAttribute="trailing" secondItem="f1i-M6-eNG" secondAttribute="trailing" id="UJF-Aa-p1k"/>
+                <constraint firstItem="VBh-HJ-Hsl" firstAttribute="top" secondItem="jf6-xG-UF1" secondAttribute="bottom" constant="4" id="Unp-3s-Prn"/>
                 <constraint firstItem="IQ8-K4-5CX" firstAttribute="top" secondItem="H9a-N4-xDt" secondAttribute="bottom" constant="4" id="W29-Gj-v7X"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="kas-7q-TbK" secondAttribute="trailing" constant="20" symbolic="YES" id="XnT-jM-uWw"/>
                 <constraint firstItem="paR-ax-h5M" firstAttribute="top" secondItem="2BH-mP-kfr" secondAttribute="top" id="ZwF-7T-SvE"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="9Rd-yY-b8t" secondAttribute="trailing" id="Zza-J1-F3v"/>
+                <constraint firstItem="w2K-eR-xqK" firstAttribute="centerY" secondItem="nuY-oY-ief" secondAttribute="centerY" id="aOx-Nk-jwh"/>
                 <constraint firstItem="xXS-nP-Chk" firstAttribute="leading" secondItem="0Re-PY-hmC" secondAttribute="leading" id="aYZ-dq-yBE"/>
                 <constraint firstItem="kas-7q-TbK" firstAttribute="leading" secondItem="NZA-64-tXh" secondAttribute="trailing" constant="10" id="c73-Gh-U6L"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="A2r-Qf-VPp" secondAttribute="trailing" constant="20" symbolic="YES" id="ccv-z1-Qnu"/>
                 <constraint firstItem="IQ8-K4-5CX" firstAttribute="leading" secondItem="H9a-N4-xDt" secondAttribute="leading" id="cpx-2e-hcB"/>
-                <constraint firstItem="f1i-M6-eNG" firstAttribute="leading" secondItem="9Rd-yY-b8t" secondAttribute="leading" id="eNp-ch-ApK"/>
+                <constraint firstAttribute="trailing" secondItem="ZAh-6z-ZS8" secondAttribute="trailing" id="dUy-Bs-FiR"/>
                 <constraint firstItem="xXS-nP-Chk" firstAttribute="top" secondItem="0Re-PY-hmC" secondAttribute="bottom" constant="12" id="fO3-5j-FCq"/>
                 <constraint firstItem="paR-ax-h5M" firstAttribute="leading" secondItem="gZf-gF-XoY" secondAttribute="leading" constant="120" id="fWo-4I-DAC"/>
-                <constraint firstAttribute="bottom" secondItem="f1i-M6-eNG" secondAttribute="bottom" constant="12" id="gbV-a3-0aM"/>
+                <constraint firstItem="oPy-hC-O47" firstAttribute="top" secondItem="Ty3-Qg-ysu" secondAttribute="bottom" constant="4" id="fZ8-Oy-EhY"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="jf6-xG-UF1" secondAttribute="trailing" constant="12" id="fvX-Px-0Pz"/>
+                <constraint firstItem="A2r-Qf-VPp" firstAttribute="leading" secondItem="wqd-66-Fxt" secondAttribute="trailing" constant="8" id="h3S-Yh-vwA"/>
                 <constraint firstItem="NZA-64-tXh" firstAttribute="baseline" secondItem="paR-ax-h5M" secondAttribute="baseline" id="hly-ga-NBA"/>
+                <constraint firstItem="oPy-hC-O47" firstAttribute="leading" secondItem="Ty3-Qg-ysu" secondAttribute="leading" id="i0H-qv-HF5"/>
                 <constraint firstItem="EWs-Ib-pVZ" firstAttribute="leading" secondItem="NZA-64-tXh" secondAttribute="leading" id="k0a-vZ-1e2"/>
-                <constraint firstItem="9Rd-yY-b8t" firstAttribute="leading" secondItem="IQ8-K4-5CX" secondAttribute="leading" id="l0x-ri-x8e"/>
+                <constraint firstItem="6Tu-h1-NQu" firstAttribute="top" secondItem="w2K-eR-xqK" secondAttribute="bottom" constant="4" id="kf5-Qd-Thk"/>
                 <constraint firstItem="NZA-64-tXh" firstAttribute="leading" secondItem="paR-ax-h5M" secondAttribute="trailing" constant="8" id="mRg-ce-YRy"/>
+                <constraint firstItem="wqd-66-Fxt" firstAttribute="baseline" secondItem="A2r-Qf-VPp" secondAttribute="baseline" id="mkQ-Mf-QSE"/>
                 <constraint firstItem="2BH-mP-kfr" firstAttribute="leading" secondItem="gZf-gF-XoY" secondAttribute="leading" id="pDP-Rm-tDg"/>
                 <constraint firstItem="0Re-PY-hmC" firstAttribute="leading" secondItem="4rB-d2-drE" secondAttribute="leading" id="q9a-bj-3IP"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="bL4-aH-JLz" secondAttribute="trailing" constant="20" symbolic="YES" id="qY1-l2-zm1"/>
+                <constraint firstItem="wqd-66-Fxt" firstAttribute="top" secondItem="6Tu-h1-NQu" secondAttribute="bottom" constant="5" id="qkF-0G-8EE"/>
                 <constraint firstItem="4rB-d2-drE" firstAttribute="top" secondItem="paR-ax-h5M" secondAttribute="bottom" constant="16" id="rCv-37-pHD"/>
+                <constraint firstItem="w2K-eR-xqK" firstAttribute="leading" secondItem="nuY-oY-ief" secondAttribute="trailing" constant="8" id="rQW-oX-C8k"/>
                 <constraint firstItem="kas-7q-TbK" firstAttribute="baseline" secondItem="paR-ax-h5M" secondAttribute="baseline" id="rWF-ZF-Tlb"/>
+                <constraint firstItem="bL4-aH-JLz" firstAttribute="leading" secondItem="w2K-eR-xqK" secondAttribute="trailing" constant="4" id="sSS-dt-KAq"/>
+                <constraint firstAttribute="trailing" secondItem="VBh-HJ-Hsl" secondAttribute="trailing" id="sqM-h5-Xgo"/>
                 <constraint firstAttribute="trailing" secondItem="40Z-9R-jw0" secondAttribute="trailing" id="u8t-cI-LR5"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="EWs-Ib-pVZ" secondAttribute="trailing" constant="20" symbolic="YES" id="uSA-lp-egl"/>
+                <constraint firstItem="nuY-oY-ief" firstAttribute="top" secondItem="oPy-hC-O47" secondAttribute="bottom" constant="6" id="uZ0-R8-yfD"/>
                 <constraint firstItem="H9a-N4-xDt" firstAttribute="top" secondItem="40Z-9R-jw0" secondAttribute="bottom" constant="8" id="w3M-iD-Ho3"/>
                 <constraint firstItem="H9a-N4-xDt" firstAttribute="leading" secondItem="40Z-9R-jw0" secondAttribute="leading" id="ybt-SY-BgR"/>
             </constraints>
-            <point key="canvasLocation" x="783" y="394.5"/>
+            <point key="canvasLocation" x="783" y="560"/>
         </customView>
-        <customView id="bsP-Kc-xXR" userLabel="Prefs &gt; Codec &gt; Audio">
+        <customView id="bsP-Kc-xXR">
             <rect key="frame" x="0.0" y="0.0" width="480" height="192"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
@@ -255,7 +388,7 @@
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="160" id="NAx-xr-hr8"/>
                     </constraints>
-                    <tokenFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" allowsEditingTextAttributes="YES" id="RBR-T9-Cw3">
+                    <tokenFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" allowsEditingTextAttributes="YES" id="RBR-T9-Cw3">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -383,6 +516,9 @@
                 </textField>
                 <popUpButton horizontalHuggingPriority="200" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Min-k4-E1V">
                     <rect key="frame" x="266" y="33" width="76" height="25"/>
+                    <constraints>
+                        <constraint firstAttribute="width" relation="lessThanOrEqual" constant="300" id="gCa-l2-dK8"/>
+                    </constraints>
                     <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="iQf-Gb-IuO" id="Eau-zf-my0">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="menu"/>
@@ -462,7 +598,7 @@
                 <constraint firstItem="iB2-dA-Y1E" firstAttribute="leading" secondItem="JFX-OT-X7j" secondAttribute="trailing" constant="8" id="vpv-fy-V0A"/>
                 <constraint firstItem="0Ig-J7-VYp" firstAttribute="top" secondItem="bsP-Kc-xXR" secondAttribute="top" constant="8" id="xTx-Rf-Dxq"/>
             </constraints>
-            <point key="canvasLocation" x="783" y="660"/>
+            <point key="canvasLocation" x="792" y="75"/>
         </customView>
     </objects>
 </document>

--- a/iina/InspectorWindowController.swift
+++ b/iina/InspectorWindowController.swift
@@ -33,6 +33,7 @@ class InspectorWindowController: NSWindowController, NSTableViewDelegate, NSTabl
   @IBOutlet weak var vdecoderField: NSTextField!
   @IBOutlet weak var vcolorspaceField: NSTextField!
   @IBOutlet weak var vprimariesField: NSTextField!
+  @IBOutlet weak var vPixelFormat: NSTextField!
 
   @IBOutlet weak var voField: NSTextField!
   @IBOutlet weak var vsizeField: NSTextField!
@@ -203,12 +204,7 @@ class InspectorWindowController: NSWindowController, NSTableViewDelegate, NSTabl
 
       if PlayerCore.lastActive.mainWindow.loaded && controller.fileLoaded {
         if #available(macOS 10.15, *), let colorspace = PlayerCore.lastActive.mainWindow.videoView.videoLayer.colorspace {
-          var isHdr: Bool
-          if #available(macOS 11.0, *) {
-            isHdr = CGColorSpaceUsesExtendedRange(colorspace) || CGColorSpaceUsesITUR_2100TF(colorspace)
-          } else {
-            isHdr = colorspace.isHDR()
-          }
+          let isHdr = colorspace != VideoView.SRGB
           self.vcolorspaceField.stringValue = "\(colorspace.name!) (\(isHdr ? "H" : "S")DR)"
         } else {
           self.vcolorspaceField.stringValue = "Unspecified (SDR)"
@@ -217,6 +213,17 @@ class InspectorWindowController: NSWindowController, NSTableViewDelegate, NSTabl
         self.vcolorspaceField.stringValue = "N/A"
       }
       self.setLabelColor(self.vcolorspaceField, by: controller.fileLoaded)
+
+      if PlayerCore.lastActive.mainWindow.loaded && controller.fileLoaded {
+        if let hwPf = controller.getString(MPVProperty.videoParamsHwPixelformat) {
+          self.vPixelFormat.stringValue = "\(hwPf) (HW)"
+        } else if let swPf = controller.getString(MPVProperty.videoParamsPixelformat) {
+          self.vPixelFormat.stringValue = "\(swPf) (SW)"
+        } else {
+          self.vPixelFormat.stringValue = "N/A"
+        }
+      }
+      self.setLabelColor(self.vPixelFormat, by: controller.fileLoaded)
     }
   }
 

--- a/iina/PrefCodecViewController.swift
+++ b/iina/PrefCodecViewController.swift
@@ -108,4 +108,16 @@ class PrefCodecViewController: PreferenceViewController, PreferenceWindowEmbedda
     toneMappingTargetPeakTextField.isEnabled = sender.state == .on;
     toneMappingAlgorithmPopUpBtn.isEnabled = sender.state == .on;
   }
+
+  @IBAction func toneMappingHelpAction(_ sender: Any) {
+    NSWorkspace.shared.open(URL(string: AppData.toneMappingHelpLink)!)
+  }
+
+  @IBAction func targetPeakHelpAction(_ sender: Any) {
+    NSWorkspace.shared.open(URL(string: AppData.targetPeakHelpLink)!)
+  }
+
+  @IBAction func algorithmHelpAction(_ sender: Any) {
+    NSWorkspace.shared.open(URL(string: AppData.algorithmHelpLink)!)
+  }
 }

--- a/iina/PrefCodecViewController.swift
+++ b/iina/PrefCodecViewController.swift
@@ -46,7 +46,6 @@ class PrefCodecViewController: PreferenceViewController, PreferenceWindowEmbedda
     super.viewDidLoad()
     audioLangTokenField.commaSeparatedValues = Preference.string(for: .audioLanguage) ?? ""
     updateHwdecDescription()
-    updateEnableToneMapping(enableToneMappingBtn)
   }
 
   override func viewWillAppear() {
@@ -102,11 +101,6 @@ class PrefCodecViewController: PreferenceViewController, PreferenceWindowEmbedda
   private func updateHwdecDescription() {
     let hwdec: Preference.HardwareDecoderOption = Preference.enum(for: .hardwareDecoder)
     hwdecDescriptionTextField.stringValue = hwdec.localizedDescription
-  }
-
-  @IBAction func updateEnableToneMapping(_ sender: NSButton) {
-    toneMappingTargetPeakTextField.isEnabled = sender.state == .on;
-    toneMappingAlgorithmPopUpBtn.isEnabled = sender.state == .on;
   }
 
   @IBAction func toneMappingHelpAction(_ sender: Any) {

--- a/iina/PrefCodecViewController.swift
+++ b/iina/PrefCodecViewController.swift
@@ -38,11 +38,15 @@ class PrefCodecViewController: PreferenceViewController, PreferenceWindowEmbedda
 
   @IBOutlet weak var audioDevicePopUp: NSPopUpButton!
 
+  @IBOutlet weak var enableToneMappingBtn: NSButton!
+  @IBOutlet weak var toneMappingTargetPeakTextField: NSTextField!
+  @IBOutlet weak var toneMappingAlgorithmPopUpBtn: NSPopUpButton!
 
   override func viewDidLoad() {
     super.viewDidLoad()
     audioLangTokenField.commaSeparatedValues = Preference.string(for: .audioLanguage) ?? ""
     updateHwdecDescription()
+    updateEnableToneMapping(enableToneMappingBtn)
   }
 
   override func viewWillAppear() {
@@ -98,5 +102,10 @@ class PrefCodecViewController: PreferenceViewController, PreferenceWindowEmbedda
   private func updateHwdecDescription() {
     let hwdec: Preference.HardwareDecoderOption = Preference.enum(for: .hardwareDecoder)
     hwdecDescriptionTextField.stringValue = hwdec.localizedDescription
+  }
+
+  @IBAction func updateEnableToneMapping(_ sender: NSButton) {
+    toneMappingTargetPeakTextField.isEnabled = sender.state == .on;
+    toneMappingAlgorithmPopUpBtn.isEnabled = sender.state == .on;
   }
 }

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -151,6 +151,9 @@ struct Preference {
     static let forceDedicatedGPU = Key("forceDedicatedGPU")
     static let loadIccProfile = Key("loadIccProfile")
     static let enableHdrSupport = Key("enableHdrSupport")
+    static let enableToneMapping = Key("enableToneMapping")
+    static let toneMappingTargetPeak = Key("toneMappingTargetPeak")
+    static let toneMappingAlgorithm = Key("toneMappingAlgorithm")
 
     static let audioThreads = Key("audioThreads")
     static let audioLanguage = Key("audioLanguage")
@@ -581,6 +584,36 @@ struct Preference {
     }
   }
 
+  enum ToneMappingAlgorithmOption: Int, InitializingFromKey {
+    case auto = 0
+    case clip
+    case mobius
+    case reinhard
+    case hable
+    case bt_2390
+    case gamma
+    case linear
+
+    static var defaultValue = ToneMappingAlgorithmOption.auto
+
+    init?(key: Key) {
+      self.init(rawValue: Preference.integer(for: key))
+    }
+
+    var mpvString: String {
+      switch self {
+      case .auto: return "auto"
+      case .clip: return "clip"
+      case .mobius: return "mobius"
+      case .reinhard: return "reinhard"
+      case .hable: return "hable"
+      case .bt_2390: return "bt.2390"
+      case .gamma: return "gamma"
+      case .linear: return "linear"
+      }
+    }
+  }
+
   enum ResizeWindowTiming: Int, InitializingFromKey {
     case always = 0
     case onlyWhenOpen
@@ -737,6 +770,9 @@ struct Preference {
     .forceDedicatedGPU: false,
     .loadIccProfile: true,
     .enableHdrSupport: true,
+    .enableToneMapping: false,
+    .toneMappingTargetPeak: 0,
+    .toneMappingAlgorithm: "auto",
     .audioThreads: 0,
     .audioLanguage: "",
     .maxVolume: 100,

--- a/iina/en.lproj/PrefCodecViewController.strings
+++ b/iina/en.lproj/PrefCodecViewController.strings
@@ -76,8 +76,8 @@
 /* Class = "NSTextFieldCell"; title = "nits"; ObjectID = "baO-xy-7hD"; */
 "baO-xy-7hD.title" = "nits";
 
-/* Class = "NSTextFieldCell"; title = "Measured peak brightness of the display. If set to 0, IINA will attempt to detect this value."; ObjectID = "aTt-aZ-rjK"; */
-"aTt-aZ-rjK.title" = "Measured peak brightness of the display. If set to 0, IINA will attempt to detect this value.";
+/* Class = "NSTextFieldCell"; title = "Measured peak brightness of the display. If set to 0, IINA detects this value. If detection fails, IINA sets the target peak to 400."; ObjectID = "aTt-aZ-rjK"; */
+"aTt-aZ-rjK.title" = "Measured peak brightness of the display. If set to 0, IINA detects this value. If detection fails, IINA sets the target peak to 400.";
 
 /* Class = "NSTextFieldCell"; title = "Algorithm:"; ObjectID = "qzI-rq-PqO"; */
 "qzI-rq-PqO.title" = "Algorithm:";

--- a/iina/en.lproj/PrefCodecViewController.strings
+++ b/iina/en.lproj/PrefCodecViewController.strings
@@ -63,3 +63,24 @@
 
 /* Class = "NSTextFieldCell"; title = "Enable HDR mode by default when playing HDR videos."; ObjectID = "ZgQ-bc-yEE"; */
 "ZgQ-bc-yEE.title" = "Enable HDR mode by default when playing HDR videos.";
+
+/* Class = "NSButtonCell"; title = "Enable tone mapping"; ObjectID = "a5Y-gU-JTj"; */
+"a5Y-gU-JTj.title" = "Enable tone mapping";
+
+/* Class = "NSTextFieldCell"; title = "Enable tone mapping images onto the display"; ObjectID = "mNn-cb-IVw"; */
+"mNn-cb-IVw.title" = "Enable tone mapping images onto the display";
+
+/* Class = "NSTextFieldCell"; title = "Target peak:"; ObjectID = "xVk-OA-kOf"; */
+"xVk-OA-kOf.title" = "Target peak:";
+
+/* Class = "NSTextFieldCell"; title = "nits"; ObjectID = "baO-xy-7hD"; */
+"baO-xy-7hD.title" = "nits";
+
+/* Class = "NSTextFieldCell"; title = "Measured peak brightness of the display. If set to 0, IINA will attempt to detect this value."; ObjectID = "aTt-aZ-rjK"; */
+"aTt-aZ-rjK.title" = "Measured peak brightness of the display. If set to 0, IINA will attempt to detect this value.";
+
+/* Class = "NSTextFieldCell"; title = "Algorithm:"; ObjectID = "qzI-rq-PqO"; */
+"qzI-rq-PqO.title" = "Algorithm:";
+
+/* Class = "NSTextFieldCell"; title = "Algorithm to use for tone mapping images onto the display."; ObjectID = "szA-8r-plt"; */
+"szA-8r-plt.title" = "Algorithm to use for tone mapping images onto the display.";

--- a/iina/iina-Bridging-Header.h
+++ b/iina/iina-Bridging-Header.h
@@ -22,6 +22,10 @@
 
 #import <Availability.h>
 
+#pragma mark - CoreDisplay.framework
+
+extern CFDictionaryRef _Nullable CoreDisplay_DisplayCreateInfoDictionary(CGDirectDisplayID display);
+
 #pragma mark - PIP.framework
 
 NS_ASSUME_NONNULL_BEGIN


### PR DESCRIPTION
This commit will:
- Add the new settings `enableToneMapping`, `toneMappingTargetPeak` and `toneMappingAlgorithm`
- Update the `Audio/Video` settings panel to allow the user to control these settings
- Update `VideoView.refreshEdrMode` to support these new settings
- Add the `CoreDisplay` framework to the Xcode project
- Add support to `VideoView.refreshEdrMode` to automatically determine the target peak setting based on the peak brightness of the display using the `CoreDisplay` framework
- Add reporting of the pixel format to the Inspector window
- Enhance HDR detection in `InspectorWindowController.updateInfo`
- Correct the path to the PiP framework in the Xcode project

These change provide the ability to mpv's tone mapping when playing HDR videos.

The main author of these changes is Carter Li. This is a merge of changes that have been tested in his IINA fork. A few minor changes were made during the merge.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4358.

---

**Description:**
