### PR TITLE
Allow changing width of music mode window (fixes #3484)

### DIFF
--- a/iina/Base.lproj/MiniPlayerWindowController.xib
+++ b/iina/Base.lproj/MiniPlayerWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -44,20 +44,20 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" frameAutosaveName="IINAMiniPlayerWindow" animationBehavior="default" tabbingMode="disallowed" id="F0z-JX-Cv5" userLabel="MiniPlayer Window" customClass="MiniPlayerWindow" customModule="IINA" customModuleProvider="target">
-            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
+            <windowStyleMask key="styleMask" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenNone="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="300" height="72"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1728" height="1079"/>
             <value key="minSize" type="size" width="300" height="72"/>
-            <view key="contentView" id="se5-gp-TjO">
+            <view key="contentView" id="se5-gp-TjO" userLabel="MiniPlayerWindow Content View">
                 <rect key="frame" x="0.0" y="0.0" width="300" height="72"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="WD9-DD-LNj">
+                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="WD9-DD-LNj" userLabel="VideoWrapper View">
                         <rect key="frame" x="0.0" y="72" width="300" height="0.0"/>
                         <subviews>
-                            <customView wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Psi-wJ-2SC">
+                            <customView wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Psi-wJ-2SC" userLabel="DefaultAlbumArt View">
                                 <rect key="frame" x="0.0" y="-300" width="300" height="300"/>
                                 <constraints>
                                     <constraint firstAttribute="width" secondItem="Psi-wJ-2SC" secondAttribute="height" multiplier="1:1" id="aXc-tY-3t0"/>
@@ -71,57 +71,22 @@
                             <constraint firstAttribute="trailing" secondItem="Psi-wJ-2SC" secondAttribute="trailing" id="xov-sj-bTG"/>
                         </constraints>
                     </customView>
-                    <visualEffectView wantsLayer="YES" blendingMode="behindWindow" material="underWindowBackground" state="active" translatesAutoresizingMaskIntoConstraints="NO" id="HdA-I9-dRJ">
+                    <visualEffectView wantsLayer="YES" blendingMode="behindWindow" material="underWindowBackground" state="active" translatesAutoresizingMaskIntoConstraints="NO" id="HdA-I9-dRJ" userLabel="Background View">
                         <rect key="frame" x="0.0" y="0.0" width="300" height="72"/>
                         <subviews>
-                            <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xAK-xc-Njn" customClass="DurationDisplayTextField" customModule="IINA" customModuleProvider="target">
-                                <rect key="frame" x="260" y="9" width="36" height="11"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="32" id="Dnz-rF-ikZ"/>
-                                </constraints>
-                                <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="-:--:--" id="V74-PQ-Yfr">
-                                    <font key="font" metaFont="label" size="9"/>
-                                    <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
-                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                </textFieldCell>
-                                <connections>
-                                    <binding destination="-2" name="font" keyPath="monospacedFont" id="TM3-Ri-L7h"/>
-                                </connections>
-                            </textField>
-                            <textField horizontalHuggingPriority="249" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9EY-2T-Ebf" customClass="DurationDisplayTextField" customModule="IINA" customModuleProvider="target">
-                                <rect key="frame" x="4" y="9" width="36" height="11"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="32" id="1iE-QR-s8H"/>
-                                </constraints>
-                                <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="-:--:--" id="WnA-NE-3bG">
-                                    <font key="font" metaFont="label" size="9"/>
-                                    <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
-                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                </textFieldCell>
-                                <connections>
-                                    <binding destination="-2" name="font" keyPath="monospacedFont" id="ivC-kT-hEO"/>
-                                </connections>
-                            </textField>
-                            <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="e3M-Ma-JJM">
-                                <rect key="frame" x="42" y="5" width="216" height="19"/>
-                                <sliderCell key="cell" continuous="YES" refusesFirstResponder="YES" state="on" alignment="left" maxValue="100" doubleValue="50" tickMarkPosition="above" sliderType="linear" id="Y51-2C-Qcg" customClass="PlaySliderCell" customModule="IINA" customModuleProvider="target"/>
-                                <connections>
-                                    <action selector="playSliderChanges:" target="-2" id="qdw-Jb-iyq"/>
-                                </connections>
-                            </slider>
-                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="Zv7-H8-iOq">
-                                <rect key="frame" x="0.0" y="24" width="300" height="48"/>
+                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="Zv7-H8-iOq" userLabel="MediaInfo View">
+                                <rect key="frame" x="20" y="24" width="258" height="48"/>
                                 <subviews>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="h25-bp-EvL" customClass="ScrollingTextField" customModule="IINA" customModuleProvider="target">
-                                        <rect key="frame" x="133" y="26" width="35" height="16"/>
+                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="h25-bp-EvL" userLabel="Title Label" customClass="ScrollingTextField" customModule="IINA" customModuleProvider="target">
+                                        <rect key="frame" x="-22" y="26" width="304" height="16"/>
                                         <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" alignment="center" title="Title" id="Rs9-6l-6vp">
                                             <font key="font" metaFont="system"/>
                                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kcj-EY-i9R" customClass="ScrollingTextField" customModule="IINA" customModuleProvider="target">
-                                        <rect key="frame" x="109" y="8" width="82" height="14"/>
+                                    <textField wantsLayer="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kcj-EY-i9R" userLabel="Artist-Album Label" customClass="ScrollingTextField" customModule="IINA" customModuleProvider="target">
+                                        <rect key="frame" x="-22" y="8" width="304" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Artist - Album" id="Nle-gv-CWY">
                                             <font key="font" metaFont="message" size="11"/>
                                             <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -130,77 +95,15 @@
                                     </textField>
                                 </subviews>
                                 <constraints>
-                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="h25-bp-EvL" secondAttribute="trailing" constant="24" id="4DV-b1-VzX"/>
-                                    <constraint firstItem="kcj-EY-i9R" firstAttribute="centerX" secondItem="Zv7-H8-iOq" secondAttribute="centerX" id="DYZ-sc-L0I"/>
                                     <constraint firstItem="h25-bp-EvL" firstAttribute="top" secondItem="Zv7-H8-iOq" secondAttribute="top" constant="6" id="Qaf-SS-SCV"/>
-                                    <constraint firstItem="kcj-EY-i9R" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Zv7-H8-iOq" secondAttribute="leading" constant="24" id="U84-tV-T8O"/>
-                                    <constraint firstItem="h25-bp-EvL" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Zv7-H8-iOq" secondAttribute="leading" constant="24" id="gIX-TM-h4K"/>
                                     <constraint firstItem="kcj-EY-i9R" firstAttribute="top" secondItem="h25-bp-EvL" secondAttribute="bottom" constant="4" id="mbp-t7-SX2"/>
-                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="kcj-EY-i9R" secondAttribute="trailing" constant="24" id="qt7-Ax-WS9"/>
                                     <constraint firstAttribute="height" constant="48" id="uWg-wb-QM5"/>
-                                    <constraint firstItem="h25-bp-EvL" firstAttribute="centerX" secondItem="Zv7-H8-iOq" secondAttribute="centerX" id="uob-1w-0x0"/>
                                 </constraints>
                             </customView>
-                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="cDR-8J-QI7">
+                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="cDR-8J-QI7" userLabel="Control View">
                                 <rect key="frame" x="0.0" y="24" width="300" height="48"/>
                                 <subviews>
-                                    <button translatesAutoresizingMaskIntoConstraints="NO" id="aC9-OK-a4x">
-                                        <rect key="frame" x="138" y="8" width="28" height="28"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="28" id="8Q7-Km-TpD"/>
-                                            <constraint firstAttribute="width" secondItem="aC9-OK-a4x" secondAttribute="height" multiplier="1:1" id="PbK-hg-vA0"/>
-                                        </constraints>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="play" imagePosition="only" alignment="center" alternateImage="pause" refusesFirstResponder="YES" state="on" imageScaling="proportionallyUpOrDown" inset="2" id="F9X-N7-Uv0">
-                                            <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
-                                            <font key="font" metaFont="system"/>
-                                        </buttonCell>
-                                        <connections>
-                                            <action selector="playButtonAction:" target="-2" id="tSb-as-bee"/>
-                                        </connections>
-                                    </button>
-                                    <button translatesAutoresizingMaskIntoConstraints="NO" id="998-mn-oHJ">
-                                        <rect key="frame" x="186" y="8" width="28" height="28"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" secondItem="998-mn-oHJ" secondAttribute="height" multiplier="1:1" id="pWX-4v-Q2E"/>
-                                            <constraint firstAttribute="height" constant="28" id="uZt-EE-yyu"/>
-                                        </constraints>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="nextr" imagePosition="only" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="DPp-zB-KXR">
-                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                            <font key="font" metaFont="system"/>
-                                        </buttonCell>
-                                        <connections>
-                                            <action selector="nextBtnAction:" target="-2" id="ivD-3f-1va"/>
-                                        </connections>
-                                    </button>
-                                    <button translatesAutoresizingMaskIntoConstraints="NO" id="nSh-lh-jim">
-                                        <rect key="frame" x="86" y="8" width="28" height="28"/>
-                                        <constraints>
-                                            <constraint firstAttribute="width" secondItem="nSh-lh-jim" secondAttribute="height" multiplier="1:1" id="pei-u3-qXH"/>
-                                            <constraint firstAttribute="height" constant="28" id="vgp-bk-9d7"/>
-                                        </constraints>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="nextl" imagePosition="only" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="bti-JU-2h9">
-                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                            <font key="font" metaFont="system"/>
-                                        </buttonCell>
-                                        <connections>
-                                            <action selector="prevBtnAction:" target="-2" id="BDa-Ku-caU"/>
-                                        </connections>
-                                    </button>
-                                    <button translatesAutoresizingMaskIntoConstraints="NO" id="a5L-QK-yog">
-                                        <rect key="frame" x="234" y="15" width="14" height="14"/>
-                                        <constraints>
-                                            <constraint firstAttribute="height" constant="14" id="0Bh-cC-tiD"/>
-                                            <constraint firstAttribute="width" secondItem="a5L-QK-yog" secondAttribute="height" multiplier="1:1" id="EP9-Dl-Hbh"/>
-                                        </constraints>
-                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="playlist" imagePosition="only" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="9be-Tw-9hy">
-                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                            <font key="font" metaFont="system"/>
-                                        </buttonCell>
-                                        <connections>
-                                            <action selector="togglePlaylist:" target="-2" id="0da-p5-HBI"/>
-                                        </connections>
-                                    </button>
-                                    <button translatesAutoresizingMaskIntoConstraints="NO" id="fUy-ap-8fj">
+                                    <button translatesAutoresizingMaskIntoConstraints="NO" id="fUy-ap-8fj" userLabel="Volume Button">
                                         <rect key="frame" x="49" y="15" width="17" height="14"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="14" id="o7f-KV-JoD"/>
@@ -214,7 +117,63 @@
                                             <action selector="volumeBtnAction:" target="-2" id="ynf-E4-jte"/>
                                         </connections>
                                     </button>
-                                    <button translatesAutoresizingMaskIntoConstraints="NO" id="KFz-Kp-RxC">
+                                    <button translatesAutoresizingMaskIntoConstraints="NO" id="nSh-lh-jim" userLabel="Prev Button">
+                                        <rect key="frame" x="86" y="8" width="28" height="28"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="nSh-lh-jim" secondAttribute="height" multiplier="1:1" id="pei-u3-qXH"/>
+                                            <constraint firstAttribute="height" constant="28" id="vgp-bk-9d7"/>
+                                        </constraints>
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="nextl" imagePosition="only" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="bti-JU-2h9">
+                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <action selector="prevBtnAction:" target="-2" id="BDa-Ku-caU"/>
+                                        </connections>
+                                    </button>
+                                    <button translatesAutoresizingMaskIntoConstraints="NO" id="aC9-OK-a4x" userLabel="Play Button">
+                                        <rect key="frame" x="138" y="8" width="28" height="28"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="28" id="8Q7-Km-TpD"/>
+                                            <constraint firstAttribute="width" secondItem="aC9-OK-a4x" secondAttribute="height" multiplier="1:1" id="PbK-hg-vA0"/>
+                                        </constraints>
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="play" imagePosition="only" alignment="center" alternateImage="pause" refusesFirstResponder="YES" state="on" imageScaling="proportionallyUpOrDown" inset="2" id="F9X-N7-Uv0">
+                                            <behavior key="behavior" pushIn="YES" changeContents="YES" lightByContents="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <action selector="playButtonAction:" target="-2" id="tSb-as-bee"/>
+                                        </connections>
+                                    </button>
+                                    <button translatesAutoresizingMaskIntoConstraints="NO" id="998-mn-oHJ" userLabel="Next Button">
+                                        <rect key="frame" x="186" y="8" width="28" height="28"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" secondItem="998-mn-oHJ" secondAttribute="height" multiplier="1:1" id="pWX-4v-Q2E"/>
+                                            <constraint firstAttribute="height" constant="28" id="uZt-EE-yyu"/>
+                                        </constraints>
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="nextr" imagePosition="only" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="DPp-zB-KXR">
+                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <action selector="nextBtnAction:" target="-2" id="ivD-3f-1va"/>
+                                        </connections>
+                                    </button>
+                                    <button translatesAutoresizingMaskIntoConstraints="NO" id="a5L-QK-yog" userLabel="TogglePlaylist Button">
+                                        <rect key="frame" x="234" y="15" width="14" height="14"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="14" id="0Bh-cC-tiD"/>
+                                            <constraint firstAttribute="width" secondItem="a5L-QK-yog" secondAttribute="height" multiplier="1:1" id="EP9-Dl-Hbh"/>
+                                        </constraints>
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="playlist" imagePosition="only" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="9be-Tw-9hy">
+                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <action selector="togglePlaylist:" target="-2" id="0da-p5-HBI"/>
+                                        </connections>
+                                    </button>
+                                    <button translatesAutoresizingMaskIntoConstraints="NO" id="KFz-Kp-RxC" userLabel="ToggleVideo Button">
                                         <rect key="frame" x="260" y="15" width="14" height="14"/>
                                         <constraints>
                                             <constraint firstAttribute="width" secondItem="KFz-Kp-RxC" secondAttribute="height" multiplier="1:1" id="gIv-1I-vU2"/>
@@ -231,12 +190,12 @@
                                 </subviews>
                                 <constraints>
                                     <constraint firstItem="nSh-lh-jim" firstAttribute="centerY" secondItem="aC9-OK-a4x" secondAttribute="centerY" id="9tz-su-lQa"/>
+                                    <constraint firstAttribute="bottom" secondItem="aC9-OK-a4x" secondAttribute="bottom" constant="8" id="Kp2-t1-s8k"/>
                                     <constraint firstItem="aC9-OK-a4x" firstAttribute="top" secondItem="cDR-8J-QI7" secondAttribute="top" constant="12" id="Kzm-iJ-Vkp"/>
                                     <constraint firstItem="KFz-Kp-RxC" firstAttribute="centerY" secondItem="a5L-QK-yog" secondAttribute="centerY" id="LaN-Gb-lL9"/>
                                     <constraint firstItem="KFz-Kp-RxC" firstAttribute="leading" secondItem="a5L-QK-yog" secondAttribute="trailing" constant="12" id="PpO-ZM-V3M"/>
                                     <constraint firstItem="fUy-ap-8fj" firstAttribute="centerY" secondItem="aC9-OK-a4x" secondAttribute="centerY" id="PvJ-Gl-h60"/>
                                     <constraint firstItem="nSh-lh-jim" firstAttribute="leading" secondItem="fUy-ap-8fj" secondAttribute="trailing" constant="20" id="SGi-ju-KtN"/>
-                                    <constraint firstAttribute="height" constant="48" id="fao-NR-5SG"/>
                                     <constraint firstItem="aC9-OK-a4x" firstAttribute="leading" secondItem="nSh-lh-jim" secondAttribute="trailing" constant="24" id="kCv-eh-zx2"/>
                                     <constraint firstItem="998-mn-oHJ" firstAttribute="centerY" secondItem="aC9-OK-a4x" secondAttribute="centerY" id="ldG-Yz-2vC"/>
                                     <constraint firstItem="aC9-OK-a4x" firstAttribute="centerX" secondItem="cDR-8J-QI7" secondAttribute="centerX" constant="2" id="pI1-nE-AtV"/>
@@ -245,10 +204,45 @@
                                     <constraint firstItem="998-mn-oHJ" firstAttribute="leading" secondItem="aC9-OK-a4x" secondAttribute="trailing" constant="20" id="yL9-7r-6VR"/>
                                 </constraints>
                             </customView>
+                            <textField wantsLayer="YES" horizontalHuggingPriority="249" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9EY-2T-Ebf" userLabel="LeftPlayPosition Label" customClass="DurationDisplayTextField" customModule="IINA" customModuleProvider="target">
+                                <rect key="frame" x="4" y="11" width="36" height="11"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="32" id="1iE-QR-s8H"/>
+                                </constraints>
+                                <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="-:--:--" id="WnA-NE-3bG">
+                                    <font key="font" metaFont="label" size="9"/>
+                                    <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                                <connections>
+                                    <binding destination="-2" name="font" keyPath="monospacedFont" id="ivC-kT-hEO"/>
+                                </connections>
+                            </textField>
+                            <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="e3M-Ma-JJM" userLabel="Play Slider">
+                                <rect key="frame" x="42" y="0.0" width="216" height="28"/>
+                                <sliderCell key="cell" continuous="YES" refusesFirstResponder="YES" state="on" alignment="left" maxValue="100" doubleValue="50" tickMarkPosition="above" sliderType="linear" id="Y51-2C-Qcg" customClass="PlaySliderCell" customModule="IINA" customModuleProvider="target"/>
+                                <connections>
+                                    <action selector="playSliderChanges:" target="-2" id="qdw-Jb-iyq"/>
+                                </connections>
+                            </slider>
+                            <textField wantsLayer="YES" horizontalHuggingPriority="249" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xAK-xc-Njn" userLabel="RightPlayPosition Label" customClass="DurationDisplayTextField" customModule="IINA" customModuleProvider="target">
+                                <rect key="frame" x="260" y="11" width="36" height="11"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="32" id="Dnz-rF-ikZ"/>
+                                </constraints>
+                                <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="-:--:--" id="V74-PQ-Yfr">
+                                    <font key="font" metaFont="label" size="9"/>
+                                    <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                                <connections>
+                                    <binding destination="-2" name="font" keyPath="monospacedFont" id="TM3-Ri-L7h"/>
+                                </connections>
+                            </textField>
                         </subviews>
                         <constraints>
-                            <constraint firstItem="Zv7-H8-iOq" firstAttribute="leading" secondItem="HdA-I9-dRJ" secondAttribute="leading" id="0RG-9U-PfH"/>
-                            <constraint firstItem="e3M-Ma-JJM" firstAttribute="top" secondItem="HdA-I9-dRJ" secondAttribute="top" constant="50" id="9qE-pN-912"/>
+                            <constraint firstItem="Zv7-H8-iOq" firstAttribute="leading" secondItem="HdA-I9-dRJ" secondAttribute="leading" constant="20" id="0RG-9U-PfH"/>
+                            <constraint firstItem="e3M-Ma-JJM" firstAttribute="top" secondItem="HdA-I9-dRJ" secondAttribute="top" constant="46" id="9qE-pN-912"/>
                             <constraint firstItem="9EY-2T-Ebf" firstAttribute="leading" secondItem="HdA-I9-dRJ" secondAttribute="leading" constant="6" id="CDO-gT-VfY"/>
                             <constraint firstItem="9EY-2T-Ebf" firstAttribute="centerY" secondItem="e3M-Ma-JJM" secondAttribute="centerY" id="HEK-U3-nXU"/>
                             <constraint firstItem="xAK-xc-Njn" firstAttribute="centerY" secondItem="e3M-Ma-JJM" secondAttribute="centerY" id="IxN-QB-clc"/>
@@ -262,34 +256,32 @@
                             <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="cDR-8J-QI7" secondAttribute="bottom" constant="24" id="n2O-up-sBQ"/>
                             <constraint firstItem="xAK-xc-Njn" firstAttribute="leading" secondItem="e3M-Ma-JJM" secondAttribute="trailing" constant="6" id="oEQ-mY-BqT"/>
                             <constraint firstAttribute="trailing" secondItem="cDR-8J-QI7" secondAttribute="trailing" id="uCr-Bo-TON"/>
-                            <constraint firstAttribute="trailing" secondItem="Zv7-H8-iOq" secondAttribute="trailing" id="vmF-Ea-a1k"/>
+                            <constraint firstAttribute="trailing" secondItem="Zv7-H8-iOq" secondAttribute="trailing" constant="22" id="vmF-Ea-a1k"/>
                         </constraints>
                     </visualEffectView>
-                    <visualEffectView wantsLayer="YES" blendingMode="behindWindow" material="underWindowBackground" state="active" translatesAutoresizingMaskIntoConstraints="NO" id="dkl-qd-rae">
-                        <rect key="frame" x="0.0" y="-200" width="300" height="200"/>
+                    <visualEffectView wantsLayer="YES" blendingMode="behindWindow" material="underWindowBackground" state="active" translatesAutoresizingMaskIntoConstraints="NO" id="dkl-qd-rae" userLabel="PlaylistWrapper View">
+                        <rect key="frame" x="0.0" y="0.0" width="300" height="0.0"/>
                         <subviews>
                             <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="qN9-Wd-Ae5">
-                                <rect key="frame" x="0.0" y="197" width="300" height="5"/>
+                                <rect key="frame" x="0.0" y="-3" width="300" height="5"/>
                             </box>
                         </subviews>
                         <constraints>
-                            <constraint firstAttribute="width" constant="300" id="7Iq-RW-lqo"/>
-                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="200" id="SB2-oa-OYU"/>
                             <constraint firstItem="qN9-Wd-Ae5" firstAttribute="leading" secondItem="dkl-qd-rae" secondAttribute="leading" id="hBp-pv-9rw"/>
                             <constraint firstAttribute="trailing" secondItem="qN9-Wd-Ae5" secondAttribute="trailing" id="k5e-VP-pYu"/>
                             <constraint firstItem="qN9-Wd-Ae5" firstAttribute="top" secondItem="dkl-qd-rae" secondAttribute="top" id="ykA-Bq-lAq"/>
                         </constraints>
                     </visualEffectView>
-                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="ejt-zy-gzd">
+                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="ejt-zy-gzd" userLabel="WindowButtons View">
                         <rect key="frame" x="4" y="34" width="19" height="34"/>
                         <subviews>
-                            <visualEffectView wantsLayer="YES" blendingMode="withinWindow" material="popover" state="active" translatesAutoresizingMaskIntoConstraints="NO" id="3Xd-pn-agj">
+                            <visualEffectView wantsLayer="YES" blendingMode="withinWindow" material="popover" state="active" translatesAutoresizingMaskIntoConstraints="NO" id="3Xd-pn-agj" userLabel="CloseButtonBackground View">
                                 <rect key="frame" x="0.0" y="0.0" width="19" height="34"/>
                                 <subviews>
-                                    <button toolTip="Close Mini Player" translatesAutoresizingMaskIntoConstraints="NO" id="F4P-Wj-5qw">
-                                        <rect key="frame" x="4" y="19" width="11" height="11"/>
+                                    <button toolTip="Close Mini Player" translatesAutoresizingMaskIntoConstraints="NO" id="F4P-Wj-5qw" userLabel="CloseBtnVE Button">
+                                        <rect key="frame" x="4" y="16" width="11" height="17"/>
                                         <constraints>
-                                            <constraint firstAttribute="width" constant="11" id="NZV-D4-mqS"/>
+                                            <constraint firstAttribute="width" secondItem="F4P-Wj-5qw" secondAttribute="height" multiplier="1:1" id="Hks-Ia-q0r"/>
                                             <constraint firstAttribute="height" constant="11" id="woL-CQ-7tN"/>
                                         </constraints>
                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSStopProgressFreestandingTemplate" imagePosition="only" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="A3f-Go-Xss">
@@ -297,11 +289,11 @@
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
                                     </button>
-                                    <button toolTip="Back to video mode" translatesAutoresizingMaskIntoConstraints="NO" id="WS6-ix-uBJ">
+                                    <button toolTip="Back to video mode" translatesAutoresizingMaskIntoConstraints="NO" id="WS6-ix-uBJ" userLabel="BackBtnVE Button">
                                         <rect key="frame" x="4" y="4" width="11" height="11"/>
                                         <constraints>
                                             <constraint firstAttribute="height" constant="11" id="9uR-hA-I1D"/>
-                                            <constraint firstAttribute="width" constant="11" id="md9-Kw-q6R"/>
+                                            <constraint firstAttribute="width" secondItem="WS6-ix-uBJ" secondAttribute="height" multiplier="1:1" id="yuJ-Ax-OpH"/>
                                         </constraints>
                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="back" imagePosition="overlaps" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="FaS-tJ-QNE">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -322,14 +314,14 @@
                                     <constraint firstAttribute="trailing" secondItem="WS6-ix-uBJ" secondAttribute="trailing" constant="4" id="tcm-kc-gnR"/>
                                 </constraints>
                             </visualEffectView>
-                            <box boxType="custom" cornerRadius="8" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="NWy-Hm-vxL">
+                            <box boxType="custom" cornerRadius="8" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="NWy-Hm-vxL" userLabel="CloseBtnBackgroundView Box">
                                 <rect key="frame" x="2" y="2" width="17" height="30"/>
                                 <view key="contentView" id="SH0-Bg-0kB">
                                     <rect key="frame" x="1" y="1" width="15" height="28"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <button toolTip="Close Mini Player" translatesAutoresizingMaskIntoConstraints="NO" id="hZH-NM-Lst">
-                                            <rect key="frame" x="2" y="15" width="11" height="11"/>
+                                            <rect key="frame" x="2" y="12" width="11" height="17"/>
                                             <constraints>
                                                 <constraint firstAttribute="width" secondItem="hZH-NM-Lst" secondAttribute="height" multiplier="1:1" id="LSx-9r-gMd"/>
                                                 <constraint firstAttribute="height" constant="11" id="RKA-bS-WrY"/>
@@ -381,15 +373,21 @@
                 <constraints>
                     <constraint firstItem="dkl-qd-rae" firstAttribute="top" secondItem="HdA-I9-dRJ" secondAttribute="bottom" id="0W4-FN-tBa"/>
                     <constraint firstItem="ejt-zy-gzd" firstAttribute="top" secondItem="se5-gp-TjO" secondAttribute="top" constant="4" id="6rW-3W-21z"/>
+                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="kcj-EY-i9R" secondAttribute="trailing" priority="499" id="8tD-Pn-0eE"/>
                     <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="HdA-I9-dRJ" secondAttribute="bottom" id="CJ6-Xd-Pyo"/>
                     <constraint firstItem="HdA-I9-dRJ" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" id="EdS-0d-ohu"/>
+                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="h25-bp-EvL" secondAttribute="trailing" priority="499" id="FZb-vB-KVi"/>
                     <constraint firstAttribute="trailing" secondItem="HdA-I9-dRJ" secondAttribute="trailing" id="HP4-5D-1Fa"/>
                     <constraint firstAttribute="trailing" secondItem="dkl-qd-rae" secondAttribute="trailing" id="Ijy-z8-oYC"/>
                     <constraint firstItem="HdA-I9-dRJ" firstAttribute="top" relation="greaterThanOrEqual" secondItem="se5-gp-TjO" secondAttribute="top" id="KWN-bK-Z8C"/>
+                    <constraint firstAttribute="trailing" relation="lessThanOrEqual" secondItem="kcj-EY-i9R" secondAttribute="trailing" priority="501" id="Qud-6h-D0H"/>
                     <constraint firstAttribute="bottom" secondItem="dkl-qd-rae" secondAttribute="bottom" priority="250" id="TgY-LJ-TLI"/>
                     <constraint firstAttribute="trailing" secondItem="WD9-DD-LNj" secondAttribute="trailing" id="U5V-IX-6UZ"/>
+                    <constraint firstItem="h25-bp-EvL" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" id="UlC-Bh-ckc"/>
                     <constraint firstItem="ejt-zy-gzd" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" constant="4" id="VJK-N0-ZMG"/>
                     <constraint firstItem="WD9-DD-LNj" firstAttribute="top" secondItem="se5-gp-TjO" secondAttribute="top" priority="750" id="Vve-4d-4UK"/>
+                    <constraint firstAttribute="trailing" relation="lessThanOrEqual" secondItem="h25-bp-EvL" secondAttribute="trailing" priority="501" id="erf-H5-UAZ"/>
+                    <constraint firstItem="kcj-EY-i9R" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" id="hSR-s9-n4T"/>
                     <constraint firstItem="HdA-I9-dRJ" firstAttribute="top" secondItem="WD9-DD-LNj" secondAttribute="bottom" id="m9y-eT-GRX"/>
                     <constraint firstItem="HdA-I9-dRJ" firstAttribute="top" secondItem="se5-gp-TjO" secondAttribute="top" id="sJO-Qa-tUh"/>
                     <constraint firstItem="WD9-DD-LNj" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" id="tqw-qA-JsS"/>
@@ -406,33 +404,12 @@
                 <outlet property="view" destination="JoU-Y0-cxJ" id="hS6-FI-qsI"/>
             </connections>
         </viewController>
-        <customView id="JoU-Y0-cxJ">
-            <rect key="frame" x="0.0" y="0.0" width="183" height="29"/>
+        <customView id="JoU-Y0-cxJ" userLabel="Volume Slider View">
+            <rect key="frame" x="0.0" y="0.0" width="183" height="32"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ene-VG-UYY">
-                    <rect key="frame" x="37" y="7" width="100" height="15"/>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="100" id="22P-mK-lYF"/>
-                    </constraints>
-                    <sliderCell key="cell" controlSize="small" continuous="YES" refusesFirstResponder="YES" state="on" alignment="left" maxValue="100" doubleValue="50" tickMarkPosition="above" sliderType="linear" id="rZ7-sj-3jn" customClass="VolumeSliderCell" customModule="IINA" customModuleProvider="target"/>
-                    <connections>
-                        <action selector="volumeSliderChanges:" target="-2" id="24x-7W-lsa"/>
-                    </connections>
-                </slider>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="MP6-sS-T7f">
-                    <rect key="frame" x="143" y="8" width="34" height="14"/>
-                    <constraints>
-                        <constraint firstAttribute="width" constant="30" id="UDC-wZ-xua"/>
-                    </constraints>
-                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="50" id="aot-6J-Jp7">
-                        <font key="font" metaFont="message" size="11"/>
-                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
-                <button translatesAutoresizingMaskIntoConstraints="NO" id="5Og-lg-qvH">
-                    <rect key="frame" x="12" y="8" width="17" height="14"/>
+                <button translatesAutoresizingMaskIntoConstraints="NO" id="5Og-lg-qvH" userLabel="Mute Button">
+                    <rect key="frame" x="12" y="9" width="17" height="14"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="14" id="cUj-wp-dxX"/>
                     </constraints>
@@ -444,6 +421,27 @@
                         <action selector="muteButtonAction:" target="-2" id="u5U-Dm-QKi"/>
                     </connections>
                 </button>
+                <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ene-VG-UYY" userLabel="Volume Slider">
+                    <rect key="frame" x="35" y="6" width="104" height="20"/>
+                    <constraints>
+                        <constraint firstAttribute="width" constant="100" id="22P-mK-lYF"/>
+                    </constraints>
+                    <sliderCell key="cell" controlSize="small" continuous="YES" refusesFirstResponder="YES" state="on" alignment="left" maxValue="100" doubleValue="50" tickMarkPosition="above" sliderType="linear" id="rZ7-sj-3jn" customClass="VolumeSliderCell" customModule="IINA" customModuleProvider="target"/>
+                    <connections>
+                        <action selector="volumeSliderChanges:" target="-2" id="24x-7W-lsa"/>
+                    </connections>
+                </slider>
+                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="MP6-sS-T7f" userLabel="50 Label">
+                    <rect key="frame" x="143" y="9" width="34" height="14"/>
+                    <constraints>
+                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="30" id="UDC-wZ-xua"/>
+                    </constraints>
+                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="50" id="aot-6J-Jp7" userLabel="50 Cell">
+                        <font key="font" metaFont="message" size="11"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
             </subviews>
             <constraints>
                 <constraint firstItem="5Og-lg-qvH" firstAttribute="leading" secondItem="JoU-Y0-cxJ" secondAttribute="leading" constant="12" id="21L-XX-pZ8"/>
@@ -465,7 +463,7 @@
         </popover>
     </objects>
     <resources>
-        <image name="NSStopProgressFreestandingTemplate" width="14" height="14"/>
+        <image name="NSStopProgressFreestandingTemplate" width="20" height="20"/>
         <image name="back" width="11" height="11"/>
         <image name="mute" width="16" height="14"/>
         <image name="nextl" width="24" height="24"/>

--- a/iina/Base.lproj/PlaylistViewController.xib
+++ b/iina/Base.lproj/PlaylistViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19529"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -29,14 +29,14 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY" customClass="PlaylistView" customModule="IINA" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="241" height="285"/>
+            <rect key="frame" x="0.0" y="0.0" width="241" height="284"/>
             <subviews>
-                <stackView distribution="fillEqually" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="250" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EHy-pe-5wJ">
-                    <rect key="frame" x="0.0" y="237" width="241" height="48"/>
+                <stackView distribution="fillEqually" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="250" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EHy-pe-5wJ" userLabel="TabButtons Stack View">
+                    <rect key="frame" x="0.0" y="235" width="241" height="48"/>
                     <subviews>
                         <button translatesAutoresizingMaskIntoConstraints="NO" id="5Zq-JQ-XO4">
                             <rect key="frame" x="8" y="0.0" width="109" height="48"/>
-                            <buttonCell key="cell" type="square" title="PLAYLIST" bezelStyle="shadowlessSquare" alignment="center" lineBreakMode="truncatingMiddle" imageScaling="proportionallyDown" inset="2" id="fAq-Pq-ThP">
+                            <buttonCell key="cell" type="square" title="PLAYLIST" bezelStyle="shadowlessSquare" alignment="center" lineBreakMode="truncatingMiddle" refusesFirstResponder="YES" imageScaling="proportionallyDown" inset="2" id="fAq-Pq-ThP">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="systemBold"/>
                             </buttonCell>
@@ -46,9 +46,9 @@
                         </button>
                         <button translatesAutoresizingMaskIntoConstraints="NO" id="SOR-3l-PFj">
                             <rect key="frame" x="125" y="0.0" width="108" height="48"/>
-                            <buttonCell key="cell" type="square" title="CHAPTERS" bezelStyle="shadowlessSquare" alignment="center" lineBreakMode="truncatingMiddle" imageScaling="proportionallyDown" inset="2" id="jUF-xa-uRI">
+                            <buttonCell key="cell" type="square" title="CHAPTERS" bezelStyle="shadowlessSquare" alignment="center" lineBreakMode="truncatingMiddle" refusesFirstResponder="YES" imageScaling="proportionallyDown" inset="2" id="jUF-xa-uRI">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                <font key="font" metaFont="system"/>
+                                <font key="font" metaFont="systemBold"/>
                             </buttonCell>
                             <connections>
                                 <action selector="chaptersBtnAction:" target="-2" id="Gpo-6e-oRu"/>
@@ -71,25 +71,25 @@
                     </customSpacing>
                 </stackView>
                 <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="glW-5x-LJr">
-                    <rect key="frame" x="0.0" y="235" width="241" height="5"/>
+                    <rect key="frame" x="0.0" y="233" width="241" height="5"/>
                 </box>
                 <tabView drawsBackground="NO" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="Yym-Zw-Hd8">
-                    <rect key="frame" x="0.0" y="0.0" width="241" height="238"/>
+                    <rect key="frame" x="0.0" y="0.0" width="241" height="236"/>
                     <font key="font" metaFont="system"/>
                     <tabViewItems>
                         <tabViewItem label="Playlist" identifier="1" id="rjs-Qf-mT6">
                             <view key="view" id="BXH-zz-cse">
-                                <rect key="frame" x="0.0" y="0.0" width="241" height="241"/>
+                                <rect key="frame" x="0.0" y="0.0" width="241" height="236"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="28" horizontalPageScroll="10" verticalLineScroll="28" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n5h-uy-hbd">
-                                        <rect key="frame" x="0.0" y="24" width="236" height="217"/>
+                                        <rect key="frame" x="0.0" y="24" width="236" height="212"/>
                                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="2M9-8L-veI">
-                                            <rect key="frame" x="0.0" y="0.0" width="236" height="217"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="236" height="212"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" tableStyle="fullWidth" columnResizing="NO" autosaveColumns="NO" rowHeight="26" viewBased="YES" id="xIa-sI-0Xn">
-                                                    <rect key="frame" x="0.0" y="0.0" width="236" height="217"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="236" height="212"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <size key="intercellSpacing" width="3" height="2"/>
                                                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.080000000000000002" colorSpace="calibratedRGB"/>
@@ -379,7 +379,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="241" height="288"/>
                                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="6tr-hz-bdD">
                                             <rect key="frame" x="0.0" y="0.0" width="241" height="288"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="31" rowSizeStyle="automatic" viewBased="YES" id="BvG-MR-6LX">
                                                     <rect key="frame" x="0.0" y="0.0" width="241" height="288"/>

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -8,9 +8,11 @@
 
 import Cocoa
 
-fileprivate let DefaultPlaylistHeight: CGFloat = 300
-fileprivate let AutoHidePlaylistThreshold: CGFloat = 200
+// Hide playlist if its height is too small to display at least 3 items:
+fileprivate let PlaylistMinHeight: CGFloat = 138
 fileprivate let AnimationDurationShowControl: TimeInterval = 0.2
+fileprivate let MiniPlayerMinWidth: CGFloat = 300
+fileprivate let UIAnimationDuration = 0.25
 
 class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
 
@@ -32,7 +34,9 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
   @IBOutlet weak var volumeSliderView: NSView!
   @IBOutlet weak var backgroundView: NSVisualEffectView!
   @IBOutlet weak var closeButtonView: NSView!
+  // Mini island containing window buttons which hover over album art / video:
   @IBOutlet weak var closeButtonBackgroundViewVE: NSVisualEffectView!
+  // Mini island containing window buttons which appear next to controls (when video not visible):
   @IBOutlet weak var closeButtonBackgroundViewBox: NSBox!
   @IBOutlet weak var closeButtonVE: NSButton!
   @IBOutlet weak var backButtonVE: NSButton!
@@ -51,13 +55,38 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
   @IBOutlet weak var defaultAlbumArt: NSView!
   @IBOutlet weak var togglePlaylistButton: NSButton!
   @IBOutlet weak var toggleAlbumArtButton: NSButton!
-  
-  var isPlaylistVisible = false
-  var isVideoVisible = true
 
-  var videoViewAspectConstraint: NSLayoutConstraint?
+  /// When resizing the window, need to control the aspect ratio of `videoView`. But cannot use an `aspectRatio` constraint,
+  /// because: when playlist is hidden but videoView is shown, that prevents the window from being expanded when the user drags
+  /// from the right window edge. Possibly AppKit treats it like a fixed-width constraint. Workaround: use only a `height` constraint
+  /// and recalculate it from the video's aspect ratio whenever the window's width changes.
+  private var videoWrapperViewHeightConstraint: NSLayoutConstraint!
 
-  private var originalWindowFrame: NSRect!
+  private var videoAspectRatio: CGFloat = 1
+
+  var isPlaylistVisible: Bool {
+    get {
+      Preference.bool(for: .musicModeShowPlaylist)
+    }
+    set {
+      // We already use autosave to save the window frame across launches, so one would think we could
+      // determinte whether the playlist is visible just by inspecting the window's size.
+      // But we still need to save this info and restore it in case IINA is later relaunched using
+      // some very different display/resolution which changes the window size.
+      Preference.set(newValue, for: .musicModeShowPlaylist)
+    }
+  }
+
+  var isVideoVisible: Bool {
+    get {
+      Preference.bool(for: .musicModeShowAlbumArt)
+    }
+    set {
+      Preference.set(newValue, for: .musicModeShowAlbumArt)
+    }
+  }
+
+  static let maxWindowWidth = CGFloat(Preference.float(for: .musicModeMaxWidth))
 
   lazy var hideVolumePopover: DispatchWorkItem = {
     DispatchWorkItem {
@@ -73,7 +102,8 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
   override func windowDidLoad() {
     super.windowDidLoad()
 
-    guard let window = window else { return }
+    guard let window = window,
+          let contentView = window.contentView else { return }
 
     window.styleMask = [.fullSizeContentView, .titled, .resizable, .closable]
     window.isMovableByWindowBackground = true
@@ -89,14 +119,17 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
       button?.frame.size = .zero
     }
 
-    setToInitialWindowSize(display: false, animate: false)
+    contentView.widthAnchor.constraint(greaterThanOrEqualToConstant: MiniPlayerMinWidth).isActive = true
+    contentView.widthAnchor.constraint(lessThanOrEqualToConstant: MiniPlayerWindowController.maxWindowWidth).isActive = true
+
+    playlistWrapperView.heightAnchor.constraint(greaterThanOrEqualToConstant: PlaylistMinHeight).isActive = true
 
     controlViewTopConstraint.isActive = false
 
     // tracking area
     let trackingView = NSView()
     trackingView.translatesAutoresizingMaskIntoConstraints = false
-    window.contentView?.addSubview(trackingView, positioned: .above, relativeTo: nil)
+    contentView.addSubview(trackingView, positioned: .above, relativeTo: nil)
     Utility.quickConstraints(["H:|[v]|"], ["v": trackingView])
     NSLayoutConstraint.activate([
       NSLayoutConstraint(item: trackingView, attribute: .bottom, relatedBy: .equal, toItem: backgroundView, attribute: .bottom, multiplier: 1, constant: 0),
@@ -105,19 +138,21 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     trackingView.addTrackingArea(NSTrackingArea(rect: trackingView.bounds, options: [.activeAlways, .inVisibleRect, .mouseEnteredAndExited], owner: self, userInfo: nil))
 
     // default album art
-    defaultAlbumArt.isHidden = false
     defaultAlbumArt.wantsLayer = true
     defaultAlbumArt.layer?.contents = #imageLiteral(resourceName: "default-album-art")
 
     // close button
     closeButtonVE.action = #selector(self.close)
     closeButtonBox.action = #selector(self.close)
-    closeButtonView.alphaValue = 0
     closeButtonBackgroundViewVE.roundCorners(withRadius: 8)
     closeButtonBackgroundViewBox.isHidden = true
 
-    // switching UI
+    // hide controls initially
+    closeButtonBackgroundViewBox.isHidden = true
+    closeButtonView.alphaValue = 0
     controlView.alphaValue = 0
+
+    updateVideoViewLayout()
     
     // tool tips
     togglePlaylistButton.toolTip = Preference.ToolBarButton.playlist.description()
@@ -131,6 +166,10 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     }
     volumeSlider.maxValue = Double(Preference.integer(for: .maxVolume))
     volumePopover.delegate = self
+
+    addObserver(to: .default, forName: .iinaTracklistChanged, object: player) { [self] _ in
+      adjustLayoutForVideoChange()
+    }
   }
 
   override internal func setMaterial(_ theme: Preference.Theme?) {
@@ -183,6 +222,14 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
 
   // MARK: - Window delegate: Open / Close
 
+  override func showWindow(_ sender: Any?) {
+    /// Video aspect ratio may have changed if a different video is being shown than last time.
+    /// Use `constrainWindowSize()` and `setFrame()` to gracefully adapt layout as needed
+    adjustLayoutForVideoChange()
+
+    super.showWindow(sender)
+  }
+
   func windowWillClose(_ notification: Notification) {
     player.switchedToMiniPlayerManually = false
     player.switchedBackFromMiniPlayerManually = false
@@ -195,31 +242,31 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
 
   // MARK: - Window delegate: Size
 
-  func windowWillStartLiveResize(_ notification: Notification) {
-    originalWindowFrame = window!.frame
+  func windowWillResize(_ window: NSWindow, to requestedSize: NSSize) -> NSSize {
+    if !window.inLiveResize && requestedSize.width <= MiniPlayerMinWidth {
+      // Responding with the current size seems to work much better with certain window management tools
+      // (e.g. BetterTouchTool's window snapping) than trying to respond with the min size,
+      // which seems to result in the window manager retrying with different sizes, which results in flickering.
+      Logger.log("WindowWillResize: requestedSize smaller than min \(MiniPlayerMinWidth); returning existing size", level: .verbose, subsystem: player.subsystem)
+      return window.frame.size
+    }
+
+    return constrainWindowSize(requestedSize)
   }
 
   func windowDidResize(_ notification: Notification) {
     guard let window = window, !window.inLiveResize else { return }
+
+    updateVideoViewHeightConstraint()
     videoView.videoLayer.draw()
   }
 
   func windowDidEndLiveResize(_ notification: Notification) {
-    guard let window = window else { return }
-    let windowHeight = normalWindowHeight()
-    if isPlaylistVisible {
-      // hide
-      if window.frame.height < windowHeight + AutoHidePlaylistThreshold {
-        isPlaylistVisible = false
-        setToInitialWindowSize()
-      }
-    } else {
-      // show
-      if window.frame.height < windowHeight + AutoHidePlaylistThreshold {
-        setToInitialWindowSize()
-      } else {
-        isPlaylistVisible = true
-      }
+    let playlistHeight = currentPlaylistHeight()
+    if playlistHeight >= PlaylistMinHeight {
+      // save playlist height
+      Logger.log("Saving playlist height: \(playlistHeight)")
+      Preference.set(playlistHeight, for: .musicModePlaylistHeight)
     }
   }
 
@@ -299,34 +346,6 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     }
   }
 
-  func updateVideoSize() {
-    guard let window = window else { return }
-    let (width, height) = player.originalVideoSize
-    let aspect = (width == 0 || height == 0) ? 1 : CGFloat(width) / CGFloat(height)
-    let currentHeight = videoView.frame.height
-    let newHeight = videoView.frame.width / aspect
-    updateVideoViewAspectConstraint(withAspect: aspect)
-    // resize window
-    guard isVideoVisible else { return }
-    var frame = window.frame
-    frame.size.height += newHeight - currentHeight - 0.5
-    window.setFrame(frame, display: true, animate: false)
-  }
-
-  func updateVideoViewAspectConstraint(withAspect aspect: CGFloat) {
-    if let constraint = videoViewAspectConstraint {
-      constraint.isActive = false
-    }
-    videoViewAspectConstraint = NSLayoutConstraint(item: videoView, attribute: .width, relatedBy: .equal,
-                                                   toItem: videoView, attribute: .height, multiplier: aspect, constant: 0)
-    videoViewAspectConstraint?.isActive = true
-  }
-
-  func setToInitialWindowSize(display: Bool = true, animate: Bool = true) {
-    guard let window = window else { return }
-    window.setFrame(window.frame.rectWithoutPlaylistHeight(providedWindowHeight: normalWindowHeight()), display: display, animate: animate)
-  }
-
   // MARK: - NSPopoverDelegate
 
   func popoverWillClose(_ notification: Notification) {
@@ -360,45 +379,6 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
 
   // MARK: - IBActions
 
-  @IBAction func togglePlaylist(_ sender: Any) {
-    guard let window = window else { return }
-    if isPlaylistVisible {
-      // hide
-      isPlaylistVisible = false
-      setToInitialWindowSize()
-    } else {
-      // show
-      isPlaylistVisible = true
-      player.mainWindow.playlistView.reloadData(playlist: true, chapters: true)
-
-      var newFrame = window.frame
-      newFrame.origin.y -= DefaultPlaylistHeight
-      newFrame.size.height += DefaultPlaylistHeight
-      window.setFrame(newFrame, display: true, animate: true)
-    }
-    Preference.set(isPlaylistVisible, for: .musicModeShowPlaylist)
-  }
-
-  @IBAction func toggleVideoView(_ sender: Any) {
-    guard let window = window else { return }
-    isVideoVisible = !isVideoVisible
-    videoWrapperViewBottomConstraint.isActive = isVideoVisible
-    controlViewTopConstraint.isActive = !isVideoVisible
-    closeButtonBackgroundViewVE.isHidden = !isVideoVisible
-    closeButtonBackgroundViewBox.isHidden = isVideoVisible
-    let videoViewHeight = round(videoView.frame.height)
-    if isVideoVisible {
-      var frame = window.frame
-      frame.size.height += videoViewHeight
-      window.setFrame(frame, display: true, animate: false)
-    } else {
-      var frame = window.frame
-      frame.size.height -= videoViewHeight
-      window.setFrame(frame, display: true, animate: false)
-    }
-    Preference.set(isVideoVisible, for: .musicModeShowAlbumArt)
-  }
-
   @IBAction func backBtnAction(_ sender: NSButton) {
     player.switchBackFromMiniPlayer(automatically: false)
   }
@@ -419,11 +399,167 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     }
   }
 
-  // MARK: - Utils
+  @IBAction func togglePlaylist(_ sender: Any) {
+    guard let window = window else { return }
+    guard let screen = window.screen else { return }
+    let showPlaylist = !isPlaylistVisible
+    Logger.log("Toggling playlist visibility from \(!showPlaylist) to \(showPlaylist)", level: .verbose)
+    self.isPlaylistVisible = showPlaylist
+    let currentPlaylistHeight = currentPlaylistHeight()
+    var newFrame = window.frame
 
-  private func normalWindowHeight() -> CGFloat {
-    return 72 + (isVideoVisible ? videoWrapperView.frame.height : 0)
+    if showPlaylist {
+      player.mainWindow.playlistView.reloadData(playlist: true, chapters: true)
+
+      // Try to show playlist using previous height
+      let desiredPlaylistHeight = CGFloat(Preference.float(for: .musicModePlaylistHeight))
+      // The window may be in the middle of a previous toggle, so we can't just assume window's current frame
+      // represents a state where the playlist is fully shown or fully hidden. Instead, start by computing the height
+      // we want to set, and then figure out the changes needed to the window's existing frame.
+      let targetHeightToAdd = desiredPlaylistHeight - currentPlaylistHeight
+      // Fill up screen if needed
+      newFrame.size.height += targetHeightToAdd
+    } else { // hide playlist
+      // Save playlist height first
+      if currentPlaylistHeight > PlaylistMinHeight {
+        Preference.set(currentPlaylistHeight, for: .musicModePlaylistHeight)
+      }
+    }
+
+    // May need to reduce size of video/art to fit playlist on screen, or other adjustments:
+    newFrame.size = constrainWindowSize(newFrame.size)
+    let heightDifference = newFrame.height - window.frame.height
+    // adjust window origin to expand downwards, but do not allow bottom of window to fall offscreen
+    newFrame.origin.y = max(newFrame.origin.y - heightDifference, screen.visibleFrame.origin.y)
+
+    window.animator().setFrame(newFrame, display: true, animate: !AccessibilityPreferences.motionReductionEnabled)
   }
+
+  @IBAction func toggleVideoView(_ sender: Any) {
+    guard let window = window else { return }
+    isVideoVisible = !isVideoVisible
+    Logger.log("Toggling videoView visibility from \(!isVideoVisible) to \(isVideoVisible)", level: .verbose)
+    updateVideoViewLayout()
+    let videoViewHeight = round(videoView.frame.height)
+    var frame = window.frame
+    if isVideoVisible {
+      frame.size.height += videoViewHeight
+    } else {
+      frame.size.height -= videoViewHeight
+    }
+    frame.size = constrainWindowSize(frame.size)
+    window.setFrame(frame, display: true, animate: false)
+  }
+
+  // MARK: - Layout
+
+  private func updateVideoViewLayout() {
+    videoWrapperViewBottomConstraint.isActive = isVideoVisible
+    controlViewTopConstraint.isActive = !isVideoVisible
+    closeButtonBackgroundViewVE.isHidden = !isVideoVisible
+    closeButtonBackgroundViewBox.isHidden = isVideoVisible
+  }
+
+  /// The MiniPlayerWindow's width must be between `MiniPlayerMinWidth` and `Preference.musicModeMaxWidth`.
+  /// It is composed of up to 3 vertical sections:
+  /// 1. `videoWrapperView`: Visible if `isVideoVisible` is true). Scales with the aspect ratio of its video
+  /// 2. `backgroundView`: Visible always. Fixed height
+  /// 3. `playlistWrapperView`: Visible if `isPlaylistVisible` is true. Height is user resizable, and must be >= `PlaylistMinHeight`
+  /// Must also ensure that window stays within the bounds of the screen it is in. Almost all of the time the window  will be
+  /// height-bounded instead of width-bounded.
+  private func constrainWindowSize(_ requestedSize: NSSize, animate: Bool = false) -> NSSize {
+    guard let screen = window?.screen else { return requestedSize }
+    /// When the window's width changes, the video scales to match while keeping its aspect ratio,
+    /// and the control bar (`backgroundView`) and playlist are pushed down.
+    /// Calculate the maximum width/height the art can grow to so that `backgroundView` is not pushed off the screen.
+    let visibleScreenSize = screen.visibleFrame.size
+    let minPlaylistHeight = isPlaylistVisible ? PlaylistMinHeight : 0
+
+    let maxWindowWidth: CGFloat
+    if isVideoVisible {
+      var maxVideoHeight = visibleScreenSize.height - backgroundView.frame.height - minPlaylistHeight
+      /// `maxVideoHeight` can be negative if very short screen! Fall back to height based on `MiniPlayerMinWidth` if needed
+      maxVideoHeight = max(maxVideoHeight, MiniPlayerMinWidth / videoAspectRatio)
+      maxWindowWidth = maxVideoHeight * videoAspectRatio
+    } else {
+      maxWindowWidth = MiniPlayerWindowController.maxWindowWidth
+    }
+
+    let newWidth: CGFloat
+    if requestedSize.width < MiniPlayerMinWidth {
+      // Clamp to min width
+      newWidth = MiniPlayerMinWidth
+    } else if requestedSize.width > maxWindowWidth {
+      // Clamp to max width
+      newWidth = maxWindowWidth
+    } else {
+      // Requested size is valid
+      newWidth = requestedSize.width
+    }
+    let videoHeight = isVideoVisible ? newWidth / videoAspectRatio : 0
+    let minWindowHeight = videoHeight + backgroundView.frame.height + minPlaylistHeight
+    // Make sure height is within acceptable values
+    var newHeight = max(requestedSize.height, minWindowHeight)
+    let maxHeight = isPlaylistVisible ? visibleScreenSize.height : minWindowHeight
+    newHeight = min(newHeight, maxHeight)
+    let newWindowSize = NSSize(width: newWidth, height: newHeight)
+    Logger.log("Constrained miniPlayerWindow. VideoAspect: \(videoAspectRatio), RequestedSize: \(requestedSize), NewSize: \(newWindowSize)", level: .verbose)
+
+    updateVideoViewHeightConstraint(height: videoHeight, animate: animate)
+    return newWindowSize
+  }
+
+  // Returns the current height of the window,
+  // including the album art, but not including the playlist.
+  private var windowHeightWithoutPlaylist: CGFloat {
+    guard let window = window else { return backgroundView.frame.height }
+    return backgroundView.frame.height + (isVideoVisible ? window.frame.width / videoAspectRatio : 0)
+  }
+
+  private func currentPlaylistHeight() -> CGFloat {
+    guard let window = window else { return 0 }
+    return window.frame.height - windowHeightWithoutPlaylist
+  }
+
+  private func updateVideoViewHeightConstraint(height: CGFloat? = nil, animate: Bool = false) {
+    let newHeight: CGFloat
+    guard isVideoVisible else { return }
+    guard let window = window else { return }
+
+    newHeight = height ?? window.frame.width / videoAspectRatio
+    Logger.log("Updating videoWrapperViewHeightConstraint to \(newHeight)")
+
+    if let videoWrapperViewHeightConstraint = videoWrapperViewHeightConstraint {
+      if animate {
+        videoWrapperViewHeightConstraint.animator().constant = newHeight
+      } else {
+        videoWrapperViewHeightConstraint.constant = newHeight
+      }
+    } else {
+      videoWrapperViewHeightConstraint = videoWrapperView.heightAnchor.constraint(equalToConstant: newHeight)
+      videoWrapperViewHeightConstraint.isActive = true
+    }
+    videoWrapperView.superview!.layout()
+  }
+
+  private func adjustLayoutForVideoChange() {
+    guard let window = window else { return }
+
+    let (width, height) = player.originalVideoSize
+    videoAspectRatio = (width == 0 || height == 0) ? 1 : CGFloat(width) / CGFloat(height)
+
+    defaultAlbumArt.isHidden = player.info.vid != 0
+
+    NSAnimationContext.runAnimationGroup({ (context) in
+      context.duration = UIAnimationDuration
+
+      var newFrame = window.frame
+      newFrame.size = constrainWindowSize(newFrame.size, animate: true)
+      window.animator().setFrame(newFrame, display: true, animate: !AccessibilityPreferences.motionReductionEnabled)
+    })
+  }
+
+  // MARK: - Utils
 
   internal override func handleIINACommand(_ cmd: IINACommand) {
     super.handleIINACommand(cmd)
@@ -435,13 +571,4 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     }
   }
 
-}
-
-fileprivate extension NSRect {
-  func rectWithoutPlaylistHeight(providedWindowHeight windowHeight: CGFloat) -> NSRect {
-    var newRect = self
-    newRect.origin.y += (newRect.height - windowHeight)
-    newRect.size.height = windowHeight
-    return newRect
-  }
 }

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -536,8 +536,9 @@ class PlayerCore: NSObject {
     }
     switchedBackFromMiniPlayerManually = false
 
-    let needRestoreLayout = !miniPlayer.loaded
-    miniPlayer.showWindow(self)
+    // build mini player window offscreen for now
+    miniPlayer.window?.orderOut(self)
+    isInMiniPlayer = true
 
     miniPlayer.updateTitle()
     syncUITime()
@@ -566,38 +567,11 @@ class PlayerCore: NSObject {
     miniPlayer.videoWrapperView.addSubview(videoView, positioned: .below, relativeTo: nil)
     Utility.quickConstraints(["H:|[v]|", "V:|[v]|"], ["v": videoView])
 
-    let (width, height) = originalVideoSize
-    let aspect = (width == 0 || height == 0) ? 1 : CGFloat(width) / CGFloat(height)
-    miniPlayer.updateVideoViewAspectConstraint(withAspect: aspect)
-    miniPlayer.window?.layoutIfNeeded()
-
-    // if received video size before switching to music mode, hide default album art
-    if info.vid != 0 {
-      miniPlayer.defaultAlbumArt.isHidden = true
-    }
-    // in case of video size changed, reset mini player window size if playlist is folded
-    if !miniPlayer.isPlaylistVisible {
-      miniPlayer.setToInitialWindowSize(display: true, animate: false)
-    }
-
-    // hide main window
+    // hide main window, and show mini player window
     mainWindow.window?.orderOut(self)
-    isInMiniPlayer = true
+    miniPlayer.showWindow(self)
 
     videoView.videoLayer.draw(forced: true)
-
-    // restore layout
-    if needRestoreLayout {
-      if !Preference.bool(for: .musicModeShowAlbumArt) {
-        miniPlayer.toggleVideoView(self)
-        if let origin = miniPlayer.window?.frame.origin {
-          miniPlayer.window?.setFrameOrigin(.init(x: origin.x, y: origin.y + miniPlayer.videoView.frame.height))
-        }
-      }
-      if Preference.bool(for: .musicModeShowPlaylist) {
-        miniPlayer.togglePlaylist(self)
-      }
-    }
     
     events.emit(.musicModeChanged, data: true)
   }
@@ -612,8 +586,6 @@ class PlayerCore: NSObject {
     mainWindow.playlistView.useCompactTabHeight = false
     // add back video view
     let mainWindowContentView = mainWindow.window!.contentView
-    miniPlayer.videoViewAspectConstraint?.isActive = false
-    miniPlayer.videoViewAspectConstraint = nil
     mainWindow.videoView.removeFromSuperview()
     mainWindowContentView?.addSubview(mainWindow.videoView, positioned: .below, relativeTo: nil)
     ([.top, .bottom, .left, .right] as [NSLayoutConstraint.Attribute]).forEach { attr in
@@ -1529,10 +1501,6 @@ class PlayerCore: NSObject {
       if info.vid == 0 {
         notifyMainWindowVideoSizeChanged()
       }
-
-      if self.isInMiniPlayer {
-        miniPlayer.defaultAlbumArt.isHidden = self.info.vid != 0
-      }
     }
     if Preference.bool(for: .fullScreenWhenOpen) && !mainWindow.fsState.isFullscreen && !isInMiniPlayer {
       DispatchQueue.main.async(execute: self.mainWindow.toggleWindowFullScreen)
@@ -1754,9 +1722,6 @@ class PlayerCore: NSObject {
 
   func notifyMainWindowVideoSizeChanged() {
     mainWindow.adjustFrameByVideoSize()
-    if isInMiniPlayer {
-      miniPlayer.updateVideoSize()
-    }
   }
 
   // difficult to use option set

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -137,6 +137,8 @@ struct Preference {
     static let autoSwitchToMusicMode = Key("autoSwitchToMusicMode")
     static let musicModeShowPlaylist = Key("musicModeShowPlaylist")
     static let musicModeShowAlbumArt = Key("musicModeShowAlbumArt")
+    static let musicModePlaylistHeight = Key("musicModePlaylistHeight")
+    static let musicModeMaxWidth = Key("musicModeMaxWidth")
 
     static let displayTimeAndBatteryInFullScreen = Key("displayTimeAndBatteryInFullScreen")
 
@@ -758,7 +760,9 @@ struct Preference {
     .thumbnailWidth: 240,
     .autoSwitchToMusicMode: true,
     .musicModeShowPlaylist: false,
+    .musicModePlaylistHeight: 300,
     .musicModeShowAlbumArt: true,
+    .musicModeMaxWidth: 1000,
     .displayTimeAndBatteryInFullScreen: false,
 
     .windowBehaviorWhenPip: WindowBehaviorWhenPip.doNothing.rawValue,


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issues #3484 / #3764.

---

**Description:**

This patch:

- Allows resizing the width of the music mode window up to 1000px (which can be changed via a hidden pref key).
- Fixes bugs which prevented the restore of location & size of music mode window across launches in all its configurations (with album art hidden or shown, playlist hidden or shown).
- Retains height of the music mode playlist across toggles and across app launches
- Changes window resize behavior so that resizing no longer hides/shows the playlist; it has to be explicitly toggled. Also, playlist now has a minimum height so that the window can be resized reliably.
- Fixes numerous other small layout issues/glitches relating to music mode.