### PR TITLE
Fix scroll views do not respect reduce motion, #4374

### DIFF
--- a/iina/AccessibilityPreferences.swift
+++ b/iina/AccessibilityPreferences.swift
@@ -17,6 +17,42 @@ struct AccessibilityPreferences {
     return motionReductionEnabled ? 0 : duration
   }
 
+  /// Adjusts the elasticity of the view and all of the subviews, if the user has enabled `Reduce motion` in macOS system settings.
+  ///
+  /// If `Reduce motion` is enabled then the view and  all of the subviews will be traversed searching for scroll views. Any scroll
+  /// views will have their [horizontalScrollElasticity](https://developer.apple.com/documentation/appkit/nsscrollview/1403540-horizontalscrollelasticity)
+  /// and [verticalScrollElasticity](https://developer.apple.com/documentation/appkit/nsscrollview/1403475-verticalscrollelasticity)
+  /// properties set to [none](https://developer.apple.com/documentation/appkit/nsscrollview/elasticity/none).
+  /// This reduces the bouncing rubber band scrolling effect which can be a problem for users with vestibular disorders.
+  /// - Parameter view: View hierarchy to adjust.
+  static func adjustElasticityInSubviews(_ view: NSView) {
+    guard motionReductionEnabled else { return }
+    view.forEachSuperview() { view in
+      if let scrollView = view as? NSScrollView {
+        scrollView.horizontalScrollElasticity = .none
+        scrollView.verticalScrollElasticity = .none
+     }
+    }
+  }
+
+  /// Adjusts the elasticity of the view and its ancestors, if the user has enabled `Reduce motion` in macOS system settings.
+  ///
+  /// If `Reduce motion` is enabled then the view and its ancestors will be traversed searching for scroll views. Any scroll views will
+  /// have their [horizontalScrollElasticity](https://developer.apple.com/documentation/appkit/nsscrollview/1403540-horizontalscrollelasticity)
+  /// and [verticalScrollElasticity](https://developer.apple.com/documentation/appkit/nsscrollview/1403475-verticalscrollelasticity)
+  /// properties set to [none](https://developer.apple.com/documentation/appkit/nsscrollview/elasticity/none).
+  /// This reduces the bouncing rubber band scrolling effect which can be a problem for users with vestibular disorders.
+  /// - Parameter view: View hierarchy to adjust.
+  static func adjustElasticityInSuperviews(_ view: NSView) {
+    guard motionReductionEnabled else { return }
+    view.forEachSuperview() { view in
+      if let scrollView = view as? NSScrollView {
+        scrollView.horizontalScrollElasticity = .none
+        scrollView.verticalScrollElasticity = .none
+      }
+    }
+  }
+
   /// Reflects whether the macOS System Preference accessibility option to retuce motion is in an enabled state.
   ///
   /// This property provides a wrapper around the `NSWorkspace` property so that code that needs to check this preference setting

--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -704,3 +704,27 @@ extension Process {
     return (process, stdout, stderr)
   }
 }
+
+extension NSView {
+
+  /// Calls the given closure on this view and all of the subviews.
+  ///
+  /// A recursive depth first traversal algorithm is used to visit all of the subviews.
+  /// - Parameter body: A closure that takes a view as a parameter.
+  func forEachSubview(_ body: (NSView) throws -> Void) rethrows {
+    try body(self)
+    for view in self.subviews {
+      try view.forEachSubview(body)
+    }
+  }
+
+  /// Calls the given closure on this view and each of its superviews.
+  /// - Parameter body: A closure that takes a view as a parameter.
+  func forEachSuperview(_ body: (NSView) throws -> Void) rethrows {
+    var view: NSView? = self
+    while view != nil {
+      try body(view!)
+      view = view!.superview
+    }
+  }
+}

--- a/iina/FilterWindowController.swift
+++ b/iina/FilterWindowController.swift
@@ -59,6 +59,9 @@ class FilterWindowController: NSWindowController, NSWindowDelegate {
     Utility.quickConstraints(["H:|[v]|", "V:|[v]|", "H:|[w]|", "V:|[w]|"], ["v": upperView, "w": lowerView])
     splitView.setPosition(splitView.frame.height - 140, ofDividerAt: 0)
 
+    AccessibilityPreferences.adjustElasticityInSubviews(currentFiltersTableView)
+    AccessibilityPreferences.adjustElasticityInSubviews(savedFiltersTableView)
+
     savedFilters = (Preference.array(for: filterType == MPVProperty.af ? .savedAudioFilters : .savedVideoFilters) ?? []).compactMap(SavedFilter.init(dict:))
     filters = PlayerCore.lastActive.mpv.getFilters(filterType)
     currentFiltersTableView.reloadData()

--- a/iina/HistoryWindowController.swift
+++ b/iina/HistoryWindowController.swift
@@ -71,6 +71,7 @@ class HistoryWindowController: NSWindowController, NSOutlineViewDelegate, NSOutl
     outlineView.target = self
     outlineView.doubleAction = #selector(doubleAction)
     outlineView.expandItem(nil, expandChildren: true)
+    AccessibilityPreferences.adjustElasticityInSubviews(outlineView)
   }
 
   func reloadData() {

--- a/iina/InitialWindowController.swift
+++ b/iina/InitialWindowController.swift
@@ -184,6 +184,7 @@ class InitialWindowController: NSWindowController {
                                         options: [.activeInKeyWindow, .mouseMoved], owner: self, userInfo: nil))
     recentFilesTableView.addTrackingArea(NSTrackingArea(rect: recentFilesTableView.bounds,
                                                         options: [.activeInKeyWindow, .mouseEnteredAndExited], owner: self, userInfo: nil))
+    AccessibilityPreferences.adjustElasticityInSubviews(recentFilesTableView)
 
     setMaterial(Preference.enum(for: .themeMaterial))
 

--- a/iina/InspectorWindowController.swift
+++ b/iina/InspectorWindowController.swift
@@ -76,6 +76,7 @@ class InspectorWindowController: NSWindowController, NSTableViewDelegate, NSTabl
     watchProperties = Preference.array(for: .watchProperties) as! [String]
     watchTableView.delegate = self
     watchTableView.dataSource = self
+    AccessibilityPreferences.adjustElasticityInSubviews(watchTableView)
 
     deleteButton.isEnabled = false
 

--- a/iina/LogWindowController.swift
+++ b/iina/LogWindowController.swift
@@ -33,7 +33,7 @@ class LogWindowController: NSWindowController, NSMenuDelegate {
     let tableViewMenu = NSMenu()
     tableViewMenu.addItem(withTitle: "Copy", action: #selector(menuCopy), keyEquivalent: "")
     logTableView.menu = tableViewMenu
-
+    AccessibilityPreferences.adjustElasticityInSubviews(logTableView)
     levelPopUpButton.menu?.items.forEach {
       $0.image = LogWindowController.indicatorIcon(withColor: colorMap[$0.tag]!)
     }

--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -93,6 +93,7 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
     super.viewDidLoad()
     withAllTableViews { (view) in
       view.dataSource = self
+      AccessibilityPreferences.adjustElasticityInSuperviews(view)
     }
     playlistTableView.menu?.delegate = self
 

--- a/iina/PrefAdvancedViewController.swift
+++ b/iina/PrefAdvancedViewController.swift
@@ -60,6 +60,7 @@ class PrefAdvancedViewController: PreferenceViewController, PreferenceWindowEmbe
     optionsTableView.dataSource = self
     optionsTableView.delegate = self
     optionsTableView.sizeLastColumnToFit()
+    AccessibilityPreferences.adjustElasticityInSuperviews(optionsTableView)
     removeButton.isEnabled = false
 
     enableAdvancedSettingsBtn.checked = Preference.bool(for: .enableAdvancedSettings)

--- a/iina/PrefKeyBindingViewController.swift
+++ b/iina/PrefKeyBindingViewController.swift
@@ -62,8 +62,10 @@ class PrefKeyBindingViewController: NSViewController, PreferenceWindowEmbeddable
 
     kbTableView.delegate = self
     kbTableView.doubleAction = Preference.bool(for: .displayKeyBindingRawValues) ? nil : #selector(editRow)
+    AccessibilityPreferences.adjustElasticityInSuperviews(kbTableView)
     confTableView.dataSource = self
     confTableView.delegate = self
+    AccessibilityPreferences.adjustElasticityInSuperviews(confTableView)
 
     removeKmBtn.isEnabled = false
 

--- a/iina/QuickSettingViewController.swift
+++ b/iina/QuickSettingViewController.swift
@@ -182,6 +182,7 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
       view.delegate = self
       view.dataSource = self
       view.superview?.superview?.layer?.cornerRadius = 4
+      AccessibilityPreferences.adjustElasticityInSuperviews(view)
     }
 
     // colors


### PR DESCRIPTION
This commit will:
- Add the methods `adjustElasticityInSubviews` and `adjustElasticityInSuperviews` to `AccessibilityPreferences`
- Extend `NSView`, adding the methods `forEachSubview` and `forEachSuperview` to `Extensions`
- Change `FilterWindowController`, `HistoryWindowController`, `InitialWindowController`, `InspectorWindowController`, `LogWindowController`, `PlaylistViewController`, `PrefAdvancedViewController`, `PrefKeyBindingViewController` and `QuickSettingViewController` to use the new `AccessibilityPreferences` methods

These changes will set `horizontalScrollElasticity` and `verticalScrollElasticity` to `none` for scroll views in these IINA windows if reduce motion is enabled. This does not eliminate the rubber band scrolling animation effect, only reduce it. Scrolling at high speed will still bounce when the end of the view is reached.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4374.

---

**Description:**
