### PR TITLE
Fix crash quitting with Inspector window open, #4456

### DIFF
--- a/iina/InspectorWindowController.swift
+++ b/iina/InspectorWindowController.swift
@@ -99,8 +99,10 @@ class InspectorWindowController: NSWindowController, NSTableViewDelegate, NSTabl
   }
 
   func updateInfo(dynamic: Bool = false) {
-    let controller = PlayerCore.lastActive.mpv!
-    let info = PlayerCore.lastActive.info
+    let player = PlayerCore.lastActive
+    guard !player.isStopping, !player.isStopped, !player.isShuttingDown, !player.isShutdown else { return }
+    let controller = player.mpv!
+    let info = player.info
 
     DispatchQueue.main.async {
 


### PR DESCRIPTION
This commit will change InspectorWindowController.updateInfo to not update the inspector window if the active player core is being stopped or shutdown.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4456.

---

**Description:**
