### PR TITLE
Improve playlist side panel buttons layout for German localization (fixes #3585)

### DIFF
--- a/iina/Base.lproj/PlaylistViewController.xib
+++ b/iina/Base.lproj/PlaylistViewController.xib
@@ -20,6 +20,7 @@
                 <outlet property="removeBtn" destination="xKm-J1-NZs" id="cgl-XX-dEK"/>
                 <outlet property="shuffleBtn" destination="xhU-qn-3aa" id="Zof-fw-Jg4"/>
                 <outlet property="subPopover" destination="nSf-Kp-eDQ" id="PUs-AK-r1c"/>
+                <outlet property="tabHeightConstraint" destination="So5-Pf-aJb" id="EFJ-yr-PVa"/>
                 <outlet property="tabView" destination="Yym-Zw-Hd8" id="xXL-Ne-hHh"/>
                 <outlet property="totalLengthLabel" destination="icQ-T6-fV9" id="D9Z-Th-JVy"/>
                 <outlet property="view" destination="Hz6-mo-xeY" id="0bl-1N-x8E"/>
@@ -28,25 +29,67 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY" customClass="PlaylistView" customModule="IINA" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="241" height="328"/>
+            <rect key="frame" x="0.0" y="0.0" width="241" height="285"/>
             <subviews>
+                <stackView distribution="fillEqually" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="250" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EHy-pe-5wJ">
+                    <rect key="frame" x="0.0" y="237" width="241" height="48"/>
+                    <subviews>
+                        <button translatesAutoresizingMaskIntoConstraints="NO" id="5Zq-JQ-XO4">
+                            <rect key="frame" x="8" y="0.0" width="109" height="48"/>
+                            <buttonCell key="cell" type="square" title="PLAYLIST" bezelStyle="shadowlessSquare" alignment="center" lineBreakMode="truncatingMiddle" imageScaling="proportionallyDown" inset="2" id="fAq-Pq-ThP">
+                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                <font key="font" metaFont="systemBold"/>
+                            </buttonCell>
+                            <connections>
+                                <action selector="playlistBtnAction:" target="-2" id="cyl-Pk-pTN"/>
+                            </connections>
+                        </button>
+                        <button translatesAutoresizingMaskIntoConstraints="NO" id="SOR-3l-PFj">
+                            <rect key="frame" x="125" y="0.0" width="108" height="48"/>
+                            <buttonCell key="cell" type="square" title="CHAPTERS" bezelStyle="shadowlessSquare" alignment="center" lineBreakMode="truncatingMiddle" imageScaling="proportionallyDown" inset="2" id="jUF-xa-uRI">
+                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                <font key="font" metaFont="system"/>
+                            </buttonCell>
+                            <connections>
+                                <action selector="chaptersBtnAction:" target="-2" id="Gpo-6e-oRu"/>
+                            </connections>
+                        </button>
+                    </subviews>
+                    <edgeInsets key="edgeInsets" left="8" right="8" top="0.0" bottom="0.0"/>
+                    <constraints>
+                        <constraint firstItem="5Zq-JQ-XO4" firstAttribute="height" secondItem="EHy-pe-5wJ" secondAttribute="height" id="29X-qd-h1b"/>
+                        <constraint firstAttribute="height" constant="48" identifier="tabHeightConstraint" id="So5-Pf-aJb"/>
+                        <constraint firstItem="SOR-3l-PFj" firstAttribute="height" secondItem="EHy-pe-5wJ" secondAttribute="height" id="TUb-gE-ZcM"/>
+                    </constraints>
+                    <visibilityPriorities>
+                        <integer value="1000"/>
+                        <integer value="1000"/>
+                    </visibilityPriorities>
+                    <customSpacing>
+                        <real value="3.4028234663852886e+38"/>
+                        <real value="3.4028234663852886e+38"/>
+                    </customSpacing>
+                </stackView>
+                <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="glW-5x-LJr">
+                    <rect key="frame" x="0.0" y="235" width="241" height="5"/>
+                </box>
                 <tabView drawsBackground="NO" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="Yym-Zw-Hd8">
-                    <rect key="frame" x="0.0" y="0.0" width="241" height="263"/>
+                    <rect key="frame" x="0.0" y="0.0" width="241" height="238"/>
                     <font key="font" metaFont="system"/>
                     <tabViewItems>
                         <tabViewItem label="Playlist" identifier="1" id="rjs-Qf-mT6">
                             <view key="view" id="BXH-zz-cse">
-                                <rect key="frame" x="0.0" y="0.0" width="241" height="263"/>
+                                <rect key="frame" x="0.0" y="0.0" width="241" height="241"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="28" horizontalPageScroll="10" verticalLineScroll="28" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n5h-uy-hbd">
-                                        <rect key="frame" x="0.0" y="24" width="236" height="239"/>
+                                        <rect key="frame" x="0.0" y="24" width="236" height="217"/>
                                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="2M9-8L-veI">
-                                            <rect key="frame" x="0.0" y="0.0" width="236" height="239"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="236" height="217"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" tableStyle="fullWidth" columnResizing="NO" autosaveColumns="NO" rowHeight="26" viewBased="YES" id="xIa-sI-0Xn">
-                                                    <rect key="frame" x="0.0" y="0.0" width="236" height="239"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="236" height="217"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <size key="intercellSpacing" width="3" height="2"/>
                                                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.080000000000000002" colorSpace="calibratedRGB"/>
@@ -329,17 +372,17 @@
                         </tabViewItem>
                         <tabViewItem label="Chapters" identifier="2" id="aaR-kR-im0">
                             <view key="view" id="8o0-5f-a79">
-                                <rect key="frame" x="0.0" y="0.0" width="241" height="294"/>
+                                <rect key="frame" x="0.0" y="0.0" width="241" height="288"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="33" horizontalPageScroll="10" verticalLineScroll="33" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Lmd-sc-A3b">
-                                        <rect key="frame" x="0.0" y="0.0" width="241" height="294"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="241" height="288"/>
                                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="6tr-hz-bdD">
-                                            <rect key="frame" x="0.0" y="0.0" width="241" height="294"/>
-                                            <autoresizingMask key="autoresizingMask"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="241" height="288"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="31" rowSizeStyle="automatic" viewBased="YES" id="BvG-MR-6LX">
-                                                    <rect key="frame" x="0.0" y="0.0" width="241" height="294"/>
+                                                    <rect key="frame" x="0.0" y="0.0" width="241" height="288"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <size key="intercellSpacing" width="3" height="2"/>
                                                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.080000000000000002" colorSpace="calibratedRGB"/>
@@ -457,56 +500,16 @@
                         </tabViewItem>
                     </tabViewItems>
                 </tabView>
-                <stackView distribution="fillEqually" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="250" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EHy-pe-5wJ">
-                    <rect key="frame" x="0.0" y="263" width="241" height="48"/>
-                    <subviews>
-                        <button translatesAutoresizingMaskIntoConstraints="NO" id="5Zq-JQ-XO4">
-                            <rect key="frame" x="8" y="16" width="109" height="16"/>
-                            <buttonCell key="cell" type="square" title="PLAYLIST" bezelStyle="shadowlessSquare" alignment="center" lineBreakMode="truncatingMiddle" imageScaling="proportionallyDown" inset="2" id="fAq-Pq-ThP">
-                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                <font key="font" metaFont="systemBold"/>
-                            </buttonCell>
-                            <connections>
-                                <action selector="playlistBtnAction:" target="-2" id="cyl-Pk-pTN"/>
-                            </connections>
-                        </button>
-                        <button translatesAutoresizingMaskIntoConstraints="NO" id="SOR-3l-PFj">
-                            <rect key="frame" x="125" y="16" width="108" height="16"/>
-                            <buttonCell key="cell" type="square" title="CHAPTERS" bezelStyle="shadowlessSquare" alignment="center" lineBreakMode="truncatingMiddle" imageScaling="proportionallyDown" inset="2" id="jUF-xa-uRI">
-                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                <font key="font" metaFont="system"/>
-                            </buttonCell>
-                            <connections>
-                                <action selector="chaptersBtnAction:" target="-2" id="Gpo-6e-oRu"/>
-                            </connections>
-                        </button>
-                    </subviews>
-                    <edgeInsets key="edgeInsets" left="8" right="8" top="0.0" bottom="0.0"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="48" id="So5-Pf-aJb"/>
-                    </constraints>
-                    <visibilityPriorities>
-                        <integer value="1000"/>
-                        <integer value="1000"/>
-                    </visibilityPriorities>
-                    <customSpacing>
-                        <real value="3.4028234663852886e+38"/>
-                        <real value="3.4028234663852886e+38"/>
-                    </customSpacing>
-                </stackView>
-                <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="glW-5x-LJr">
-                    <rect key="frame" x="0.0" y="260" width="241" height="5"/>
-                </box>
             </subviews>
             <constraints>
                 <constraint firstItem="glW-5x-LJr" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="39I-Qr-eeL"/>
-                <constraint firstItem="Yym-Zw-Hd8" firstAttribute="top" secondItem="EHy-pe-5wJ" secondAttribute="bottom" id="IBe-qW-YYZ"/>
                 <constraint firstAttribute="bottom" secondItem="Yym-Zw-Hd8" secondAttribute="bottom" id="VEC-3U-YTI"/>
                 <constraint firstItem="Yym-Zw-Hd8" firstAttribute="top" secondItem="glW-5x-LJr" secondAttribute="bottom" constant="-1" id="WkM-Vo-1QO"/>
                 <constraint firstAttribute="trailing" secondItem="Yym-Zw-Hd8" secondAttribute="trailing" id="Wu2-Mo-8NM"/>
+                <constraint firstItem="glW-5x-LJr" firstAttribute="bottom" secondItem="EHy-pe-5wJ" secondAttribute="bottom" id="XMu-Q4-t5u"/>
                 <constraint firstItem="EHy-pe-5wJ" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="cS1-5e-pc1"/>
                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="240" id="clJ-Nh-tAc"/>
-                <constraint firstItem="EHy-pe-5wJ" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="6" id="hIy-74-Vej"/>
+                <constraint firstItem="EHy-pe-5wJ" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="hIy-74-Vej"/>
                 <constraint firstItem="Yym-Zw-Hd8" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="iKz-2C-iJv"/>
                 <constraint firstAttribute="trailing" secondItem="glW-5x-LJr" secondAttribute="trailing" id="kNZ-El-hDd"/>
                 <constraint firstAttribute="trailing" secondItem="EHy-pe-5wJ" secondAttribute="trailing" id="qJ3-wJ-mDn"/>

--- a/iina/Base.lproj/PlaylistViewController.xib
+++ b/iina/Base.lproj/PlaylistViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="17506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="19529" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="17506"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="19529"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -10,7 +10,7 @@
             <connections>
                 <outlet property="addBtn" destination="W9C-Z7-hiI" id="oly-ab-4Lc"/>
                 <outlet property="addFileMenu" destination="WJF-Uz-W4x" id="r2E-07-2v4"/>
-                <outlet property="buttonTopConstraint" destination="hLh-Or-ZUd" id="wDU-9e-scd"/>
+                <outlet property="buttonTopConstraint" destination="hIy-74-Vej" id="sM9-lJ-qud"/>
                 <outlet property="chapterTableView" destination="BvG-MR-6LX" id="WoF-Wg-fqX"/>
                 <outlet property="chaptersBtn" destination="SOR-3l-PFj" id="W2q-tm-TA0"/>
                 <outlet property="deleteBtn" destination="7my-AM-8Ts" id="wTg-jz-wRa"/>
@@ -20,7 +20,6 @@
                 <outlet property="removeBtn" destination="xKm-J1-NZs" id="cgl-XX-dEK"/>
                 <outlet property="shuffleBtn" destination="xhU-qn-3aa" id="Zof-fw-Jg4"/>
                 <outlet property="subPopover" destination="nSf-Kp-eDQ" id="PUs-AK-r1c"/>
-                <outlet property="tabHeightConstraint" destination="aPN-VC-eZR" id="Vuo-Yl-46m"/>
                 <outlet property="tabView" destination="Yym-Zw-Hd8" id="xXL-Ne-hHh"/>
                 <outlet property="totalLengthLabel" destination="icQ-T6-fV9" id="D9Z-Th-JVy"/>
                 <outlet property="view" destination="Hz6-mo-xeY" id="0bl-1N-x8E"/>
@@ -29,25 +28,25 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY" customClass="PlaylistView" customModule="IINA" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="241" height="334"/>
+            <rect key="frame" x="0.0" y="0.0" width="241" height="328"/>
             <subviews>
                 <tabView drawsBackground="NO" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="Yym-Zw-Hd8">
-                    <rect key="frame" x="0.0" y="0.0" width="241" height="294"/>
+                    <rect key="frame" x="0.0" y="0.0" width="241" height="263"/>
                     <font key="font" metaFont="system"/>
                     <tabViewItems>
                         <tabViewItem label="Playlist" identifier="1" id="rjs-Qf-mT6">
-                            <view key="view" ambiguous="YES" id="BXH-zz-cse">
-                                <rect key="frame" x="0.0" y="0.0" width="241" height="282"/>
+                            <view key="view" id="BXH-zz-cse">
+                                <rect key="frame" x="0.0" y="0.0" width="241" height="263"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
-                                    <scrollView ambiguous="YES" borderType="none" autohidesScrollers="YES" horizontalLineScroll="28" horizontalPageScroll="10" verticalLineScroll="28" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n5h-uy-hbd">
-                                        <rect key="frame" x="0.0" y="24" width="236" height="258"/>
-                                        <clipView key="contentView" ambiguous="YES" drawsBackground="NO" copiesOnScroll="NO" id="2M9-8L-veI">
-                                            <rect key="frame" x="0.0" y="0.0" width="236" height="258"/>
+                                    <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="28" horizontalPageScroll="10" verticalLineScroll="28" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="n5h-uy-hbd">
+                                        <rect key="frame" x="0.0" y="24" width="236" height="239"/>
+                                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="2M9-8L-veI">
+                                            <rect key="frame" x="0.0" y="0.0" width="236" height="239"/>
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
-                                                <tableView focusRingType="none" verticalHuggingPriority="750" ambiguous="YES" allowsExpansionToolTips="YES" tableStyle="fullWidth" columnResizing="NO" autosaveColumns="NO" rowHeight="26" viewBased="YES" id="xIa-sI-0Xn">
-                                                    <rect key="frame" x="0.0" y="0.0" width="236" height="258"/>
+                                                <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" tableStyle="fullWidth" columnResizing="NO" autosaveColumns="NO" rowHeight="26" viewBased="YES" id="xIa-sI-0Xn">
+                                                    <rect key="frame" x="0.0" y="0.0" width="236" height="239"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <size key="intercellSpacing" width="3" height="2"/>
                                                     <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.080000000000000002" colorSpace="calibratedRGB"/>
@@ -216,10 +215,10 @@
                                             <autoresizingMask key="autoresizingMask"/>
                                         </scroller>
                                     </scrollView>
-                                    <customView ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="X2W-MY-vYB" userLabel="ToolBar">
+                                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="X2W-MY-vYB" userLabel="ToolBar">
                                         <rect key="frame" x="0.0" y="0.0" width="236" height="24"/>
                                         <subviews>
-                                            <button verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xKm-J1-NZs" userLabel="Remove Button">
+                                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xKm-J1-NZs" userLabel="Remove Button">
                                                 <rect key="frame" x="186" y="0.0" width="24" height="24"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="24" id="V4F-VM-w6F"/>
@@ -232,7 +231,7 @@
                                                     <action selector="removeBtnAction:" target="-2" id="Ihy-Ga-m0c"/>
                                                 </connections>
                                             </button>
-                                            <button verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7my-AM-8Ts">
+                                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="7my-AM-8Ts">
                                                 <rect key="frame" x="210" y="0.0" width="24" height="24"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="24" id="6gk-wr-fJW"/>
@@ -271,7 +270,7 @@
                                                     <action selector="shuffleBtnAction:" target="-2" id="ZiC-jw-zzz"/>
                                                 </connections>
                                             </button>
-                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="icQ-T6-fV9">
+                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="icQ-T6-fV9">
                                                 <rect key="frame" x="102" y="5" width="33" height="14"/>
                                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" title="Label" id="6J7-iM-V5h">
                                                     <font key="font" metaFont="controlContent" size="11"/>
@@ -279,7 +278,7 @@
                                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                 </textFieldCell>
                                             </textField>
-                                            <button verticalHuggingPriority="750" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="W9C-Z7-hiI" userLabel="Add Button">
+                                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="W9C-Z7-hiI" userLabel="Add Button">
                                                 <rect key="frame" x="162" y="0.0" width="24" height="24"/>
                                                 <constraints>
                                                     <constraint firstAttribute="width" constant="24" id="Wbf-h5-7Gb"/>
@@ -337,7 +336,7 @@
                                         <rect key="frame" x="0.0" y="0.0" width="241" height="294"/>
                                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="6tr-hz-bdD">
                                             <rect key="frame" x="0.0" y="0.0" width="241" height="294"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="31" rowSizeStyle="automatic" viewBased="YES" id="BvG-MR-6LX">
                                                     <rect key="frame" x="0.0" y="0.0" width="241" height="294"/>
@@ -458,50 +457,59 @@
                         </tabViewItem>
                     </tabViewItems>
                 </tabView>
-                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SOR-3l-PFj">
-                    <rect key="frame" x="121" y="294" width="120" height="48"/>
-                    <buttonCell key="cell" type="square" title="CHAPTERS" bezelStyle="shadowlessSquare" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyDown" inset="2" id="jUF-xa-uRI">
-                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="systemBold"/>
-                    </buttonCell>
-                    <connections>
-                        <action selector="chaptersBtnAction:" target="-2" id="Gpo-6e-oRu"/>
-                    </connections>
-                </button>
-                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5Zq-JQ-XO4">
-                    <rect key="frame" x="0.0" y="294" width="121" height="48"/>
+                <stackView distribution="fillEqually" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="250" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EHy-pe-5wJ">
+                    <rect key="frame" x="0.0" y="263" width="241" height="48"/>
+                    <subviews>
+                        <button translatesAutoresizingMaskIntoConstraints="NO" id="5Zq-JQ-XO4">
+                            <rect key="frame" x="8" y="16" width="109" height="16"/>
+                            <buttonCell key="cell" type="square" title="PLAYLIST" bezelStyle="shadowlessSquare" alignment="center" lineBreakMode="truncatingMiddle" imageScaling="proportionallyDown" inset="2" id="fAq-Pq-ThP">
+                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                <font key="font" metaFont="systemBold"/>
+                            </buttonCell>
+                            <connections>
+                                <action selector="playlistBtnAction:" target="-2" id="cyl-Pk-pTN"/>
+                            </connections>
+                        </button>
+                        <button translatesAutoresizingMaskIntoConstraints="NO" id="SOR-3l-PFj">
+                            <rect key="frame" x="125" y="16" width="108" height="16"/>
+                            <buttonCell key="cell" type="square" title="CHAPTERS" bezelStyle="shadowlessSquare" alignment="center" lineBreakMode="truncatingMiddle" imageScaling="proportionallyDown" inset="2" id="jUF-xa-uRI">
+                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                <font key="font" metaFont="system"/>
+                            </buttonCell>
+                            <connections>
+                                <action selector="chaptersBtnAction:" target="-2" id="Gpo-6e-oRu"/>
+                            </connections>
+                        </button>
+                    </subviews>
+                    <edgeInsets key="edgeInsets" left="8" right="8" top="0.0" bottom="0.0"/>
                     <constraints>
-                        <constraint firstAttribute="height" constant="48" id="aPN-VC-eZR"/>
+                        <constraint firstAttribute="height" constant="48" id="So5-Pf-aJb"/>
                     </constraints>
-                    <buttonCell key="cell" type="square" title="PLAYLIST" bezelStyle="shadowlessSquare" alignment="center" refusesFirstResponder="YES" imageScaling="proportionallyDown" inset="2" id="fAq-Pq-ThP">
-                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                        <font key="font" metaFont="systemBold"/>
-                    </buttonCell>
-                    <connections>
-                        <action selector="playlistBtnAction:" target="-2" id="cyl-Pk-pTN"/>
-                    </connections>
-                </button>
+                    <visibilityPriorities>
+                        <integer value="1000"/>
+                        <integer value="1000"/>
+                    </visibilityPriorities>
+                    <customSpacing>
+                        <real value="3.4028234663852886e+38"/>
+                        <real value="3.4028234663852886e+38"/>
+                    </customSpacing>
+                </stackView>
                 <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="glW-5x-LJr">
-                    <rect key="frame" x="0.0" y="291" width="241" height="5"/>
+                    <rect key="frame" x="0.0" y="260" width="241" height="5"/>
                 </box>
             </subviews>
             <constraints>
                 <constraint firstItem="glW-5x-LJr" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="39I-Qr-eeL"/>
-                <constraint firstItem="Yym-Zw-Hd8" firstAttribute="top" secondItem="5Zq-JQ-XO4" secondAttribute="bottom" id="EOu-Jc-A7S"/>
+                <constraint firstItem="Yym-Zw-Hd8" firstAttribute="top" secondItem="EHy-pe-5wJ" secondAttribute="bottom" id="IBe-qW-YYZ"/>
                 <constraint firstAttribute="bottom" secondItem="Yym-Zw-Hd8" secondAttribute="bottom" id="VEC-3U-YTI"/>
                 <constraint firstItem="Yym-Zw-Hd8" firstAttribute="top" secondItem="glW-5x-LJr" secondAttribute="bottom" constant="-1" id="WkM-Vo-1QO"/>
                 <constraint firstAttribute="trailing" secondItem="Yym-Zw-Hd8" secondAttribute="trailing" id="Wu2-Mo-8NM"/>
-                <constraint firstAttribute="trailing" secondItem="SOR-3l-PFj" secondAttribute="trailing" id="atA-b5-vwd"/>
+                <constraint firstItem="EHy-pe-5wJ" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="cS1-5e-pc1"/>
                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="240" id="clJ-Nh-tAc"/>
-                <constraint firstItem="5Zq-JQ-XO4" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="elP-iu-vPl"/>
-                <constraint firstItem="5Zq-JQ-XO4" firstAttribute="width" secondItem="Hz6-mo-xeY" secondAttribute="width" multiplier="0.5" id="epQ-jC-a0B"/>
-                <constraint firstItem="5Zq-JQ-XO4" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="hLh-Or-ZUd"/>
+                <constraint firstItem="EHy-pe-5wJ" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="6" id="hIy-74-Vej"/>
                 <constraint firstItem="Yym-Zw-Hd8" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="iKz-2C-iJv"/>
-                <constraint firstItem="SOR-3l-PFj" firstAttribute="top" secondItem="5Zq-JQ-XO4" secondAttribute="top" id="iZK-4D-ROr"/>
                 <constraint firstAttribute="trailing" secondItem="glW-5x-LJr" secondAttribute="trailing" id="kNZ-El-hDd"/>
-                <constraint firstItem="SOR-3l-PFj" firstAttribute="width" secondItem="Hz6-mo-xeY" secondAttribute="width" multiplier="0.5" id="owL-kO-fvO"/>
-                <constraint firstItem="SOR-3l-PFj" firstAttribute="height" secondItem="5Zq-JQ-XO4" secondAttribute="height" id="sRW-ep-6n7"/>
-                <constraint firstItem="SOR-3l-PFj" firstAttribute="leading" secondItem="5Zq-JQ-XO4" secondAttribute="trailing" id="u9W-D2-kD5"/>
+                <constraint firstAttribute="trailing" secondItem="EHy-pe-5wJ" secondAttribute="trailing" id="qJ3-wJ-mDn"/>
             </constraints>
             <point key="canvasLocation" x="149.5" y="217.5"/>
         </customView>


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #3585.

---

**Description:**
This PR brings #3586 up to date with the current `develop` branch and adds some minor improvements. Summary 

1. Cherry-picked the commit from #3586 and resolved conflicts.
2. The original commit puts the "Playlist" and "Chapters" buttons in an `NSStackView`, so that it matches the design of the Quick Settings button group. It adds 8px insets to the left and right, which prevents the buttons from touching the sides of the sidebar. (Though the Quick Settings stack view has 20px offsets from the left and right of its 3 buttons, 8px looks better with the 2 Playlist/Chapter buttons).
3. Fixed an issue with the original PR where a binding was accidentally removed, causing Music Mode to crash.
4. Added/Changed some constraints to clean up warnings in Interface Builder.
5. Re-ordered XML elements so that order of views listed from top to bottom in Interface Builder matches the position in which they appear in the UI from top to bottom. (IB makes some assumptions based on their order in the XML, so it is important to keep the topmost elements listed before the lower elements to keep it from getting confused).