### PR TITLE
Fix TAB & ESC key bindings not working in main player & music mode windows (fixes #4465)

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -238,6 +238,7 @@
 		B4E446F725CB54EF0069F06E /* Mustache in Frameworks */ = {isa = PBXBuildFile; productRef = B4E446F625CB54EF0069F06E /* Mustache */; };
 		B4E4470125CE3F930069F06E /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = B4E4470025CE3F930069F06E /* Sparkle */; };
 		C789872F1E34EF170005769F /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = C78987311E34EF170005769F /* InfoPlist.strings */; };
+		D1B4E24E2A3AFC9100E36F1D /* MiniPlayerWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B4E24D2A3AFC9100E36F1D /* MiniPlayerWindow.swift */; };
 		E301EFDA21312AB300BC8588 /* KeychainAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = E301EFD921312AB300BC8588 /* KeychainAccess.swift */; };
 		E30D2EBD21F5FD2600E1FF0D /* PluginOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30D2EBC21F5FD2600E1FF0D /* PluginOverlayView.swift */; };
 		E322A4F820A8442E00C67D32 /* PlaylistPlaybackProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E322A4F720A8442E00C67D32 /* PlaylistPlaybackProgressView.swift */; };
@@ -1518,6 +1519,7 @@
 		C7DBA5EB1F07C5FD00C2B416 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/InitialWindowController.strings; sourceTree = "<group>"; };
 		C7DC79CE1EC63821002DE23B /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/HistoryWindowController.strings; sourceTree = "<group>"; };
 		C7E90B522087EC5700A58B6B /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/SubChooseViewController.strings; sourceTree = "<group>"; };
+		D1B4E24D2A3AFC9100E36F1D /* MiniPlayerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerWindow.swift; sourceTree = "<group>"; };
 		D27556FC1EC6E1C300CAB2A4 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/HistoryWindowController.strings"; sourceTree = "<group>"; };
 		D27E35CE1E379B6D0064BE57 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/MainMenu.strings"; sourceTree = "<group>"; };
 		D27E35CF1E379B6D0064BE57 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/MainWindowController.strings"; sourceTree = "<group>"; };
@@ -2031,6 +2033,7 @@
 			children = (
 				84A0BA931D2F9E9600BC8DA1 /* MainMenu.xib */,
 				E38BD4AE20054BD9007635FC /* MainWindow.swift */,
+				D1B4E24D2A3AFC9100E36F1D /* MiniPlayerWindow.swift */,
 				84CFC92523F8DDE000381E5B /* PlayerWindowController.swift */,
 				84A0BA9C1D2FAD4000BC8DA1 /* MainWindowController.swift */,
 				51CACB9429D500290034CEE5 /* VideoPIPViewController.swift */,
@@ -2762,6 +2765,7 @@
 				E353070521496CE4008FE492 /* PrefPluginViewController.swift in Sources */,
 				840820111ECF6C1800361416 /* FileGroup.swift in Sources */,
 				E374160C20F138A900B4F7F9 /* CollapseView.swift in Sources */,
+				D1B4E24E2A3AFC9100E36F1D /* MiniPlayerWindow.swift in Sources */,
 				84A0BA901D2F8D4100BC8DA1 /* IINAError.swift in Sources */,
 				84C6D3621EAF8D63009BF721 /* HistoryController.swift in Sources */,
 				E38B3213214FB9EA000F6D27 /* PrefPluginPermissionView.swift in Sources */,

--- a/iina/Base.lproj/MiniPlayerWindowController.xib
+++ b/iina/Base.lproj/MiniPlayerWindowController.xib
@@ -43,7 +43,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" frameAutosaveName="IINAMiniPlayerWindow" animationBehavior="default" tabbingMode="disallowed" id="F0z-JX-Cv5">
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" frameAutosaveName="IINAMiniPlayerWindow" animationBehavior="default" tabbingMode="disallowed" id="F0z-JX-Cv5" userLabel="MiniPlayer Window" customClass="MiniPlayerWindow" customModule="IINA" customModuleProvider="target">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenNone="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>

--- a/iina/Base.lproj/PlaylistViewController.xib
+++ b/iina/Base.lproj/PlaylistViewController.xib
@@ -460,7 +460,7 @@
                 </tabView>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SOR-3l-PFj">
                     <rect key="frame" x="121" y="294" width="120" height="48"/>
-                    <buttonCell key="cell" type="square" title="CHAPTERS" bezelStyle="shadowlessSquare" alignment="center" imageScaling="proportionallyDown" inset="2" id="jUF-xa-uRI">
+                    <buttonCell key="cell" type="square" title="CHAPTERS" bezelStyle="shadowlessSquare" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyDown" inset="2" id="jUF-xa-uRI">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="systemBold"/>
                     </buttonCell>
@@ -473,7 +473,7 @@
                     <constraints>
                         <constraint firstAttribute="height" constant="48" id="aPN-VC-eZR"/>
                     </constraints>
-                    <buttonCell key="cell" type="square" title="PLAYLIST" bezelStyle="shadowlessSquare" alignment="center" imageScaling="proportionallyDown" inset="2" id="fAq-Pq-ThP">
+                    <buttonCell key="cell" type="square" title="PLAYLIST" bezelStyle="shadowlessSquare" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyDown" inset="2" id="fAq-Pq-ThP">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="systemBold"/>
                     </buttonCell>

--- a/iina/MainWindow.swift
+++ b/iina/MainWindow.swift
@@ -11,12 +11,12 @@ import Cocoa
 class MainWindow: NSWindow {
   var forceKeyAndMain = false
 
-  override func cancelOperation(_ sender: Any?) {
-    let controller = windowController as! MainWindowController
-    if let kb = PlayerCore.keyBindings["ESC"] {
-      controller.handleKeyBinding(kb)
-    } else {
-      super.cancelOperation(sender)
+  override func keyDown(with event: NSEvent) {
+    /// Forward all key events which the window receives to its controller.
+    /// This allows `ESC` & `TAB` key bindings to work, instead of getting swallowed by
+    /// MacOS keyboard focus navigation (which we don't use).
+    if let controller = windowController as? MainWindowController {
+      controller.keyDown(with: event)
     }
   }
 

--- a/iina/MiniPlayerWindow.swift
+++ b/iina/MiniPlayerWindow.swift
@@ -1,0 +1,21 @@
+//
+//  MiniPlayerWindow.swift
+//  iina
+//
+//  Created by Matt Svoboda on 2023-06-15.
+//  Copyright © 2023 lhc. All rights reserved.
+//
+
+import Foundation
+
+class MiniPlayerWindow: NSWindow {
+
+  override func keyDown(with event: NSEvent) {
+    /// Forward all key events which the window receives to its controller.
+    /// This allows `ESC` & `TAB` key bindings to work, instead of getting swallowed by
+    /// MacOS keyboard focus navigation (which we don't use).
+    if let controller = windowController as? MiniPlayerWindowController {
+      controller.player.mainWindow.keyDown(with: event)
+    }
+  }
+}

--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -464,16 +464,6 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
 
   // MARK: - Table delegates
 
-  // Due to NSTableView's type select feature, space key will be passed to
-  // other responders like other keys. This is a workaround to prevent space
-  // key cannot toggle pause when the table view is first responder.
-  func tableView(_ tableView: NSTableView, shouldTypeSelectFor event: NSEvent, withCurrentSearch searchString: String?) -> Bool {
-    if event.characters == " " {
-      mainWindow.keyDown(with: event)
-    }
-    return false
-  }
-
   func tableViewSelectionDidChange(_ notification: Notification) {
     let tv = notification.object as! NSTableView
     if tv == playlistTableView {


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4465.

---

**Description:**
Uses `NSWindow` subclasses for `MainWindow` and `MiniPlayerWIndow`, and overrides `keyDown()` so that it bypasses MacOS's built-in diversion of the `TAB` & `ESC` keys for keyboard navigation, which IINA does not desire to use for these windows. This allows `TAB` and `ESC` key bindings to work. (Note that `ESC` was working for `MainWindow` due to a workaround, but not `MiniPlayerWIndow`; while `TAB` was not working for either).

I ended up duplicating the code for `keyDown()` in each window class, because I found I needed separate subclasses for each window which inherited directly from `NSWindow`. Originally I tried to create a common base class which inherited from `NSWindow`, and then have both windows inherit from that, but that didn't seem to work.

Removes the workaround for `ESC` from `MainWindow`, because it's no longer needed. Removes the workaround for sending `SPACE` from `PlaylistViewController`, because it now was sending a second unwanted space.

One wrinkle with this solution is that it drew a focus ring around either the Playlist or Chapters tab button because it was detected as the first responder. I was unable to find a way to say "no first responder please", but setting `refusesFirstResponder="YES"` for each of these got rid of the focus rings.