### PR TITLE
Improve Music Mode auto-switch override logic (fixes #4461)

### DIFF
--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -112,11 +112,11 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     // close button
     closeButtonVE.action = #selector(self.close)
     closeButtonBox.action = #selector(self.close)
-    closeButtonView.alphaValue = 0
     closeButtonBackgroundViewVE.roundCorners(withRadius: 8)
-    closeButtonBackgroundViewBox.isHidden = true
 
-    // switching UI
+    // hide controls initially
+    closeButtonBackgroundViewBox.isHidden = true
+    closeButtonView.alphaValue = 0
     controlView.alphaValue = 0
     
     // tool tips
@@ -184,10 +184,9 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
   // MARK: - Window delegate: Open / Close
 
   func windowWillClose(_ notification: Notification) {
-    player.switchedToMiniPlayerManually = false
-    player.switchedBackFromMiniPlayerManually = false
     if !player.isShuttingDown {
       // not needed if called when terminating the whole app
+      player.overrideAutoSwitchToMusicMode = false
       player.switchBackFromMiniPlayer(automatically: true, showMainWindow: false)
     }
     player.mainWindow.close()
@@ -400,7 +399,7 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
   }
 
   @IBAction func backBtnAction(_ sender: NSButton) {
-    player.switchBackFromMiniPlayer(automatically: false)
+    player.switchBackFromMiniPlayer()
   }
 
   @IBAction func nextBtnAction(_ sender: NSButton) {

--- a/iina/MiniPlayerWindowMenuActions.swift
+++ b/iina/MiniPlayerWindowMenuActions.swift
@@ -16,7 +16,7 @@ extension MiniPlayerWindowController {
 
 
   @objc func menuSwitchToMiniPlayer(_ sender: NSMenuItem) {
-    player.switchBackFromMiniPlayer(automatically: false)
+    player.switchBackFromMiniPlayer()
   }
 
 }

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -58,6 +58,7 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
     .verticalScrollAction,
     .playlistShowMetadata,
     .playlistShowMetadataInMusicMode,
+    .autoSwitchToMusicMode,
   ]
   
   override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey : Any]?, context: UnsafeMutableRawPointer?) {
@@ -109,6 +110,8 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
       if player.isPlaylistVisible {
         player.mainWindow.playlistView.playlistTableView.reloadData()
       }
+    case PK.autoSwitchToMusicMode.rawValue:
+      player.overrideAutoSwitchToMusicMode = false
     default:
       return
     }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4461.

---

**Description:**

### Rationale
If the user manually enters Music Mode for a non-audio file (or exits Music Mode for an audio-file), they have indicated that they want to override the default behavior, and likely want to stay in that state until they indicate otherwise. They indicate otherwise by either toggling Music Mode again (thus undoing their previous behavior), or by enabling `Switch to "music mode" automatically` in `Settings`.

### Details

This replaces `switchedToMiniPlayerManually` and `switchedBackFromMiniPlayerManually` in `PlayerCore` with a single var, `overrideAutoSwitchToMusicMode`, which fixes inconsistent behavior reported in #4461.

It also cleans up the `autoSwitchToMusicMode` logic in `PlayerCore.trackListChanged()` so:
- It's more understandable.
- Removes the requirement that `audioStatusWasUnkownBefore` is `true`. This is totally redundant because it is covered by the checks which occur right afterwards.

The single state variable, `overrideAutoSwitchToMusicMode`, if true, keeps the current music mode state (off/on), even when the media changes and `autoSwitchToMusicMode` is true in the preferences. Its behavior is simple:
- The first time the user manually toggles Music Mode, it's set to `true`, so automatic switching is disabled, even if `autoSwitchToMusicMode` is true in the preferences.
- The next time the user manually toggles Music Mode, it's set to `false`, so automatic switching goes back to using the value of `autoSwitchToMusicMode` in the preferences.
- The value of `overrideAutoSwitchToMusicMode` is set back to `false` when the player window is closed, or if `autoSwitchToMusicMode` is changed in the preferences. (It doesn't make sense to stay in manual override if the user has just indicated that they want to enable auto-switch).
- The value of `overrideAutoSwitchToMusicMode` is not used if the `autoSwitchToMusicMode` pref is `false`.