### PR TITLE
Fix the Advanced Settings Aren't Searchable, #4512

### DIFF
--- a/iina/Base.lproj/PrefAdvancedViewController.xib
+++ b/iina/Base.lproj/PrefAdvancedViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -24,6 +24,15 @@
             <rect key="frame" x="0.0" y="0.0" width="480" height="52"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
+                <textField identifier="SectionTitleTop" hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" id="ySI-Io-yr8" userLabel="Top">
+                    <rect key="frame" x="211" y="18" width="57" height="16"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Top" id="Qeu-Jp-bNP">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="M2l-at-Cbp">
                     <rect key="frame" x="0.0" y="0.0" width="336" height="14"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="The following settings will require restarting IINA to take effect." id="HMa-Vz-EUk">
@@ -69,8 +78,17 @@
             <rect key="frame" x="0.0" y="0.0" width="480" height="99"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="shz-CZ-kqM">
-                    <rect key="frame" x="140" y="1" width="148" height="32"/>
+                <textField identifier="SectionTitleLogging" hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" id="JVL-Sw-TcX" userLabel="Logging">
+                    <rect key="frame" x="211" y="42" width="57" height="16"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Logging" id="BK9-mL-ip5">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <button identifier="FunctionalButtonLogDirectory" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="shz-CZ-kqM">
+                    <rect key="frame" x="139" y="1" width="147" height="32"/>
                     <buttonCell key="cell" type="push" title="Open log directory" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="JDA-g3-RNX">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -80,7 +98,7 @@
                         <binding destination="nyg-fH-Pug" name="enabled" keyPath="values.enableAdvancedSettings" id="CH7-kE-1sm"/>
                     </connections>
                 </button>
-                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="XBa-zS-RVU">
+                <button identifier="FunctionalButtonShowLog" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="XBa-zS-RVU">
                     <rect key="frame" x="-6" y="1" width="148" height="32"/>
                     <buttonCell key="cell" type="push" title="Show log viewer" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Owx-92-Ogg">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>

--- a/iina/Base.lproj/PrefAdvancedViewController.xib
+++ b/iina/Base.lproj/PrefAdvancedViewController.xib
@@ -51,7 +51,7 @@
                         <action selector="helpBtnAction:" target="-2" id="G8C-1V-IMW"/>
                     </connections>
                 </button>
-                <customView translatesAutoresizingMaskIntoConstraints="NO" id="PCZ-06-pn4" customClass="Switch" customModule="IINA" customModuleProvider="target">
+                <customView identifier="FunctionalButtonEnableAdvanced" translatesAutoresizingMaskIntoConstraints="NO" id="PCZ-06-pn4" customClass="Switch" customModule="IINA" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="18" width="459" height="28"/>
                     <userDefinedRuntimeAttributes>
                         <userDefinedRuntimeAttribute type="boolean" keyPath="switchOnLeft" value="YES"/>

--- a/iina/Base.lproj/PrefKeyBindingViewController.xib
+++ b/iina/Base.lproj/PrefKeyBindingViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -119,7 +119,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KZA-hu-vhZ">
+                <button identifier="FunctionalButtonShowConfig" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KZA-hu-vhZ">
                     <rect key="frame" x="-6" y="1" width="210" height="32"/>
                     <buttonCell key="cell" type="push" title="Show the config file in Finder" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="gDo-JL-a9k">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -365,7 +365,7 @@
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="AuR-Lj-Iz4">
+                <button identifier="FunctionalButtonImportConfig" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="AuR-Lj-Iz4">
                     <rect key="frame" x="202" y="1" width="206" height="32"/>
                     <buttonCell key="cell" type="push" title="Import an existing config file" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="6cO-C0-33g">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>

--- a/iina/Base.lproj/PrefKeyBindingViewController.xib
+++ b/iina/Base.lproj/PrefKeyBindingViewController.xib
@@ -33,7 +33,7 @@
                     <constraints>
                         <constraint firstAttribute="height" constant="14" id="lOm-I3-MpB"/>
                     </constraints>
-                    <buttonCell key="cell" type="check" title="Use media keys" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="2WY-CR-baD">
+                    <buttonCell key="cell" type="check" title="Use system media control" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="2WY-CR-baD">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>

--- a/iina/Base.lproj/PrefUtilsViewController.xib
+++ b/iina/Base.lproj/PrefUtilsViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -40,7 +40,7 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9bz-Mj-bPf">
+                <button identifier="FunctionalButtonDefaultApp" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9bz-Mj-bPf">
                     <rect key="frame" x="-6" y="1" width="254" height="32"/>
                     <buttonCell key="cell" type="push" title="Set IINA as the Default Application…" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="e1p-Aa-WFG">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>

--- a/iina/PrefPluginViewController.xib
+++ b/iina/PrefPluginViewController.xib
@@ -44,6 +44,15 @@
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY" userLabel="Prefs &gt; Plugins View">
             <rect key="frame" x="0.0" y="0.0" width="480" height="545"/>
             <subviews>
+                <textField identifier="SectionTitlePlugins" hidden="YES" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" id="bIU-VC-U2r" userLabel="Plugins">
+                    <rect key="frame" x="211" y="265" width="57" height="16"/>
+                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Plugins" id="uW4-Bs-Wg3">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
                 <scrollView autohidesScrollers="YES" horizontalLineScroll="38" horizontalPageScroll="10" verticalLineScroll="38" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZZO-wR-pQN">
                     <rect key="frame" x="0.0" y="8" width="160" height="400"/>
                     <clipView key="contentView" id="MLE-fd-V2n">
@@ -157,7 +166,7 @@
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kmI-AD-0GL">
+                                    <button identifier="FunctionalButtonUninstallPlugin" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kmI-AD-0GL">
                                         <rect key="frame" x="238" y="368" width="60" height="17"/>
                                         <buttonCell key="cell" type="roundRect" title="Uninstall" bezelStyle="roundedRect" alignment="center" controlSize="small" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ue8-hU-kLm">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -454,7 +463,7 @@
                                             <action selector="tabSwitched:" target="-2" id="kXO-mk-C1a"/>
                                         </connections>
                                     </segmentedControl>
-                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sl8-zI-7f5">
+                                    <button identifier="FunctionalButtonShowPlugin" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="sl8-zI-7f5">
                                         <rect key="frame" x="138" y="368" width="92" height="17"/>
                                         <buttonCell key="cell" type="roundRect" title="Show in Finder" bezelStyle="roundedRect" alignment="center" controlSize="small" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="drh-6w-3z1">
                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -533,7 +542,7 @@
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DbD-Cu-uoz">
+                <button identifier="FunctionalButtonInstallGitHub" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="DbD-Cu-uoz">
                     <rect key="frame" x="-7" y="454" width="159" height="32"/>
                     <buttonCell key="cell" type="push" title="Install from GitHub..." bezelStyle="rounded" alignment="center" lineBreakMode="truncatingTail" state="on" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="enP-C1-4vu">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -554,7 +563,7 @@
                 <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="q8W-0n-Rem">
                     <rect key="frame" x="0.0" y="442" width="480" height="5"/>
                 </box>
-                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="K9h-qs-0tJ">
+                <button identifier="FunctionalButtonInstallLocal" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="K9h-qs-0tJ">
                     <rect key="frame" x="150" y="454" width="210" height="32"/>
                     <buttonCell key="cell" type="push" title="Install from a local package…" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="sdU-FG-dTO">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>

--- a/iina/PreferenceWindowController.swift
+++ b/iina/PreferenceWindowController.swift
@@ -189,7 +189,7 @@ class PreferenceWindowController: NSWindowController {
       ["utilities", "PrefUtilsViewController"],
     ]
     if IINA_ENABLE_PLUGIN_SYSTEM {
-      viewMap.insert(["plugin", "PrefPluginViewController"], at: 8)
+      viewMap.insert(["plugins", "PrefPluginViewController"], at: 8)
     }
     let labelDict = [String: [String: [String]]](
       uniqueKeysWithValues: viewMap.map { (NSLocalizedString("preference.\($0[0])", comment: ""), self.getLabelDict(inNibNamed: $0[1])) })
@@ -348,7 +348,7 @@ class PreferenceWindowController: NSWindowController {
 
   private func getTitle(from view: NSView) -> String? {
     if let label = view as? NSTextField,
-      !label.isEditable, label.textColor == .labelColor,
+      !label.isEditable, label.textColor == .labelColor, label.stringValue != "Label",
       !label.identifierStartsWith("AccessoryLabel"), !label.identifierStartsWith("Trigger") {
       return formSearchTerm(label.stringValue)
     } else if let button = view as? NSButton,

--- a/iina/PreferenceWindowController.swift
+++ b/iina/PreferenceWindowController.swift
@@ -10,10 +10,13 @@ import Cocoa
 
 fileprivate extension String {
   func removedLastSemicolon() -> String {
-    if self.hasSuffix(":") || self.hasSuffix("：") {
-      return String(self.dropLast())
-    }
+    let trimed = trimWhitespaceSuffix()
+    guard !trimed.hasSuffix(":") else { return String(trimed.dropLast()) }
     return self
+  }
+
+  func trimWhitespaceSuffix() -> String {
+    self.replacingOccurrences(of: "\\s+$", with: "", options: .regularExpression)
   }
 }
 
@@ -227,7 +230,7 @@ class PreferenceWindowController: NSWindowController {
 
   @IBAction func searchFieldAction(_ sender: Any) {
     guard !isIndexing else { return }
-    let searchString = searchField.stringValue.lowercased()
+    let searchString = searchField.stringValue.lowercased().trimWhitespaceSuffix().removedLastSemicolon()
     if searchString == lastString { return }
     if searchString.count == 0 {
       dismissCompletionList()
@@ -328,7 +331,7 @@ class PreferenceWindowController: NSWindowController {
   ///
   /// The UI labels and titles contain extraneous characters that must be removed for them to be used as a search term.
   /// - Parameter string: The string to turn into a search term.
-  /// - Returns: The given string with extraneous character removed.
+  /// - Returns: The given string with extraneous characters removed.
   private func formSearchTerm(_ string: String) -> String {
     string.trimmingCharacters(in: .whitespacesAndNewlines)
       .replacingOccurrences(of: "[:…()\"\n]", with: "", options: .regularExpression)

--- a/iina/en.lproj/PrefGeneralViewController.strings
+++ b/iina/en.lproj/PrefGeneralViewController.strings
@@ -123,7 +123,7 @@
 "jeK-46-2BG.title" = "History:";
 
 /* Class = "NSButtonCell"; title = "Show artist and track name for audio files when avaliable"; ObjectID = "kBI-Th-bBV"; */
-"kBI-Th-bBV.title" = "Show artist and track name for audio files when avaliable";
+"kBI-Th-bBV.title" = "Show artist and track name for audio files when available";
 
 /* Class = "NSButtonCell"; title = "Play upon entering full screen"; ObjectID = "lOw-pu-Llm"; */
 "lOw-pu-Llm.title" = "Play upon entering full screen";

--- a/iina/en.lproj/PrefGeneralViewController.strings
+++ b/iina/en.lproj/PrefGeneralViewController.strings
@@ -122,7 +122,7 @@
 /* Class = "NSTextFieldCell"; title = "History:"; ObjectID = "jeK-46-2BG"; */
 "jeK-46-2BG.title" = "History:";
 
-/* Class = "NSButtonCell"; title = "Show artist and track name for audio files when avaliable"; ObjectID = "kBI-Th-bBV"; */
+/* Class = "NSButtonCell"; title = "Show artist and track name for audio files when available"; ObjectID = "kBI-Th-bBV"; */
 "kBI-Th-bBV.title" = "Show artist and track name for audio files when available";
 
 /* Class = "NSButtonCell"; title = "Play upon entering full screen"; ObjectID = "lOw-pu-Llm"; */

--- a/iina/en.lproj/PrefKeyBindingViewController.strings
+++ b/iina/en.lproj/PrefKeyBindingViewController.strings
@@ -1,5 +1,5 @@
 /* Class = "NSButtonCell"; title = "Use media keys"; ObjectID = "2WY-CR-baD"; */
-"2WY-CR-baD.title" = "Use media keys";
+"2WY-CR-baD.title" = "Use system media control";
 
 /* Class = "NSButtonCell"; title = "Display raw values"; ObjectID = "3RK-1k-otl"; */
 "3RK-1k-otl.title" = "Display raw values";

--- a/iina/en.lproj/PrefKeyBindingViewController.strings
+++ b/iina/en.lproj/PrefKeyBindingViewController.strings
@@ -1,4 +1,4 @@
-/* Class = "NSButtonCell"; title = "Use media keys"; ObjectID = "2WY-CR-baD"; */
+/* Class = "NSButtonCell"; title = "Use system media control"; ObjectID = "2WY-CR-baD"; */
 "2WY-CR-baD.title" = "Use system media control";
 
 /* Class = "NSButtonCell"; title = "Display raw values"; ObjectID = "3RK-1k-otl"; */


### PR DESCRIPTION
This commit will:
- Add `SectionTitleTop` hidden label to `Advanced` tab
- Add `SectionTitleLogging` hidden label to `Advanced` tab
- Add `FunctionalButtonShowLog` identifier to `Show log viewer` button on  `Advanced` tab
- Add `FunctionalButtonLogDirectory`  identifier to `Open log directory` button on  `Advanced` tab
- Add `FunctionalButtonShowConfig` identifier to `Show the config file in Finder` button on `Key Bindings` tab
- Add `FunctionalButtonImportConfig` identifier to `Import an existing config file` button on `Key Bindings` tab
- Add `FunctionalButtonDefaultApp` identifier to `Set IINA as the Default Application…` button on `Utilities` tab
- Add `formSearchTerm` method to `PreferenceWindowController` that removes extraneous characters from labels and titles
- Correct the spelling of available on `General` tab
- Change `Use media keys` to be  `Use system media control` to match UI
- Add a `logLabelDict` method to `PreferenceWindowController` that logs the search terms found by scanning NIBs

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4512.

---

**Description:**
