### PR TITLE
Close JPEG-XL decoding/screenshot support, #3852

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		513A4FFA29B53F8100A8EA7D /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513A4FF929B53F8100A8EA7D /* Atomic.swift */; };
 		515B5E5A2A579903001FCD49 /* iina-plugin in Copy Executables */ = {isa = PBXBuildFile; fileRef = E38558872A484A2D0083772D /* iina-plugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		5196819A29EC963F00B05D55 /* CoreDisplay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5196819929EC963F00B05D55 /* CoreDisplay.framework */; };
+		51854CDA2A1C489300C40B78 /* FFmpegLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51854CD92A1C489300C40B78 /* FFmpegLogger.swift */; };
 		519872FF26879B9B00F84BCC /* AccessibilityPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519872FE26879B9B00F84BCC /* AccessibilityPreferences.swift */; };
 		51AC1CAB2A9FBF3700DF7079 /* OpenSubClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC1CAA2A9FBF3700DF7079 /* OpenSubClient.swift */; };
 		51C1BA3A291CA76700C1208A /* InfoDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C1BA39291CA76700C1208A /* InfoDictionary.swift */; };
@@ -933,6 +934,7 @@
 		51626CB029F1CECD0000CCC9 /* version_major.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = version_major.h; sourceTree = "<group>"; };
 		51626CBA29F1CEFB0000CCC9 /* version_major.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = version_major.h; sourceTree = "<group>"; };
 		5196819929EC963F00B05D55 /* CoreDisplay.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreDisplay.framework; path = /System/Library/Frameworks/CoreDisplay.framework; sourceTree = "<group>"; };
+		51854CD92A1C489300C40B78 /* FFmpegLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FFmpegLogger.swift; sourceTree = "<group>"; };
 		519872FE26879B9B00F84BCC /* AccessibilityPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPreferences.swift; sourceTree = "<group>"; };
 		51A0F0F629FA2C8E000130CF /* Beta.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Beta.xcconfig; sourceTree = "<group>"; };
 		51AC1CAA2A9FBF3700DF7079 /* OpenSubClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSubClient.swift; sourceTree = "<group>"; };
@@ -2233,6 +2235,7 @@
 				84A886E21E24F2D3008755BB /* Sub */,
 				8497A4831D2FF573005F504F /* iina-Bridging-Header.h */,
 				513A4FF929B53F8100A8EA7D /* Atomic.swift */,
+				51854CD92A1C489300C40B78 /* FFmpegLogger.swift */,
 				84A0BA9A1D2FAB4100BC8DA1 /* Parameter.swift */,
 				84EB1F061D2F5E76004FA5A1 /* Utility.swift */,
 				8461C52F1D462488006E91FF /* VideoTime.swift */,
@@ -2897,6 +2900,7 @@
 				84F5D4951E44D5230060A838 /* KeyBindingCriterion.swift in Sources */,
 				846121BD1F35FCA500ABB39C /* DraggingDetect.swift in Sources */,
 				84A886EC1E2573A5008755BB /* JustExtension.swift in Sources */,
+				51854CDA2A1C489300C40B78 /* FFmpegLogger.swift in Sources */,
 				84D0FB811F5E5A4000C6A6A7 /* CropBoxViewController.swift in Sources */,
 				84D377631D6B66DE007F7396 /* MPVPlaylistItem.swift in Sources */,
 				E3ECC89E1FE9A6D900BED8C7 /* GeometryDef.swift in Sources */,

--- a/iina/Base.lproj/PrefGeneralViewController.xib
+++ b/iina/Base.lproj/PrefGeneralViewController.xib
@@ -588,6 +588,12 @@
                                 <menuItem title="PNG" state="on" id="3XO-ks-TDg"/>
                                 <menuItem title="JPEG (.jpg)" tag="1" id="tmy-ty-8uK"/>
                                 <menuItem title="JPEG (.jpeg)" tag="2" id="NVh-C5-b9i"/>
+                                <menuItem title="WebP (.webp)" tag="3" id="KOO-mQ-9JG">
+                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                </menuItem>
+                                <menuItem title="JPEG XL (.jxl)" tag="4" id="H5d-pS-Cum">
+                                    <modifierMask key="keyEquivalentModifierMask"/>
+                                </menuItem>
                             </items>
                         </menu>
                     </popUpButtonCell>
@@ -795,6 +801,7 @@
                 <constraint firstItem="pfH-CF-O2T" firstAttribute="leading" secondItem="Kmu-J1-cbE" secondAttribute="leading" id="c9q-SG-bJV"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="4zm-YX-iM8" secondAttribute="trailing" id="ca7-1x-vvq"/>
                 <constraint firstItem="pfH-CF-O2T" firstAttribute="top" secondItem="Kmu-J1-cbE" secondAttribute="top" constant="8" id="di6-Om-iYm"/>
+
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="gxK-Zo-PtQ" secondAttribute="trailing" priority="100" id="eWv-bL-SZ2"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="da1-EI-Ny1" secondAttribute="trailing" id="l2x-XY-er0"/>
                 <constraint firstItem="gxK-Zo-PtQ" firstAttribute="top" secondItem="4zm-YX-iM8" secondAttribute="bottom" constant="8" id="lnd-OY-DqJ"/>

--- a/iina/FFmpegController.h
+++ b/iina/FFmpegController.h
@@ -38,6 +38,21 @@
 
 @property(nonatomic) NSInteger thumbnailCount;
 
+/// Initializes and returns an image object with the contents of the specified URL
+///
+/// At this time, the normal [NSImage](https://developer.apple.com/documentation/appkit/nsimage/1519907-init)
+/// initializer will fail to create an image object if the image file was encoded in [JPEG XL](https://jpeg.org/jpegxl/) format.
+/// In older versions of macOS this will also occur if the image file was encoded in [WebP](https://en.wikipedia.org/wiki/WebP/)
+/// format. As these are supported formats for screenshots it is desirable to have an alternative method for creating image objects that
+/// supports these formats so that a screenshot preview can be displayed as is done for other screenshot formats. This method is
+/// intended to be used when the normal AppKit supplied initializer is unable to create an image.
+/// - Attention: This method only supports decoding JPEG XL and WebP encoded images. It is not intended to replace the normal
+///       AppKit supplied initializer.
+/// - Parameter url: The URL identifying the image.
+/// - Returns: An initialized NSImage object or null if the method cannot create an image representation from the contents of the
+///       specified URL.
++ (nullable NSImage *)createNSImageWithContentsOf:(nonnull NSURL *)url;
+
 - (void)generateThumbnailForFile:(nonnull NSString *)file
                       thumbWidth:(int)thumbWidth;
 

--- a/iina/FFmpegController.h
+++ b/iina/FFmpegController.h
@@ -51,7 +51,7 @@
 /// - Parameter url: The URL identifying the image.
 /// - Returns: An initialized NSImage object or null if the method cannot create an image representation from the contents of the
 ///       specified URL.
-+ (nullable NSImage *)createNSImageWithContentsOf:(nonnull NSURL *)url;
++ (nullable NSImage *)createNSImageWithContentsOfURL:(nonnull NSURL *)url;
 
 - (void)generateThumbnailForFile:(nonnull NSString *)file
                       thumbWidth:(int)thumbWidth;

--- a/iina/FFmpegController.m
+++ b/iina/FFmpegController.m
@@ -18,20 +18,26 @@
 #import <libavutil/mastering_display_metadata.h>
 #pragma clang diagnostic pop
 
+#import "IINA-Swift.h"
+
+#define ERROR(msg, ...) [FFmpegLogger error:([NSString stringWithFormat:(msg), ##__VA_ARGS__])];
+#define LOG(msg, ...) [FFmpegLogger debug:([NSString stringWithFormat:(msg), ##__VA_ARGS__])];
+#define WARN(msg, ...) [FFmpegLogger warn:([NSString stringWithFormat:(msg), ##__VA_ARGS__])];
+
 #define THUMB_COUNT_DEFAULT 100
 
 #define CHECK_NOTNULL(ptr,msg) if (ptr == NULL) {\
-NSLog(@"Error when getting thumbnails: %@", msg);\
+ERROR(@"Error when getting thumbnails: %@", msg);\
 return -1;\
 }
 
 #define CHECK_SUCCESS(ret,msg) if (ret < 0) {\
-NSLog(@"Error when getting thumbnails: %@ (%d)", msg, ret);\
+ERROR(@"Error when getting thumbnails: %@ (%d)", msg, ret);\
 return -1;\
 }
 
 #define CHECK(ret,msg) if (!(ret)) {\
-NSLog(@"Error when getting thumbnails: %@", msg);\
+ERROR(@"Error when getting thumbnails: %@", msg);\
 return -1;\
 }
 
@@ -70,6 +76,7 @@ return -1;\
   return self;
 }
 
+// MARK: - Generating Thumbnails
 
 - (void)generateThumbnailForFile:(NSString *)file
                       thumbWidth:(int)thumbWidth
@@ -131,7 +138,7 @@ return -1;\
 
   // Check whether the denominator (AVRational.den) is zero to prevent division-by-zero
   if (videoAvgFrameRate.den == 0 || av_q2d(videoAvgFrameRate) == 0) {
-    NSLog(@"Avg frame rate = 0, ignore");
+    LOG(@"Avg frame rate = 0, ignore");
     return -1;
   }
 
@@ -149,7 +156,7 @@ return -1;\
   if (pCodecCtx->pix_fmt < 0 || pCodecCtx->pix_fmt >= AV_PIX_FMT_NB) {
     avcodec_free_context(&pCodecCtx);
     avformat_close_input(&pFormatCtx);
-    NSLog(@"Error when getting thumbnails: Pixel format is null");
+    ERROR(@"Error when getting thumbnails: Pixel format is null");
     return -1;
   }
 
@@ -283,7 +290,7 @@ return -1;\
   // Close the video file
   avformat_close_input(&pFormatCtx);
 
-  // NSLog(@"Thumbnails generated.");
+  // LOG(@"Thumbnails generated.");
   return 0;
 }
 
@@ -335,6 +342,8 @@ return -1;\
   }
 }
 
+// MARK: - Probing Video
+
 + (NSDictionary *)probeVideoInfoForFile:(nonnull NSString *)file
 {
   int ret;
@@ -346,7 +355,7 @@ return -1;\
   ret = avformat_open_input(&pFormatCtx, cFilename, NULL, NULL);
   free(cFilename);
   if (ret < 0) {
-    NSLog(@"Error when opening file %@ to obtain info: %s (%d)", file, av_err2str(ret), ret);
+    ERROR(@"Error when opening file %@ to obtain info: %s (%d)", file, av_err2str(ret), ret);
     return NULL;
   }
 
@@ -354,7 +363,7 @@ return -1;\
   if (duration <= 0) {
     ret = avformat_find_stream_info(pFormatCtx, NULL);
     if (ret < 0) {
-      NSLog(@"Error when probing %@ to obtain info: %s (%d)", file, av_err2str(ret), ret);
+      ERROR(@"Error when probing %@ to obtain info: %s (%d)", file, av_err2str(ret), ret);
       duration = -1;
     } else
       duration = pFormatCtx->duration;
@@ -371,5 +380,325 @@ return -1;\
 
   return info;
 }
+
+// MARK: - Decoding Image
+
++ (NSImage *)createNSImageWithContentsOf:(nonnull NSURL *)url
+{
+  // Variables holding objects that will need to be freed.
+  AVFormatContext *pFormatCtx = NULL;
+  AVCodecContext *pCodecCtx = NULL;
+  AVPacket *packet = NULL;
+  AVFrame *pFrame = NULL;
+  AVFrame *pFrameRGB = NULL;
+  uint8_t *pFrameRGBBuffer = NULL;
+  struct SwsContext *swsContext = NULL;
+  CGColorSpaceRef cgColorSpace = NULL;
+  CGContextRef cgContext = NULL;
+  CGImageRef cgImage = NULL;
+
+  @try {
+    char *cFilename = strdup(url.fileSystemRepresentation);
+
+#if DEBUG
+    LOG(@"Creating image with contents of file: %s", cFilename)
+#endif
+
+    int ret = avformat_open_input(&pFormatCtx, cFilename, NULL, NULL);
+    free(cFilename);
+    if (ret < 0) {
+      ERROR(@"Error when opening file %@ to construct NSImage: %s (%d)", url, av_err2str(ret), ret);
+      return NULL;
+    }
+
+    ret = avformat_find_stream_info(pFormatCtx, NULL);
+    if (ret < 0) {
+      ERROR(@"Cannot get stream info: %s (%d)", av_err2str(ret), ret);
+      return NULL;
+    }
+
+    // Expecting image files to have one video stream.
+    if (pFormatCtx->nb_streams != 1) {
+      ERROR(@"Expected one stream found: %d", pFormatCtx->nb_streams);
+      return NULL;
+    }
+    const AVStream *pVideoStream = pFormatCtx->streams[0];
+    const enum AVMediaType codecType = pVideoStream->codecpar->codec_type;
+    if (codecType != AVMEDIA_TYPE_VIDEO) {
+      ERROR(@"Unexpected stream type: %s (%d)", av_get_media_type_string(codecType), codecType);
+      return NULL;
+    }
+    // Expecting the number of frames to be unknown (0) or 1.
+    if (pVideoStream->nb_frames > 1) {
+      ERROR(@"Expected one frame found: %lld", pVideoStream->nb_frames);
+      return NULL;
+    }
+
+    const AVCodec *pCodec = avcodec_find_decoder(pVideoStream->codecpar->codec_id);
+    if (!pCodec) {
+      ERROR(@"Cannot get decoder codec: %d", pVideoStream->codecpar->codec_id);
+      return NULL;
+    }
+
+    // This method is only intended to be used for JPEG XL or WebP encoded images. As only these
+    // formats have been tested, refuse to process other formats.
+    if (pCodec->id != AV_CODEC_ID_JPEGXL && pCodec->id != AV_CODEC_ID_WEBP) {
+      ERROR(@"Unexpected encoding: %s (%d)", pCodec->name, pCodec->id);
+      return NULL;
+    }
+
+    pCodecCtx = avcodec_alloc_context3(pCodec);
+    if (!pCodecCtx) {
+      ERROR(@"Cannot alloc codec context: %s (%d)", pCodec->name, pCodec->id);
+      return NULL;
+    }
+    avcodec_parameters_to_context(pCodecCtx, pVideoStream->codecpar);
+    if (pCodecCtx->pix_fmt < 0 || pCodecCtx->pix_fmt >= AV_PIX_FMT_NB) {
+      ERROR(@"Invalid pixel format: %d", pCodecCtx->pix_fmt);
+      return NULL;
+    }
+
+    // Permit use of multiple threads for decoding. By default thread count is set to one which
+    // disables use of multiple threads. Setting it to zero allows the codec to use multiple
+    // threads. This is only done if the codec has the capability of using multiple threads for
+    // decoding an individual frame as testing showed the WebP codec, which does not have this
+    // capability, reacted badly to being given permission to use multiple threads. When this
+    // property was set to anything other than one WebP decoding failed with "Resource temporarily
+    // unavailable". The JPEG XL codec has this capability and will take advantage of multiple
+    // threads. Testing on a MacBook Pro with the M1 Max chip showed a 40% reduction in the time to
+    // decode a JPEG XL screenshot of a 4K video when using multiple threads. Normally speed of
+    // decoding is not an issue, however mpv provides screenshot options that control the encoding
+    // compression and quality. Changing these settings can result in the creation of screenshots
+    // that take multiple seconds to decode. The thread count must be set before opening the codec.
+    if (pCodec->capabilities & AV_CODEC_CAP_OTHER_THREADS) {
+      pCodecCtx->thread_count = 0;
+    }
+
+    ret = avcodec_open2(pCodecCtx, pCodec, NULL);
+    if (ret < 0) {
+      ERROR(@"Cannot open codec: %s (%d)", av_err2str(ret), ret);
+      return NULL;
+    }
+
+    packet = av_packet_alloc();
+    ret = av_read_frame(pFormatCtx, packet);
+    if (ret < 0) {
+      ERROR(@"Cannot read packet: %s (%d)", av_err2str(ret), ret);
+      return NULL;
+    }
+    if (packet->stream_index != 0) {
+      ERROR(@"Unexpected video stream: %d", packet->stream_index);
+      return NULL;
+    }
+
+    pFrame = av_frame_alloc();
+    if (!pFrame) {
+      ERROR(@"Cannot alloc frame");
+      return NULL;
+    }
+
+    ret = avcodec_send_packet(pCodecCtx, packet);
+    if (ret < 0) {
+      ERROR(@"Cannot send packet: %s (%d)", av_err2str(ret), ret);
+      return NULL;
+    }
+    ret = avcodec_receive_frame(pCodecCtx, pFrame);
+    if (ret < 0) {
+      ERROR(@"Cannot receive frame: %s (%d)", av_err2str(ret), ret);
+      return NULL;
+    }
+
+#if DEBUG
+    [FFmpegController logFrame:pCodec:pFrame];
+#endif
+
+    // CGImage requires the image frame to be converted to RGBA.
+    pFrameRGB = av_frame_alloc();
+    if (!pFrameRGB) {
+      ERROR(@"Cannot alloc RGBA frame");
+      return NULL;
+    }
+    pFrameRGB->width = pFrame->width;
+    pFrameRGB->height = pFrame->height;
+
+    // Determine the appropriate RGBA pixel format to convert to.
+    CGBitmapInfo bitmapInfo;
+    switch (pFrame->format) {
+      default:
+        // If this message is logged then the situation needs to be investigated to determine the
+        // correct conversion. Fall through and treat this as a SDR image.
+        WARN(@"Unexpected pixel format: %s (%d)", av_get_pix_fmt_name(pFrame->format),
+             pFrame->format);
+      case AV_PIX_FMT_ARGB: // WebP with screenshot-webp-lossless mpv option enabled.
+      case AV_PIX_FMT_RGB24: // JPEG XL SDR video.
+      case AV_PIX_FMT_YUV420P: // WebP default.
+        pFrameRGB->format = AV_PIX_FMT_RGBA;
+        bitmapInfo = (CGBitmapInfo)kCGImageAlphaPremultipliedLast;
+        break;
+      case AV_PIX_FMT_RGB48LE: // JPEG XL HDR video.
+        // Workaround missing FFmpeg 6.0 scalar capabilities. As per Apple EDR requires using 16 bit
+        // floating point components in the image bit map. Therefore we want the scalar to convert
+        // the frame to the AV_PIX_FMT_RGBAF16LE pixel formation. However when that was specified
+        // the call to sws_getContext returned NULL. The scalar printed the message "rgbaf16le is
+        // not supported as output pixel format" to the console. As a workaround we convert to
+        // AV_PIX_FMT_RGBA64LE and then convert the components to floating point.
+        pFrameRGB->format = AV_PIX_FMT_RGBA64LE;
+        bitmapInfo = kCGImageByteOrder16Little | kCGImageAlphaPremultipliedLast |
+            kCGBitmapFloatComponents;
+    }
+
+    // Determine required buffer size and allocate the buffer.
+    const int size = av_image_get_buffer_size(pFrameRGB->format, pFrame->width, pFrame->height, 1);
+    pFrameRGBBuffer = (uint8_t *)av_malloc(size);
+    if (!pFrameRGBBuffer) {
+      ERROR(@"Cannot alloc RGBA buffer");
+      return NULL;
+    }
+
+    // Assign appropriate parts of buffer to image planes in pFrameRGB.
+    ret = av_image_fill_arrays(pFrameRGB->data, pFrameRGB->linesize, pFrameRGBBuffer,
+        pFrameRGB->format, pFrameRGB->width, pFrameRGB->height, 1);
+    if (ret < 0) {
+      ERROR(@"Cannot fill data for RGBA frame: %s (%d)", av_err2str(ret), ret);
+      return NULL;
+    }
+
+    // Convert the image frame to RGBA using the FFmpeg scaler.
+    swsContext = sws_getContext(pFrame->width, pFrame->height, pFrame->format,
+        pFrameRGB->width, pFrameRGB->height, pFrameRGB->format, SWS_BILINEAR, NULL, NULL, NULL);
+    if (!swsContext) {
+      ERROR(@"Cannot alloc sws context");
+      return NULL;
+    }
+    sws_scale(swsContext, (const uint8_t* const *)pFrame->data, pFrame->linesize, 0, pFrame->height,
+        pFrameRGB->data, pFrameRGB->linesize);
+
+    // Obtain information about the pixel format that is needed to create the bitmap image.
+    const AVPixFmtDescriptor *pixFmtDesc = av_pix_fmt_desc_get(pFrameRGB->format);
+    if (!pixFmtDesc){
+      ERROR(@"Cannot get descriptor for pixel format: %s (%d)",
+            av_get_pix_fmt_name(pFrameRGB->format), pFrameRGB->format);
+      return NULL;
+    }
+    const int bitsPerPixel = av_get_bits_per_pixel(pixFmtDesc);
+    const int bitsPerComponent = bitsPerPixel / pixFmtDesc->nb_components;
+    const int bytesPerPixel = bitsPerPixel / 8;
+
+    if (pFrameRGB->format == AV_PIX_FMT_RGBA64LE) {
+      // Apply the second part of the workaround for the FFmpeg scalar not supporting conversion to
+      // the pixel format AV_PIX_FMT_RGBAF16LE. Traverse the frame converting the pixel components
+      // to short floating point values.
+      const int bytesPerComponent = bitsPerComponent / 8;
+      const int bytesPerRow = pFrameRGB->width * bytesPerPixel;
+      // Each row of pixels in memory may contain extra padding for performance reasons. The
+      // linesize gives the actual number of bytes each row consumes in the frame buffer.
+      const int strideInBytes = pFrameRGB->linesize[0];
+      for (int rowOffset = 0; rowOffset < size; rowOffset += strideInBytes) {
+        // Convert each pixel component in the row.
+        for (int index = rowOffset; index < rowOffset + bytesPerRow; index += bytesPerComponent) {
+          uint16_t componentValue;
+          memcpy(&componentValue, &pFrameRGB->data[0][index], sizeof componentValue);
+          const _Float16 asFloat = (float)componentValue / USHRT_MAX;
+          memcpy(&pFrameRGB->data[0][index], &asFloat, sizeof asFloat);
+        }
+      }
+    }
+
+    // Determine the color space to use for the image.
+    switch (pFrame->color_primaries) {
+      default:
+        // If this message is logged then the situation needs to be investigated to determine the
+        // correct color space. Fall through and treat this as a SDR image.
+        WARN(@"Unexpected color primaries: %s (%d)",
+             av_color_primaries_name(pFrame->color_primaries), pFrame->color_primaries);
+      case AVCOL_PRI_UNSPECIFIED:
+      case AVCOL_PRI_BT709:
+        cgColorSpace = CGColorSpaceCreateDeviceRGB();
+        break;
+      case AVCOL_PRI_BT2020:
+        if (@available(macOS 11.0, *)) {
+          cgColorSpace = CGColorSpaceCreateWithName(kCGColorSpaceITUR_2100_PQ);
+        } else if (@available(macOS 10.15.4, *)) {
+            cgColorSpace = CGColorSpaceCreateWithName(kCGColorSpaceITUR_2020_PQ);
+        } else if (@available(macOS 10.14.6, *)) {
+            cgColorSpace = CGColorSpaceCreateWithName(kCGColorSpaceITUR_2020_PQ_EOTF);
+        } else {
+          cgColorSpace = CGColorSpaceCreateDeviceRGB();
+        }
+        break;
+      case AVCOL_PRI_SMPTE432:
+        if (@available(macOS 10.15.4, *)) {
+          cgColorSpace = CGColorSpaceCreateWithName(kCGColorSpaceDisplayP3_PQ);
+        } else if (@available(macOS 10.14.6, *)) {
+          cgColorSpace = CGColorSpaceCreateWithName(kCGColorSpaceDisplayP3_PQ_EOTF);
+        } else {
+          cgColorSpace = CGColorSpaceCreateDeviceRGB();
+        }
+    }
+    if (!cgColorSpace) {
+      ERROR(@"Cannot create color space");
+      return NULL;
+    }
+
+#if DEBUG
+    LOG(@"Selected %s color space for bitmap image",
+        CFStringGetCStringPtr(CGColorSpaceCopyName(cgColorSpace), CFStringGetSystemEncoding()));
+    LOG(@"Creating bitmap image with %d bits per component and %d bytes per pixel",
+        bitsPerComponent, bytesPerPixel);
+#endif
+
+    cgContext = CGBitmapContextCreate(pFrameRGB->data[0], pFrameRGB->width, pFrameRGB->height,
+        bitsPerComponent, pFrameRGB->width * bytesPerPixel, cgColorSpace, bitmapInfo);
+    if (!cgContext) {
+      ERROR(@"Cannot create bitmap context");
+      return NULL;
+    }
+    cgImage = CGBitmapContextCreateImage(cgContext);
+    if (!cgImage) {
+      ERROR(@"Cannot create bitmap image");
+      return NULL;
+    }
+
+    NSImage *image = [[NSImage alloc] initWithCGImage:cgImage size: NSZeroSize];
+    if (!image) {
+      ERROR(@"Cannot create image");
+    }
+    return image;
+  }
+  @finally {
+    // All of these methods accept null, no need to check if the object was allocated.
+    CGImageRelease(cgImage);
+    CGContextRelease(cgContext);
+    CGColorSpaceRelease(cgColorSpace);
+    sws_freeContext(swsContext);
+    av_freep(&pFrameRGBBuffer);
+    av_frame_free(&pFrameRGB);
+    av_frame_free(&pFrame);
+    av_packet_free(&packet);
+    avcodec_free_context(&pCodecCtx);
+    avformat_close_input(&pFormatCtx);
+  }
+}
+
+// MARK: - Logging
+
+#if DEBUG
+/// Log details about the given decoded frame.
+/// - Parameters:
+///   - pCodec: The codec that decoded the frame.
+///   - pFrame: The decoded frame to log.
++ (void)logFrame:(const AVCodec *)pCodec
+                :(const AVFrame *)pFrame
+{
+  LOG(@"Decoded %s frame", pCodec->long_name);
+  LOG(@"Pixel format: %s (%d)", av_get_pix_fmt_name(pFrame->format), pFrame->format);
+  LOG(@"Color range: %s (%d)", av_color_range_name(pFrame->color_range), pFrame->color_range);
+  LOG(@"Color primaries: %s (%d)", av_color_primaries_name(pFrame->color_primaries), pFrame->color_primaries);
+  LOG(@"Color transfer: %s (%d)", av_color_transfer_name(pFrame->color_trc), pFrame->color_trc);
+  LOG(@"Color space: %s (%d)", av_color_space_name(pFrame->colorspace), pFrame->colorspace);
+  LOG(@"Width: %d", pFrame->width);
+  LOG(@"Height: %d", pFrame->height);
+}
+#endif
 
 @end

--- a/iina/FFmpegLogger.swift
+++ b/iina/FFmpegLogger.swift
@@ -1,0 +1,32 @@
+//
+//  FFmpegControllerLogger.swift
+//  iina
+//
+//  Created by low-batt on 5/22/23.
+//  Copyright © 2023 lhc. All rights reserved.
+//
+
+import Foundation
+
+/// Logger for the `FFmpegController`.
+///
+/// This class gives the `FFmpegController`, which is implemented in Objective-C, the ability to log messages using the
+/// `Logger`.class.
+@objc class FFmpegLogger: NSObject {
+
+  @objc static func debug(_ message: String) {
+    Logger.log(message, subsystem: Logger.Sub.ffmpeg)
+  }
+
+  @objc static func error(_ message: String) {
+    Logger.log(message, level: .error, subsystem: Logger.Sub.ffmpeg)
+  }
+
+  @objc static func warn(_ message: String) {
+    Logger.log(message, level: .warning, subsystem: Logger.Sub.ffmpeg)
+  }
+}
+
+extension Logger.Sub {
+  static let ffmpeg = Logger.makeSubsystem("ffmpeg")
+}

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2023,7 +2023,7 @@ class MainWindowController: PlayerWindowController {
       accessoryView.layer?.opacity = 0
 
       NSAnimationContext.runAnimationGroup({ context in
-        context.duration = 0.3
+        context.duration = AccessibilityPreferences.adjustedDuration(0.3)
         context.allowsImplicitAnimation = true
         window!.setFrame(newFrame, display: true)
         osdVisualEffectView.layoutSubtreeIfNeeded()

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -866,6 +866,27 @@ class PlayerCore: NSObject {
     return true
   }
 
+  /// Initializes and returns an image object with the contents of the specified URL.
+  ///
+  /// At this time, the normal [NSImage](https://developer.apple.com/documentation/appkit/nsimage/1519907-init)
+  /// initializer will fail to create an image object if the image file was encoded in [JPEG XL](https://jpeg.org/jpegxl/) format.
+  /// In older versions of macOS this will also occur if the image file was encoded in [WebP](https://en.wikipedia.org/wiki/WebP/)
+  /// format. As these are supported formats for screenshots this method will fall back to using FFmpeg to create the `NSImage` if
+  /// the normal initializer fails to return an object.
+  /// - Parameter url: The URL identifying the image.
+  /// - Returns: An initialized `NSImage` object or `nil` if the method cannot create an image representation from the contents
+  ///       of the specified URL.
+  private func createImage(_ url: URL) -> NSImage? {
+    if let image = NSImage(contentsOf: url) {
+      return image
+    }
+    // The following internal property was added to provide a way to disable the FFmpeg image
+    // decoder should a problem be discovered by users running old versions of macOS.
+    guard Preference.bool(for: .enableFFmpegImageDecoder) else { return nil }
+    Logger.log("Using FFmpeg to decode screenshot: \(url)")
+    return FFmpegController.createNSImage(withContentsOf: url)
+  }
+
   func screenshotCallback() {
     let saveToFile = Preference.bool(for: .screenshotSaveToFile)
     let saveToClipboard = Preference.bool(for: .screenshotCopyToClipboard)
@@ -874,7 +895,7 @@ class PlayerCore: NSObject {
 
     guard let imageFolder = mpv.getString(MPVOption.Screenshot.screenshotDirectory) else { return }
     guard let lastScreenshotURL = Utility.getLatestScreenshot(from: imageFolder) else { return }
-    guard let image = NSImage(contentsOf: lastScreenshotURL) else {
+    guard let image = createImage(lastScreenshotURL) else {
       self.sendOSD(.screenshot)
       if !saveToFile {
         try? FileManager.default.removeItem(at: lastScreenshotURL)

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -292,10 +292,13 @@ struct Preference {
     /** Alerts */
     static let suppressCannotPreventDisplaySleep = Key("suppressCannotPreventDisplaySleep")
 
+    /** Internal */
     static let iinaEnablePluginSystem = Key("iinaEnablePluginSystem")
 
     /** Workaround for issue [#4688](https://github.com/iina/iina/issues/4688) */
     static let recentDocuments = Key("recentDocuments")
+
+    static let enableFFmpegImageDecoder = Key("enableFFmpegImageDecoder")
   }
 
   // MARK: - Enums
@@ -873,7 +876,9 @@ struct Preference {
 
     .suppressCannotPreventDisplaySleep: false,
 
-    .recentDocuments: [Any]()
+    .recentDocuments: [Any](),
+
+    .enableFFmpegImageDecoder: true
   ]
 
 

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -537,10 +537,8 @@ struct Preference {
     case png = 0
     case jpg
     case jpeg
-    case ppm
-    case pgm
-    case pgmyuv
-    case tga
+    case webp
+    case jxl
 
     static var defaultValue = ScreenshotFormat.png
 
@@ -554,10 +552,8 @@ struct Preference {
         case .png: return "png"
         case .jpg: return "jpg"
         case .jpeg: return "jpeg"
-        case .ppm: return "ppm"
-        case .pgm: return "pgm"
-        case .pgmyuv: return "pgmyuv"
-        case .tga: return "tga"
+        case .webp: return "webp"
+        case .jxl: return "jxl"
         }
       }
     }


### PR DESCRIPTION
This commit will:
- Remove `ppm`, `pgm`, `pgmyuv` and `tga` from the `Preferences.ScreenshotFormat` enum
- Add `webp` and `jxl` to the `Preferences.ScreenshotFormat` enum
- Add `WebP (.webp)` and `JPEG XL (.jxl)` as choices for the `Format` setting in the `Screenshots` section of `General` settings

NOTE that removing enumeration cases breaks backward compatibility as the new cases reuse the tag values previously assigned to `ppm` and `pgm`. These four screenshot formats were dropped by mpv and removed from IINA's setting panel back in 2017. Anyone using these old formats would have had to update their settings therefore it should be acceptable to reuse the tag values.

The main author of these changes is Carter Li. This is a merge of changes that have been tested in his IINA fork.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #3852.

---

**Description:**
