### PR TITLE
Load external subtitle option opens directory of current video (fixes #4382)

### DIFF
--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -316,7 +316,8 @@ extension MainMenuActionHandler {
 
 extension MainMenuActionHandler {
   @objc func menuLoadExternalSub(_ sender: NSMenuItem) {
-    Utility.quickOpenPanel(title: "Load external subtitle file", chooseDir: false) { url in
+    let currentDir = player.info.currentURL?.deletingLastPathComponent()
+    Utility.quickOpenPanel(title: "Load external subtitle file", chooseDir: false, dir: currentDir) { url in
       self.player.loadExternalSubFile(url, delay: true)
     }
   }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #.

---

**Description:**
This commit will allow `NSOpenPanel` to open in current playing video's directory when loading subtitle from `Load External Subtitle...` option from `Subtitles` menu. This behaviour is already present when loading subtitle from `Quick Settings > Subtitles > External Subtitles:` 