### PR TITLE
Send directory arg to mpv instead of processing in IINA (fixes #4434)

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -294,12 +294,18 @@ class PlayerCore: NSObject {
     guard !urls.isEmpty else { return 0 }
     let urls = Utility.resolveURLs(urls)
 
-    // handle BD folders and m3u / m3u8 files first
-    if urls.count == 1 && (isBDFolder(urls[0]) ||
-      Utility.playlistFileExt.contains(urls[0].absoluteString.lowercasedPathExtension)) {
-      info.shouldAutoLoadFiles = false
-      open(urls[0])
-      return nil
+    // Handle folder URL (to support mpv shuffle, etc), BD folders and m3u / m3u8 files first.
+    // For these cases, mpv will load/build the playlist and notify IINA when it can be retrieved.
+    if urls.count == 1 {
+      let url = urls[0]
+
+      if url.isExistingDirectory
+          || isBDFolder(url)
+          || Utility.playlistFileExt.contains(url.absoluteString.lowercasedPathExtension) {
+        info.shouldAutoLoadFiles = false
+        open(url)
+        return nil
+      }
     }
 
     let playableFiles = getPlayableFiles(in: urls)


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4434.

---

**Description:**

This simple change checks if there is only one path arg given, and if that path arg is a local directory. If true, sends it to mpv to process instead of processing it directly via IINA's code. This allows `iina-cli --mpv-shuffle` to work properly, at least for the case where there is only one path arg given. This should provide a workable solution for most users. (If one were to try implementing this for multiple path args and allow for fully compatibility with mpv while not breaking IINA's directory loading features, it looks like larger structural changes would be needed).