### PR TITLE
Add a checkmark to the A-B Loop menu item

### DIFF
--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -443,6 +443,7 @@ class MenuController: NSObject, NSMenuDelegate {
           player.mainWindow.playlistView.currentTab == .chapters
     chapterPanel?.title = isDisplayingChapters ? Constants.String.hideChaptersPanel : Constants.String.chaptersPanel
     pause.title = player.info.isPaused ? Constants.String.resume : Constants.String.pause
+    abLoop.state = player.isABLoopActive ? .on : .off
     let isLoop = player.mpv.getString(MPVOption.PlaybackControl.loopFile) == "inf"
     fileLoop.state = isLoop ? .on : .off
     let isPlaylistLoop = player.mpv.getString(MPVOption.PlaybackControl.loopPlaylist)

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -216,6 +216,10 @@ class PlayerCore: NSObject {
     }
   }
 
+  var isABLoopActive: Bool {
+    abLoopA != 0 && abLoopB != 0 && mpv.getString(MPVOption.PlaybackControl.abLoopCount) != "0"
+  }
+
   static var keyBindings: [String: KeyMapping] = [:]
 
   override init() {


### PR DESCRIPTION
This commit will add a checkmark to the `A-B Loop` menu item in the `Playback` menu when looping is active.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
