### PR TITLE
fix plugin postMessage(name, data) JSON.parse fail when fields in data contains newline

### DIFF
--- a/iina/JavascriptMessageHub.swift
+++ b/iina/JavascriptMessageHub.swift
@@ -27,7 +27,7 @@ class JavascriptMessageHub {
         webView.evaluateJavaScript("window.iina._emit(`\(name)`)")
         return
       }
-      webView.evaluateJavaScript("window.iina._emit(`\(name)`, `\(dataString)`)")
+      webView.evaluateJavaScript("window.iina._emit(`\(name)`, String.raw`\(dataString)`)")
     }
   }
 


### PR DESCRIPTION

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**


example plugin code

```js
iina.standaloneWindow.postMessage('test', { a: 'b\nc' })
```

example webpage code
```js
iina.onMessage('test', data => {
  console.log(data)
})
```


when `postMessage(name, data)` `data.a` contains newline `\n`, will cause errors show like `unterminated string` in JSON.parse


![image](https://github.com/iina/iina/assets/4067115/0f127fcd-7375-41cb-b993-e5dab55c2191)

![image](https://github.com/iina/iina/assets/4067115/f27f198c-4b6a-4f63-aa29-0742895a7f3c)

----------- 

this fix use ES6 `String.raw`, and it do work for this case

![image](https://github.com/iina/iina/assets/4067115/6628ccf2-64f5-4977-87be-f80d1843c890)

![image](https://github.com/iina/iina/assets/4067115/d1ef3657-b5fa-4a1a-b689-2984b0b5e133)



-----------

## about `String.raw`
- supported since Safari 9 [OS X 10.9]
  - https://caniuse.com/?search=String.raw
  - https://en.wikipedia.org/wiki/Safari_version_history


## other ways to fix

manual escape like https://stackoverflow.com/questions/15843570/objective-c-how-to-convert-nsstring-to-escaped-json-string



