### PR TITLE
Fix order of filter parameters is random, #4262

### DIFF
--- a/iina/FilterWindowController.swift
+++ b/iina/FilterWindowController.swift
@@ -414,14 +414,8 @@ class NewFilterSheetViewController: NSViewController, NSTableViewDelegate, NSTab
       stackView.addArrangedSubview(input)
       self.currentBindings[name] = input
     }
-    if let paramOrder = preset.paramOrder {
-      for name in paramOrder {
-        generateInputs(name, preset.params[name]!)
-      }
-    } else {
-      for (name, param) in preset.params {
-        generateInputs(name, param)
-      }
+    for name in preset.paramOrder {
+      generateInputs(name, preset.params[name]!)
     }
   }
 


### PR DESCRIPTION
This commit will:
- Change the FilterPreset property paramOrder to not be optional
- Add setting of paramOrder to all filter presets
- Change NewFilterSheetViewController.showSettings to always use paramOrder

This insures the order of the UI controls displayed to the user representing the filter parameters remains consistent.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4262.

---

**Description:**
