### PR TITLE
Fix disclosure triangles do not respect reduce motion, #4370

### DIFF
--- a/iina/CollapseView.swift
+++ b/iina/CollapseView.swift
@@ -67,7 +67,7 @@ class CollapseView: NSStackView {
     setVisibilityPriority(folded ? .notVisible : .mustHold, for: contentView!)
     if animated {
       NSAnimationContext.runAnimationGroup({ context in
-        context.duration = 0.25
+        context.duration = AccessibilityPreferences.adjustedDuration(0.25)
         context.allowsImplicitAnimation = true
         self.window?.layoutIfNeeded()
       }, completionHandler: nil)


### PR DESCRIPTION
This commit will change CollapseView.updateContentView to use AccessibilityPreferences.adjustedDuration to disable the sliding animation if reduce motion is enabled.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4370.

---

**Description:**
