### PR TITLE
Update highlight of sidebar tab buttons so they all match (fixes issue #4332)

### DIFF
--- a/iina/Base.lproj/PlaylistViewController.xib
+++ b/iina/Base.lproj/PlaylistViewController.xib
@@ -462,7 +462,7 @@
                     <rect key="frame" x="121" y="294" width="120" height="48"/>
                     <buttonCell key="cell" type="square" title="CHAPTERS" bezelStyle="shadowlessSquare" alignment="center" imageScaling="proportionallyDown" inset="2" id="jUF-xa-uRI">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="system"/>
+                        <font key="font" metaFont="systemBold"/>
                     </buttonCell>
                     <connections>
                         <action selector="chaptersBtnAction:" target="-2" id="Gpo-6e-oRu"/>

--- a/iina/ExtendedColors.swift
+++ b/iina/ExtendedColors.swift
@@ -37,7 +37,7 @@ extension NSColor.Name {
   static let sidebarTabTintActive = NSColor.Name("SidebarTabTintActive")
 }
 
-@available(OSX 10.14, *)
+@available(macOS 10.14, *)
 extension NSColor {
   static let sidebarTabTint: NSColor = NSColor(named: .sidebarTabTint)!
   static let sidebarTabTintActive: NSColor = NSColor(named: .sidebarTabTintActive)!

--- a/iina/ExtendedColors.swift
+++ b/iina/ExtendedColors.swift
@@ -36,3 +36,9 @@ extension NSColor.Name {
   static let sidebarTabTint = NSColor.Name("SidebarTabTint")
   static let sidebarTabTintActive = NSColor.Name("SidebarTabTintActive")
 }
+
+@available(OSX 10.14, *)
+extension NSColor {
+  static let sidebarTabTint: NSColor = NSColor(named: .sidebarTabTint)!
+  static let sidebarTabTintActive: NSColor = NSColor(named: .sidebarTabTintActive)!
+}

--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -224,15 +224,23 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
     switch tab {
     case .playlist:
       tabView.selectTabViewItem(at: 0)
-      Utility.setBoldTitle(for: playlistBtn, true)
-      Utility.setBoldTitle(for: chaptersBtn, false)
+      updateTabActiveStatus(for: playlistBtn, isActive: true)
+      updateTabActiveStatus(for: chaptersBtn, isActive: false)
     case .chapters:
       tabView.selectTabViewItem(at: 1)
-      Utility.setBoldTitle(for: chaptersBtn, true)
-      Utility.setBoldTitle(for: playlistBtn, false)
+      updateTabActiveStatus(for: playlistBtn, isActive: false)
+      updateTabActiveStatus(for: chaptersBtn, isActive: true)
     }
 
     currentTab = tab
+  }
+
+  private func updateTabActiveStatus(for btn: NSButton, isActive: Bool) {
+    if #available(macOS 10.14, *) {
+      btn.contentTintColor = isActive ? NSColor.sidebarTabTintActive : NSColor.sidebarTabTint
+    } else {
+      Utility.setBoldTitle(for: btn, isActive)
+    }
   }
 
   // MARK: - NSTableViewDataSource

--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -118,6 +118,9 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
     if pendingSwitchRequest != nil {
       switchToTab(pendingSwitchRequest!)
       pendingSwitchRequest = nil
+    } else {
+      // Initial display: need to draw highlight for currentTab
+      updateTabButtons(activeTab: currentTab)
     }
 
     // nofitications
@@ -221,18 +224,27 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
 
   /** Switch tab (for internal call) */
   private func switchToTab(_ tab: TabViewType) {
+    updateTabButtons(activeTab: tab)
     switch tab {
     case .playlist:
       tabView.selectTabViewItem(at: 0)
-      updateTabActiveStatus(for: playlistBtn, isActive: true)
-      updateTabActiveStatus(for: chaptersBtn, isActive: false)
     case .chapters:
       tabView.selectTabViewItem(at: 1)
-      updateTabActiveStatus(for: playlistBtn, isActive: false)
-      updateTabActiveStatus(for: chaptersBtn, isActive: true)
     }
 
     currentTab = tab
+  }
+
+  // Updates display of all tabs buttons to indicate that the given tab is active and the rest are not
+  private func updateTabButtons(activeTab: TabViewType) {
+    switch activeTab {
+    case .playlist:
+      updateTabActiveStatus(for: playlistBtn, isActive: true)
+      updateTabActiveStatus(for: chaptersBtn, isActive: false)
+    case .chapters:
+      updateTabActiveStatus(for: playlistBtn, isActive: false)
+      updateTabActiveStatus(for: chaptersBtn, isActive: true)
+    }
   }
 
   private func updateTabActiveStatus(for btn: NSButton, isActive: Bool) {

--- a/iina/QuickSettingViewController.swift
+++ b/iina/QuickSettingViewController.swift
@@ -8,12 +8,6 @@
 
 import Cocoa
 
-@available(OSX 10.14, *)
-fileprivate extension NSColor {
-  static let sidebarTabTint: NSColor = NSColor(named: .sidebarTabTint)!
-  static let sidebarTabTintActive: NSColor = NSColor(named: .sidebarTabTintActive)!
-}
-
 class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTableViewDelegate, SidebarViewController {
   override var nibName: NSNib.Name {
     return NSNib.Name("QuickSettingViewController")


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4332.

---

**Description:**

Analysis: For newer versions of MacOS (10.14+), the 3 Quick Settings tab buttons are displayed all in bold, and the active tab's button text tint is set to pure black. However, the Playlist & Chapters tabs were following (what looks like) an older scheme: the active tab was bold, and the other tab was not bold; neither had a special tint. (The Quick Settings tabs fall back to this behavior for older versions of MacOS).

This update changes Playlist & Chapters so that they match the behavior of the other three
