### PR TITLE
Fix an issue where stop command doesn't close mini player

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -1228,7 +1228,7 @@ class MPVController: NSObject {
         player.info.isIdle = true
         if fileLoaded {
           fileLoaded = false
-          player.closeMainWindow()
+          player.closeWindow()
         }
         receivedEndFileWhileLoading = false
       }

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1901,10 +1901,14 @@ class PlayerCore: NSObject {
     }
   }
 
-  func closeMainWindow() {
+  func closeWindow() {
     DispatchQueue.main.async {
       self.isStopped = true
-      self.mainWindow.close()
+      if self.isInMiniPlayer {
+        self.miniPlayer.close()
+      } else {
+        self.mainWindow.close()
+      }
     }
   }
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)

---

**Description:**
When a stop command is sent to a main window, the window will close. However, if the stop command is sent to a mini player window, the playback will stop, but the mini player window will still remain.

Steps to reproduce:
- Set a keybinding to the mpv "stop" command
- Open two windows: one of which is in mini player
- Try to press the key to send stop command to two windows and observe the different behavior

This commit closes the mini player on responding to idle-active if in mini player.
