### PR TITLE
Fix heap buffer overflow in levDistance, #4449

### DIFF
--- a/iina/ObjcUtils.m
+++ b/iina/ObjcUtils.m
@@ -50,11 +50,18 @@ static inline int min(int a, int b, int c) {
   
   str0 = [@" " stringByAppendingString:str0];
   str1 = [@" " stringByAppendingString:str1];
-  const wchar_t *cstr0 = (const wchar_t *)[str0 cStringUsingEncoding:NSUTF32LittleEndianStringEncoding];
-  const wchar_t *cstr1 = (const wchar_t *)[str1 cStringUsingEncoding:NSUTF32LittleEndianStringEncoding];
-  size_t len0 = wcslen(cstr0);
-  size_t len1 = wcslen(cstr1);
-  
+
+  // Convert from variable length character encoding to fixed length UTF-32 to make it easy to
+  // access individual characters.
+  const NSData *str0AsUTF32 = [str0 dataUsingEncoding:NSUTF32LittleEndianStringEncoding];
+  const NSData *str1AsUTF32 = [str1 dataUsingEncoding:NSUTF32LittleEndianStringEncoding];
+  const NSUInteger len0 = str0AsUTF32.length / sizeof(wchar_t);
+  const NSUInteger len1 = str1AsUTF32.length / sizeof(wchar_t);
+
+  // CAUTION these strings are not null terminated.
+  const wchar_t *cstr0 = (const wchar_t *)[str0AsUTF32 bytes];
+  const wchar_t *cstr1 = (const wchar_t *)[str1AsUTF32 bytes];;
+
   int *_dist = malloc(sizeof(int) * (len0 + 1) * (len1 + 1));
   int (*dist)[len0 + 1][len1 + 1] = (int (*)[len0 + 1][len1 + 1])_dist;
   for (i = 0; i <= len0; ++i)
@@ -70,7 +77,7 @@ static inline int min(int a, int b, int c) {
     for (i = 1; i <= len0; ++i)
       (*dist)[i][j] = min((*dist)[i - 1][j] + INDEL_WEIGHT,
                           (*dist)[i][j - 1] + INDEL_WEIGHT,
-                          (*dist)[i - 1][j - 1] + (cstr0[i] == cstr1[j] ? 0 : SUBSTITUTION_WEIGHT));
+                          (*dist)[i - 1][j - 1] + (cstr0[i - 1] == cstr1[j - 1] ? 0 : SUBSTITUTION_WEIGHT));
   
   int result = (*dist)[len0][len1];
   free(_dist);


### PR DESCRIPTION
This commit will:
- Remove use of wcslen from levDistance
- Correct off by one indexing in levDistance

This corrects two separate issues with reading memory outside of bounds that were detected by the address sanitizer.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4449.

---

**Description:**
