### PR TITLE
Add a checkmark to the Music Mode menu item

### DIFF
--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -463,6 +463,7 @@ class MenuController: NSObject, NSMenuDelegate {
     alwaysOnTop.state = isOntop ? .on : .off
     deinterlace.state = player.info.deinterlace ? .on : .off
     fullScreen.title = isInFullScreen ? Constants.String.exitFullScreen : Constants.String.fullScreen
+    miniPlayer.state = player.isInMiniPlayer ? .on : .off
     pictureInPicture?.title = isInPIP ? Constants.String.exitPIP : Constants.String.pip
     delogo.state = isDelogo ? .on : .off
   }


### PR DESCRIPTION
This commit will add a checkmark to the `Music Mode` menu item in the `Video` menu when the mini player is active.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
A minor change to make this menu item adhere to Apple's Human Interface Guidelines for toggle menus.