### PR TITLE
Fix possible PlaySliderCell crash

### DIFF
--- a/iina/PlaySliderCell.swift
+++ b/iina/PlaySliderCell.swift
@@ -22,15 +22,12 @@ fileprivate extension NSColor {
 }
 
 class PlaySliderCell: NSSliderCell {
-  weak var _playerCore: PlayerCore!
+  unowned var _playerCore: PlayerCore!
   var playerCore: PlayerCore {
     if let player = _playerCore { return player }
 
     let windowController = self.controlView!.window!.windowController
-    if let mainWindowController = windowController as? MainWindowController {
-      return mainWindowController.player
-    }
-    let player = (windowController as! MiniPlayerWindowController).player
+    let player = (windowController as! PlayerWindowController).player
     _playerCore = player
     return player
   }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
It doesn't happen on the official IINA develop branch, but entering/exiting from fullscreen would crash about 1 out of 5 times on my [development branch](https://github.com/svobs/iina/commit/97bf2d15b4c55bd4d8ac29eae91874f5fde41fd0). I believe the reason for the difference is that I'm using longer animations which are more likely to make the bug appear.

An analysis of the code in `PlaySliderCell.swift` revealed that although it makes an attempt to cache the reference to `PlayerCore`, it's only doing that for mini-player windows. For "MainWIndow" it's returning immediately.

This PR patches the hole. Also it changes `_playerCore` from `weak` to `unowned`. I found [this post](https://www.andrewcbancroft.com/2015/05/08/strong-weak-and-unowned-sorting-out-arc-and-swift/) linked to from StackOverflow, which declares:

> When two instances are optionally related to one another, make sure that one of those instances holds a `weak` reference to the other.
> When two instances are related in such a way that one of the instances can’t exist without the other, the instance with the mandatory dependency needs to hold an `unowned` reference to the other instance.