### PR TITLE
Add log messages containing Mac platform details

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -21,6 +21,7 @@
 		519872FF26879B9B00F84BCC /* AccessibilityPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519872FE26879B9B00F84BCC /* AccessibilityPreferences.swift */; };
 		51C1BA3A291CA76700C1208A /* InfoDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C1BA39291CA76700C1208A /* InfoDictionary.swift */; };
 		51CACB9529D500290034CEE5 /* VideoPIPViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51CACB9429D500290034CEE5 /* VideoPIPViewController.swift */; };
+		51DE55C92A6646710050AD06 /* Sysctl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DE55C82A6646710050AD06 /* Sysctl.swift */; };
 		51E63DFB29CFB031008AFC20 /* PlaySlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E63DFA29CFB031008AFC20 /* PlaySlider.swift */; };
 		51E63DFD29CFB04C008AFC20 /* PlaySliderLoopKnob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E63DFC29CFB04B008AFC20 /* PlaySliderLoopKnob.swift */; };
 		51F7974728C7E00200812D0D /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F7974628C7E00200812D0D /* Lock.swift */; };
@@ -881,6 +882,7 @@
 		51A0F0F629FA2C8E000130CF /* Beta.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Beta.xcconfig; sourceTree = "<group>"; };
 		51C1BA39291CA76700C1208A /* InfoDictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InfoDictionary.swift; sourceTree = "<group>"; };
 		51CACB9429D500290034CEE5 /* VideoPIPViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPIPViewController.swift; sourceTree = "<group>"; };
+		51DE55C82A6646710050AD06 /* Sysctl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sysctl.swift; sourceTree = "<group>"; };
 		51E63DFA29CFB031008AFC20 /* PlaySlider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaySlider.swift; sourceTree = "<group>"; };
 		51E63DFC29CFB04B008AFC20 /* PlaySliderLoopKnob.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaySliderLoopKnob.swift; sourceTree = "<group>"; };
 		51F7974628C7E00200812D0D /* Lock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
@@ -2191,6 +2193,7 @@
 				E38B3215214FF700000F6D27 /* EventController.swift */,
 				E39A11FC240F176E00A67F9F /* StringEncodingName.swift */,
 				51C1BA39291CA76700C1208A /* InfoDictionary.swift */,
+				51DE55C82A6646710050AD06 /* Sysctl.swift */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -2920,6 +2923,7 @@
 				847C62CA1DC13CDA00E1EF16 /* PrefGeneralViewController.swift in Sources */,
 				E3530700214908DD008FE492 /* JavascriptAPIHttp.swift in Sources */,
 				84FBF23E1EF06A90003EA491 /* ThumbnailCache.swift in Sources */,
+				51DE55C92A6646710050AD06 /* Sysctl.swift in Sources */,
 				845FB0C71D39462E00C011E0 /* ControlBarView.swift in Sources */,
 				E3513AFB20F120F600F8C347 /* PreferenceViewController.swift in Sources */,
 				E38BD4AF20054BD9007635FC /* MainWindow.swift in Sources */,

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -132,6 +132,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     Logger.log("Built \(date) from branch \(branch), commit \(commit)")
   }
 
+  /// Log details about the Mac IINA is running on.
+  ///
+  /// Certain IINA capabilities, such as hardware acceleration, are contingent upon aspects of the Mac IINA is running on. If available,
+  /// this method will log:
+  /// - macOS version
+  /// - model identifier of the Mac
+  /// - kind of processor
+  private func logPlatformDetails() {
+    Logger.log("Running under macOS \(ProcessInfo.processInfo.operatingSystemVersionString)")
+    guard let cpu = Sysctl.shared.machineCpuBrandString, let model = Sysctl.shared.hwModel else { return }
+    Logger.log("On a \(model) with an \(cpu) processor")
+  }
 
   // MARK: - SPUUpdaterDelegate
   @IBOutlet var updaterController: SPUStandardUpdaterController!
@@ -179,6 +191,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
       Logger.log("  \(library.name) \(AppDelegate.versionAsString(library.version))")
     }
     logBuildDetails()
+    logPlatformDetails()
 
     Logger.log("App will launch")
 

--- a/iina/Sysctl.swift
+++ b/iina/Sysctl.swift
@@ -1,0 +1,42 @@
+//
+//  Sysctl.swift
+//  iina
+//
+//  Created by low-batt on 7/18/23.
+//  Copyright © 2023 lhc. All rights reserved.
+//
+
+import Foundation
+
+/// Wrapper to provide easy access to system information accessible through [sysctlbyname](https://developer.apple.com/documentation/kernel/1387446-sysctlbyname).
+///
+/// - Important: The values returned by the computed properties are optional because we do not know if the kernel state is
+///     available in old versions of macOS supported by IINA.
+struct Sysctl {
+  static let shared = Sysctl()
+
+  /// Mac model identifier, e.g., `MacBookPro18,2`.
+  var hwModel: String? { getString("hw.model") }
+  
+  /// CPU chip, e.g., `Apple M1 Max`.
+  var machineCpuBrandString: String? { getString("machdep.cpu.brand_string") }
+  
+  /// Retrieve the kernel state with the given name as a string.
+  /// - Parameter name: Name of the state to retrieve.
+  /// - Returns: Value of given state or `nil` if the value can not be obtained.
+  private func getString(_ name: String) -> String? {
+    var size = 0
+    // Get the size of the string.
+    guard sysctlbyname(name, nil, &size, nil, 0) == EXIT_SUCCESS else {
+      Logger.log("Call to sysctlbyname for \(name) failed: \(String(cString: strerror(errno))) (\(errno))")
+      return nil
+    }
+    // Now get the named kernel state as a string.
+    var value = [CChar](repeating: 0,  count: Int(size))
+    guard sysctlbyname(name, &value, &size, nil, 0) == EXIT_SUCCESS else {
+      Logger.log("Call to sysctlbyname for \(name) failed: \(String(cString: strerror(errno))) (\(errno))")
+      return nil
+    }
+    return String(cString: value)
+  }
+}


### PR DESCRIPTION
This commit will add code to emit two log messages at startup that provide the following information:
- macOS version
- model identifier of the Mac
- kind of processor

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
