### PR TITLE
Fix audio continues after window closed, #3995

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1486,6 +1486,10 @@ class PlayerCore: NSObject {
     invalidateTimer()
     triedUsingExactSeekForCurrentFile = false
     info.fileLoading = false
+    // Playback will move directly from stopped to loading when transitioning to the next file in
+    // the playlist.
+    isStopping = false
+    isStopped = false
     info.haveDownloadedSub = false
     checkUnsyncedWindowOptions()
     // generate thumbnails if window has loaded video


### PR DESCRIPTION
This commit will correct the change made by faulty commit c849eb768a6ef91be22349408869fb09eeb02066 that reintroduced this problem.

After the next release the plan is to refactor these PlayerCore state flags into a state enumeration.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #3995.

---

**Description:**
