### PR TITLE
Fix MenuController object leaked, #4415

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -88,7 +88,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
   /// Whether the shutdown sequence timed out.
   private var timedOut = false
 
-  @IBOutlet weak var menuController: MenuController!
+  @IBOutlet var menuController: MenuController!
 
   @IBOutlet weak var dockMenu: NSMenu!
 
@@ -134,7 +134,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 
 
   // MARK: - SPUUpdaterDelegate
-  @IBOutlet weak var updaterController: SPUStandardUpdaterController!
+  @IBOutlet var updaterController: SPUStandardUpdaterController!
 
   func feedURLString(for updater: SPUUpdater) -> String? {
     return Preference.bool(for: .receiveBetaUpdate) ? AppData.appcastBetaLink : AppData.appcastLink


### PR DESCRIPTION
This commit will remove the weak keyword from the AppDelegate menuController and updaterController properties.

As per Apple, outlets from the file owner to top-level objects in a nib file should be strong. With this change IINA no longer leaks MenuController and SPUStandardUpdaterController objects.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4415.

---

**Description:**
