### PR TITLE
Fix Xcode reports memory leak in getImageFrom, #4412

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -598,18 +598,6 @@ class MPVController: NSObject {
     return str
   }
 
-  func getScreenshot(_ arg: String) -> NSImage? {
-    var args = try! MPVNode.create(["screenshot-raw", arg])
-    defer {
-      MPVNode.free(args)
-    }
-    var result = mpv_node()
-    mpv_command_node(self.mpv, &args, &result)
-    let image = ObjcUtils.getImageFrom(&result)
-    mpv_free_node_contents(&result)
-    return image;
-  }
-
   /** Get filter. only "af" or "vf" is supported for name */
   func getFilters(_ name: String) -> [MPVFilter] {
     Logger.ensure(name == MPVProperty.vf || name == MPVProperty.af, "getFilters() do not support \(name)!")

--- a/iina/ObjcUtils.h
+++ b/iina/ObjcUtils.h
@@ -12,6 +12,5 @@
 + (BOOL)silenced:(void(^)(void))tryBlock;
 
 + (NSUInteger)levDistance:(NSString *)str0 and:(NSString *)str1;
-+ (NSImage *)getImageFrom:(mpv_node *)image;
 
 @end

--- a/iina/ObjcUtils.m
+++ b/iina/ObjcUtils.m
@@ -77,35 +77,4 @@ static inline int min(int a, int b, int c) {
   return result;
 }
 
-+ (NSImage *)getImageFrom:(mpv_node *)image {
-  mpv_node *list = image->u.list->values;
-  uint64_t width = list[0].u.int64;
-  uint64_t height = list[1].u.int64;
-  uint64_t pixels = width * height;
-  uint8_t *pixel_array = list[4].u.ba->data;
-  size_t size = pixels * 4 * sizeof(uint8_t);
-  uint8_t *buffer = malloc(size);
-  memcpy(buffer, pixel_array, size);
-  int i;
-  // The pixel array mpv returns arrange color data as "B8G8R8X8",
-  // whereas CGImages's data provider needs RGBA, so swap each
-  // pixel at index 0 and 2.
-  for (i = 0; i < pixels; ++i) {
-    uint64_t x = i << 2, y = i << 2 | 2;
-    uint8_t t = buffer[x];
-    buffer[x] = buffer[y];
-    buffer[y] = t;
-  }
-  CGDataProviderRef ref = CGDataProviderCreateWithData(nil, buffer,
-                                                       list[4].u.ba->size, nil);
-  CGImageRef cgImage = CGImageCreate(width, height, 8, 4 * 8, width * 4,
-                                     CGColorSpaceCreateDeviceRGB(),
-                                     (CGBitmapInfo)kCGImageAlphaPremultipliedLast,
-                                     ref, nil, true, kCGRenderingIntentDefault);
-
-  NSImage *nsImage = [[NSImage alloc] initWithCGImage:cgImage size:NSZeroSize];
-  free(buffer);
-  return nsImage;
-}
-
 @end


### PR DESCRIPTION
This commit will:
- Remove the method MPVController.getScreenshot
- Remove the method ObjcUtils.getImageFrom

IINA was not leaking memory. The memory leak Xcode detected was in code that is no longer used.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4412.

---

**Description:**
