### PR TITLE
Inspector window: allow Watch table column resizing + clean & polish layout

### DIFF
--- a/iina/Base.lproj/InspectorWindowController.xib
+++ b/iina/Base.lproj/InspectorWindowController.xib
@@ -1086,7 +1086,7 @@
                                                         <rect key="frame" x="0.0" y="0.0" width="420" height="201"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <subviews>
-                                                            <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" multipleSelection="NO" typeSelect="NO" autosaveName="InspectorWatchTable" rowSizeStyle="automatic" headerView="pnK-fx-7et" viewBased="YES" floatsGroupRows="NO" id="oUp-DO-OKl" userLabel="WatchTable Table View">
+                                                            <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" typeSelect="NO" autosaveName="InspectorWatchTable" rowSizeStyle="automatic" headerView="pnK-fx-7et" viewBased="YES" floatsGroupRows="NO" id="oUp-DO-OKl" userLabel="WatchTable Table View">
                                                                 <rect key="frame" x="0.0" y="0.0" width="420" height="173"/>
                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                 <size key="intercellSpacing" width="0.0" height="2"/>

--- a/iina/Base.lproj/InspectorWindowController.xib
+++ b/iina/Base.lproj/InspectorWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="20037" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="20037"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21701"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -63,246 +63,93 @@
         <window title="Inspector" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hidesOnDeactivate="YES" releasedWhenClosed="NO" frameAutosaveName="IINAInspectorPanel" animationBehavior="default" id="F0z-JX-Cv5" customClass="NSPanel">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" utility="YES" HUD="YES"/>
             <rect key="contentRect" x="1539" y="436" width="350" height="430"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1728" height="1079"/>
-            <view key="contentView" id="se5-gp-TjO">
-                <rect key="frame" x="0.0" y="0.0" width="350" height="476"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2056" height="1285"/>
+            <view key="contentView" id="se5-gp-TjO" userLabel="InspectorWindow Content View">
+                <rect key="frame" x="0.0" y="0.0" width="350" height="485"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <tabView drawsBackground="NO" controlSize="small" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="wHY-jo-uW0">
-                        <rect key="frame" x="12" y="12" width="326" height="428"/>
+                        <rect key="frame" x="12" y="12" width="326" height="437"/>
                         <tabViewItems>
                             <tabViewItem label="General" identifier="1" id="f7a-XG-NCc">
                                 <view key="view" id="mRY-yK-FeT">
-                                    <rect key="frame" x="0.0" y="0.0" width="326" height="428"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="326" height="437"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="I9X-Rp-scA">
-                                            <rect key="frame" x="10" y="404" width="44" height="16"/>
+                                            <rect key="frame" x="10" y="413" width="44" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="VIDEO" id="gDG-Eq-1Bc">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hBf-Sx-lbf">
-                                            <rect key="frame" x="92" y="376" width="224" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Format Label" id="c6m-YO-xqZ">
-                                                <font key="font" usesAppearanceFont="YES"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Hmg-bS-UMv">
-                                            <rect key="frame" x="92" y="222" width="224" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Size Label" id="rcA-a7-rVn">
-                                                <font key="font" usesAppearanceFont="YES"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4PF-1d-gZO">
-                                            <rect key="frame" x="92" y="200" width="224" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="BR1 Label" id="Aes-4j-UT6">
-                                                <font key="font" usesAppearanceFont="YES"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="a3w-YC-7oN">
-                                            <rect key="frame" x="92" y="109" width="224" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Format Label" id="cwF-5C-5nd">
-                                                <font key="font" usesAppearanceFont="YES"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="GaY-iG-tAy">
-                                            <rect key="frame" x="92" y="87" width="224" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Codec Label" id="etG-FX-Rzo">
-                                                <font key="font" usesAppearanceFont="YES"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="L3Y-pD-V9R">
-                                            <rect key="frame" x="92" y="43" width="224" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Channels Label" id="6mx-wH-SBP">
-                                                <font key="font" usesAppearanceFont="YES"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="S6Z-fT-kcG">
-                                            <rect key="frame" x="92" y="21" width="224" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="BR2 Label" id="4Ph-yc-lsv">
-                                                <font key="font" usesAppearanceFont="YES"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aGE-iz-M2h">
-                                            <rect key="frame" x="10" y="378" width="78" height="14"/>
-                                            <constraints>
-                                                <constraint firstAttribute="width" constant="74" id="ciu-up-5ds"/>
-                                            </constraints>
+                                            <rect key="frame" x="10" y="387" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Format:" id="PQD-yB-mm6">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="6EL-aj-Hjq">
-                                            <rect key="frame" x="10" y="110" width="78" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Format:" id="5H6-qJ-RDS">
-                                                <font key="font" metaFont="smallSystemBold"/>
+                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hBf-Sx-lbf">
+                                            <rect key="frame" x="94" y="387" width="222" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="c6m-YO-xqZ">
+                                                <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FwA-X7-Alr">
-                                            <rect key="frame" x="10" y="356" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="365" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Codec:" id="bki-sE-xCA">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Zp5-es-UTa">
-                                            <rect key="frame" x="10" y="88" width="78" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Codec:" id="n0s-eM-42w">
-                                                <font key="font" metaFont="smallSystemBold"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gxW-1z-Af9">
-                                            <rect key="frame" x="10" y="224" width="78" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Size:" id="f2P-qb-wRx">
-                                                <font key="font" metaFont="smallSystemBold"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EiP-Mu-9cf">
-                                            <rect key="frame" x="10" y="44" width="78" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Channels:" id="it3-05-Pwu">
-                                                <font key="font" metaFont="smallSystemBold"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="apr-sq-JIb">
-                                            <rect key="frame" x="10" y="22" width="78" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Bit Rate:" id="A4y-LL-x0z">
-                                                <font key="font" metaFont="smallSystemBold"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Qke-bh-4oG">
-                                            <rect key="frame" x="10" y="202" width="78" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Bit Rate:" id="jyV-Pd-UvH">
-                                                <font key="font" metaFont="smallSystemBold"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ira-RI-5kc">
-                                            <rect key="frame" x="92" y="333" width="224" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="HwD Label" id="iMk-qU-kVv">
+                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="6sj-bN-LIv">
+                                            <rect key="frame" x="94" y="365" width="222" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" id="SzU-uF-10g">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="z1d-SG-OZB">
-                                            <rect key="frame" x="10" y="334" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="343" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Hw Decoder:" id="DHh-ne-10f">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ldf-jT-tdl">
-                                            <rect key="frame" x="10" y="246" width="78" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Driver:" id="I2E-6Z-Gnn">
-                                                <font key="font" metaFont="smallSystemBold"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="GSF-Y5-FGJ">
-                                            <rect key="frame" x="10" y="66" width="78" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Driver:" id="MME-KZ-jrG">
-                                                <font key="font" metaFont="smallSystemBold"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5yU-sy-R0n">
-                                            <rect key="frame" x="92" y="244" width="224" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Driver Label" id="3bw-Kl-SeY">
-                                                <font key="font" usesAppearanceFont="YES"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="IXe-pS-a3x">
-                                            <rect key="frame" x="12" y="162" width="302" height="5"/>
-                                        </box>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hGO-dV-reB">
-                                            <rect key="frame" x="10" y="136" width="45" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="AUDIO" id="nrG-IH-kFg">
-                                                <font key="font" usesAppearanceFont="YES"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="v4j-fa-olc">
-                                            <rect key="frame" x="92" y="65" width="224" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Driver Label" id="MTG-ez-V2R">
-                                                <font key="font" usesAppearanceFont="YES"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Nn4-TP-Hpd">
-                                            <rect key="frame" x="10" y="0.0" width="78" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Sample Rate:" id="llF-4b-Z8b">
-                                                <font key="font" metaFont="smallSystemBold"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="c90-dT-hDG">
-                                            <rect key="frame" x="92" y="178" width="224" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="FPS Label" id="ZIA-g4-WqZ">
+                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ira-RI-5kc">
+                                            <rect key="frame" x="94" y="343" width="222" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="iMk-qU-kVv">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Xol-2r-g7u">
-                                            <rect key="frame" x="10" y="312" width="75" height="14"/>
-                                            <constraints>
-                                                <constraint firstAttribute="width" constant="71" id="ULh-mH-glh"/>
-                                            </constraints>
+                                            <rect key="frame" x="10" y="321" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Primaries:" id="1kw-LO-KmJ">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dOE-eM-QQi">
-                                            <rect key="frame" x="10" y="180" width="78" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="FPS:" id="7QX-tu-rvs">
-                                                <font key="font" metaFont="smallSystemBold"/>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="s9S-zN-lwA">
+                                            <rect key="frame" x="94" y="321" width="222" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="b34-md-3Dx">
+                                                <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Hm9-gI-9j7">
-                                            <rect key="frame" x="10" y="290" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="299" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Colorspace:" id="mLo-Wc-BoO">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -310,39 +157,15 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wxy-f3-FrW">
-                                            <rect key="frame" x="92" y="289" width="228" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Colorspace Label" id="iMO-Ze-egg">
-                                                <font key="font" usesAppearanceFont="YES"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ghr-q6-WAW">
-                                            <rect key="frame" x="92" y="-1" width="224" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="SampleRate Label" id="4di-sR-tOh">
-                                                <font key="font" usesAppearanceFont="YES"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="6sj-bN-LIv">
-                                            <rect key="frame" x="92" y="355" width="224" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Codec Label" id="SzU-uF-10g">
-                                                <font key="font" usesAppearanceFont="YES"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="s9S-zN-lwA">
-                                            <rect key="frame" x="92" y="311" width="224" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Primaries Label" id="b34-md-3Dx">
+                                            <rect key="frame" x="94" y="299" width="222" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="iMO-Ze-egg">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dyh-2O-q0Y">
-                                            <rect key="frame" x="10" y="268" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="277" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Pixel Format:" id="UrR-u2-hFz">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -350,8 +173,179 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WWd-BJ-GxF">
-                                            <rect key="frame" x="92" y="267" width="228" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Pixel Format Label" id="BsT-Yz-AgP">
+                                            <rect key="frame" x="94" y="277" width="222" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="BsT-Yz-AgP">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ldf-jT-tdl">
+                                            <rect key="frame" x="10" y="255" width="78" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Driver:" id="I2E-6Z-Gnn">
+                                                <font key="font" metaFont="smallSystemBold"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5yU-sy-R0n">
+                                            <rect key="frame" x="94" y="255" width="222" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="3bw-Kl-SeY">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gxW-1z-Af9">
+                                            <rect key="frame" x="10" y="233" width="78" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Size:" id="f2P-qb-wRx">
+                                                <font key="font" metaFont="smallSystemBold"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Hmg-bS-UMv">
+                                            <rect key="frame" x="94" y="233" width="222" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="rcA-a7-rVn">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Qke-bh-4oG">
+                                            <rect key="frame" x="10" y="211" width="78" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Bit Rate:" id="jyV-Pd-UvH">
+                                                <font key="font" metaFont="smallSystemBold"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4PF-1d-gZO">
+                                            <rect key="frame" x="94" y="211" width="222" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="Aes-4j-UT6">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dOE-eM-QQi">
+                                            <rect key="frame" x="10" y="189" width="78" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="FPS:" id="7QX-tu-rvs">
+                                                <font key="font" metaFont="smallSystemBold"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="c90-dT-hDG">
+                                            <rect key="frame" x="94" y="189" width="222" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="ZIA-g4-WqZ">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="IXe-pS-a3x">
+                                            <rect key="frame" x="12" y="174" width="302" height="5"/>
+                                        </box>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hGO-dV-reB">
+                                            <rect key="frame" x="10" y="148" width="45" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="AUDIO" id="nrG-IH-kFg">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="6EL-aj-Hjq">
+                                            <rect key="frame" x="10" y="122" width="78" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Format:" id="5H6-qJ-RDS">
+                                                <font key="font" metaFont="smallSystemBold"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="a3w-YC-7oN">
+                                            <rect key="frame" x="94" y="122" width="222" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="cwF-5C-5nd">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Zp5-es-UTa">
+                                            <rect key="frame" x="10" y="100" width="78" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Codec:" id="n0s-eM-42w">
+                                                <font key="font" metaFont="smallSystemBold"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="GaY-iG-tAy">
+                                            <rect key="frame" x="94" y="100" width="222" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="etG-FX-Rzo">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="GSF-Y5-FGJ">
+                                            <rect key="frame" x="10" y="78" width="78" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Driver:" id="MME-KZ-jrG">
+                                                <font key="font" metaFont="smallSystemBold"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="v4j-fa-olc">
+                                            <rect key="frame" x="94" y="78" width="222" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="MTG-ez-V2R">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EiP-Mu-9cf">
+                                            <rect key="frame" x="10" y="56" width="78" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Channels:" id="it3-05-Pwu">
+                                                <font key="font" metaFont="smallSystemBold"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="L3Y-pD-V9R">
+                                            <rect key="frame" x="94" y="56" width="222" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="6mx-wH-SBP">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="apr-sq-JIb">
+                                            <rect key="frame" x="10" y="34" width="78" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Bit Rate:" id="A4y-LL-x0z">
+                                                <font key="font" metaFont="smallSystemBold"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="S6Z-fT-kcG">
+                                            <rect key="frame" x="94" y="34" width="222" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="4Ph-yc-lsv">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Nn4-TP-Hpd">
+                                            <rect key="frame" x="10" y="12" width="78" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Sample Rate:" id="llF-4b-Z8b">
+                                                <font key="font" metaFont="smallSystemBold"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ghr-q6-WAW">
+                                            <rect key="frame" x="94" y="12" width="222" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="4di-sR-tOh">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -359,52 +353,46 @@
                                         </textField>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstItem="s9S-zN-lwA" firstAttribute="leading" secondItem="Xol-2r-g7u" secondAttribute="trailing" constant="11" id="1vt-IH-Iya"/>
-                                        <constraint firstItem="S6Z-fT-kcG" firstAttribute="centerY" secondItem="apr-sq-JIb" secondAttribute="centerY" id="2Oo-I6-UOA"/>
                                         <constraint firstItem="Ldf-jT-tdl" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="2hf-ZX-KTv"/>
-                                        <constraint firstItem="a3w-YC-7oN" firstAttribute="leading" secondItem="6EL-aj-Hjq" secondAttribute="trailing" constant="8" id="2sg-ag-cr5"/>
                                         <constraint firstItem="I9X-Rp-scA" firstAttribute="top" secondItem="mRY-yK-FeT" secondAttribute="top" constant="8" id="3Kz-P5-r1d"/>
-                                        <constraint firstItem="Ira-RI-5kc" firstAttribute="leading" secondItem="z1d-SG-OZB" secondAttribute="trailing" constant="8" id="4bA-8N-DF7"/>
-                                        <constraint firstItem="6sj-bN-LIv" firstAttribute="leading" secondItem="FwA-X7-Alr" secondAttribute="trailing" constant="8" id="4mV-f5-Pah"/>
-                                        <constraint firstItem="Zp5-es-UTa" firstAttribute="width" secondItem="6EL-aj-Hjq" secondAttribute="width" id="6AO-Ke-cUQ"/>
-                                        <constraint firstItem="GSF-Y5-FGJ" firstAttribute="top" secondItem="Zp5-es-UTa" secondAttribute="bottom" constant="8" id="6BA-AD-lOL"/>
-                                        <constraint firstItem="v4j-fa-olc" firstAttribute="centerY" secondItem="GSF-Y5-FGJ" secondAttribute="centerY" id="7WF-b9-IRe"/>
+                                        <constraint firstItem="v4j-fa-olc" firstAttribute="firstBaseline" secondItem="GSF-Y5-FGJ" secondAttribute="firstBaseline" id="4kN-Ti-nOj"/>
+                                        <constraint firstItem="GSF-Y5-FGJ" firstAttribute="top" secondItem="Zp5-es-UTa" secondAttribute="bottom" constant="8" symbolic="YES" id="6BA-AD-lOL"/>
+                                        <constraint firstItem="FwA-X7-Alr" firstAttribute="trailing" secondItem="aGE-iz-M2h" secondAttribute="trailing" id="8N3-t8-as8"/>
                                         <constraint firstAttribute="trailing" secondItem="v4j-fa-olc" secondAttribute="trailing" constant="12" id="8Tf-Ky-7WP"/>
-                                        <constraint firstItem="6sj-bN-LIv" firstAttribute="centerY" secondItem="FwA-X7-Alr" secondAttribute="centerY" id="8ax-Nq-2MU"/>
                                         <constraint firstItem="GSF-Y5-FGJ" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="leading" id="9UE-9C-GAq"/>
-                                        <constraint firstItem="dyh-2O-q0Y" firstAttribute="top" secondItem="Hm9-gI-9j7" secondAttribute="bottom" constant="8" id="9en-Dh-zLJ"/>
-                                        <constraint firstItem="Hm9-gI-9j7" firstAttribute="top" secondItem="Xol-2r-g7u" secondAttribute="bottom" constant="8" id="AWt-7R-ZTa"/>
-                                        <constraint firstItem="EiP-Mu-9cf" firstAttribute="width" secondItem="6EL-aj-Hjq" secondAttribute="width" id="B7U-fB-UtT"/>
+                                        <constraint firstItem="dyh-2O-q0Y" firstAttribute="top" secondItem="Hm9-gI-9j7" secondAttribute="bottom" constant="8" symbolic="YES" id="9en-Dh-zLJ"/>
+                                        <constraint firstItem="Hm9-gI-9j7" firstAttribute="top" secondItem="Xol-2r-g7u" secondAttribute="bottom" constant="8" symbolic="YES" id="AWt-7R-ZTa"/>
                                         <constraint firstItem="aGE-iz-M2h" firstAttribute="top" secondItem="I9X-Rp-scA" secondAttribute="bottom" constant="12" id="BeU-Ai-D6V"/>
-                                        <constraint firstItem="4PF-1d-gZO" firstAttribute="top" secondItem="Qke-bh-4oG" secondAttribute="top" id="Bk1-vV-0Tx"/>
-                                        <constraint firstItem="EiP-Mu-9cf" firstAttribute="top" secondItem="GSF-Y5-FGJ" secondAttribute="bottom" constant="8" id="CUV-7x-VlA"/>
+                                        <constraint firstItem="EiP-Mu-9cf" firstAttribute="top" secondItem="GSF-Y5-FGJ" secondAttribute="bottom" constant="8" symbolic="YES" id="CUV-7x-VlA"/>
                                         <constraint firstItem="IXe-pS-a3x" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="Cac-kJ-o6N"/>
                                         <constraint firstItem="hGO-dV-reB" firstAttribute="top" secondItem="IXe-pS-a3x" secondAttribute="bottom" constant="12" id="Cwm-iG-Pfx"/>
-                                        <constraint firstItem="v4j-fa-olc" firstAttribute="leading" secondItem="GSF-Y5-FGJ" secondAttribute="trailing" constant="8" id="Dyx-ec-SEg"/>
                                         <constraint firstItem="apr-sq-JIb" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="EDW-pS-WKA"/>
-                                        <constraint firstItem="GaY-iG-tAy" firstAttribute="centerY" secondItem="Zp5-es-UTa" secondAttribute="centerY" id="EIV-rr-gPU"/>
+                                        <constraint firstItem="c90-dT-hDG" firstAttribute="firstBaseline" secondItem="dOE-eM-QQi" secondAttribute="firstBaseline" id="F9s-do-74K"/>
                                         <constraint firstAttribute="trailing" secondItem="Ghr-q6-WAW" secondAttribute="trailing" constant="12" id="FUu-xZ-5Xl"/>
                                         <constraint firstItem="Zp5-es-UTa" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="leading" id="FWX-bw-bIH"/>
-                                        <constraint firstItem="Nn4-TP-Hpd" firstAttribute="top" secondItem="apr-sq-JIb" secondAttribute="bottom" constant="8" id="GBu-9s-Fr1"/>
+                                        <constraint firstItem="Hmg-bS-UMv" firstAttribute="firstBaseline" secondItem="gxW-1z-Af9" secondAttribute="firstBaseline" id="Fig-UD-p78"/>
+                                        <constraint firstItem="Nn4-TP-Hpd" firstAttribute="top" secondItem="apr-sq-JIb" secondAttribute="bottom" constant="8" symbolic="YES" id="GBu-9s-Fr1"/>
                                         <constraint firstItem="gxW-1z-Af9" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="leading" id="GQ9-zo-mEU"/>
+                                        <constraint firstItem="Ira-RI-5kc" firstAttribute="firstBaseline" secondItem="z1d-SG-OZB" secondAttribute="firstBaseline" id="Guf-DJ-CDB"/>
                                         <constraint firstAttribute="trailing" secondItem="hBf-Sx-lbf" secondAttribute="trailing" constant="12" id="Hb2-Jx-92q"/>
                                         <constraint firstAttribute="trailing" secondItem="s9S-zN-lwA" secondAttribute="trailing" constant="12" id="IGE-Cy-hnw"/>
                                         <constraint firstItem="6EL-aj-Hjq" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="IVp-gv-R6l"/>
-                                        <constraint firstItem="dOE-eM-QQi" firstAttribute="top" secondItem="Qke-bh-4oG" secondAttribute="bottom" constant="8" id="IeA-aF-B4p"/>
+                                        <constraint firstItem="dOE-eM-QQi" firstAttribute="top" secondItem="Qke-bh-4oG" secondAttribute="bottom" constant="8" symbolic="YES" id="IeA-aF-B4p"/>
                                         <constraint firstItem="S6Z-fT-kcG" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="JCa-Tx-DnU"/>
                                         <constraint firstAttribute="trailing" secondItem="5yU-sy-R0n" secondAttribute="trailing" constant="12" id="JQ0-Sh-UIg"/>
-                                        <constraint firstItem="5yU-sy-R0n" firstAttribute="leading" secondItem="Ldf-jT-tdl" secondAttribute="trailing" constant="8" id="JvH-4D-ruB"/>
+                                        <constraint firstItem="gxW-1z-Af9" firstAttribute="trailing" secondItem="aGE-iz-M2h" secondAttribute="trailing" id="JWY-Sr-coc"/>
                                         <constraint firstAttribute="trailing" secondItem="IXe-pS-a3x" secondAttribute="trailing" constant="12" id="KBV-cz-iXk"/>
                                         <constraint firstItem="dOE-eM-QQi" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="Kjz-Mb-fWY"/>
                                         <constraint firstItem="FwA-X7-Alr" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="KsH-MB-nUa"/>
-                                        <constraint firstItem="wxy-f3-FrW" firstAttribute="centerY" secondItem="Hm9-gI-9j7" secondAttribute="centerY" id="MDM-cn-OsR"/>
-                                        <constraint firstItem="S6Z-fT-kcG" firstAttribute="leading" secondItem="apr-sq-JIb" secondAttribute="trailing" constant="8" id="MDj-Eu-KPY"/>
-                                        <constraint firstItem="L3Y-pD-V9R" firstAttribute="leading" secondItem="EiP-Mu-9cf" secondAttribute="trailing" constant="8" id="NNT-Uy-giv"/>
                                         <constraint firstItem="L3Y-pD-V9R" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="Ncn-iQ-S8E"/>
                                         <constraint firstItem="EiP-Mu-9cf" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="O08-wB-hSa"/>
+                                        <constraint firstItem="4PF-1d-gZO" firstAttribute="firstBaseline" secondItem="Qke-bh-4oG" secondAttribute="firstBaseline" id="O6R-iL-i7y"/>
                                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="I9X-Rp-scA" secondAttribute="trailing" constant="20" symbolic="YES" id="PSJ-nK-rFv"/>
-                                        <constraint firstItem="Xol-2r-g7u" firstAttribute="top" secondItem="z1d-SG-OZB" secondAttribute="bottom" constant="8" id="Q7j-tD-FPY"/>
-                                        <constraint firstAttribute="trailing" secondItem="WWd-BJ-GxF" secondAttribute="trailing" constant="8" id="QXi-hD-VTS"/>
+                                        <constraint firstItem="6EL-aj-Hjq" firstAttribute="trailing" secondItem="aGE-iz-M2h" secondAttribute="trailing" id="PTg-uH-5kk"/>
+                                        <constraint firstItem="Xol-2r-g7u" firstAttribute="trailing" secondItem="aGE-iz-M2h" secondAttribute="trailing" id="PmS-ee-KFS"/>
+                                        <constraint firstItem="Hm9-gI-9j7" firstAttribute="trailing" secondItem="aGE-iz-M2h" secondAttribute="trailing" id="Q43-vx-Px8"/>
+                                        <constraint firstItem="Xol-2r-g7u" firstAttribute="top" secondItem="z1d-SG-OZB" secondAttribute="bottom" constant="8" symbolic="YES" id="Q7j-tD-FPY"/>
+                                        <constraint firstAttribute="trailing" secondItem="WWd-BJ-GxF" secondAttribute="trailing" constant="12" id="QXi-hD-VTS"/>
                                         <constraint firstItem="Nn4-TP-Hpd" firstAttribute="leading" secondItem="apr-sq-JIb" secondAttribute="leading" id="QYI-0x-rCQ"/>
                                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="hGO-dV-reB" secondAttribute="trailing" constant="20" symbolic="YES" id="QwD-zL-Ztq"/>
                                         <constraint firstItem="6EL-aj-Hjq" firstAttribute="top" secondItem="hGO-dV-reB" secondAttribute="bottom" constant="12" id="RSl-a2-Yuc"/>
@@ -412,82 +400,76 @@
                                         <constraint firstAttribute="trailing" secondItem="S6Z-fT-kcG" secondAttribute="trailing" constant="12" id="Ryg-im-8s1"/>
                                         <constraint firstItem="GaY-iG-tAy" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="Sj5-Vc-ro8"/>
                                         <constraint firstItem="Hm9-gI-9j7" firstAttribute="leading" secondItem="Ldf-jT-tdl" secondAttribute="leading" id="UBG-1H-tXQ"/>
-                                        <constraint firstItem="WWd-BJ-GxF" firstAttribute="centerY" secondItem="dyh-2O-q0Y" secondAttribute="centerY" id="UMW-Lu-GG7"/>
-                                        <constraint firstItem="GaY-iG-tAy" firstAttribute="leading" secondItem="Zp5-es-UTa" secondAttribute="trailing" constant="8" id="Vaf-by-Sni"/>
-                                        <constraint firstItem="IXe-pS-a3x" firstAttribute="top" secondItem="dOE-eM-QQi" secondAttribute="bottom" constant="15" id="VoV-xO-OWt"/>
+                                        <constraint firstItem="dOE-eM-QQi" firstAttribute="trailing" secondItem="aGE-iz-M2h" secondAttribute="trailing" id="UuL-Jm-iVi"/>
+                                        <constraint firstItem="Nn4-TP-Hpd" firstAttribute="trailing" secondItem="aGE-iz-M2h" secondAttribute="trailing" id="V2p-SR-zUk"/>
+                                        <constraint firstItem="S6Z-fT-kcG" firstAttribute="firstBaseline" secondItem="apr-sq-JIb" secondAttribute="firstBaseline" id="Vcv-QI-WRx"/>
+                                        <constraint firstItem="IXe-pS-a3x" firstAttribute="top" secondItem="dOE-eM-QQi" secondAttribute="bottom" constant="12" id="VoV-xO-OWt"/>
                                         <constraint firstItem="Hm9-gI-9j7" firstAttribute="leading" secondItem="Xol-2r-g7u" secondAttribute="leading" id="VvP-S8-Obo"/>
-                                        <constraint firstItem="6EL-aj-Hjq" firstAttribute="width" secondItem="aGE-iz-M2h" secondAttribute="width" id="WYv-xd-gGz"/>
                                         <constraint firstItem="a3w-YC-7oN" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="Wb3-tr-ceH"/>
                                         <constraint firstItem="gxW-1z-Af9" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="WgR-Zu-MYa"/>
-                                        <constraint firstItem="WWd-BJ-GxF" firstAttribute="leading" secondItem="dyh-2O-q0Y" secondAttribute="trailing" constant="8" symbolic="YES" id="Wik-Qn-a7H"/>
-                                        <constraint firstItem="GSF-Y5-FGJ" firstAttribute="width" secondItem="6EL-aj-Hjq" secondAttribute="width" id="Wl4-bL-h7a"/>
                                         <constraint firstItem="Zp5-es-UTa" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="Wu6-X4-E6P"/>
-                                        <constraint firstItem="FwA-X7-Alr" firstAttribute="width" secondItem="aGE-iz-M2h" secondAttribute="width" id="WwN-iG-RWR"/>
-                                        <constraint firstItem="Ghr-q6-WAW" firstAttribute="centerY" secondItem="Nn4-TP-Hpd" secondAttribute="centerY" id="XL9-9Q-I2k"/>
-                                        <constraint firstItem="apr-sq-JIb" firstAttribute="width" secondItem="6EL-aj-Hjq" secondAttribute="width" id="XcZ-hG-1xl"/>
                                         <constraint firstAttribute="trailing" secondItem="Ira-RI-5kc" secondAttribute="trailing" constant="12" id="Xu9-fa-hY9"/>
                                         <constraint firstItem="4PF-1d-gZO" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="Y12-qn-U8K"/>
                                         <constraint firstItem="dOE-eM-QQi" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="leading" id="Z1d-20-yCO"/>
-                                        <constraint firstItem="Xol-2r-g7u" firstAttribute="centerY" secondItem="s9S-zN-lwA" secondAttribute="centerY" id="ZI2-Cn-1bS"/>
                                         <constraint firstItem="Nn4-TP-Hpd" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="leading" id="a0B-Ou-PQK"/>
-                                        <constraint firstItem="Zp5-es-UTa" firstAttribute="top" secondItem="6EL-aj-Hjq" secondAttribute="bottom" constant="8" id="a2v-4n-GuM"/>
-                                        <constraint firstItem="dOE-eM-QQi" firstAttribute="width" secondItem="aGE-iz-M2h" secondAttribute="width" id="aYl-iT-dlL"/>
-                                        <constraint firstItem="c90-dT-hDG" firstAttribute="top" secondItem="dOE-eM-QQi" secondAttribute="top" id="ag4-DH-fga"/>
-                                        <constraint firstItem="gxW-1z-Af9" firstAttribute="width" secondItem="aGE-iz-M2h" secondAttribute="width" id="akY-wD-ybQ"/>
+                                        <constraint firstItem="Zp5-es-UTa" firstAttribute="top" secondItem="6EL-aj-Hjq" secondAttribute="bottom" constant="8" symbolic="YES" id="a2v-4n-GuM"/>
+                                        <constraint firstItem="dyh-2O-q0Y" firstAttribute="trailing" secondItem="aGE-iz-M2h" secondAttribute="trailing" id="aCh-9N-jzk"/>
                                         <constraint firstItem="Ghr-q6-WAW" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="bQX-25-hTg"/>
-                                        <constraint firstItem="z1d-SG-OZB" firstAttribute="width" secondItem="aGE-iz-M2h" secondAttribute="width" id="cKL-vM-mwO"/>
-                                        <constraint firstItem="Hmg-bS-UMv" firstAttribute="leading" secondItem="gxW-1z-Af9" secondAttribute="trailing" constant="8" id="cfg-sm-rHH"/>
+                                        <constraint firstItem="Qke-bh-4oG" firstAttribute="trailing" secondItem="aGE-iz-M2h" secondAttribute="trailing" id="can-6q-FYg"/>
+                                        <constraint firstItem="Ldf-jT-tdl" firstAttribute="trailing" secondItem="aGE-iz-M2h" secondAttribute="trailing" id="cd6-dH-DMM"/>
+                                        <constraint firstItem="apr-sq-JIb" firstAttribute="trailing" secondItem="aGE-iz-M2h" secondAttribute="trailing" id="cj6-RG-72j"/>
                                         <constraint firstItem="z1d-SG-OZB" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="leading" id="dYK-Xc-OZs"/>
                                         <constraint firstItem="WWd-BJ-GxF" firstAttribute="leading" secondItem="wxy-f3-FrW" secondAttribute="leading" id="db1-bQ-fR4"/>
                                         <constraint firstItem="c90-dT-hDG" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="df8-rX-9EY"/>
-                                        <constraint firstItem="5yU-sy-R0n" firstAttribute="top" secondItem="Ldf-jT-tdl" secondAttribute="top" id="dro-jH-hsY"/>
                                         <constraint firstItem="Hmg-bS-UMv" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="eAg-yb-hsG"/>
                                         <constraint firstAttribute="trailing" secondItem="a3w-YC-7oN" secondAttribute="trailing" constant="12" id="eED-Na-2RZ"/>
-                                        <constraint firstItem="Qke-bh-4oG" firstAttribute="width" secondItem="aGE-iz-M2h" secondAttribute="width" id="ej7-Oa-y3x"/>
+                                        <constraint firstItem="s9S-zN-lwA" firstAttribute="firstBaseline" secondItem="Xol-2r-g7u" secondAttribute="firstBaseline" id="ezd-Vj-9Vz"/>
                                         <constraint firstItem="Ldf-jT-tdl" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="leading" id="fB7-nN-IIT"/>
-                                        <constraint firstItem="Ldf-jT-tdl" firstAttribute="width" secondItem="aGE-iz-M2h" secondAttribute="width" id="fY7-EG-phO"/>
-                                        <constraint firstItem="Ghr-q6-WAW" firstAttribute="leading" secondItem="Nn4-TP-Hpd" secondAttribute="trailing" constant="8" id="foT-Tf-JQv"/>
-                                        <constraint firstItem="z1d-SG-OZB" firstAttribute="top" secondItem="FwA-X7-Alr" secondAttribute="bottom" constant="8" id="gEv-KW-ulc"/>
+                                        <constraint firstItem="WWd-BJ-GxF" firstAttribute="firstBaseline" secondItem="dyh-2O-q0Y" secondAttribute="firstBaseline" id="fUm-O4-q7C"/>
+                                        <constraint firstItem="z1d-SG-OZB" firstAttribute="trailing" secondItem="aGE-iz-M2h" secondAttribute="trailing" id="gBT-IF-VJG"/>
+                                        <constraint firstItem="z1d-SG-OZB" firstAttribute="top" secondItem="FwA-X7-Alr" secondAttribute="bottom" constant="8" symbolic="YES" id="gEv-KW-ulc"/>
                                         <constraint firstItem="I9X-Rp-scA" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="ge4-CS-u71"/>
-                                        <constraint firstItem="hBf-Sx-lbf" firstAttribute="top" secondItem="aGE-iz-M2h" secondAttribute="top" id="gfN-Qg-rgg"/>
                                         <constraint firstItem="s9S-zN-lwA" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="gvJ-s5-9JQ"/>
-                                        <constraint firstAttribute="trailing" secondItem="wxy-f3-FrW" secondAttribute="trailing" constant="8" id="h3Q-EH-DAh"/>
+                                        <constraint firstAttribute="trailing" secondItem="wxy-f3-FrW" secondAttribute="trailing" constant="12" id="h3Q-EH-DAh"/>
+                                        <constraint firstItem="EiP-Mu-9cf" firstAttribute="trailing" secondItem="aGE-iz-M2h" secondAttribute="trailing" id="hCn-Cp-aqK"/>
+                                        <constraint firstItem="Ghr-q6-WAW" firstAttribute="firstBaseline" secondItem="Nn4-TP-Hpd" secondAttribute="firstBaseline" id="hD1-G8-yMX"/>
                                         <constraint firstItem="Hm9-gI-9j7" firstAttribute="trailing" secondItem="Ldf-jT-tdl" secondAttribute="trailing" id="hMi-2J-yRo"/>
                                         <constraint firstItem="GSF-Y5-FGJ" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="i0p-ui-YMu"/>
-                                        <constraint firstItem="Nn4-TP-Hpd" firstAttribute="trailing" secondItem="apr-sq-JIb" secondAttribute="trailing" id="iNS-zp-cwE"/>
-                                        <constraint firstItem="Hmg-bS-UMv" firstAttribute="top" secondItem="gxW-1z-Af9" secondAttribute="top" id="iUC-2p-Ecw"/>
-                                        <constraint firstItem="4PF-1d-gZO" firstAttribute="leading" secondItem="Qke-bh-4oG" secondAttribute="trailing" constant="8" id="j1i-QZ-FtV"/>
                                         <constraint firstAttribute="trailing" secondItem="4PF-1d-gZO" secondAttribute="trailing" constant="12" id="jsh-VI-XQh"/>
                                         <constraint firstAttribute="trailing" secondItem="L3Y-pD-V9R" secondAttribute="trailing" constant="12" id="jvN-c9-5sL"/>
-                                        <constraint firstItem="c90-dT-hDG" firstAttribute="leading" secondItem="dOE-eM-QQi" secondAttribute="trailing" constant="8" id="kqM-Nw-XUr"/>
                                         <constraint firstItem="wxy-f3-FrW" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="lOe-BJ-1nS"/>
-                                        <constraint firstItem="Qke-bh-4oG" firstAttribute="top" secondItem="gxW-1z-Af9" secondAttribute="bottom" constant="8" id="mm4-st-lkq"/>
+                                        <constraint firstItem="Qke-bh-4oG" firstAttribute="top" secondItem="gxW-1z-Af9" secondAttribute="bottom" constant="8" symbolic="YES" id="mm4-st-lkq"/>
                                         <constraint firstItem="aGE-iz-M2h" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="mqs-Uu-Fxb"/>
                                         <constraint firstItem="dyh-2O-q0Y" firstAttribute="leading" secondItem="Hm9-gI-9j7" secondAttribute="leading" id="my4-Mf-EV1"/>
                                         <constraint firstAttribute="trailing" secondItem="c90-dT-hDG" secondAttribute="trailing" constant="12" id="o2v-Jf-HiJ"/>
                                         <constraint firstItem="Qke-bh-4oG" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="odY-rn-vAx"/>
                                         <constraint firstItem="v4j-fa-olc" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="oy0-v4-evT"/>
-                                        <constraint firstItem="Ira-RI-5kc" firstAttribute="centerY" secondItem="z1d-SG-OZB" secondAttribute="centerY" id="p6l-VR-6fk"/>
                                         <constraint firstItem="6sj-bN-LIv" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="pIi-ue-WQt"/>
+                                        <constraint firstItem="Zp5-es-UTa" firstAttribute="trailing" secondItem="aGE-iz-M2h" secondAttribute="trailing" id="pNU-Zi-Owm"/>
                                         <constraint firstItem="z1d-SG-OZB" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="pcf-6y-Q1g"/>
+                                        <constraint firstItem="GaY-iG-tAy" firstAttribute="firstBaseline" secondItem="Zp5-es-UTa" secondAttribute="firstBaseline" id="pjb-1x-p0K"/>
                                         <constraint firstItem="Qke-bh-4oG" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="leading" id="qm5-A1-cGH"/>
-                                        <constraint firstItem="hBf-Sx-lbf" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="trailing" constant="8" id="r3N-FI-PJf"/>
+                                        <constraint firstItem="hBf-Sx-lbf" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="trailing" constant="10" id="r3N-FI-PJf"/>
                                         <constraint firstItem="5yU-sy-R0n" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="r8i-x9-6Rp"/>
                                         <constraint firstItem="apr-sq-JIb" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="leading" id="rBi-h4-iir"/>
-                                        <constraint firstItem="Ldf-jT-tdl" firstAttribute="top" secondItem="dyh-2O-q0Y" secondAttribute="bottom" constant="8" id="rdm-PD-bK4"/>
-                                        <constraint firstItem="a3w-YC-7oN" firstAttribute="centerY" secondItem="6EL-aj-Hjq" secondAttribute="centerY" id="sjN-af-eHt"/>
-                                        <constraint firstAttribute="bottom" secondItem="Nn4-TP-Hpd" secondAttribute="bottom" id="t6V-ol-Uji"/>
+                                        <constraint firstItem="5yU-sy-R0n" firstAttribute="firstBaseline" secondItem="Ldf-jT-tdl" secondAttribute="firstBaseline" id="rIX-f5-zhq"/>
+                                        <constraint firstItem="Ldf-jT-tdl" firstAttribute="top" secondItem="dyh-2O-q0Y" secondAttribute="bottom" constant="8" symbolic="YES" id="rdm-PD-bK4"/>
+                                        <constraint firstItem="wxy-f3-FrW" firstAttribute="firstBaseline" secondItem="Hm9-gI-9j7" secondAttribute="firstBaseline" id="sDi-Y3-zFf"/>
+                                        <constraint firstItem="a3w-YC-7oN" firstAttribute="firstBaseline" secondItem="6EL-aj-Hjq" secondAttribute="firstBaseline" id="sjN-af-eHt"/>
+                                        <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="Nn4-TP-Hpd" secondAttribute="bottom" constant="12" id="t6V-ol-Uji"/>
+                                        <constraint firstItem="GSF-Y5-FGJ" firstAttribute="trailing" secondItem="aGE-iz-M2h" secondAttribute="trailing" id="tF6-Um-Se0"/>
                                         <constraint firstItem="Hm9-gI-9j7" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="leading" id="tmx-fb-lh3"/>
                                         <constraint firstAttribute="trailing" secondItem="6sj-bN-LIv" secondAttribute="trailing" constant="12" id="u7h-K0-24X"/>
-                                        <constraint firstItem="apr-sq-JIb" firstAttribute="top" secondItem="EiP-Mu-9cf" secondAttribute="bottom" constant="8" id="uJk-Nw-s4Z"/>
+                                        <constraint firstItem="apr-sq-JIb" firstAttribute="top" secondItem="EiP-Mu-9cf" secondAttribute="bottom" constant="8" symbolic="YES" id="uJk-Nw-s4Z"/>
                                         <constraint firstItem="hGO-dV-reB" firstAttribute="leading" secondItem="mRY-yK-FeT" secondAttribute="leading" constant="12" id="uNt-y6-N4V"/>
-                                        <constraint firstItem="L3Y-pD-V9R" firstAttribute="centerY" secondItem="EiP-Mu-9cf" secondAttribute="centerY" id="vFV-7S-mb9"/>
                                         <constraint firstItem="Ira-RI-5kc" firstAttribute="leading" secondItem="hBf-Sx-lbf" secondAttribute="leading" id="vLD-eR-5PH"/>
+                                        <constraint firstItem="6sj-bN-LIv" firstAttribute="firstBaseline" secondItem="FwA-X7-Alr" secondAttribute="firstBaseline" id="w1D-Rl-LlY"/>
                                         <constraint firstAttribute="trailing" secondItem="Hmg-bS-UMv" secondAttribute="trailing" constant="12" id="wVP-q3-lxd"/>
-                                        <constraint firstItem="wxy-f3-FrW" firstAttribute="leading" secondItem="Hm9-gI-9j7" secondAttribute="trailing" constant="8" symbolic="YES" id="wb6-CS-SWb"/>
+                                        <constraint firstItem="L3Y-pD-V9R" firstAttribute="firstBaseline" secondItem="EiP-Mu-9cf" secondAttribute="firstBaseline" id="xYw-WF-BaY"/>
+                                        <constraint firstItem="hBf-Sx-lbf" firstAttribute="firstBaseline" secondItem="aGE-iz-M2h" secondAttribute="firstBaseline" id="xae-O1-zoL"/>
                                         <constraint firstItem="gxW-1z-Af9" firstAttribute="top" secondItem="Ldf-jT-tdl" secondAttribute="bottom" constant="8" id="yK3-UG-NL7"/>
                                         <constraint firstItem="FwA-X7-Alr" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="leading" id="zIp-fJ-n7n"/>
-                                        <constraint firstItem="FwA-X7-Alr" firstAttribute="top" secondItem="aGE-iz-M2h" secondAttribute="bottom" constant="8" id="zjy-ws-J03"/>
+                                        <constraint firstItem="FwA-X7-Alr" firstAttribute="top" secondItem="aGE-iz-M2h" secondAttribute="bottom" constant="8" symbolic="YES" id="zjy-ws-J03"/>
                                         <constraint firstItem="Xol-2r-g7u" firstAttribute="leading" secondItem="aGE-iz-M2h" secondAttribute="leading" id="zmy-n6-ecX"/>
                                     </constraints>
                                 </view>
@@ -506,7 +488,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <popUpButton horizontalHuggingPriority="240" verticalHuggingPriority="750" horizontalCompressionResistancePriority="500" translatesAutoresizingMaskIntoConstraints="NO" id="hGJ-d0-aJu">
-                                            <rect key="frame" x="57" y="348" width="261" height="22"/>
+                                            <rect key="frame" x="56" y="349" width="262" height="22"/>
                                             <popUpButtonCell key="cell" type="push" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" id="oaq-Mf-xDk">
                                                 <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                                                 <font key="font" usesAppearanceFont="YES"/>
@@ -517,98 +499,34 @@
                                             </connections>
                                         </popUpButton>
                                         <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="bln-RN-oa7">
-                                            <rect key="frame" x="12" y="337" width="302" height="5"/>
+                                            <rect key="frame" x="12" y="338" width="302" height="5"/>
                                         </box>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="X2o-Mf-T1P">
-                                            <rect key="frame" x="10" y="313" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="314" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="ID:" id="mZG-ik-Led">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="roj-p2-656">
-                                            <rect key="frame" x="94" y="311" width="222" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="Go3-bS-2ev">
+                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="roj-p2-656">
+                                            <rect key="frame" x="94" y="314" width="222" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="Go3-bS-2ev">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oof-Fn-7Cw">
-                                            <rect key="frame" x="10" y="291" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="292" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Properties:" id="dtn-wS-j6U">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3ZF-PG-IIG">
-                                            <rect key="frame" x="10" y="269" width="78" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Source ID:" id="jCY-og-BAa">
-                                                <font key="font" metaFont="smallSystemBold"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="l4x-fQ-Uau">
-                                            <rect key="frame" x="10" y="247" width="78" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Title:" id="9eq-rd-zGy">
-                                                <font key="font" metaFont="smallSystemBold"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Dl1-oz-GjJ">
-                                            <rect key="frame" x="10" y="225" width="78" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Language:" id="FIw-CH-b05">
-                                                <font key="font" metaFont="smallSystemBold"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="brr-Ci-pQU">
-                                            <rect key="frame" x="10" y="203" width="78" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="File Path:" id="Jxp-Wf-BhU">
-                                                <font key="font" metaFont="smallSystemBold"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="a9p-qC-0t4">
-                                            <rect key="frame" x="10" y="181" width="78" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Codec:" id="daB-hU-mku">
-                                                <font key="font" metaFont="smallSystemBold"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="l34-Lu-Nzf">
-                                            <rect key="frame" x="10" y="159" width="78" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Decoder:" id="xix-0S-ehE">
-                                                <font key="font" metaFont="smallSystemBold"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Rif-ov-KDp">
-                                            <rect key="frame" x="10" y="137" width="78" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="FPS:" id="1dz-Vt-0MO">
-                                                <font key="font" metaFont="smallSystemBold"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OgS-y8-ape">
-                                            <rect key="frame" x="10" y="115" width="78" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Channels:" id="Luq-rQ-aO4">
-                                                <font key="font" metaFont="smallSystemBold"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Xwe-B4-BI5">
-                                            <rect key="frame" x="94" y="289" width="48" height="16"/>
+                                            <rect key="frame" x="94" y="292" width="48" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Default" id="S3X-Df-UMB">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -616,7 +534,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bch-Xl-vY8">
-                                            <rect key="frame" x="146" y="289" width="47" height="16"/>
+                                            <rect key="frame" x="146" y="292" width="47" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Forced" id="0vG-Pg-DIl">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -624,7 +542,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lU2-XA-lgf">
-                                            <rect key="frame" x="197" y="289" width="58" height="16"/>
+                                            <rect key="frame" x="197" y="292" width="58" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Selected" id="P65-zr-dOH">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -632,88 +550,152 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fKd-iK-TBJ">
-                                            <rect key="frame" x="259" y="289" width="54" height="16"/>
+                                            <rect key="frame" x="259" y="292" width="54" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="External" id="PLL-fC-blc">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="n48-Ey-Kcr">
-                                            <rect key="frame" x="94" y="267" width="222" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="ujs-p7-wXC">
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3ZF-PG-IIG">
+                                            <rect key="frame" x="10" y="270" width="78" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Source ID:" id="jCY-og-BAa">
+                                                <font key="font" metaFont="smallSystemBold"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="n48-Ey-Kcr">
+                                            <rect key="frame" x="94" y="270" width="222" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="ujs-p7-wXC">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="gNk-wZ-LBX">
-                                            <rect key="frame" x="94" y="245" width="222" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Label" id="fYh-pA-yDU">
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="l4x-fQ-Uau">
+                                            <rect key="frame" x="10" y="248" width="78" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Title:" id="9eq-rd-zGy">
+                                                <font key="font" metaFont="smallSystemBold"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="gNk-wZ-LBX">
+                                            <rect key="frame" x="94" y="248" width="222" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" id="fYh-pA-yDU">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="YOn-R8-CUB">
-                                            <rect key="frame" x="94" y="179" width="222" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="UPK-o2-eTo">
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Dl1-oz-GjJ">
+                                            <rect key="frame" x="10" y="226" width="78" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Language:" id="FIw-CH-b05">
+                                                <font key="font" metaFont="smallSystemBold"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="6Jf-Z2-tkZ">
+                                            <rect key="frame" x="94" y="226" width="222" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="KS6-aw-wh6">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="6Jf-Z2-tkZ">
-                                            <rect key="frame" x="94" y="223" width="222" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="KS6-aw-wh6">
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="brr-Ci-pQU">
+                                            <rect key="frame" x="10" y="204" width="78" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="File Path:" id="Jxp-Wf-BhU">
+                                                <font key="font" metaFont="smallSystemBold"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="LXL-wc-JRh">
+                                            <rect key="frame" x="94" y="204" width="222" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" id="jMN-aN-DqI">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="LXL-wc-JRh">
-                                            <rect key="frame" x="94" y="201" width="222" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Label" id="jMN-aN-DqI">
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="a9p-qC-0t4">
+                                            <rect key="frame" x="10" y="182" width="78" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Codec:" id="daB-hU-mku">
+                                                <font key="font" metaFont="smallSystemBold"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="YOn-R8-CUB">
+                                            <rect key="frame" x="94" y="182" width="222" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="UPK-o2-eTo">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1Ov-rH-BM1">
-                                            <rect key="frame" x="94" y="157" width="222" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Label" id="7Iw-nT-Mdz">
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="l34-Lu-Nzf">
+                                            <rect key="frame" x="10" y="160" width="78" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Decoder:" id="xix-0S-ehE">
+                                                <font key="font" metaFont="smallSystemBold"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="1Ov-rH-BM1">
+                                            <rect key="frame" x="94" y="160" width="222" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" id="7Iw-nT-Mdz">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="VR8-mY-Zfn">
-                                            <rect key="frame" x="94" y="113" width="222" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="21M-40-ac5">
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Rif-ov-KDp">
+                                            <rect key="frame" x="10" y="138" width="78" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="FPS:" id="1dz-Vt-0MO">
+                                                <font key="font" metaFont="smallSystemBold"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="U7e-QU-Pta">
+                                            <rect key="frame" x="94" y="138" width="222" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="u39-dg-rLQ">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Hk9-2W-Vxc">
-                                            <rect key="frame" x="94" y="91" width="222" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="MKd-dP-Mkb">
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OgS-y8-ape">
+                                            <rect key="frame" x="10" y="116" width="78" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Channels:" id="Luq-rQ-aO4">
+                                                <font key="font" metaFont="smallSystemBold"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="VR8-mY-Zfn">
+                                            <rect key="frame" x="94" y="116" width="222" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="21M-40-ac5">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fj8-mz-w6w">
-                                            <rect key="frame" x="10" y="93" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="94" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Sample Rate:" id="vrP-XL-Weg">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="U7e-QU-Pta">
-                                            <rect key="frame" x="94" y="135" width="222" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="u39-dg-rLQ">
+                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Hk9-2W-Vxc">
+                                            <rect key="frame" x="94" y="94" width="222" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="MKd-dP-Mkb">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -721,86 +703,95 @@
                                         </textField>
                                     </subviews>
                                     <constraints>
-                                        <constraint firstItem="VR8-mY-Zfn" firstAttribute="top" secondItem="OgS-y8-ape" secondAttribute="top" id="06G-j4-fMO"/>
+                                        <constraint firstItem="6Jf-Z2-tkZ" firstAttribute="leading" secondItem="roj-p2-656" secondAttribute="leading" id="04y-fn-aTM"/>
+                                        <constraint firstItem="Xwe-B4-BI5" firstAttribute="leading" secondItem="roj-p2-656" secondAttribute="leading" id="0gP-lE-Anm"/>
                                         <constraint firstItem="oof-Fn-7Cw" firstAttribute="leading" secondItem="CWu-ZF-Vg7" secondAttribute="leading" constant="12" id="0lj-Vx-7Jn"/>
+                                        <constraint firstItem="brr-Ci-pQU" firstAttribute="top" secondItem="Dl1-oz-GjJ" secondAttribute="bottom" constant="8" symbolic="YES" id="13W-6h-JAk"/>
                                         <constraint firstAttribute="trailing" secondItem="roj-p2-656" secondAttribute="trailing" constant="12" id="1qT-Fl-EXz"/>
-                                        <constraint firstItem="LXL-wc-JRh" firstAttribute="top" secondItem="6Jf-Z2-tkZ" secondAttribute="bottom" constant="6" id="1tL-HM-VBq"/>
                                         <constraint firstItem="fKd-iK-TBJ" firstAttribute="leading" secondItem="lU2-XA-lgf" secondAttribute="trailing" constant="8" id="1tv-Gf-YHE"/>
+                                        <constraint firstItem="3ZF-PG-IIG" firstAttribute="trailing" secondItem="X2o-Mf-T1P" secondAttribute="trailing" id="2Tz-gy-NhO"/>
                                         <constraint firstItem="lU2-XA-lgf" firstAttribute="leading" secondItem="bch-Xl-vY8" secondAttribute="trailing" constant="8" id="2hI-Tz-Zyo"/>
                                         <constraint firstItem="brr-Ci-pQU" firstAttribute="leading" secondItem="CWu-ZF-Vg7" secondAttribute="leading" constant="12" id="3fc-QV-ZHS"/>
+                                        <constraint firstItem="roj-p2-656" firstAttribute="firstBaseline" secondItem="X2o-Mf-T1P" secondAttribute="firstBaseline" id="4eR-u2-aO1"/>
                                         <constraint firstItem="OgS-y8-ape" firstAttribute="leading" secondItem="CWu-ZF-Vg7" secondAttribute="leading" constant="12" id="4jf-ot-kht"/>
+                                        <constraint firstItem="Hk9-2W-Vxc" firstAttribute="firstBaseline" secondItem="fj8-mz-w6w" secondAttribute="firstBaseline" id="4kI-xJ-6vN"/>
                                         <constraint firstItem="a9p-qC-0t4" firstAttribute="leading" secondItem="CWu-ZF-Vg7" secondAttribute="leading" constant="12" id="4qV-OV-6Vn"/>
-                                        <constraint firstItem="1Ov-rH-BM1" firstAttribute="top" secondItem="l34-Lu-Nzf" secondAttribute="top" id="5td-2o-b68"/>
+                                        <constraint firstItem="oof-Fn-7Cw" firstAttribute="top" secondItem="X2o-Mf-T1P" secondAttribute="bottom" constant="8" symbolic="YES" id="5Aq-YH-B3E"/>
+                                        <constraint firstItem="l4x-fQ-Uau" firstAttribute="trailing" secondItem="X2o-Mf-T1P" secondAttribute="trailing" id="5ms-uZ-nnN"/>
+                                        <constraint firstItem="lU2-XA-lgf" firstAttribute="firstBaseline" secondItem="oof-Fn-7Cw" secondAttribute="firstBaseline" id="5oq-rg-ixe"/>
+                                        <constraint firstItem="Hk9-2W-Vxc" firstAttribute="leading" secondItem="roj-p2-656" secondAttribute="leading" id="5vG-wU-Wfr"/>
                                         <constraint firstItem="Dl1-oz-GjJ" firstAttribute="leading" secondItem="CWu-ZF-Vg7" secondAttribute="leading" constant="12" id="5xA-IG-K5n"/>
-                                        <constraint firstAttribute="trailing" secondItem="gNk-wZ-LBX" secondAttribute="trailing" constant="12" id="7hk-8B-BzD"/>
-                                        <constraint firstItem="Xwe-B4-BI5" firstAttribute="top" secondItem="roj-p2-656" secondAttribute="bottom" constant="6" id="7hu-Sp-EXN"/>
-                                        <constraint firstItem="l4x-fQ-Uau" firstAttribute="width" secondItem="X2o-Mf-T1P" secondAttribute="width" id="AHk-bK-QaM"/>
-                                        <constraint firstItem="bch-Xl-vY8" firstAttribute="top" secondItem="Xwe-B4-BI5" secondAttribute="top" id="AKs-vA-408"/>
+                                        <constraint firstItem="l4x-fQ-Uau" firstAttribute="top" secondItem="3ZF-PG-IIG" secondAttribute="bottom" constant="8" id="6b9-D5-Lnq"/>
+                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="gNk-wZ-LBX" secondAttribute="trailing" constant="12" id="7hk-8B-BzD"/>
+                                        <constraint firstItem="VR8-mY-Zfn" firstAttribute="leading" secondItem="roj-p2-656" secondAttribute="leading" id="7ip-Xz-EO7"/>
+                                        <constraint firstItem="U7e-QU-Pta" firstAttribute="firstBaseline" secondItem="Rif-ov-KDp" secondAttribute="firstBaseline" id="8L3-Od-zZC"/>
+                                        <constraint firstItem="OgS-y8-ape" firstAttribute="top" secondItem="Rif-ov-KDp" secondAttribute="bottom" constant="8" symbolic="YES" id="8kZ-zW-jyC"/>
+                                        <constraint firstItem="l34-Lu-Nzf" firstAttribute="top" secondItem="a9p-qC-0t4" secondAttribute="bottom" constant="8" symbolic="YES" id="9TX-7T-WDn"/>
+                                        <constraint firstItem="LXL-wc-JRh" firstAttribute="trailing" secondItem="roj-p2-656" secondAttribute="trailing" id="9an-s3-fmO"/>
+                                        <constraint firstItem="Dl1-oz-GjJ" firstAttribute="trailing" secondItem="X2o-Mf-T1P" secondAttribute="trailing" id="BIY-6C-LK0"/>
                                         <constraint firstItem="o1n-DX-V8d" firstAttribute="top" secondItem="CWu-ZF-Vg7" secondAttribute="top" constant="12" id="C2f-AA-E0B"/>
-                                        <constraint firstItem="Rif-ov-KDp" firstAttribute="width" secondItem="X2o-Mf-T1P" secondAttribute="width" id="C5l-UO-uCa"/>
-                                        <constraint firstItem="Hk9-2W-Vxc" firstAttribute="top" secondItem="VR8-mY-Zfn" secondAttribute="bottom" constant="6" id="CGX-U5-IAZ"/>
-                                        <constraint firstItem="fKd-iK-TBJ" firstAttribute="top" secondItem="lU2-XA-lgf" secondAttribute="top" id="Dlt-NX-tq3"/>
-                                        <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="Hk9-2W-Vxc" secondAttribute="bottom" constant="16" id="EEg-60-bnN"/>
-                                        <constraint firstAttribute="trailing" secondItem="6Jf-Z2-tkZ" secondAttribute="trailing" constant="12" id="EGn-rj-yL6"/>
-                                        <constraint firstItem="1Ov-rH-BM1" firstAttribute="top" secondItem="YOn-R8-CUB" secondAttribute="bottom" constant="6" id="GU3-ts-JNO"/>
-                                        <constraint firstAttribute="trailing" secondItem="LXL-wc-JRh" secondAttribute="trailing" constant="12" id="GXq-xp-VQc"/>
-                                        <constraint firstItem="YOn-R8-CUB" firstAttribute="top" secondItem="LXL-wc-JRh" secondAttribute="bottom" constant="6" id="GiE-49-LyG"/>
-                                        <constraint firstItem="Xwe-B4-BI5" firstAttribute="leading" secondItem="oof-Fn-7Cw" secondAttribute="trailing" constant="10" id="HQ9-JT-9d7"/>
-                                        <constraint firstItem="3ZF-PG-IIG" firstAttribute="width" secondItem="X2o-Mf-T1P" secondAttribute="width" id="HcU-e1-Box"/>
-                                        <constraint firstItem="n48-Ey-Kcr" firstAttribute="leading" secondItem="3ZF-PG-IIG" secondAttribute="trailing" constant="10" id="HkR-Un-fgh"/>
-                                        <constraint firstItem="gNk-wZ-LBX" firstAttribute="top" secondItem="n48-Ey-Kcr" secondAttribute="bottom" constant="6" id="IKw-Am-5Fs"/>
-                                        <constraint firstItem="n48-Ey-Kcr" firstAttribute="top" secondItem="Xwe-B4-BI5" secondAttribute="bottom" constant="6" id="Jk5-jE-Ger"/>
-                                        <constraint firstItem="LXL-wc-JRh" firstAttribute="top" secondItem="brr-Ci-pQU" secondAttribute="top" id="Jlt-gG-7Hv"/>
-                                        <constraint firstAttribute="trailing" secondItem="VR8-mY-Zfn" secondAttribute="trailing" constant="12" id="Lwa-wh-y5U"/>
+                                        <constraint firstItem="YOn-R8-CUB" firstAttribute="leading" secondItem="roj-p2-656" secondAttribute="leading" id="DtK-ca-0TP"/>
+                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="6Jf-Z2-tkZ" secondAttribute="trailing" constant="12" id="EGn-rj-yL6"/>
+                                        <constraint firstItem="bch-Xl-vY8" firstAttribute="firstBaseline" secondItem="oof-Fn-7Cw" secondAttribute="firstBaseline" id="EaW-Pv-1Vy"/>
+                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="LXL-wc-JRh" secondAttribute="trailing" constant="12" id="GXq-xp-VQc"/>
+                                        <constraint firstItem="oof-Fn-7Cw" firstAttribute="trailing" secondItem="X2o-Mf-T1P" secondAttribute="trailing" id="Gdh-V4-5UX"/>
+                                        <constraint firstItem="YOn-R8-CUB" firstAttribute="trailing" secondItem="roj-p2-656" secondAttribute="trailing" id="K4n-Lj-eS6"/>
+                                        <constraint firstItem="LXL-wc-JRh" firstAttribute="leading" secondItem="roj-p2-656" secondAttribute="leading" id="K9M-qB-JT9"/>
+                                        <constraint firstItem="VR8-mY-Zfn" firstAttribute="firstBaseline" secondItem="OgS-y8-ape" secondAttribute="firstBaseline" id="Kaj-ZT-VUT"/>
+                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="VR8-mY-Zfn" secondAttribute="trailing" constant="12" id="Lwa-wh-y5U"/>
                                         <constraint firstItem="X2o-Mf-T1P" firstAttribute="leading" secondItem="CWu-ZF-Vg7" secondAttribute="leading" constant="12" id="MWN-1d-TYa"/>
-                                        <constraint firstItem="YOn-R8-CUB" firstAttribute="top" secondItem="a9p-qC-0t4" secondAttribute="top" id="N51-UO-qqo"/>
-                                        <constraint firstItem="gNk-wZ-LBX" firstAttribute="leading" secondItem="l4x-fQ-Uau" secondAttribute="trailing" constant="10" id="NEw-3J-kau"/>
-                                        <constraint firstAttribute="trailing" secondItem="n48-Ey-Kcr" secondAttribute="trailing" constant="12" id="NFK-u1-rp1"/>
-                                        <constraint firstAttribute="trailing" secondItem="YOn-R8-CUB" secondAttribute="trailing" constant="12" id="Nyc-LZ-skN"/>
-                                        <constraint firstItem="U7e-QU-Pta" firstAttribute="leading" secondItem="Rif-ov-KDp" secondAttribute="trailing" constant="10" id="Q0s-bS-XgV"/>
-                                        <constraint firstAttribute="trailing" secondItem="Hk9-2W-Vxc" secondAttribute="trailing" constant="12" id="TDt-3R-ocO"/>
-                                        <constraint firstItem="Hk9-2W-Vxc" firstAttribute="leading" secondItem="fj8-mz-w6w" secondAttribute="trailing" constant="10" id="TME-LB-xlS"/>
+                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="n48-Ey-Kcr" secondAttribute="trailing" constant="12" id="NFK-u1-rp1"/>
+                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="YOn-R8-CUB" secondAttribute="trailing" constant="12" id="Nyc-LZ-skN"/>
+                                        <constraint firstItem="gNk-wZ-LBX" firstAttribute="trailing" secondItem="roj-p2-656" secondAttribute="trailing" id="OSq-kM-mzD"/>
+                                        <constraint firstItem="a9p-qC-0t4" firstAttribute="trailing" secondItem="X2o-Mf-T1P" secondAttribute="trailing" id="PQb-VX-kCo"/>
+                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Hk9-2W-Vxc" secondAttribute="trailing" constant="12" id="TDt-3R-ocO"/>
                                         <constraint firstItem="Rif-ov-KDp" firstAttribute="leading" secondItem="CWu-ZF-Vg7" secondAttribute="leading" constant="12" id="UYm-Ky-UkO"/>
-                                        <constraint firstItem="lU2-XA-lgf" firstAttribute="top" secondItem="bch-Xl-vY8" secondAttribute="top" id="VwV-H7-eLp"/>
-                                        <constraint firstItem="oof-Fn-7Cw" firstAttribute="width" secondItem="X2o-Mf-T1P" secondAttribute="width" id="W0s-HQ-pJ9"/>
+                                        <constraint firstItem="Rif-ov-KDp" firstAttribute="top" secondItem="l34-Lu-Nzf" secondAttribute="bottom" constant="8" symbolic="YES" id="VZZ-ZP-8xm"/>
                                         <constraint firstItem="X2o-Mf-T1P" firstAttribute="top" secondItem="bln-RN-oa7" secondAttribute="bottom" constant="12" id="WFL-hh-cUR"/>
-                                        <constraint firstItem="VR8-mY-Zfn" firstAttribute="leading" secondItem="OgS-y8-ape" secondAttribute="trailing" constant="10" id="Xp7-ce-Eth"/>
-                                        <constraint firstItem="6Jf-Z2-tkZ" firstAttribute="leading" secondItem="Dl1-oz-GjJ" secondAttribute="trailing" constant="10" id="Ypb-NQ-tgn"/>
-                                        <constraint firstItem="gNk-wZ-LBX" firstAttribute="top" secondItem="l4x-fQ-Uau" secondAttribute="top" id="Z4S-V7-B4m"/>
+                                        <constraint firstItem="fj8-mz-w6w" firstAttribute="top" secondItem="OgS-y8-ape" secondAttribute="bottom" constant="8" symbolic="YES" id="Wzj-Pr-zPr"/>
+                                        <constraint firstItem="YOn-R8-CUB" firstAttribute="firstBaseline" secondItem="a9p-qC-0t4" secondAttribute="firstBaseline" id="XBp-bh-wSh"/>
+                                        <constraint firstItem="Xwe-B4-BI5" firstAttribute="firstBaseline" secondItem="oof-Fn-7Cw" secondAttribute="firstBaseline" id="YDv-On-0eQ"/>
+                                        <constraint firstItem="VR8-mY-Zfn" firstAttribute="trailing" secondItem="roj-p2-656" secondAttribute="trailing" id="Yef-Fi-1pK"/>
                                         <constraint firstAttribute="trailing" secondItem="bln-RN-oa7" secondAttribute="trailing" constant="12" id="Znu-ne-meV"/>
-                                        <constraint firstItem="OgS-y8-ape" firstAttribute="width" secondItem="X2o-Mf-T1P" secondAttribute="width" id="aSX-Yd-U0w"/>
-                                        <constraint firstItem="roj-p2-656" firstAttribute="top" secondItem="X2o-Mf-T1P" secondAttribute="top" id="b8q-ZH-rEe"/>
-                                        <constraint firstItem="brr-Ci-pQU" firstAttribute="width" secondItem="X2o-Mf-T1P" secondAttribute="width" id="bpx-7W-5Pj"/>
+                                        <constraint firstItem="OgS-y8-ape" firstAttribute="trailing" secondItem="X2o-Mf-T1P" secondAttribute="trailing" id="ZpJ-oX-vtO"/>
+                                        <constraint firstItem="3ZF-PG-IIG" firstAttribute="top" secondItem="oof-Fn-7Cw" secondAttribute="bottom" constant="8" symbolic="YES" id="afK-ot-Gkt"/>
                                         <constraint firstAttribute="trailing" secondItem="hGJ-d0-aJu" secondAttribute="trailing" constant="12" id="bzJ-y2-NTF"/>
-                                        <constraint firstItem="Dl1-oz-GjJ" firstAttribute="width" secondItem="X2o-Mf-T1P" secondAttribute="width" id="c9m-uC-2ia"/>
-                                        <constraint firstAttribute="trailing" secondItem="U7e-QU-Pta" secondAttribute="trailing" constant="12" id="dNk-KQ-Y9B"/>
-                                        <constraint firstItem="Hk9-2W-Vxc" firstAttribute="top" secondItem="fj8-mz-w6w" secondAttribute="top" id="eU9-Wz-ACv"/>
-                                        <constraint firstItem="YOn-R8-CUB" firstAttribute="leading" secondItem="a9p-qC-0t4" secondAttribute="trailing" constant="10" id="fFw-kg-O20"/>
-                                        <constraint firstItem="6Jf-Z2-tkZ" firstAttribute="top" secondItem="gNk-wZ-LBX" secondAttribute="bottom" constant="6" id="fXY-8R-itA"/>
-                                        <constraint firstAttribute="trailing" secondItem="1Ov-rH-BM1" secondAttribute="trailing" constant="12" id="g1R-pA-oGr"/>
+                                        <constraint firstItem="n48-Ey-Kcr" firstAttribute="firstBaseline" secondItem="3ZF-PG-IIG" secondAttribute="firstBaseline" id="cEK-T4-2mC"/>
+                                        <constraint firstItem="1Ov-rH-BM1" firstAttribute="firstBaseline" secondItem="l34-Lu-Nzf" secondAttribute="firstBaseline" id="cpd-86-kKR"/>
+                                        <constraint firstItem="n48-Ey-Kcr" firstAttribute="leading" secondItem="roj-p2-656" secondAttribute="leading" id="d8G-40-AP7"/>
+                                        <constraint firstItem="fKd-iK-TBJ" firstAttribute="firstBaseline" secondItem="oof-Fn-7Cw" secondAttribute="firstBaseline" id="d8J-Jw-sMP"/>
+                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="U7e-QU-Pta" secondAttribute="trailing" constant="12" id="dNk-KQ-Y9B"/>
+                                        <constraint firstItem="Hk9-2W-Vxc" firstAttribute="trailing" secondItem="roj-p2-656" secondAttribute="trailing" id="e00-mS-fjv"/>
+                                        <constraint firstItem="gNk-wZ-LBX" firstAttribute="leading" secondItem="roj-p2-656" secondAttribute="leading" id="f0j-a3-1Gh"/>
+                                        <constraint firstItem="6Jf-Z2-tkZ" firstAttribute="firstBaseline" secondItem="Dl1-oz-GjJ" secondAttribute="firstBaseline" id="fFs-Fe-Jop"/>
+                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="1Ov-rH-BM1" secondAttribute="trailing" constant="12" id="g1R-pA-oGr"/>
+                                        <constraint firstItem="brr-Ci-pQU" firstAttribute="trailing" secondItem="X2o-Mf-T1P" secondAttribute="trailing" id="gJh-Sb-UBf"/>
                                         <constraint firstItem="roj-p2-656" firstAttribute="leading" secondItem="X2o-Mf-T1P" secondAttribute="trailing" constant="10" id="gZs-cz-209"/>
-                                        <constraint firstItem="n48-Ey-Kcr" firstAttribute="top" secondItem="3ZF-PG-IIG" secondAttribute="top" id="h6T-z4-dBL"/>
                                         <constraint firstItem="3ZF-PG-IIG" firstAttribute="leading" secondItem="CWu-ZF-Vg7" secondAttribute="leading" constant="12" id="hdc-oJ-vaO"/>
-                                        <constraint firstItem="U7e-QU-Pta" firstAttribute="top" secondItem="1Ov-rH-BM1" secondAttribute="bottom" constant="6" id="kvZ-bQ-Ryi"/>
-                                        <constraint firstItem="1Ov-rH-BM1" firstAttribute="leading" secondItem="l34-Lu-Nzf" secondAttribute="trailing" constant="10" id="lwA-Yx-GO4"/>
-                                        <constraint firstItem="l34-Lu-Nzf" firstAttribute="width" secondItem="X2o-Mf-T1P" secondAttribute="width" id="lys-LV-BmY"/>
+                                        <constraint firstItem="a9p-qC-0t4" firstAttribute="top" secondItem="brr-Ci-pQU" secondAttribute="bottom" constant="8" symbolic="YES" id="hrP-t8-cRH"/>
+                                        <constraint firstItem="n48-Ey-Kcr" firstAttribute="trailing" secondItem="roj-p2-656" secondAttribute="trailing" id="jAh-Xc-FZZ"/>
+                                        <constraint firstItem="gNk-wZ-LBX" firstAttribute="firstBaseline" secondItem="l4x-fQ-Uau" secondAttribute="firstBaseline" id="jED-mL-9vT"/>
+                                        <constraint firstItem="LXL-wc-JRh" firstAttribute="firstBaseline" secondItem="brr-Ci-pQU" secondAttribute="firstBaseline" id="kvl-tB-54F"/>
+                                        <constraint firstItem="1Ov-rH-BM1" firstAttribute="trailing" secondItem="roj-p2-656" secondAttribute="trailing" id="m15-6Z-jNy"/>
+                                        <constraint firstItem="1Ov-rH-BM1" firstAttribute="leading" secondItem="roj-p2-656" secondAttribute="leading" id="msN-cp-LEH"/>
                                         <constraint firstItem="hGJ-d0-aJu" firstAttribute="baseline" secondItem="o1n-DX-V8d" secondAttribute="baseline" id="ner-5D-zgT"/>
+                                        <constraint firstItem="Rif-ov-KDp" firstAttribute="trailing" secondItem="X2o-Mf-T1P" secondAttribute="trailing" id="osL-3n-ydm"/>
+                                        <constraint firstItem="U7e-QU-Pta" firstAttribute="leading" secondItem="roj-p2-656" secondAttribute="leading" id="p8a-KP-8IV"/>
                                         <constraint firstItem="bln-RN-oa7" firstAttribute="leading" secondItem="CWu-ZF-Vg7" secondAttribute="leading" constant="12" id="pH3-a2-6Il"/>
                                         <constraint firstItem="o1n-DX-V8d" firstAttribute="leading" secondItem="CWu-ZF-Vg7" secondAttribute="leading" constant="12" id="png-z9-JlT"/>
                                         <constraint firstItem="bln-RN-oa7" firstAttribute="top" secondItem="hGJ-d0-aJu" secondAttribute="bottom" constant="12" id="qSL-65-wiU"/>
+                                        <constraint firstItem="U7e-QU-Pta" firstAttribute="trailing" secondItem="roj-p2-656" secondAttribute="trailing" id="qek-Tc-Jgk"/>
                                         <constraint firstItem="bch-Xl-vY8" firstAttribute="leading" secondItem="Xwe-B4-BI5" secondAttribute="trailing" constant="8" id="qkU-We-WPs"/>
-                                        <constraint firstItem="VR8-mY-Zfn" firstAttribute="top" secondItem="U7e-QU-Pta" secondAttribute="bottom" constant="6" id="rbG-md-CLB"/>
-                                        <constraint firstItem="6Jf-Z2-tkZ" firstAttribute="top" secondItem="Dl1-oz-GjJ" secondAttribute="top" id="sRm-qN-ddx"/>
-                                        <constraint firstItem="LXL-wc-JRh" firstAttribute="leading" secondItem="brr-Ci-pQU" secondAttribute="trailing" constant="10" id="uWh-Z5-ZhU"/>
+                                        <constraint firstItem="6Jf-Z2-tkZ" firstAttribute="trailing" secondItem="roj-p2-656" secondAttribute="trailing" id="rNp-Qz-uQU"/>
+                                        <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="fj8-mz-w6w" secondAttribute="bottom" constant="12" id="rdf-e8-T5Z"/>
+                                        <constraint firstItem="fj8-mz-w6w" firstAttribute="trailing" secondItem="X2o-Mf-T1P" secondAttribute="trailing" id="sOo-Xl-LX6"/>
+                                        <constraint firstItem="Dl1-oz-GjJ" firstAttribute="top" secondItem="l4x-fQ-Uau" secondAttribute="bottom" constant="8" symbolic="YES" id="sQV-sT-nDr"/>
                                         <constraint firstItem="fj8-mz-w6w" firstAttribute="leading" secondItem="CWu-ZF-Vg7" secondAttribute="leading" constant="12" id="vvY-4T-4Sl"/>
-                                        <constraint firstItem="U7e-QU-Pta" firstAttribute="top" secondItem="Rif-ov-KDp" secondAttribute="top" id="wxr-QX-Uhe"/>
-                                        <constraint firstItem="a9p-qC-0t4" firstAttribute="width" secondItem="X2o-Mf-T1P" secondAttribute="width" id="xJm-zQ-jig"/>
-                                        <constraint firstItem="Xwe-B4-BI5" firstAttribute="top" secondItem="oof-Fn-7Cw" secondAttribute="top" id="xWi-mB-I1L"/>
+                                        <constraint firstItem="l34-Lu-Nzf" firstAttribute="trailing" secondItem="X2o-Mf-T1P" secondAttribute="trailing" id="wL3-ad-o0K"/>
                                         <constraint firstItem="l34-Lu-Nzf" firstAttribute="leading" secondItem="CWu-ZF-Vg7" secondAttribute="leading" constant="12" id="xlc-Zz-IJY"/>
                                         <constraint firstItem="l4x-fQ-Uau" firstAttribute="leading" secondItem="CWu-ZF-Vg7" secondAttribute="leading" constant="12" id="y1e-2W-gIV"/>
-                                        <constraint firstItem="hGJ-d0-aJu" firstAttribute="leading" secondItem="o1n-DX-V8d" secondAttribute="trailing" constant="11" id="y4b-2B-xbG"/>
+                                        <constraint firstItem="hGJ-d0-aJu" firstAttribute="leading" secondItem="o1n-DX-V8d" secondAttribute="trailing" constant="10" id="y4b-2B-xbG"/>
                                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="fKd-iK-TBJ" secondAttribute="trailing" constant="12" id="zgp-ho-erG"/>
-                                        <constraint firstItem="fj8-mz-w6w" firstAttribute="width" secondItem="X2o-Mf-T1P" secondAttribute="width" id="zgr-5f-HZF"/>
                                     </constraints>
                                 </view>
                             </tabViewItem>
@@ -809,9 +800,17 @@
                                     <rect key="frame" x="0.0" y="0.0" width="326" height="382"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
+                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JYJ-iA-Cdg">
+                                            <rect key="frame" x="10" y="356" width="56" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="File path:" id="4jf-w4-kkv">
+                                                <font key="font" metaFont="smallSystemBold"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
                                         <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="nJF-Fe-glJ">
                                             <rect key="frame" x="10" y="336" width="306" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" selectable="YES" sendsActionOnEndEditing="YES" title="Multiline Label" id="JkC-3s-Ela">
+                                            <textFieldCell key="cell" controlSize="small" selectable="YES" sendsActionOnEndEditing="YES" id="JkC-3s-Ela">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -828,9 +827,9 @@
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3Lj-7X-tNH">
-                                            <rect key="frame" x="95" y="275" width="37" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="QTi-nO-v8c">
+                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UBX-ge-nPN">
+                                            <rect key="frame" x="76" y="297" width="240" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="Zaf-qd-A4D">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -844,10 +843,10 @@
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JYJ-iA-Cdg">
-                                            <rect key="frame" x="10" y="356" width="306" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="File path:" id="4jf-w4-kkv">
-                                                <font key="font" metaFont="smallSystemBold"/>
+                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3Lj-7X-tNH">
+                                            <rect key="frame" x="76" y="275" width="240" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="QTi-nO-v8c">
+                                                <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
@@ -860,49 +859,41 @@
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
+                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="uzH-YO-YLT">
+                                            <rect key="frame" x="76" y="253" width="240" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="sgp-Kk-awA">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IpH-Qz-kKo">
-                                            <rect key="frame" x="10" y="233" width="60" height="14"/>
+                                            <rect key="frame" x="10" y="231" width="60" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Chapters:" id="PBk-VC-4gu">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
+                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="PgQ-KO-dy8">
+                                            <rect key="frame" x="76" y="231" width="240" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="IME-9M-YdQ">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2xR-1D-bSh">
-                                            <rect key="frame" x="10" y="211" width="60" height="14"/>
+                                            <rect key="frame" x="10" y="209" width="60" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Editions:" id="POj-mQ-zP9">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="uzH-YO-YLT">
-                                            <rect key="frame" x="95" y="253" width="37" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="sgp-Kk-awA">
-                                                <font key="font" usesAppearanceFont="YES"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="PgQ-KO-dy8">
-                                            <rect key="frame" x="95" y="231" width="37" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="IME-9M-YdQ">
-                                                <font key="font" usesAppearanceFont="YES"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yhp-8h-TAd">
-                                            <rect key="frame" x="95" y="209" width="37" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="xIH-Dc-ZRT">
-                                                <font key="font" usesAppearanceFont="YES"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UBX-ge-nPN">
-                                            <rect key="frame" x="95" y="296" width="37" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="Zaf-qd-A4D">
+                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yhp-8h-TAd">
+                                            <rect key="frame" x="76" y="209" width="240" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="xIH-Dc-ZRT">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -913,34 +904,40 @@
                                         <constraint firstItem="3Lj-7X-tNH" firstAttribute="leading" secondItem="uzH-YO-YLT" secondAttribute="leading" id="098-D8-MFD"/>
                                         <constraint firstItem="SEN-lo-1AP" firstAttribute="baseline" secondItem="uzH-YO-YLT" secondAttribute="baseline" id="1d2-7Z-MXW"/>
                                         <constraint firstItem="2xR-1D-bSh" firstAttribute="top" secondItem="IpH-Qz-kKo" secondAttribute="bottom" constant="8" symbolic="YES" id="1g1-Fb-bgm"/>
+                                        <constraint firstItem="PgQ-KO-dy8" firstAttribute="trailing" secondItem="UBX-ge-nPN" secondAttribute="trailing" id="33A-yV-hyv"/>
                                         <constraint firstItem="PgQ-KO-dy8" firstAttribute="leading" secondItem="yhp-8h-TAd" secondAttribute="leading" id="39v-vb-d1W"/>
-                                        <constraint firstItem="IpH-Qz-kKo" firstAttribute="top" secondItem="SEN-lo-1AP" secondAttribute="bottom" constant="6" id="3dm-Dy-3it"/>
-                                        <constraint firstItem="UBX-ge-nPN" firstAttribute="leading" secondItem="P6I-h4-MV9" secondAttribute="trailing" constant="29" id="5z6-Es-8y2"/>
+                                        <constraint firstAttribute="trailing" secondItem="UBX-ge-nPN" secondAttribute="trailing" constant="12" id="3BP-GN-o2x"/>
+                                        <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="JYJ-iA-Cdg" secondAttribute="trailing" constant="12" id="3dO-5X-rZZ"/>
+                                        <constraint firstItem="IpH-Qz-kKo" firstAttribute="top" secondItem="SEN-lo-1AP" secondAttribute="bottom" constant="8" symbolic="YES" id="3dm-Dy-3it"/>
+                                        <constraint firstItem="UBX-ge-nPN" firstAttribute="leading" secondItem="P6I-h4-MV9" secondAttribute="trailing" constant="10" id="5z6-Es-8y2"/>
+                                        <constraint firstAttribute="trailing" secondItem="507-xz-zeA" secondAttribute="trailing" constant="12" id="6dI-DY-sv4"/>
                                         <constraint firstItem="SEN-lo-1AP" firstAttribute="top" secondItem="EaI-Lh-edg" secondAttribute="bottom" constant="8" symbolic="YES" id="7HW-6J-gZ9"/>
                                         <constraint firstItem="JYJ-iA-Cdg" firstAttribute="top" secondItem="foT-8J-MwC" secondAttribute="top" constant="12" id="7eH-bs-Vdb"/>
-                                        <constraint firstItem="JYJ-iA-Cdg" firstAttribute="trailing" secondItem="nJF-Fe-glJ" secondAttribute="trailing" id="AX9-Gc-e50"/>
+                                        <constraint firstItem="yhp-8h-TAd" firstAttribute="firstBaseline" secondItem="2xR-1D-bSh" secondAttribute="firstBaseline" id="BoS-fn-ebZ"/>
                                         <constraint firstItem="EaI-Lh-edg" firstAttribute="baseline" secondItem="3Lj-7X-tNH" secondAttribute="baseline" id="D75-sx-C8F"/>
                                         <constraint firstItem="JYJ-iA-Cdg" firstAttribute="leading" secondItem="foT-8J-MwC" secondAttribute="leading" constant="12" id="Dhr-xA-SGC"/>
-                                        <constraint firstItem="IpH-Qz-kKo" firstAttribute="top" secondItem="PgQ-KO-dy8" secondAttribute="top" id="FHv-yO-7Iz"/>
                                         <constraint firstItem="EaI-Lh-edg" firstAttribute="top" secondItem="P6I-h4-MV9" secondAttribute="bottom" constant="8" symbolic="YES" id="G0T-yB-BN9"/>
                                         <constraint firstItem="507-xz-zeA" firstAttribute="leading" secondItem="P6I-h4-MV9" secondAttribute="leading" id="KMD-4e-Q1D"/>
-                                        <constraint firstItem="UBX-ge-nPN" firstAttribute="top" secondItem="507-xz-zeA" secondAttribute="bottom" constant="11" id="LbO-AH-akR"/>
                                         <constraint firstItem="IpH-Qz-kKo" firstAttribute="leading" secondItem="2xR-1D-bSh" secondAttribute="leading" id="M9R-xK-z5j"/>
                                         <constraint firstItem="SEN-lo-1AP" firstAttribute="leading" secondItem="IpH-Qz-kKo" secondAttribute="leading" id="MsZ-Zx-rYy"/>
-                                        <constraint firstItem="P6I-h4-MV9" firstAttribute="centerY" secondItem="UBX-ge-nPN" secondAttribute="centerY" id="TVo-EO-OhY"/>
+                                        <constraint firstItem="yhp-8h-TAd" firstAttribute="trailing" secondItem="UBX-ge-nPN" secondAttribute="trailing" id="NSr-sY-Ub3"/>
+                                        <constraint firstAttribute="trailing" secondItem="nJF-Fe-glJ" secondAttribute="trailing" constant="12" id="PpJ-iq-djq"/>
+                                        <constraint firstItem="P6I-h4-MV9" firstAttribute="top" secondItem="507-xz-zeA" secondAttribute="bottom" constant="12" id="QUK-V0-BmS"/>
+                                        <constraint firstItem="PgQ-KO-dy8" firstAttribute="firstBaseline" secondItem="IpH-Qz-kKo" secondAttribute="firstBaseline" id="Rro-ga-4bH"/>
                                         <constraint firstItem="507-xz-zeA" firstAttribute="top" secondItem="nJF-Fe-glJ" secondAttribute="bottom" constant="12" id="VGM-nM-VIz"/>
                                         <constraint firstItem="P6I-h4-MV9" firstAttribute="trailing" secondItem="EaI-Lh-edg" secondAttribute="trailing" id="VzA-D3-y2g"/>
                                         <constraint firstItem="SEN-lo-1AP" firstAttribute="trailing" secondItem="IpH-Qz-kKo" secondAttribute="trailing" id="WNP-Ik-PER"/>
                                         <constraint firstItem="UBX-ge-nPN" firstAttribute="leading" secondItem="3Lj-7X-tNH" secondAttribute="leading" id="Y2W-S8-LWi"/>
+                                        <constraint firstItem="uzH-YO-YLT" firstAttribute="trailing" secondItem="UBX-ge-nPN" secondAttribute="trailing" id="YoQ-q8-XPw"/>
                                         <constraint firstItem="nJF-Fe-glJ" firstAttribute="top" secondItem="JYJ-iA-Cdg" secondAttribute="bottom" constant="4" id="ZvZ-Pq-WEE"/>
                                         <constraint firstItem="EaI-Lh-edg" firstAttribute="trailing" secondItem="SEN-lo-1AP" secondAttribute="trailing" id="dDx-00-V1b"/>
+                                        <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="2xR-1D-bSh" secondAttribute="bottom" constant="12" id="dP5-Hc-lLS"/>
                                         <constraint firstItem="uzH-YO-YLT" firstAttribute="leading" secondItem="PgQ-KO-dy8" secondAttribute="leading" id="dqw-N6-0EQ"/>
-                                        <constraint firstItem="nJF-Fe-glJ" firstAttribute="trailing" secondItem="507-xz-zeA" secondAttribute="trailing" id="eZC-b7-mdu"/>
+                                        <constraint firstItem="UBX-ge-nPN" firstAttribute="firstBaseline" secondItem="P6I-h4-MV9" secondAttribute="firstBaseline" id="f1G-co-fq6"/>
                                         <constraint firstItem="JYJ-iA-Cdg" firstAttribute="leading" secondItem="nJF-Fe-glJ" secondAttribute="leading" id="fPN-2U-rPc"/>
                                         <constraint firstItem="nJF-Fe-glJ" firstAttribute="leading" secondItem="507-xz-zeA" secondAttribute="leading" id="iOZ-re-91J"/>
-                                        <constraint firstItem="JYJ-iA-Cdg" firstAttribute="centerX" secondItem="foT-8J-MwC" secondAttribute="centerX" id="iX1-Y2-bj5"/>
-                                        <constraint firstItem="2xR-1D-bSh" firstAttribute="top" secondItem="yhp-8h-TAd" secondAttribute="top" id="lUC-Ud-Ief"/>
                                         <constraint firstItem="IpH-Qz-kKo" firstAttribute="trailing" secondItem="2xR-1D-bSh" secondAttribute="trailing" id="rDd-UM-w28"/>
+                                        <constraint firstItem="3Lj-7X-tNH" firstAttribute="trailing" secondItem="UBX-ge-nPN" secondAttribute="trailing" id="tLp-4a-8lM"/>
                                         <constraint firstItem="P6I-h4-MV9" firstAttribute="leading" secondItem="EaI-Lh-edg" secondAttribute="leading" id="vBw-t1-jxL"/>
                                         <constraint firstItem="EaI-Lh-edg" firstAttribute="leading" secondItem="SEN-lo-1AP" secondAttribute="leading" id="xkY-fm-J71"/>
                                     </constraints>
@@ -948,126 +945,126 @@
                             </tabViewItem>
                             <tabViewItem label="Status" identifier="" id="VGm-BL-xOI">
                                 <view key="view" id="VWf-29-TwU">
-                                    <rect key="frame" x="0.0" y="0.0" width="400" height="387"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="326" height="382"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YAy-hh-4mE">
-                                            <rect key="frame" x="10" y="361" width="131" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="A/V Sync Diff:" id="iVK-Ck-Lyq">
+                                            <rect key="frame" x="10" y="356" width="131" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="A/V Sync Diff:" id="iVK-Ck-Lyq">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="BSs-zY-Ycq">
-                                            <rect key="frame" x="147" y="359" width="243" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="YcG-9Y-Qn6">
+                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="BSs-zY-Ycq">
+                                            <rect key="frame" x="147" y="356" width="169" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" id="YcG-9Y-Qn6">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Xx9-GE-Qp4">
-                                            <rect key="frame" x="10" y="339" width="131" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Total A/V Sync:" id="sbO-Cn-gpI">
+                                            <rect key="frame" x="10" y="334" width="131" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Total A/V Sync:" id="sbO-Cn-gpI">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cwU-SQ-A8V">
-                                            <rect key="frame" x="147" y="337" width="243" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="V7s-Tp-SD6">
+                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cwU-SQ-A8V">
+                                            <rect key="frame" x="147" y="334" width="169" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" id="V7s-Tp-SD6">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="R9k-Bu-wSB">
-                                            <rect key="frame" x="10" y="317" width="131" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Dropped Frames:" id="CrF-UR-udW">
+                                            <rect key="frame" x="10" y="312" width="131" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Dropped Frames:" id="CrF-UR-udW">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Evy-yh-2vU">
-                                            <rect key="frame" x="147" y="315" width="243" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="OZx-CU-1b5">
+                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Evy-yh-2vU">
+                                            <rect key="frame" x="147" y="312" width="169" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" id="OZx-CU-1b5">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="l4a-xE-z4Y">
-                                            <rect key="frame" x="10" y="295" width="131" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Mistimed Frames:" id="AYt-pH-UCi">
+                                            <rect key="frame" x="10" y="290" width="131" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Mistimed Frames:" id="AYt-pH-UCi">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="drh-59-1Az">
-                                            <rect key="frame" x="147" y="293" width="243" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="R14-IF-0dZ">
+                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="drh-59-1Az">
+                                            <rect key="frame" x="147" y="290" width="169" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" id="R14-IF-0dZ">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="r7h-Wk-a9A">
-                                            <rect key="frame" x="10" y="273" width="131" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Display FPS:" id="AjU-1T-aGR">
+                                            <rect key="frame" x="10" y="268" width="131" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Display FPS:" id="AjU-1T-aGR">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Soa-90-mcv">
-                                            <rect key="frame" x="147" y="271" width="243" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="wMU-ig-9zP">
+                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Soa-90-mcv">
+                                            <rect key="frame" x="147" y="268" width="169" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" id="wMU-ig-9zP">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="G90-uq-cW4">
-                                            <rect key="frame" x="10" y="251" width="131" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Estimated Output FPS:" id="g8p-Ec-awO">
+                                            <rect key="frame" x="10" y="246" width="131" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Estimated Output FPS:" id="g8p-Ec-awO">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Y8Q-PG-bHl">
-                                            <rect key="frame" x="147" y="249" width="243" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="qPy-MN-AEF">
+                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Y8Q-PG-bHl">
+                                            <rect key="frame" x="147" y="246" width="169" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" id="qPy-MN-AEF">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="XLQ-aa-TdR">
-                                            <rect key="frame" x="10" y="229" width="131" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Estimated Disp FPS" id="JN9-3E-OJp">
+                                            <rect key="frame" x="10" y="224" width="131" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Estimated Disp FPS" id="JN9-3E-OJp">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oRb-Bc-1u0">
-                                            <rect key="frame" x="147" y="227" width="243" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="ElK-iN-YiE">
+                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oRb-Bc-1u0">
+                                            <rect key="frame" x="147" y="224" width="169" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" id="ElK-iN-YiE">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
                                         <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="uvv-R0-JCz">
-                                            <rect key="frame" x="12" y="212" width="376" height="5"/>
+                                            <rect key="frame" x="12" y="209" width="302" height="5"/>
                                         </box>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Oof-hT-luu">
-                                            <rect key="frame" x="10" y="188" width="40" height="14"/>
+                                            <rect key="frame" x="10" y="185" width="40" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Watch" id="tNS-gW-PcC">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1075,20 +1072,20 @@
                                             </textFieldCell>
                                         </textField>
                                         <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9In-dC-gN9">
-                                            <rect key="frame" x="12" y="-9" width="376" height="185"/>
+                                            <rect key="frame" x="12" y="32" width="302" height="141"/>
                                             <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="MlR-S8-3gW">
-                                                <rect key="frame" x="0.0" y="0.0" width="376" height="185"/>
-                                                <autoresizingMask key="autoresizingMask"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="302" height="141"/>
+                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
-                                                    <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" typeSelect="NO" id="oUp-DO-OKl">
-                                                        <rect key="frame" x="0.0" y="0.0" width="376" height="185"/>
+                                                    <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" multipleSelection="NO" typeSelect="NO" autosaveName="InspectorWatchTable" headerView="pnK-fx-7et" id="oUp-DO-OKl">
+                                                        <rect key="frame" x="0.0" y="0.0" width="302" height="113"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <size key="intercellSpacing" width="3" height="2"/>
                                                         <color key="backgroundColor" white="0.69999999999999996" alpha="0.10000000000000001" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                         <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                                         <tableColumns>
-                                                            <tableColumn identifier="Key" editable="NO" width="116" minWidth="40" maxWidth="1000" id="zDk-Ie-EPs">
-                                                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
+                                                            <tableColumn identifier="Key" editable="NO" width="120" minWidth="40" maxWidth="1000" id="zDk-Ie-EPs">
+                                                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Key">
                                                                     <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                                 </tableHeaderCell>
@@ -1099,8 +1096,8 @@
                                                                 </textFieldCell>
                                                                 <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                             </tableColumn>
-                                                            <tableColumn identifier="Value" editable="NO" width="245" minWidth="40" maxWidth="1000" id="x6R-q7-efY">
-                                                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
+                                                            <tableColumn identifier="Value" editable="NO" width="162" minWidth="40" maxWidth="1000" id="x6R-q7-efY">
+                                                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Value">
                                                                     <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                                                 </tableHeaderCell>
@@ -1109,7 +1106,7 @@
                                                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                 </textFieldCell>
-                                                                <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                                <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
                                                             </tableColumn>
                                                         </tableColumns>
                                                     </tableView>
@@ -1119,37 +1116,40 @@
                                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="132" id="lgJ-2t-4Av"/>
                                             </constraints>
                                             <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="Xmy-WZ-mQX">
-                                                <rect key="frame" x="0.0" y="116" width="376" height="16"/>
+                                                <rect key="frame" x="0.0" y="125" width="302" height="16"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </scroller>
                                             <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="mkC-To-Cta">
                                                 <rect key="frame" x="224" y="17" width="15" height="102"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </scroller>
+                                            <tableHeaderView key="headerView" wantsLayer="YES" id="pnK-fx-7et">
+                                                <rect key="frame" x="0.0" y="0.0" width="302" height="28"/>
+                                                <autoresizingMask key="autoresizingMask"/>
+                                            </tableHeaderView>
                                         </scrollView>
                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="PST-dF-CNB">
-                                            <rect key="frame" x="12" y="-27.5" width="16" height="17"/>
+                                            <rect key="frame" x="12" y="10.5" width="16.5" height="20"/>
                                             <constraints>
-                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="16" id="Ccu-0I-ete"/>
-                                                <constraint firstAttribute="height" constant="14" id="msy-CE-lBu"/>
+                                                <constraint firstAttribute="width" secondItem="PST-dF-CNB" secondAttribute="height" multiplier="1:1" id="UCz-nS-in2"/>
+                                                <constraint firstAttribute="height" constant="16" id="qBg-Du-yni"/>
                                             </constraints>
-                                            <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" controlSize="small" lineBreakMode="truncatingTail" state="on" imageScaling="proportionallyDown" inset="2" id="C0z-MP-Vib">
+                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" lineBreakMode="truncatingTail" state="on" imageScaling="proportionallyDown" inset="2" id="C0z-MP-Vib">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <font key="font" metaFont="system"/>
                                             </buttonCell>
                                             <connections>
                                                 <action selector="addWatchAction:" target="-2" id="U1i-ud-u7Y"/>
                                             </connections>
                                         </button>
                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Tel-U0-EC3">
-                                            <rect key="frame" x="28" y="-23.5" width="16" height="9"/>
+                                            <rect key="frame" x="28" y="15" width="16.5" height="11"/>
                                             <constraints>
-                                                <constraint firstAttribute="height" constant="14" id="aAG-Y2-goP"/>
-                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="16" id="uIM-ym-BuW"/>
+                                                <constraint firstAttribute="width" secondItem="Tel-U0-EC3" secondAttribute="height" multiplier="1:1" id="PB9-gI-o4g"/>
                                             </constraints>
-                                            <buttonCell key="cell" type="smallSquare" bezelStyle="smallSquare" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" controlSize="small" lineBreakMode="truncatingTail" state="on" imageScaling="proportionallyDown" inset="2" id="kY7-c8-qmB">
+                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" lineBreakMode="truncatingTail" state="on" imageScaling="proportionallyDown" inset="2" id="kY7-c8-qmB">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <font key="font" metaFont="system"/>
                                             </buttonCell>
                                             <connections>
                                                 <action selector="removeWatchAction:" target="-2" id="q2y-lH-kyU"/>
@@ -1157,71 +1157,72 @@
                                         </button>
                                     </subviews>
                                     <constraints>
+                                        <constraint firstItem="R9k-Bu-wSB" firstAttribute="trailing" secondItem="YAy-hh-4mE" secondAttribute="trailing" id="0aV-Td-w4R"/>
                                         <constraint firstItem="BSs-zY-Ycq" firstAttribute="leading" secondItem="YAy-hh-4mE" secondAttribute="trailing" constant="10" id="1Wr-UJ-n7p"/>
                                         <constraint firstAttribute="trailing" secondItem="drh-59-1Az" secondAttribute="trailing" constant="12" id="3fy-6D-R7b"/>
-                                        <constraint firstItem="PST-dF-CNB" firstAttribute="top" secondItem="9In-dC-gN9" secondAttribute="bottom" constant="3" id="3tQ-G5-ECY"/>
-                                        <constraint firstItem="Y8Q-PG-bHl" firstAttribute="top" secondItem="G90-uq-cW4" secondAttribute="top" id="4Qz-QM-m3g"/>
+                                        <constraint firstItem="PST-dF-CNB" firstAttribute="top" secondItem="9In-dC-gN9" secondAttribute="bottom" constant="4" id="3tQ-G5-ECY"/>
                                         <constraint firstItem="cwU-SQ-A8V" firstAttribute="leading" secondItem="Xx9-GE-Qp4" secondAttribute="trailing" constant="10" id="54H-zn-ZFJ"/>
-                                        <constraint firstItem="cwU-SQ-A8V" firstAttribute="top" secondItem="Xx9-GE-Qp4" secondAttribute="top" id="5dj-zX-RZE"/>
-                                        <constraint firstItem="l4a-xE-z4Y" firstAttribute="width" secondItem="YAy-hh-4mE" secondAttribute="width" id="6E9-cZ-Nrf"/>
                                         <constraint firstItem="9In-dC-gN9" firstAttribute="leading" secondItem="VWf-29-TwU" secondAttribute="leading" constant="12" id="6u3-hN-09b"/>
                                         <constraint firstAttribute="trailing" secondItem="oRb-Bc-1u0" secondAttribute="trailing" constant="12" id="7kC-Lv-mPs"/>
                                         <constraint firstItem="Xx9-GE-Qp4" firstAttribute="leading" secondItem="VWf-29-TwU" secondAttribute="leading" constant="12" id="9cz-jP-ukR"/>
+                                        <constraint firstItem="Y8Q-PG-bHl" firstAttribute="firstBaseline" secondItem="G90-uq-cW4" secondAttribute="firstBaseline" id="AmN-Gl-2OW"/>
+                                        <constraint firstAttribute="bottom" secondItem="PST-dF-CNB" secondAttribute="bottom" constant="12" id="BFi-R5-n5r"/>
                                         <constraint firstItem="9In-dC-gN9" firstAttribute="top" secondItem="Oof-hT-luu" secondAttribute="bottom" constant="12" id="EPG-sq-qur"/>
+                                        <constraint firstItem="drh-59-1Az" firstAttribute="firstBaseline" secondItem="l4a-xE-z4Y" secondAttribute="firstBaseline" id="FBF-ZP-gHJ"/>
                                         <constraint firstItem="Tel-U0-EC3" firstAttribute="leading" secondItem="PST-dF-CNB" secondAttribute="trailing" id="FaS-Uj-OAZ"/>
                                         <constraint firstItem="Soa-90-mcv" firstAttribute="leading" secondItem="r7h-Wk-a9A" secondAttribute="trailing" constant="10" id="IRq-6F-l0K"/>
                                         <constraint firstItem="PST-dF-CNB" firstAttribute="leading" secondItem="9In-dC-gN9" secondAttribute="leading" id="Ib8-uE-P0D"/>
-                                        <constraint firstItem="Soa-90-mcv" firstAttribute="top" secondItem="r7h-Wk-a9A" secondAttribute="top" id="Jbw-kR-3dq"/>
-                                        <constraint firstItem="drh-59-1Az" firstAttribute="top" secondItem="l4a-xE-z4Y" secondAttribute="top" id="Mle-FM-hAD"/>
-                                        <constraint firstItem="G90-uq-cW4" firstAttribute="width" secondItem="YAy-hh-4mE" secondAttribute="width" id="POd-3I-0Lk"/>
                                         <constraint firstAttribute="trailing" secondItem="Y8Q-PG-bHl" secondAttribute="trailing" constant="12" id="QOY-QY-knw"/>
-                                        <constraint firstItem="Xx9-GE-Qp4" firstAttribute="width" secondItem="YAy-hh-4mE" secondAttribute="width" id="QdF-2D-IGs"/>
-                                        <constraint firstItem="r7h-Wk-a9A" firstAttribute="width" secondItem="YAy-hh-4mE" secondAttribute="width" id="QfI-Lx-c14"/>
                                         <constraint firstAttribute="trailing" secondItem="Evy-yh-2vU" secondAttribute="trailing" constant="12" id="Qlo-wr-JIn"/>
+                                        <constraint firstItem="XLQ-aa-TdR" firstAttribute="trailing" secondItem="YAy-hh-4mE" secondAttribute="trailing" id="QsZ-2v-GeS"/>
                                         <constraint firstItem="uvv-R0-JCz" firstAttribute="top" secondItem="oRb-Bc-1u0" secondAttribute="bottom" constant="12" id="R1V-jb-2Eb"/>
                                         <constraint firstItem="drh-59-1Az" firstAttribute="top" secondItem="Evy-yh-2vU" secondAttribute="bottom" constant="6" id="RdJ-rZ-FiS"/>
                                         <constraint firstAttribute="trailing" secondItem="Soa-90-mcv" secondAttribute="trailing" constant="12" id="SpJ-31-6Wt"/>
                                         <constraint firstAttribute="trailing" secondItem="BSs-zY-Ycq" secondAttribute="trailing" constant="12" id="T6i-3d-2Qz"/>
+                                        <constraint firstItem="Xx9-GE-Qp4" firstAttribute="trailing" secondItem="YAy-hh-4mE" secondAttribute="trailing" id="TcA-jw-VHI"/>
                                         <constraint firstItem="XLQ-aa-TdR" firstAttribute="leading" secondItem="VWf-29-TwU" secondAttribute="leading" constant="12" id="UKo-nw-XpB"/>
+                                        <constraint firstItem="G90-uq-cW4" firstAttribute="trailing" secondItem="YAy-hh-4mE" secondAttribute="trailing" id="VqI-G6-FV0"/>
+                                        <constraint firstItem="BSs-zY-Ycq" firstAttribute="firstBaseline" secondItem="YAy-hh-4mE" secondAttribute="firstBaseline" id="Vue-15-3M6"/>
+                                        <constraint firstItem="oRb-Bc-1u0" firstAttribute="firstBaseline" secondItem="XLQ-aa-TdR" secondAttribute="firstBaseline" id="WEP-pe-3ak"/>
                                         <constraint firstItem="cwU-SQ-A8V" firstAttribute="top" secondItem="BSs-zY-Ycq" secondAttribute="bottom" constant="6" id="X90-zN-Jsa"/>
                                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Tel-U0-EC3" secondAttribute="trailing" id="aVR-fV-9eh"/>
                                         <constraint firstItem="Y8Q-PG-bHl" firstAttribute="leading" secondItem="G90-uq-cW4" secondAttribute="trailing" constant="10" id="aYQ-xv-n6F"/>
                                         <constraint firstAttribute="trailing" secondItem="cwU-SQ-A8V" secondAttribute="trailing" constant="12" id="afa-42-bpC"/>
-                                        <constraint firstItem="oRb-Bc-1u0" firstAttribute="top" secondItem="XLQ-aa-TdR" secondAttribute="top" id="b1r-aF-o3e"/>
                                         <constraint firstItem="drh-59-1Az" firstAttribute="leading" secondItem="l4a-xE-z4Y" secondAttribute="trailing" constant="10" id="b7k-Cv-DYR"/>
                                         <constraint firstItem="uvv-R0-JCz" firstAttribute="leading" secondItem="VWf-29-TwU" secondAttribute="leading" constant="12" id="eDX-hv-gCA"/>
                                         <constraint firstItem="G90-uq-cW4" firstAttribute="leading" secondItem="VWf-29-TwU" secondAttribute="leading" constant="12" id="eKz-Ds-t06"/>
                                         <constraint firstItem="YAy-hh-4mE" firstAttribute="top" secondItem="VWf-29-TwU" secondAttribute="top" constant="12" id="fDS-Er-I6m"/>
                                         <constraint firstItem="Tel-U0-EC3" firstAttribute="top" secondItem="PST-dF-CNB" secondAttribute="top" id="fHh-fi-k6U"/>
-                                        <constraint firstAttribute="bottom" secondItem="9In-dC-gN9" secondAttribute="bottom" constant="24" id="fmX-8r-YzC"/>
                                         <constraint firstItem="R9k-Bu-wSB" firstAttribute="leading" secondItem="VWf-29-TwU" secondAttribute="leading" constant="12" id="fpp-9O-Zmf"/>
+                                        <constraint firstItem="r7h-Wk-a9A" firstAttribute="trailing" secondItem="YAy-hh-4mE" secondAttribute="trailing" id="gRu-0l-mfa"/>
                                         <constraint firstItem="oRb-Bc-1u0" firstAttribute="leading" secondItem="XLQ-aa-TdR" secondAttribute="trailing" constant="10" id="gq4-Fr-L6C"/>
+                                        <constraint firstItem="Tel-U0-EC3" firstAttribute="bottom" secondItem="PST-dF-CNB" secondAttribute="bottom" id="iPG-vs-Jys"/>
+                                        <constraint firstItem="cwU-SQ-A8V" firstAttribute="firstBaseline" secondItem="Xx9-GE-Qp4" secondAttribute="firstBaseline" id="jWy-1d-Qpr"/>
                                         <constraint firstItem="Soa-90-mcv" firstAttribute="top" secondItem="drh-59-1Az" secondAttribute="bottom" constant="6" id="k2r-1V-6tR"/>
                                         <constraint firstItem="Y8Q-PG-bHl" firstAttribute="top" secondItem="Soa-90-mcv" secondAttribute="bottom" constant="6" id="ldg-7v-3JA"/>
                                         <constraint firstItem="YAy-hh-4mE" firstAttribute="leading" secondItem="VWf-29-TwU" secondAttribute="leading" constant="12" id="mD7-6H-hHY"/>
-                                        <constraint firstItem="Evy-yh-2vU" firstAttribute="top" secondItem="R9k-Bu-wSB" secondAttribute="top" id="n3n-t0-R2p"/>
+                                        <constraint firstItem="l4a-xE-z4Y" firstAttribute="trailing" secondItem="YAy-hh-4mE" secondAttribute="trailing" id="n7j-Q6-q81"/>
+                                        <constraint firstItem="Soa-90-mcv" firstAttribute="firstBaseline" secondItem="r7h-Wk-a9A" secondAttribute="firstBaseline" id="q8o-IL-iMu"/>
                                         <constraint firstItem="r7h-Wk-a9A" firstAttribute="leading" secondItem="VWf-29-TwU" secondAttribute="leading" constant="12" id="qWT-XQ-nDa"/>
-                                        <constraint firstItem="BSs-zY-Ycq" firstAttribute="top" secondItem="YAy-hh-4mE" secondAttribute="top" id="r9k-A7-3OU"/>
                                         <constraint firstAttribute="trailing" secondItem="9In-dC-gN9" secondAttribute="trailing" constant="12" id="raH-Xs-aww"/>
+                                        <constraint firstItem="Evy-yh-2vU" firstAttribute="firstBaseline" secondItem="R9k-Bu-wSB" secondAttribute="firstBaseline" id="sHI-5a-rK6"/>
                                         <constraint firstItem="Oof-hT-luu" firstAttribute="leading" secondItem="VWf-29-TwU" secondAttribute="leading" constant="12" id="uhf-3W-HrV"/>
                                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Oof-hT-luu" secondAttribute="trailing" constant="20" symbolic="YES" id="ujq-F8-Pnc"/>
                                         <constraint firstItem="Evy-yh-2vU" firstAttribute="leading" secondItem="R9k-Bu-wSB" secondAttribute="trailing" constant="10" id="vmF-UY-Fd6"/>
                                         <constraint firstItem="l4a-xE-z4Y" firstAttribute="leading" secondItem="VWf-29-TwU" secondAttribute="leading" constant="12" id="vy3-MM-NPS"/>
-                                        <constraint firstItem="R9k-Bu-wSB" firstAttribute="width" secondItem="YAy-hh-4mE" secondAttribute="width" id="w0G-8j-Z4t"/>
                                         <constraint firstItem="oRb-Bc-1u0" firstAttribute="top" secondItem="Y8Q-PG-bHl" secondAttribute="bottom" constant="6" id="wTy-Ht-LXh"/>
                                         <constraint firstItem="Oof-hT-luu" firstAttribute="top" secondItem="uvv-R0-JCz" secondAttribute="bottom" constant="12" id="wfm-Mc-4LV"/>
                                         <constraint firstAttribute="trailing" secondItem="uvv-R0-JCz" secondAttribute="trailing" constant="12" id="xVg-Zn-RTo"/>
                                         <constraint firstItem="Evy-yh-2vU" firstAttribute="top" secondItem="cwU-SQ-A8V" secondAttribute="bottom" constant="6" id="ze3-X7-hFR"/>
-                                        <constraint firstItem="XLQ-aa-TdR" firstAttribute="width" secondItem="YAy-hh-4mE" secondAttribute="width" id="zkz-oy-l9c"/>
                                     </constraints>
                                 </view>
                             </tabViewItem>
                         </tabViewItems>
                     </tabView>
                     <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0rt-Td-kr8">
-                        <rect key="frame" x="77" y="440" width="196" height="21"/>
+                        <rect key="frame" x="87" y="449" width="176" height="21"/>
                         <segmentedCell key="cell" controlSize="small" borderStyle="border" alignment="left" style="rounded" trackingMode="selectOne" id="Fqo-1c-3L1">
-                            <font key="font" usesAppearanceFont="YES"/>
+                            <font key="font" metaFont="smallSystem"/>
                             <segments>
                                 <segment label="General" selected="YES"/>
                                 <segment label="Tracks" tag="1"/>
@@ -1251,7 +1252,7 @@
         <collectionViewItem id="STR-xi-slv"/>
     </objects>
     <resources>
-        <image name="NSAddTemplate" width="14" height="13"/>
-        <image name="NSRemoveTemplate" width="14" height="4"/>
+        <image name="NSAddTemplate" width="18" height="17"/>
+        <image name="NSRemoveTemplate" width="18" height="5"/>
     </resources>
 </document>

--- a/iina/Base.lproj/InspectorWindowController.xib
+++ b/iina/Base.lproj/InspectorWindowController.xib
@@ -26,6 +26,7 @@
                 <outlet property="fileSizeField" destination="UBX-ge-nPN" id="YZi-k9-d2u"/>
                 <outlet property="mistimedFramesField" destination="drh-59-1Az" id="IXT-ID-bLZ"/>
                 <outlet property="pathField" destination="nJF-Fe-glJ" id="zY0-Vm-keO"/>
+                <outlet property="tabButtonGroup" destination="0rt-Td-kr8" id="m0i-UC-hdu"/>
                 <outlet property="tabView" destination="wHY-jo-uW0" id="9Lk-Mi-4Aw"/>
                 <outlet property="totalAvsyncField" destination="cwU-SQ-A8V" id="wV5-3T-mBs"/>
                 <outlet property="trackChannelsField" destination="VR8-mY-Zfn" id="0Dg-SL-01x"/>
@@ -65,11 +66,11 @@
             <rect key="contentRect" x="1539" y="436" width="350" height="430"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2056" height="1285"/>
             <view key="contentView" id="se5-gp-TjO" userLabel="InspectorWindow Content View">
-                <rect key="frame" x="0.0" y="0.0" width="350" height="485"/>
+                <rect key="frame" x="0.0" y="0.0" width="350" height="430"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <tabView drawsBackground="NO" controlSize="small" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="wHY-jo-uW0">
-                        <rect key="frame" x="12" y="12" width="326" height="437"/>
+                        <rect key="frame" x="12" y="12" width="326" height="382"/>
                         <tabViewItems>
                             <tabViewItem label="General" identifier="1" id="f7a-XG-NCc">
                                 <view key="view" id="mRY-yK-FeT">
@@ -1073,30 +1074,54 @@
                                         </textField>
                                         <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9In-dC-gN9">
                                             <rect key="frame" x="12" y="32" width="302" height="141"/>
-                                            <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="MlR-S8-3gW">
+                                            <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MlR-S8-3gW">
                                                 <rect key="frame" x="0.0" y="0.0" width="302" height="141"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
-                                                    <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" multipleSelection="NO" typeSelect="NO" autosaveName="InspectorWatchTable" headerView="pnK-fx-7et" id="oUp-DO-OKl">
-                                                        <rect key="frame" x="0.0" y="0.0" width="302" height="113"/>
+                                                    <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" multipleSelection="NO" typeSelect="NO" autosaveName="InspectorWatchTable" rowSizeStyle="automatic" headerView="pnK-fx-7et" viewBased="YES" floatsGroupRows="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oUp-DO-OKl">
+                                                        <rect key="frame" x="0.0" y="0.0" width="335" height="113"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <size key="intercellSpacing" width="3" height="2"/>
-                                                        <color key="backgroundColor" white="0.69999999999999996" alpha="0.10000000000000001" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                                        <color key="backgroundColor" red="0.59999999999999998" green="0.59999999999999998" blue="0.59999999999999998" alpha="0.10000000000000001" colorSpace="custom" customColorSpace="calibratedRGB"/>
                                                         <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                                         <tableColumns>
-                                                            <tableColumn identifier="Key" editable="NO" width="120" minWidth="40" maxWidth="1000" id="zDk-Ie-EPs">
+                                                            <tableColumn identifier="Key" editable="NO" width="120" minWidth="100" maxWidth="1000" id="zDk-Ie-EPs">
                                                                 <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Key">
                                                                     <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                                    <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 </tableHeaderCell>
                                                                 <textFieldCell key="dataCell" controlSize="small" lineBreakMode="truncatingTail" selectable="YES" editable="YES" title="Text Cell" id="ydW-J5-Kk2">
                                                                     <font key="font" usesAppearanceFont="YES"/>
                                                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                 </textFieldCell>
-                                                                <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                                <tableColumnResizingMask key="resizingMask" userResizable="YES"/>
+                                                                <prototypeCellViews>
+                                                                    <tableCellView id="z2z-PI-nzs">
+                                                                        <rect key="frame" x="1" y="1" width="125" height="17"/>
+                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                        <subviews>
+                                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="vTu-fg-hiW">
+                                                                                <rect key="frame" x="2" y="1" width="121" height="16"/>
+                                                                                <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="left" title="KeyColumn Table View Cell" usesSingleLineMode="YES" id="HA9-NO-iHC">
+                                                                                    <font key="font" usesAppearanceFont="YES"/>
+                                                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                    <color key="backgroundColor" red="0.11764705882352941" green="0.11764705882352941" blue="0.11764705882352941" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                                </textFieldCell>
+                                                                            </textField>
+                                                                        </subviews>
+                                                                        <constraints>
+                                                                            <constraint firstItem="vTu-fg-hiW" firstAttribute="centerX" secondItem="z2z-PI-nzs" secondAttribute="centerX" id="4gz-5E-lPE"/>
+                                                                            <constraint firstItem="vTu-fg-hiW" firstAttribute="leading" secondItem="z2z-PI-nzs" secondAttribute="leading" constant="4" id="55D-Jr-fJc"/>
+                                                                            <constraint firstItem="vTu-fg-hiW" firstAttribute="centerY" secondItem="z2z-PI-nzs" secondAttribute="centerY" id="YQL-qe-HZD"/>
+                                                                        </constraints>
+                                                                        <connections>
+                                                                            <outlet property="textField" destination="vTu-fg-hiW" id="0Ce-oy-dXe"/>
+                                                                        </connections>
+                                                                    </tableCellView>
+                                                                </prototypeCellViews>
                                                             </tableColumn>
-                                                            <tableColumn identifier="Value" editable="NO" width="162" minWidth="40" maxWidth="1000" id="x6R-q7-efY">
+                                                            <tableColumn identifier="Value" editable="NO" width="200" minWidth="80" maxWidth="10000" id="x6R-q7-efY">
                                                                 <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Value">
                                                                     <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
@@ -1107,15 +1132,40 @@
                                                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                                                 </textFieldCell>
                                                                 <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
+                                                                <prototypeCellViews>
+                                                                    <tableCellView id="z7F-bR-0pz">
+                                                                        <rect key="frame" x="129" y="1" width="204" height="17"/>
+                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                        <subviews>
+                                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="DwZ-IW-2Yw">
+                                                                                <rect key="frame" x="4" y="1" width="196" height="16"/>
+                                                                                <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="left" title="ValueColumn Table View Cell" usesSingleLineMode="YES" id="k5Q-ii-1cq">
+                                                                                    <font key="font" usesAppearanceFont="YES"/>
+                                                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                </textFieldCell>
+                                                                            </textField>
+                                                                        </subviews>
+                                                                        <constraints>
+                                                                            <constraint firstItem="DwZ-IW-2Yw" firstAttribute="centerY" secondItem="z7F-bR-0pz" secondAttribute="centerY" id="4Fe-82-d9e"/>
+                                                                            <constraint firstItem="DwZ-IW-2Yw" firstAttribute="centerX" secondItem="z7F-bR-0pz" secondAttribute="centerX" id="Q23-7f-cjK"/>
+                                                                            <constraint firstItem="DwZ-IW-2Yw" firstAttribute="leading" secondItem="z7F-bR-0pz" secondAttribute="leading" constant="4" id="i5k-ev-16W"/>
+                                                                        </constraints>
+                                                                        <connections>
+                                                                            <outlet property="textField" destination="DwZ-IW-2Yw" id="jgq-gB-diy"/>
+                                                                        </connections>
+                                                                    </tableCellView>
+                                                                </prototypeCellViews>
                                                             </tableColumn>
                                                         </tableColumns>
                                                     </tableView>
                                                 </subviews>
+                                                <nil key="backgroundColor"/>
                                             </clipView>
                                             <constraints>
                                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="132" id="lgJ-2t-4Av"/>
                                             </constraints>
-                                            <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="Xmy-WZ-mQX">
+                                            <scroller key="horizontalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="Xmy-WZ-mQX">
                                                 <rect key="frame" x="0.0" y="125" width="302" height="16"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </scroller>
@@ -1123,8 +1173,8 @@
                                                 <rect key="frame" x="224" y="17" width="15" height="102"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </scroller>
-                                            <tableHeaderView key="headerView" wantsLayer="YES" id="pnK-fx-7et">
-                                                <rect key="frame" x="0.0" y="0.0" width="302" height="28"/>
+                                            <tableHeaderView key="headerView" wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pnK-fx-7et">
+                                                <rect key="frame" x="0.0" y="0.0" width="335" height="28"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </tableHeaderView>
                                         </scrollView>
@@ -1220,14 +1270,14 @@
                         </tabViewItems>
                     </tabView>
                     <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0rt-Td-kr8">
-                        <rect key="frame" x="87" y="449" width="176" height="21"/>
+                        <rect key="frame" x="87" y="394" width="176" height="21"/>
                         <segmentedCell key="cell" controlSize="small" borderStyle="border" alignment="left" style="rounded" trackingMode="selectOne" id="Fqo-1c-3L1">
                             <font key="font" metaFont="smallSystem"/>
                             <segments>
                                 <segment label="General" selected="YES"/>
                                 <segment label="Tracks" tag="1"/>
-                                <segment label="File"/>
-                                <segment label="Status"/>
+                                <segment label="File" tag="2"/>
+                                <segment label="Status" tag="3"/>
                             </segments>
                         </segmentedCell>
                         <connections>

--- a/iina/Base.lproj/InspectorWindowController.xib
+++ b/iina/Base.lproj/InspectorWindowController.xib
@@ -65,12 +65,12 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" utility="YES" HUD="YES"/>
             <rect key="contentRect" x="1539" y="436" width="350" height="430"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2056" height="1285"/>
-            <view key="contentView" id="se5-gp-TjO" userLabel="InspectorWindow Content View">
+            <view key="contentView" misplaced="YES" id="se5-gp-TjO" userLabel="InspectorWindow Content View">
                 <rect key="frame" x="0.0" y="0.0" width="353" height="430"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <tabView drawsBackground="NO" controlSize="small" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="wHY-jo-uW0">
-                        <rect key="frame" x="12" y="12" width="329" height="382"/>
+                        <rect key="frame" x="12" y="12" width="326" height="437"/>
                         <tabViewItems>
                             <tabViewItem label="General" identifier="1" id="f7a-XG-NCc">
                                 <view key="view" id="mRY-yK-FeT">
@@ -78,9 +78,9 @@
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="I9X-Rp-scA">
-                                            <rect key="frame" x="10" y="413" width="44" height="16"/>
+                                            <rect key="frame" x="10" y="413" width="46" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="VIDEO" id="gDG-Eq-1Bc">
-                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <font key="font" metaFont="systemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
@@ -249,9 +249,9 @@
                                             <rect key="frame" x="12" y="174" width="302" height="5"/>
                                         </box>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hGO-dV-reB">
-                                            <rect key="frame" x="10" y="148" width="45" height="16"/>
+                                            <rect key="frame" x="10" y="148" width="47" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="AUDIO" id="nrG-IH-kFg">
-                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <font key="font" metaFont="systemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
@@ -1270,7 +1270,7 @@
                         </tabViewItems>
                     </tabView>
                     <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0rt-Td-kr8">
-                        <rect key="frame" x="89" y="394" width="176" height="21"/>
+                        <rect key="frame" x="87" y="449" width="176" height="21"/>
                         <segmentedCell key="cell" controlSize="small" borderStyle="border" alignment="left" style="rounded" trackingMode="selectOne" id="Fqo-1c-3L1">
                             <font key="font" metaFont="smallSystem"/>
                             <segments>

--- a/iina/Base.lproj/InspectorWindowController.xib
+++ b/iina/Base.lproj/InspectorWindowController.xib
@@ -65,12 +65,12 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" utility="YES" HUD="YES"/>
             <rect key="contentRect" x="1539" y="436" width="350" height="430"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2056" height="1285"/>
-            <view key="contentView" misplaced="YES" id="se5-gp-TjO" userLabel="InspectorWindow Content View">
+            <view key="contentView" id="se5-gp-TjO" userLabel="InspectorWindow Content View">
                 <rect key="frame" x="0.0" y="0.0" width="353" height="430"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <tabView drawsBackground="NO" controlSize="small" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="wHY-jo-uW0">
-                        <rect key="frame" x="12" y="12" width="326" height="437"/>
+                        <rect key="frame" x="12" y="12" width="329" height="382"/>
                         <tabViewItems>
                             <tabViewItem label="General" identifier="1" id="f7a-XG-NCc">
                                 <view key="view" id="mRY-yK-FeT">
@@ -1082,7 +1082,7 @@
                                                         <rect key="frame" x="0.0" y="0.0" width="305" height="113"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <size key="intercellSpacing" width="3" height="2"/>
-                                                        <color key="backgroundColor" red="0.59999999999999998" green="0.59999999999999998" blue="0.59999999999999998" alpha="0.10000000000000001" colorSpace="custom" customColorSpace="calibratedRGB"/>
+                                                        <color key="backgroundColor" red="0.59999999999999998" green="0.59999999999999998" blue="0.59999999999999998" alpha="0.0" colorSpace="custom" customColorSpace="calibratedRGB"/>
                                                         <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                                         <tableColumns>
                                                             <tableColumn identifier="Key" editable="NO" width="140" minWidth="100" maxWidth="1000" id="zDk-Ie-EPs">
@@ -1270,7 +1270,7 @@
                         </tabViewItems>
                     </tabView>
                     <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0rt-Td-kr8">
-                        <rect key="frame" x="87" y="449" width="176" height="21"/>
+                        <rect key="frame" x="89" y="394" width="176" height="21"/>
                         <segmentedCell key="cell" controlSize="small" borderStyle="border" alignment="left" style="rounded" trackingMode="selectOne" id="Fqo-1c-3L1">
                             <font key="font" metaFont="smallSystem"/>
                             <segments>

--- a/iina/Base.lproj/InspectorWindowController.xib
+++ b/iina/Base.lproj/InspectorWindowController.xib
@@ -55,6 +55,7 @@
                 <outlet property="voField" destination="5yU-sy-R0n" id="Q0W-wm-5xc"/>
                 <outlet property="vprimariesField" destination="s9S-zN-lwA" id="U20-X9-4iz"/>
                 <outlet property="vsizeField" destination="Hmg-bS-UMv" id="LOi-KD-ZsF"/>
+                <outlet property="watchTableContainerView" destination="GYo-pW-QQ3" id="IIB-Ww-pcN"/>
                 <outlet property="watchTableView" destination="oUp-DO-OKl" id="lCS-Jn-nRL"/>
                 <outlet property="window" destination="F0z-JX-Cv5" id="gIp-Ho-8D9"/>
             </connections>
@@ -64,21 +65,25 @@
         <window title="Inspector" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" hidesOnDeactivate="YES" releasedWhenClosed="NO" frameAutosaveName="IINAInspectorPanel" animationBehavior="default" id="F0z-JX-Cv5" customClass="NSPanel">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" utility="YES" HUD="YES"/>
             <rect key="contentRect" x="1539" y="436" width="350" height="430"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2056" height="1285"/>
-            <view key="contentView" id="se5-gp-TjO" userLabel="InspectorWindow Content View">
-                <rect key="frame" x="0.0" y="0.0" width="353" height="430"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1728" height="1079"/>
+            <view key="contentView" wantsLayer="YES" id="se5-gp-TjO" userLabel="InspectorWindow Content View">
+                <rect key="frame" x="0.0" y="0.0" width="468" height="498"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <tabView drawsBackground="NO" controlSize="small" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="wHY-jo-uW0">
-                        <rect key="frame" x="12" y="12" width="329" height="382"/>
+                        <rect key="frame" x="12" y="12" width="444" height="450"/>
+                        <constraints>
+                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="444" id="YwR-Cw-Lmo"/>
+                            <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="450" id="xB0-ly-NCo"/>
+                        </constraints>
                         <tabViewItems>
                             <tabViewItem label="General" identifier="1" id="f7a-XG-NCc">
                                 <view key="view" id="mRY-yK-FeT">
-                                    <rect key="frame" x="0.0" y="0.0" width="326" height="437"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="444" height="450"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="I9X-Rp-scA">
-                                            <rect key="frame" x="10" y="413" width="46" height="16"/>
+                                            <rect key="frame" x="10" y="426" width="46" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="VIDEO" id="gDG-Eq-1Bc">
                                                 <font key="font" metaFont="systemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -86,7 +91,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aGE-iz-M2h">
-                                            <rect key="frame" x="10" y="387" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="400" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Format:" id="PQD-yB-mm6">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -94,7 +99,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hBf-Sx-lbf">
-                                            <rect key="frame" x="94" y="387" width="222" height="16"/>
+                                            <rect key="frame" x="94" y="400" width="340" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="c6m-YO-xqZ">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -102,7 +107,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FwA-X7-Alr">
-                                            <rect key="frame" x="10" y="365" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="378" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Codec:" id="bki-sE-xCA">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -110,7 +115,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="6sj-bN-LIv">
-                                            <rect key="frame" x="94" y="365" width="222" height="16"/>
+                                            <rect key="frame" x="94" y="378" width="340" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" id="SzU-uF-10g">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -118,7 +123,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="z1d-SG-OZB">
-                                            <rect key="frame" x="10" y="343" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="356" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Hw Decoder:" id="DHh-ne-10f">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -126,7 +131,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ira-RI-5kc">
-                                            <rect key="frame" x="94" y="343" width="222" height="16"/>
+                                            <rect key="frame" x="94" y="356" width="340" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="iMk-qU-kVv">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -134,7 +139,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Xol-2r-g7u">
-                                            <rect key="frame" x="10" y="321" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="334" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Primaries:" id="1kw-LO-KmJ">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -142,7 +147,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="s9S-zN-lwA">
-                                            <rect key="frame" x="94" y="321" width="222" height="16"/>
+                                            <rect key="frame" x="94" y="334" width="340" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="b34-md-3Dx">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -150,7 +155,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Hm9-gI-9j7">
-                                            <rect key="frame" x="10" y="299" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="312" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Colorspace:" id="mLo-Wc-BoO">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -158,7 +163,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wxy-f3-FrW">
-                                            <rect key="frame" x="94" y="299" width="222" height="16"/>
+                                            <rect key="frame" x="94" y="312" width="340" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="iMO-Ze-egg">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -166,7 +171,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dyh-2O-q0Y">
-                                            <rect key="frame" x="10" y="277" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="290" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Pixel Format:" id="UrR-u2-hFz">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -174,7 +179,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WWd-BJ-GxF">
-                                            <rect key="frame" x="94" y="277" width="222" height="16"/>
+                                            <rect key="frame" x="94" y="290" width="340" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="BsT-Yz-AgP">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -182,7 +187,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ldf-jT-tdl">
-                                            <rect key="frame" x="10" y="255" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="268" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Driver:" id="I2E-6Z-Gnn">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -190,7 +195,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="5yU-sy-R0n">
-                                            <rect key="frame" x="94" y="255" width="222" height="16"/>
+                                            <rect key="frame" x="94" y="268" width="340" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="3bw-Kl-SeY">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -198,7 +203,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="gxW-1z-Af9">
-                                            <rect key="frame" x="10" y="233" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="246" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Size:" id="f2P-qb-wRx">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -206,7 +211,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Hmg-bS-UMv">
-                                            <rect key="frame" x="94" y="233" width="222" height="16"/>
+                                            <rect key="frame" x="94" y="246" width="340" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="rcA-a7-rVn">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -214,7 +219,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Qke-bh-4oG">
-                                            <rect key="frame" x="10" y="211" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="224" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Bit Rate:" id="jyV-Pd-UvH">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -222,7 +227,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4PF-1d-gZO">
-                                            <rect key="frame" x="94" y="211" width="222" height="16"/>
+                                            <rect key="frame" x="94" y="224" width="340" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="Aes-4j-UT6">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -230,7 +235,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dOE-eM-QQi">
-                                            <rect key="frame" x="10" y="189" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="202" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="FPS:" id="7QX-tu-rvs">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -238,7 +243,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="c90-dT-hDG">
-                                            <rect key="frame" x="94" y="189" width="222" height="16"/>
+                                            <rect key="frame" x="94" y="202" width="340" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="ZIA-g4-WqZ">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -246,10 +251,10 @@
                                             </textFieldCell>
                                         </textField>
                                         <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="IXe-pS-a3x">
-                                            <rect key="frame" x="12" y="174" width="302" height="5"/>
+                                            <rect key="frame" x="12" y="187" width="420" height="5"/>
                                         </box>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hGO-dV-reB">
-                                            <rect key="frame" x="10" y="148" width="47" height="16"/>
+                                            <rect key="frame" x="10" y="161" width="47" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="AUDIO" id="nrG-IH-kFg">
                                                 <font key="font" metaFont="systemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -257,7 +262,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="6EL-aj-Hjq">
-                                            <rect key="frame" x="10" y="122" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="135" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Format:" id="5H6-qJ-RDS">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -265,7 +270,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="a3w-YC-7oN">
-                                            <rect key="frame" x="94" y="122" width="222" height="16"/>
+                                            <rect key="frame" x="94" y="135" width="340" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="cwF-5C-5nd">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -273,7 +278,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Zp5-es-UTa">
-                                            <rect key="frame" x="10" y="100" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="113" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Codec:" id="n0s-eM-42w">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -281,7 +286,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="GaY-iG-tAy">
-                                            <rect key="frame" x="94" y="100" width="222" height="16"/>
+                                            <rect key="frame" x="94" y="113" width="340" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="etG-FX-Rzo">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -289,7 +294,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="GSF-Y5-FGJ">
-                                            <rect key="frame" x="10" y="78" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="91" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Driver:" id="MME-KZ-jrG">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -297,7 +302,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="v4j-fa-olc">
-                                            <rect key="frame" x="94" y="78" width="222" height="16"/>
+                                            <rect key="frame" x="94" y="91" width="340" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="MTG-ez-V2R">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -305,7 +310,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EiP-Mu-9cf">
-                                            <rect key="frame" x="10" y="56" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="69" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Channels:" id="it3-05-Pwu">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -313,7 +318,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="L3Y-pD-V9R">
-                                            <rect key="frame" x="94" y="56" width="222" height="16"/>
+                                            <rect key="frame" x="94" y="69" width="340" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="6mx-wH-SBP">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -321,7 +326,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="apr-sq-JIb">
-                                            <rect key="frame" x="10" y="34" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="47" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Bit Rate:" id="A4y-LL-x0z">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -329,7 +334,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="S6Z-fT-kcG">
-                                            <rect key="frame" x="94" y="34" width="222" height="16"/>
+                                            <rect key="frame" x="94" y="47" width="340" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="4Ph-yc-lsv">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -337,7 +342,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Nn4-TP-Hpd">
-                                            <rect key="frame" x="10" y="12" width="78" height="14"/>
+                                            <rect key="frame" x="10" y="25" width="78" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Sample Rate:" id="llF-4b-Z8b">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -345,7 +350,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ghr-q6-WAW">
-                                            <rect key="frame" x="94" y="12" width="222" height="16"/>
+                                            <rect key="frame" x="94" y="25" width="340" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="4di-sR-tOh">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -946,11 +951,11 @@
                             </tabViewItem>
                             <tabViewItem label="Status" identifier="" id="VGm-BL-xOI">
                                 <view key="view" id="VWf-29-TwU">
-                                    <rect key="frame" x="0.0" y="0.0" width="329" height="382"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="444" height="450"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YAy-hh-4mE">
-                                            <rect key="frame" x="10" y="356" width="131" height="14"/>
+                                            <rect key="frame" x="10" y="424" width="131" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="A/V Sync Diff:" id="iVK-Ck-Lyq">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -958,7 +963,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="BSs-zY-Ycq">
-                                            <rect key="frame" x="147" y="356" width="172" height="16"/>
+                                            <rect key="frame" x="147" y="424" width="287" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" id="YcG-9Y-Qn6">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -966,7 +971,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Xx9-GE-Qp4">
-                                            <rect key="frame" x="10" y="334" width="131" height="14"/>
+                                            <rect key="frame" x="10" y="402" width="131" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Total A/V Sync:" id="sbO-Cn-gpI">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -974,7 +979,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cwU-SQ-A8V">
-                                            <rect key="frame" x="147" y="334" width="172" height="16"/>
+                                            <rect key="frame" x="147" y="402" width="287" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" id="V7s-Tp-SD6">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -982,7 +987,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="R9k-Bu-wSB">
-                                            <rect key="frame" x="10" y="312" width="131" height="14"/>
+                                            <rect key="frame" x="10" y="380" width="131" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Dropped Frames:" id="CrF-UR-udW">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -990,7 +995,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Evy-yh-2vU">
-                                            <rect key="frame" x="147" y="312" width="172" height="16"/>
+                                            <rect key="frame" x="147" y="380" width="287" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" id="OZx-CU-1b5">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -998,7 +1003,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="l4a-xE-z4Y">
-                                            <rect key="frame" x="10" y="290" width="131" height="14"/>
+                                            <rect key="frame" x="10" y="358" width="131" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Mistimed Frames:" id="AYt-pH-UCi">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1006,7 +1011,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="drh-59-1Az">
-                                            <rect key="frame" x="147" y="290" width="172" height="16"/>
+                                            <rect key="frame" x="147" y="358" width="287" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" id="R14-IF-0dZ">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1014,7 +1019,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="r7h-Wk-a9A">
-                                            <rect key="frame" x="10" y="268" width="131" height="14"/>
+                                            <rect key="frame" x="10" y="336" width="131" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Display FPS:" id="AjU-1T-aGR">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1022,7 +1027,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Soa-90-mcv">
-                                            <rect key="frame" x="147" y="268" width="172" height="16"/>
+                                            <rect key="frame" x="147" y="336" width="287" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" id="wMU-ig-9zP">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1030,7 +1035,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="G90-uq-cW4">
-                                            <rect key="frame" x="10" y="246" width="131" height="14"/>
+                                            <rect key="frame" x="10" y="314" width="131" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Estimated Output FPS:" id="g8p-Ec-awO">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1038,7 +1043,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Y8Q-PG-bHl">
-                                            <rect key="frame" x="147" y="246" width="172" height="16"/>
+                                            <rect key="frame" x="147" y="314" width="287" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" id="qPy-MN-AEF">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1046,7 +1051,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="XLQ-aa-TdR">
-                                            <rect key="frame" x="10" y="224" width="131" height="14"/>
+                                            <rect key="frame" x="10" y="292" width="131" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Estimated Disp FPS" id="JN9-3E-OJp">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1054,7 +1059,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oRb-Bc-1u0">
-                                            <rect key="frame" x="147" y="224" width="172" height="16"/>
+                                            <rect key="frame" x="147" y="292" width="287" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" id="ElK-iN-YiE">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1062,122 +1067,133 @@
                                             </textFieldCell>
                                         </textField>
                                         <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="uvv-R0-JCz">
-                                            <rect key="frame" x="12" y="209" width="305" height="5"/>
+                                            <rect key="frame" x="12" y="277" width="420" height="5"/>
                                         </box>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Oof-hT-luu">
-                                            <rect key="frame" x="10" y="185" width="40" height="14"/>
+                                            <rect key="frame" x="10" y="253" width="40" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Watch" id="tNS-gW-PcC">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9In-dC-gN9">
-                                            <rect key="frame" x="12" y="32" width="305" height="141"/>
-                                            <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MlR-S8-3gW">
-                                                <rect key="frame" x="0.0" y="0.0" width="305" height="141"/>
-                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                <subviews>
-                                                    <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" multipleSelection="NO" typeSelect="NO" autosaveName="InspectorWatchTable" rowSizeStyle="automatic" headerView="pnK-fx-7et" viewBased="YES" floatsGroupRows="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oUp-DO-OKl">
-                                                        <rect key="frame" x="0.0" y="0.0" width="305" height="113"/>
+                                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="GYo-pW-QQ3" userLabel="WatchTable Container View">
+                                            <rect key="frame" x="12" y="40" width="420" height="201"/>
+                                            <subviews>
+                                                <scrollView borderType="none" horizontalLineScroll="19" horizontalPageScroll="0.0" verticalLineScroll="19" verticalPageScroll="0.0" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="9In-dC-gN9" userLabel="WatchTable Scroll View">
+                                                    <rect key="frame" x="0.0" y="0.0" width="420" height="201"/>
+                                                    <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MlR-S8-3gW" userLabel="WatchTable Clip View">
+                                                        <rect key="frame" x="0.0" y="0.0" width="420" height="201"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                        <size key="intercellSpacing" width="3" height="2"/>
-                                                        <color key="backgroundColor" red="0.59999999999999998" green="0.59999999999999998" blue="0.59999999999999998" alpha="0.0" colorSpace="custom" customColorSpace="calibratedRGB"/>
-                                                        <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
-                                                        <tableColumns>
-                                                            <tableColumn identifier="Key" editable="NO" width="140" minWidth="100" maxWidth="1000" id="zDk-Ie-EPs">
-                                                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Name">
-                                                                    <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                                    <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                </tableHeaderCell>
-                                                                <textFieldCell key="dataCell" controlSize="small" lineBreakMode="truncatingTail" selectable="YES" editable="YES" title="Text Cell" id="ydW-J5-Kk2">
-                                                                    <font key="font" usesAppearanceFont="YES"/>
-                                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                </textFieldCell>
-                                                                <tableColumnResizingMask key="resizingMask" userResizable="YES"/>
-                                                                <prototypeCellViews>
-                                                                    <tableCellView id="z2z-PI-nzs">
-                                                                        <rect key="frame" x="1" y="1" width="145" height="17"/>
-                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                        <subviews>
-                                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="vTu-fg-hiW">
-                                                                                <rect key="frame" x="2" y="1" width="141" height="16"/>
-                                                                                <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="left" title="KeyColumn Table View Cell" usesSingleLineMode="YES" id="HA9-NO-iHC">
-                                                                                    <font key="font" usesAppearanceFont="YES"/>
-                                                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                    <color key="backgroundColor" red="0.11764705882352941" green="0.11764705882352941" blue="0.11764705882352941" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                                                                                </textFieldCell>
-                                                                            </textField>
-                                                                        </subviews>
-                                                                        <constraints>
-                                                                            <constraint firstItem="vTu-fg-hiW" firstAttribute="centerX" secondItem="z2z-PI-nzs" secondAttribute="centerX" id="4gz-5E-lPE"/>
-                                                                            <constraint firstItem="vTu-fg-hiW" firstAttribute="leading" secondItem="z2z-PI-nzs" secondAttribute="leading" constant="4" id="55D-Jr-fJc"/>
-                                                                            <constraint firstItem="vTu-fg-hiW" firstAttribute="centerY" secondItem="z2z-PI-nzs" secondAttribute="centerY" id="YQL-qe-HZD"/>
-                                                                        </constraints>
-                                                                        <connections>
-                                                                            <outlet property="textField" destination="vTu-fg-hiW" id="0Ce-oy-dXe"/>
-                                                                        </connections>
-                                                                    </tableCellView>
-                                                                </prototypeCellViews>
-                                                            </tableColumn>
-                                                            <tableColumn identifier="Value" editable="NO" width="147" minWidth="80" maxWidth="10000" id="x6R-q7-efY">
-                                                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Value">
-                                                                    <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                                    <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
-                                                                </tableHeaderCell>
-                                                                <textFieldCell key="dataCell" controlSize="small" lineBreakMode="truncatingTail" selectable="YES" editable="YES" title="Text Cell" id="cCV-DA-Kkq">
-                                                                    <font key="font" usesAppearanceFont="YES"/>
-                                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                </textFieldCell>
-                                                                <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
-                                                                <prototypeCellViews>
-                                                                    <tableCellView id="z7F-bR-0pz">
-                                                                        <rect key="frame" x="149" y="1" width="151" height="17"/>
-                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                        <subviews>
-                                                                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="DwZ-IW-2Yw">
-                                                                                <rect key="frame" x="2" y="1" width="147" height="16"/>
-                                                                                <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="left" title="ValueColumn Table View Cell" usesSingleLineMode="YES" id="k5Q-ii-1cq">
-                                                                                    <font key="font" usesAppearanceFont="YES"/>
-                                                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                                </textFieldCell>
-                                                                            </textField>
-                                                                        </subviews>
-                                                                        <constraints>
-                                                                            <constraint firstItem="DwZ-IW-2Yw" firstAttribute="centerY" secondItem="z7F-bR-0pz" secondAttribute="centerY" id="4Fe-82-d9e"/>
-                                                                            <constraint firstItem="DwZ-IW-2Yw" firstAttribute="centerX" secondItem="z7F-bR-0pz" secondAttribute="centerX" id="Q23-7f-cjK"/>
-                                                                            <constraint firstItem="DwZ-IW-2Yw" firstAttribute="leading" secondItem="z7F-bR-0pz" secondAttribute="leading" constant="4" id="i5k-ev-16W"/>
-                                                                        </constraints>
-                                                                        <connections>
-                                                                            <outlet property="textField" destination="DwZ-IW-2Yw" id="jgq-gB-diy"/>
-                                                                        </connections>
-                                                                    </tableCellView>
-                                                                </prototypeCellViews>
-                                                            </tableColumn>
-                                                        </tableColumns>
-                                                    </tableView>
-                                                </subviews>
-                                                <nil key="backgroundColor"/>
-                                            </clipView>
+                                                        <subviews>
+                                                            <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" multipleSelection="NO" typeSelect="NO" autosaveName="InspectorWatchTable" rowSizeStyle="automatic" headerView="pnK-fx-7et" viewBased="YES" floatsGroupRows="NO" id="oUp-DO-OKl" userLabel="WatchTable Table View">
+                                                                <rect key="frame" x="0.0" y="0.0" width="420" height="173"/>
+                                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                <size key="intercellSpacing" width="0.0" height="2"/>
+                                                                <color key="backgroundColor" red="0.59999999999999998" green="0.59999999999999998" blue="0.59999999999999998" alpha="0.0" colorSpace="custom" customColorSpace="calibratedRGB"/>
+                                                                <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
+                                                                <tableColumns>
+                                                                    <tableColumn identifier="Key" editable="NO" width="180" minWidth="120" maxWidth="1000" id="zDk-Ie-EPs" userLabel="Name Column">
+                                                                        <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Name">
+                                                                            <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                            <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                        </tableHeaderCell>
+                                                                        <textFieldCell key="dataCell" controlSize="small" lineBreakMode="truncatingTail" selectable="YES" editable="YES" title="Text Cell" id="ydW-J5-Kk2">
+                                                                            <font key="font" usesAppearanceFont="YES"/>
+                                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                            <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                        </textFieldCell>
+                                                                        <tableColumnResizingMask key="resizingMask" userResizable="YES"/>
+                                                                        <prototypeCellViews>
+                                                                            <tableCellView id="z2z-PI-nzs">
+                                                                                <rect key="frame" x="0.0" y="1" width="186" height="17"/>
+                                                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                <subviews>
+                                                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="vTu-fg-hiW">
+                                                                                        <rect key="frame" x="2" y="1" width="182" height="16"/>
+                                                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="left" title="KeyColumn Table View Cell" usesSingleLineMode="YES" id="HA9-NO-iHC">
+                                                                                            <font key="font" usesAppearanceFont="YES"/>
+                                                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                            <color key="backgroundColor" red="0.11764705882352941" green="0.11764705882352941" blue="0.11764705882352941" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                                                                        </textFieldCell>
+                                                                                    </textField>
+                                                                                </subviews>
+                                                                                <constraints>
+                                                                                    <constraint firstItem="vTu-fg-hiW" firstAttribute="centerX" secondItem="z2z-PI-nzs" secondAttribute="centerX" id="4gz-5E-lPE"/>
+                                                                                    <constraint firstItem="vTu-fg-hiW" firstAttribute="leading" secondItem="z2z-PI-nzs" secondAttribute="leading" constant="4" id="55D-Jr-fJc"/>
+                                                                                    <constraint firstItem="vTu-fg-hiW" firstAttribute="centerY" secondItem="z2z-PI-nzs" secondAttribute="centerY" id="YQL-qe-HZD"/>
+                                                                                </constraints>
+                                                                                <connections>
+                                                                                    <outlet property="textField" destination="vTu-fg-hiW" id="0Ce-oy-dXe"/>
+                                                                                </connections>
+                                                                            </tableCellView>
+                                                                        </prototypeCellViews>
+                                                                    </tableColumn>
+                                                                    <tableColumn identifier="Value" editable="NO" width="228" minWidth="120" maxWidth="10000" id="x6R-q7-efY" userLabel="Value Column">
+                                                                        <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Value">
+                                                                            <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                            <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                                        </tableHeaderCell>
+                                                                        <textFieldCell key="dataCell" controlSize="small" lineBreakMode="truncatingTail" selectable="YES" editable="YES" title="Text Cell" id="cCV-DA-Kkq">
+                                                                            <font key="font" usesAppearanceFont="YES"/>
+                                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                            <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                        </textFieldCell>
+                                                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
+                                                                        <prototypeCellViews>
+                                                                            <tableCellView id="z7F-bR-0pz">
+                                                                                <rect key="frame" x="186" y="1" width="234" height="17"/>
+                                                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                                                                                <subviews>
+                                                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="DwZ-IW-2Yw">
+                                                                                        <rect key="frame" x="2" y="1" width="230" height="16"/>
+                                                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="left" title="ValueColumn Table View Cell" usesSingleLineMode="YES" id="k5Q-ii-1cq">
+                                                                                            <font key="font" usesAppearanceFont="YES"/>
+                                                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                                        </textFieldCell>
+                                                                                    </textField>
+                                                                                </subviews>
+                                                                                <constraints>
+                                                                                    <constraint firstItem="DwZ-IW-2Yw" firstAttribute="centerY" secondItem="z7F-bR-0pz" secondAttribute="centerY" id="4Fe-82-d9e"/>
+                                                                                    <constraint firstItem="DwZ-IW-2Yw" firstAttribute="centerX" secondItem="z7F-bR-0pz" secondAttribute="centerX" id="Q23-7f-cjK"/>
+                                                                                    <constraint firstItem="DwZ-IW-2Yw" firstAttribute="leading" secondItem="z7F-bR-0pz" secondAttribute="leading" constant="4" id="i5k-ev-16W"/>
+                                                                                </constraints>
+                                                                                <connections>
+                                                                                    <outlet property="textField" destination="DwZ-IW-2Yw" id="jgq-gB-diy"/>
+                                                                                </connections>
+                                                                            </tableCellView>
+                                                                        </prototypeCellViews>
+                                                                    </tableColumn>
+                                                                </tableColumns>
+                                                            </tableView>
+                                                        </subviews>
+                                                        <nil key="backgroundColor"/>
+                                                    </clipView>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="420" id="HvA-4x-jOJ"/>
+                                                    </constraints>
+                                                    <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="Xmy-WZ-mQX">
+                                                        <rect key="frame" x="-100" y="-100" width="302" height="15"/>
+                                                        <autoresizingMask key="autoresizingMask"/>
+                                                    </scroller>
+                                                    <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="mkC-To-Cta">
+                                                        <rect key="frame" x="-100" y="-100" width="15" height="110"/>
+                                                        <autoresizingMask key="autoresizingMask"/>
+                                                    </scroller>
+                                                    <tableHeaderView key="headerView" wantsLayer="YES" id="pnK-fx-7et">
+                                                        <rect key="frame" x="0.0" y="0.0" width="420" height="28"/>
+                                                        <autoresizingMask key="autoresizingMask"/>
+                                                    </tableHeaderView>
+                                                </scrollView>
+                                            </subviews>
                                             <constraints>
-                                                <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="132" id="lgJ-2t-4Av"/>
+                                                <constraint firstAttribute="trailing" secondItem="9In-dC-gN9" secondAttribute="trailing" id="C13-p9-W6F"/>
+                                                <constraint firstItem="9In-dC-gN9" firstAttribute="leading" secondItem="GYo-pW-QQ3" secondAttribute="leading" id="MeB-EA-EaJ"/>
+                                                <constraint firstAttribute="bottom" secondItem="9In-dC-gN9" secondAttribute="bottom" id="csA-h0-OhH"/>
+                                                <constraint firstItem="9In-dC-gN9" firstAttribute="top" secondItem="GYo-pW-QQ3" secondAttribute="top" id="ghh-lD-0eW"/>
                                             </constraints>
-                                            <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="Xmy-WZ-mQX">
-                                                <rect key="frame" x="-100" y="-100" width="302" height="15"/>
-                                                <autoresizingMask key="autoresizingMask"/>
-                                            </scroller>
-                                            <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="mkC-To-Cta">
-                                                <rect key="frame" x="224" y="17" width="15" height="102"/>
-                                                <autoresizingMask key="autoresizingMask"/>
-                                            </scroller>
-                                            <tableHeaderView key="headerView" wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pnK-fx-7et">
-                                                <rect key="frame" x="0.0" y="0.0" width="305" height="28"/>
-                                                <autoresizingMask key="autoresizingMask"/>
-                                            </tableHeaderView>
-                                        </scrollView>
+                                        </customView>
                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="PST-dF-CNB">
                                             <rect key="frame" x="12" y="10.5" width="16.5" height="20"/>
                                             <constraints>
@@ -1210,19 +1226,17 @@
                                         <constraint firstItem="R9k-Bu-wSB" firstAttribute="trailing" secondItem="YAy-hh-4mE" secondAttribute="trailing" id="0aV-Td-w4R"/>
                                         <constraint firstItem="BSs-zY-Ycq" firstAttribute="leading" secondItem="YAy-hh-4mE" secondAttribute="trailing" constant="10" id="1Wr-UJ-n7p"/>
                                         <constraint firstAttribute="trailing" secondItem="drh-59-1Az" secondAttribute="trailing" constant="12" id="3fy-6D-R7b"/>
-                                        <constraint firstItem="PST-dF-CNB" firstAttribute="top" secondItem="9In-dC-gN9" secondAttribute="bottom" constant="4" id="3tQ-G5-ECY"/>
+                                        <constraint firstItem="PST-dF-CNB" firstAttribute="top" secondItem="GYo-pW-QQ3" secondAttribute="bottom" constant="12" id="4bi-ji-Cuy"/>
                                         <constraint firstItem="cwU-SQ-A8V" firstAttribute="leading" secondItem="Xx9-GE-Qp4" secondAttribute="trailing" constant="10" id="54H-zn-ZFJ"/>
-                                        <constraint firstItem="9In-dC-gN9" firstAttribute="leading" secondItem="VWf-29-TwU" secondAttribute="leading" constant="12" id="6u3-hN-09b"/>
                                         <constraint firstAttribute="trailing" secondItem="oRb-Bc-1u0" secondAttribute="trailing" constant="12" id="7kC-Lv-mPs"/>
                                         <constraint firstItem="Xx9-GE-Qp4" firstAttribute="leading" secondItem="VWf-29-TwU" secondAttribute="leading" constant="12" id="9cz-jP-ukR"/>
                                         <constraint firstItem="Y8Q-PG-bHl" firstAttribute="firstBaseline" secondItem="G90-uq-cW4" secondAttribute="firstBaseline" id="AmN-Gl-2OW"/>
                                         <constraint firstAttribute="bottom" secondItem="PST-dF-CNB" secondAttribute="bottom" constant="12" id="BFi-R5-n5r"/>
-                                        <constraint firstItem="9In-dC-gN9" firstAttribute="top" secondItem="Oof-hT-luu" secondAttribute="bottom" constant="12" id="EPG-sq-qur"/>
                                         <constraint firstItem="drh-59-1Az" firstAttribute="firstBaseline" secondItem="l4a-xE-z4Y" secondAttribute="firstBaseline" id="FBF-ZP-gHJ"/>
                                         <constraint firstItem="Tel-U0-EC3" firstAttribute="leading" secondItem="PST-dF-CNB" secondAttribute="trailing" id="FaS-Uj-OAZ"/>
                                         <constraint firstItem="Soa-90-mcv" firstAttribute="leading" secondItem="r7h-Wk-a9A" secondAttribute="trailing" constant="10" id="IRq-6F-l0K"/>
-                                        <constraint firstItem="PST-dF-CNB" firstAttribute="leading" secondItem="9In-dC-gN9" secondAttribute="leading" id="Ib8-uE-P0D"/>
                                         <constraint firstAttribute="trailing" secondItem="Y8Q-PG-bHl" secondAttribute="trailing" constant="12" id="QOY-QY-knw"/>
+                                        <constraint firstItem="GYo-pW-QQ3" firstAttribute="top" secondItem="Oof-hT-luu" secondAttribute="bottom" constant="12" id="QcJ-fe-nkQ"/>
                                         <constraint firstAttribute="trailing" secondItem="Evy-yh-2vU" secondAttribute="trailing" constant="12" id="Qlo-wr-JIn"/>
                                         <constraint firstItem="XLQ-aa-TdR" firstAttribute="trailing" secondItem="YAy-hh-4mE" secondAttribute="trailing" id="QsZ-2v-GeS"/>
                                         <constraint firstItem="uvv-R0-JCz" firstAttribute="top" secondItem="oRb-Bc-1u0" secondAttribute="bottom" constant="12" id="R1V-jb-2Eb"/>
@@ -1234,6 +1248,7 @@
                                         <constraint firstItem="G90-uq-cW4" firstAttribute="trailing" secondItem="YAy-hh-4mE" secondAttribute="trailing" id="VqI-G6-FV0"/>
                                         <constraint firstItem="BSs-zY-Ycq" firstAttribute="firstBaseline" secondItem="YAy-hh-4mE" secondAttribute="firstBaseline" id="Vue-15-3M6"/>
                                         <constraint firstItem="oRb-Bc-1u0" firstAttribute="firstBaseline" secondItem="XLQ-aa-TdR" secondAttribute="firstBaseline" id="WEP-pe-3ak"/>
+                                        <constraint firstItem="GYo-pW-QQ3" firstAttribute="leading" secondItem="VWf-29-TwU" secondAttribute="leading" constant="12" id="WpY-aw-m8k"/>
                                         <constraint firstItem="cwU-SQ-A8V" firstAttribute="top" secondItem="BSs-zY-Ycq" secondAttribute="bottom" constant="6" id="X90-zN-Jsa"/>
                                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Tel-U0-EC3" secondAttribute="trailing" id="aVR-fV-9eh"/>
                                         <constraint firstItem="Y8Q-PG-bHl" firstAttribute="leading" secondItem="G90-uq-cW4" secondAttribute="trailing" constant="10" id="aYQ-xv-n6F"/>
@@ -1247,6 +1262,7 @@
                                         <constraint firstItem="r7h-Wk-a9A" firstAttribute="trailing" secondItem="YAy-hh-4mE" secondAttribute="trailing" id="gRu-0l-mfa"/>
                                         <constraint firstItem="oRb-Bc-1u0" firstAttribute="leading" secondItem="XLQ-aa-TdR" secondAttribute="trailing" constant="10" id="gq4-Fr-L6C"/>
                                         <constraint firstItem="Tel-U0-EC3" firstAttribute="bottom" secondItem="PST-dF-CNB" secondAttribute="bottom" id="iPG-vs-Jys"/>
+                                        <constraint firstItem="PST-dF-CNB" firstAttribute="leading" secondItem="Oof-hT-luu" secondAttribute="leading" id="iih-fC-4sq"/>
                                         <constraint firstItem="cwU-SQ-A8V" firstAttribute="firstBaseline" secondItem="Xx9-GE-Qp4" secondAttribute="firstBaseline" id="jWy-1d-Qpr"/>
                                         <constraint firstItem="Soa-90-mcv" firstAttribute="top" secondItem="drh-59-1Az" secondAttribute="bottom" constant="6" id="k2r-1V-6tR"/>
                                         <constraint firstItem="Y8Q-PG-bHl" firstAttribute="top" secondItem="Soa-90-mcv" secondAttribute="bottom" constant="6" id="ldg-7v-3JA"/>
@@ -1254,7 +1270,6 @@
                                         <constraint firstItem="l4a-xE-z4Y" firstAttribute="trailing" secondItem="YAy-hh-4mE" secondAttribute="trailing" id="n7j-Q6-q81"/>
                                         <constraint firstItem="Soa-90-mcv" firstAttribute="firstBaseline" secondItem="r7h-Wk-a9A" secondAttribute="firstBaseline" id="q8o-IL-iMu"/>
                                         <constraint firstItem="r7h-Wk-a9A" firstAttribute="leading" secondItem="VWf-29-TwU" secondAttribute="leading" constant="12" id="qWT-XQ-nDa"/>
-                                        <constraint firstAttribute="trailing" secondItem="9In-dC-gN9" secondAttribute="trailing" constant="12" id="raH-Xs-aww"/>
                                         <constraint firstItem="Evy-yh-2vU" firstAttribute="firstBaseline" secondItem="R9k-Bu-wSB" secondAttribute="firstBaseline" id="sHI-5a-rK6"/>
                                         <constraint firstItem="Oof-hT-luu" firstAttribute="leading" secondItem="VWf-29-TwU" secondAttribute="leading" constant="12" id="uhf-3W-HrV"/>
                                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Oof-hT-luu" secondAttribute="trailing" constant="20" symbolic="YES" id="ujq-F8-Pnc"/>
@@ -1263,6 +1278,7 @@
                                         <constraint firstItem="oRb-Bc-1u0" firstAttribute="top" secondItem="Y8Q-PG-bHl" secondAttribute="bottom" constant="6" id="wTy-Ht-LXh"/>
                                         <constraint firstItem="Oof-hT-luu" firstAttribute="top" secondItem="uvv-R0-JCz" secondAttribute="bottom" constant="12" id="wfm-Mc-4LV"/>
                                         <constraint firstAttribute="trailing" secondItem="uvv-R0-JCz" secondAttribute="trailing" constant="12" id="xVg-Zn-RTo"/>
+                                        <constraint firstAttribute="trailing" secondItem="GYo-pW-QQ3" secondAttribute="trailing" constant="12" id="yZG-V1-zcx"/>
                                         <constraint firstItem="Evy-yh-2vU" firstAttribute="top" secondItem="cwU-SQ-A8V" secondAttribute="bottom" constant="6" id="ze3-X7-hFR"/>
                                     </constraints>
                                 </view>
@@ -1270,7 +1286,7 @@
                         </tabViewItems>
                     </tabView>
                     <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0rt-Td-kr8">
-                        <rect key="frame" x="89" y="394" width="176" height="21"/>
+                        <rect key="frame" x="146" y="462" width="176" height="21"/>
                         <segmentedCell key="cell" controlSize="small" borderStyle="border" alignment="left" style="rounded" trackingMode="selectOne" id="Fqo-1c-3L1">
                             <font key="font" metaFont="smallSystem"/>
                             <segments>

--- a/iina/Base.lproj/InspectorWindowController.xib
+++ b/iina/Base.lproj/InspectorWindowController.xib
@@ -66,11 +66,11 @@
             <rect key="contentRect" x="1539" y="436" width="350" height="430"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2056" height="1285"/>
             <view key="contentView" id="se5-gp-TjO" userLabel="InspectorWindow Content View">
-                <rect key="frame" x="0.0" y="0.0" width="350" height="430"/>
+                <rect key="frame" x="0.0" y="0.0" width="353" height="430"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <tabView drawsBackground="NO" controlSize="small" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="wHY-jo-uW0">
-                        <rect key="frame" x="12" y="12" width="326" height="382"/>
+                        <rect key="frame" x="12" y="12" width="329" height="382"/>
                         <tabViewItems>
                             <tabViewItem label="General" identifier="1" id="f7a-XG-NCc">
                                 <view key="view" id="mRY-yK-FeT">
@@ -946,7 +946,7 @@
                             </tabViewItem>
                             <tabViewItem label="Status" identifier="" id="VGm-BL-xOI">
                                 <view key="view" id="VWf-29-TwU">
-                                    <rect key="frame" x="0.0" y="0.0" width="326" height="382"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="329" height="382"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YAy-hh-4mE">
@@ -958,7 +958,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="BSs-zY-Ycq">
-                                            <rect key="frame" x="147" y="356" width="169" height="16"/>
+                                            <rect key="frame" x="147" y="356" width="172" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" id="YcG-9Y-Qn6">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -974,7 +974,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cwU-SQ-A8V">
-                                            <rect key="frame" x="147" y="334" width="169" height="16"/>
+                                            <rect key="frame" x="147" y="334" width="172" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" id="V7s-Tp-SD6">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -990,7 +990,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Evy-yh-2vU">
-                                            <rect key="frame" x="147" y="312" width="169" height="16"/>
+                                            <rect key="frame" x="147" y="312" width="172" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" id="OZx-CU-1b5">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1006,7 +1006,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="drh-59-1Az">
-                                            <rect key="frame" x="147" y="290" width="169" height="16"/>
+                                            <rect key="frame" x="147" y="290" width="172" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" id="R14-IF-0dZ">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1022,7 +1022,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Soa-90-mcv">
-                                            <rect key="frame" x="147" y="268" width="169" height="16"/>
+                                            <rect key="frame" x="147" y="268" width="172" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" id="wMU-ig-9zP">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1038,7 +1038,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Y8Q-PG-bHl">
-                                            <rect key="frame" x="147" y="246" width="169" height="16"/>
+                                            <rect key="frame" x="147" y="246" width="172" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" id="qPy-MN-AEF">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1054,7 +1054,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oRb-Bc-1u0">
-                                            <rect key="frame" x="147" y="224" width="169" height="16"/>
+                                            <rect key="frame" x="147" y="224" width="172" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" id="ElK-iN-YiE">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -1062,7 +1062,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="uvv-R0-JCz">
-                                            <rect key="frame" x="12" y="209" width="302" height="5"/>
+                                            <rect key="frame" x="12" y="209" width="305" height="5"/>
                                         </box>
                                         <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Oof-hT-luu">
                                             <rect key="frame" x="10" y="185" width="40" height="14"/>
@@ -1072,21 +1072,21 @@
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9In-dC-gN9">
-                                            <rect key="frame" x="12" y="32" width="302" height="141"/>
+                                        <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="9In-dC-gN9">
+                                            <rect key="frame" x="12" y="32" width="305" height="141"/>
                                             <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MlR-S8-3gW">
-                                                <rect key="frame" x="0.0" y="0.0" width="302" height="141"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="305" height="141"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" multipleSelection="NO" typeSelect="NO" autosaveName="InspectorWatchTable" rowSizeStyle="automatic" headerView="pnK-fx-7et" viewBased="YES" floatsGroupRows="NO" translatesAutoresizingMaskIntoConstraints="NO" id="oUp-DO-OKl">
-                                                        <rect key="frame" x="0.0" y="0.0" width="335" height="113"/>
+                                                        <rect key="frame" x="0.0" y="0.0" width="305" height="113"/>
                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <size key="intercellSpacing" width="3" height="2"/>
                                                         <color key="backgroundColor" red="0.59999999999999998" green="0.59999999999999998" blue="0.59999999999999998" alpha="0.10000000000000001" colorSpace="custom" customColorSpace="calibratedRGB"/>
                                                         <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                                         <tableColumns>
-                                                            <tableColumn identifier="Key" editable="NO" width="120" minWidth="100" maxWidth="1000" id="zDk-Ie-EPs">
-                                                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Key">
+                                                            <tableColumn identifier="Key" editable="NO" width="140" minWidth="100" maxWidth="1000" id="zDk-Ie-EPs">
+                                                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Name">
                                                                     <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                                 </tableHeaderCell>
@@ -1098,11 +1098,11 @@
                                                                 <tableColumnResizingMask key="resizingMask" userResizable="YES"/>
                                                                 <prototypeCellViews>
                                                                     <tableCellView id="z2z-PI-nzs">
-                                                                        <rect key="frame" x="1" y="1" width="125" height="17"/>
+                                                                        <rect key="frame" x="1" y="1" width="145" height="17"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="vTu-fg-hiW">
-                                                                                <rect key="frame" x="2" y="1" width="121" height="16"/>
+                                                                                <rect key="frame" x="2" y="1" width="141" height="16"/>
                                                                                 <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="left" title="KeyColumn Table View Cell" usesSingleLineMode="YES" id="HA9-NO-iHC">
                                                                                     <font key="font" usesAppearanceFont="YES"/>
                                                                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1121,7 +1121,7 @@
                                                                     </tableCellView>
                                                                 </prototypeCellViews>
                                                             </tableColumn>
-                                                            <tableColumn identifier="Value" editable="NO" width="200" minWidth="80" maxWidth="10000" id="x6R-q7-efY">
+                                                            <tableColumn identifier="Value" editable="NO" width="147" minWidth="80" maxWidth="10000" id="x6R-q7-efY">
                                                                 <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left" title="Value">
                                                                     <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                                     <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
@@ -1134,11 +1134,11 @@
                                                                 <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
                                                                 <prototypeCellViews>
                                                                     <tableCellView id="z7F-bR-0pz">
-                                                                        <rect key="frame" x="129" y="1" width="204" height="17"/>
+                                                                        <rect key="frame" x="149" y="1" width="151" height="17"/>
                                                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                         <subviews>
                                                                             <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="DwZ-IW-2Yw">
-                                                                                <rect key="frame" x="4" y="1" width="196" height="16"/>
+                                                                                <rect key="frame" x="2" y="1" width="147" height="16"/>
                                                                                 <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="left" title="ValueColumn Table View Cell" usesSingleLineMode="YES" id="k5Q-ii-1cq">
                                                                                     <font key="font" usesAppearanceFont="YES"/>
                                                                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -1165,8 +1165,8 @@
                                             <constraints>
                                                 <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="132" id="lgJ-2t-4Av"/>
                                             </constraints>
-                                            <scroller key="horizontalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="Xmy-WZ-mQX">
-                                                <rect key="frame" x="0.0" y="125" width="302" height="16"/>
+                                            <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="Xmy-WZ-mQX">
+                                                <rect key="frame" x="-100" y="-100" width="302" height="15"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </scroller>
                                             <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="mkC-To-Cta">
@@ -1174,7 +1174,7 @@
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </scroller>
                                             <tableHeaderView key="headerView" wantsLayer="YES" translatesAutoresizingMaskIntoConstraints="NO" id="pnK-fx-7et">
-                                                <rect key="frame" x="0.0" y="0.0" width="335" height="28"/>
+                                                <rect key="frame" x="0.0" y="0.0" width="305" height="28"/>
                                                 <autoresizingMask key="autoresizingMask"/>
                                             </tableHeaderView>
                                         </scrollView>
@@ -1270,7 +1270,7 @@
                         </tabViewItems>
                     </tabView>
                     <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0rt-Td-kr8">
-                        <rect key="frame" x="87" y="394" width="176" height="21"/>
+                        <rect key="frame" x="89" y="394" width="176" height="21"/>
                         <segmentedCell key="cell" controlSize="small" borderStyle="border" alignment="left" style="rounded" trackingMode="selectOne" id="Fqo-1c-3L1">
                             <font key="font" metaFont="smallSystem"/>
                             <segments>

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "Debug builds are usually not optimized for performance, so it is not recommended to be used as daily drive. Debug builds do not support auto update.";
 "initial.bug_report" = "Report via <a href=\"https://github.com/iina/iina/issues\">GitHub issues</a>.";
 
+// Inspector Window
+"inspector.error" = "Error";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "Buffering… %d%%";
 "main.opening_stream" = "Opening stream…";

--- a/iina/InspectorWindowController.swift
+++ b/iina/InspectorWindowController.swift
@@ -351,7 +351,7 @@ class InspectorWindowController: NSWindowController, NSWindowDelegate, NSTableVi
   }
 
   func tableViewSelectionDidChange(_ notification: Notification) {
-    deleteButton.isEnabled = (watchTableView.selectedRow != -1)
+    deleteButton.isEnabled = !watchTableView.selectedRowIndexes.isEmpty
   }
 
   func resizeTableColumns(forTableWidth tableWidth: CGFloat) {
@@ -410,13 +410,20 @@ class InspectorWindowController: NSWindowController, NSWindowDelegate, NSTableVi
   }
 
   @IBAction func removeWatchAction(_ sender: AnyObject) {
-    let rowIndex = watchTableView.selectedRow
-    guard rowIndex >= 0 else { return }
+    let rowIndexes = watchTableView.selectedRowIndexes
+    guard !rowIndexes.isEmpty else { return }
 
-    watchProperties.remove(at: rowIndex)
+    let watchPropertiesOld = watchProperties
+    var watchPropertiesNew: [String] = []
+    for (index, property) in watchPropertiesOld.enumerated() {
+      if !rowIndexes.contains(index) {
+        watchPropertiesNew.append(property)
+      }
+    }
+    watchProperties = watchPropertiesNew
     saveWatchList()
 
-    watchTableView.removeRows(at: IndexSet(integer: rowIndex), withAnimation: AccessibilityPreferences.motionReductionEnabled ? [] : .slideUp)
+    watchTableView.removeRows(at: rowIndexes, withAnimation: AccessibilityPreferences.motionReductionEnabled ? [] : .slideUp)
     tableHeightConstraint?.constant = computeMinTableHeight()
     watchTableContainerView.layout()
   }

--- a/iina/InspectorWindowController.swift
+++ b/iina/InspectorWindowController.swift
@@ -337,17 +337,22 @@ class InspectorWindowController: NSWindowController, NSWindowDelegate, NSTableVi
   @IBAction func addWatchAction(_ sender: AnyObject) {
     Utility.quickPromptPanel("add_watch", sheetWindow: window) { str in
       self.watchProperties.append(str)
-      self.watchTableView.reloadData()
       self.saveWatchList()
+
+      let insertIndexSet = IndexSet(integer: self.watchTableView.numberOfRows)
+      self.watchTableView.insertRows(at: insertIndexSet, withAnimation: AccessibilityPreferences.motionReductionEnabled ? [] : .slideDown)
+      self.watchTableView.selectRowIndexes(insertIndexSet, byExtendingSelection: false)
     }
   }
 
   @IBAction func removeWatchAction(_ sender: AnyObject) {
-    if watchTableView.selectedRow >= 0 {
-      watchProperties.remove(at: watchTableView.selectedRow)
-      watchTableView.reloadData()
-    }
+    let rowIndex = watchTableView.selectedRow
+    guard rowIndex >= 0 else { return }
+
+    watchProperties.remove(at: rowIndex)
     saveWatchList()
+
+    watchTableView.removeRows(at: IndexSet(integer: rowIndex), withAnimation: AccessibilityPreferences.motionReductionEnabled ? [] : .slideUp)
   }
 
 

--- a/iina/InspectorWindowController.swift
+++ b/iina/InspectorWindowController.swift
@@ -295,10 +295,28 @@ class InspectorWindowController: NSWindowController, NSWindowDelegate, NSTableVi
 
     switch identifier {
     case .key:
-      cell.textField!.stringValue =  property
+      if let textField = cell.textField {
+        textField.stringValue =  property
+      }
       return cell
     case .value:
-      cell.textField!.stringValue =  PlayerCore.lastActive.mpv.getString(property) ?? "<Error>"
+      let player = PlayerCore.lastActive
+
+      if let textField = cell.textField {
+        if !player.isStopping, !player.isStopped, !player.isShuttingDown, !player.isShutdown,
+            let value = PlayerCore.lastActive.mpv.getString(property) {
+          textField.stringValue = value
+          textField.textColor = .controlTextColor
+        } else {
+          let errorString = NSLocalizedString("inspector.error", comment: "Error")
+
+          let italicDescriptor: NSFontDescriptor = textField.font!.fontDescriptor.withSymbolicTraits(NSFontDescriptor.SymbolicTraits.italic)
+          let errorFont = NSFont(descriptor: italicDescriptor, size: textField.font!.pointSize)
+
+          textField.attributedStringValue = NSMutableAttributedString(string: errorString, attributes: [.font: errorFont!])
+          textField.textColor = .disabledControlTextColor
+        }
+      }
       return cell
     default:
       Logger.log("Unrecognized column: '\(identifier.rawValue)'", level: .error)

--- a/iina/af.lproj/InspectorWindowController.strings
+++ b/iina/af.lproj/InspectorWindowController.strings
@@ -165,3 +165,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
 "mLo-Wc-BoO.title" = "Kleurruimte:";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "zDk-Ie-EPs"; */
+"zDk-Ie-EPs.headerCell.title" = "Naam";
+
+/* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "x6R-q7-efY"; */
+"x6R-q7-efY.headerCell.title" = "Waarde";

--- a/iina/af.lproj/Localizable.strings
+++ b/iina/af.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "Debug builds are usually not optimized for performance, so it is not recommended to be used as daily drive. Debug builds do not support auto update.";
 "initial.bug_report" = "Report via <a href=\"https://github.com/iina/iina/issues\">GitHub issues</a>.";
 
+// Inspector Window
+"inspector.error" = "Fout";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "Bufferwerking… %d%%";
 "main.opening_stream" = "Open tans stroom…";

--- a/iina/ca.lproj/InspectorWindowController.strings
+++ b/iina/ca.lproj/InspectorWindowController.strings
@@ -165,3 +165,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
 "mLo-Wc-BoO.title" = "Espai de color:";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "zDk-Ie-EPs"; */
+"zDk-Ie-EPs.headerCell.title" = "Nom";
+
+/* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "x6R-q7-efY"; */
+"x6R-q7-efY.headerCell.title" = "Valor";

--- a/iina/ca.lproj/Localizable.strings
+++ b/iina/ca.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "Debug builds are usually not optimized for performance, so it is not recommended to be used as daily drive. Debug builds do not support auto update.";
 "initial.bug_report" = "Report via <a href=\"https://github.com/iina/iina/issues\">GitHub issues</a>.";
 
+// Inspector Window
+"inspector.error" = "Error";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "Carregant… %d%%";
 "main.opening_stream" = "Obrint fluxe de dades…";

--- a/iina/cs.lproj/InspectorWindowController.strings
+++ b/iina/cs.lproj/InspectorWindowController.strings
@@ -165,3 +165,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
 "mLo-Wc-BoO.title" = "Barevný prostor:";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "zDk-Ie-EPs"; */
+"zDk-Ie-EPs.headerCell.title" = "Název";
+
+/* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "x6R-q7-efY"; */
+"x6R-q7-efY.headerCell.title" = "Hodnota";

--- a/iina/cs.lproj/Localizable.strings
+++ b/iina/cs.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "Debug builds are usually not optimized for performance, so it is not recommended to be used as daily drive. Debug builds do not support auto update.";
 "initial.bug_report" = "Report via <a href=\"https://github.com/iina/iina/issues\">GitHub issues</a>.";
 
+// Inspector Window
+"inspector.error" = "Chyba";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "Načítá se… %d%%";
 "main.opening_stream" = "Otevírám stream…";

--- a/iina/da.lproj/InspectorWindowController.strings
+++ b/iina/da.lproj/InspectorWindowController.strings
@@ -165,3 +165,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
 "mLo-Wc-BoO.title" = "Farvespektrum:";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "zDk-Ie-EPs"; */
+"zDk-Ie-EPs.headerCell.title" = "Navn";
+
+/* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "x6R-q7-efY"; */
+"x6R-q7-efY.headerCell.title" = "Værdi";

--- a/iina/da.lproj/Localizable.strings
+++ b/iina/da.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "Debug builds are usually not optimized for performance, so it is not recommended to be used as daily drive. Debug builds do not support auto update.";
 "initial.bug_report" = "Report via <a href=\"https://github.com/iina/iina/issues\">GitHub issues</a>.";
 
+// Inspector Window
+"inspector.error" = "Fejl";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "Buffering... %d%%";
 "main.opening_stream" = "Åbner stream…";

--- a/iina/de.lproj/InspectorWindowController.strings
+++ b/iina/de.lproj/InspectorWindowController.strings
@@ -165,3 +165,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
 "mLo-Wc-BoO.title" = "Farbraum:";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "zDk-Ie-EPs"; */
+"zDk-Ie-EPs.headerCell.title" = "Name";
+
+/* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "x6R-q7-efY"; */
+"x6R-q7-efY.headerCell.title" = "Wert";

--- a/iina/de.lproj/Localizable.strings
+++ b/iina/de.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "Debug-Builds sind normalerweise nicht auf Leistung optimiert, daher wird es nicht empfohlen diese für den täglichen Gebrauch einzusetzen. Debug-Builds unterstützen keine automatischen Updates.";
 "initial.bug_report" = "Melde via <a href=\"https://github.com/iina/iina/issues\">GitHub Tickets</a>.";
 
+// Inspector Window
+"inspector.error" = "Fehler";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "Puffern … %d%%";
 "main.opening_stream" = "Stream öffnen …";

--- a/iina/en-GB.lproj/InspectorWindowController.strings
+++ b/iina/en-GB.lproj/InspectorWindowController.strings
@@ -165,3 +165,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
 "mLo-Wc-BoO.title" = "Colorspace:";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "zDk-Ie-EPs"; */
+"zDk-Ie-EPs.headerCell.title" = "Name";
+
+/* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "x6R-q7-efY"; */
+"x6R-q7-efY.headerCell.title" = "Value";

--- a/iina/en-GB.lproj/Localizable.strings
+++ b/iina/en-GB.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "Debug builds are usually not optimized for performance, so it is not recommended to be used as daily drive. Debug builds do not support auto update.";
 "initial.bug_report" = "Report via <a href=\"https://github.com/iina/iina/issues\">GitHub issues</a>.";
 
+// Inspector Window
+"inspector.error" = "Error";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "Buffering… %d%%";
 "main.opening_stream" = "Opening stream…";

--- a/iina/en.lproj/InspectorWindowController.strings
+++ b/iina/en.lproj/InspectorWindowController.strings
@@ -165,3 +165,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
 "mLo-Wc-BoO.title" = "Colorspace:";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "zDk-Ie-EPs"; */
+"zDk-Ie-EPs.headerCell.title" = "Name";
+
+/* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "x6R-q7-efY"; */
+"x6R-q7-efY.headerCell.title" = "Value";

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "Debug builds are usually not optimized for performance, so it is not recommended to be used as daily drive. Debug builds do not support auto update.";
 "initial.bug_report" = "Report via <a href=\"https://github.com/iina/iina/issues\">GitHub issues</a>.";
 
+// Inspector Window
+"inspector.error" = "Error";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "Buffering… %d%%";
 "main.opening_stream" = "Opening stream…";

--- a/iina/es.lproj/InspectorWindowController.strings
+++ b/iina/es.lproj/InspectorWindowController.strings
@@ -165,3 +165,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
 "mLo-Wc-BoO.title" = "Espacio de color:";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "zDk-Ie-EPs"; */
+"zDk-Ie-EPs.headerCell.title" = "Nombre";
+
+/* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "x6R-q7-efY"; */
+"x6R-q7-efY.headerCell.title" = "Valor";

--- a/iina/es.lproj/Localizable.strings
+++ b/iina/es.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "Las compilaciones de depuración normalmente no están optimizadas para el rendimiento, por lo que no se recomienda que se utilicen de manera habitual. Las compilaciones de depuración no soportan la actualización automática.";
 "initial.bug_report" = "Notifique a través de <a href=\"https://github.com/iina/iina/issues\">GitHub issues</a>.";
 
+// Inspector Window
+"inspector.error" = "Error";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "Cargando… %d%%";
 "main.opening_stream" = "Abrir flujo de datos";

--- a/iina/fi.lproj/InspectorWindowController.strings
+++ b/iina/fi.lproj/InspectorWindowController.strings
@@ -165,3 +165,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
 "mLo-Wc-BoO.title" = "Colorspace:";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "zDk-Ie-EPs"; */
+"zDk-Ie-EPs.headerCell.title" = "Nimi";
+
+/* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "x6R-q7-efY"; */
+"x6R-q7-efY.headerCell.title" = "Arvo";

--- a/iina/fi.lproj/Localizable.strings
+++ b/iina/fi.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "Debug builds are usually not optimized for performance, so it is not recommended to be used as daily drive. Debug builds do not support auto update.";
 "initial.bug_report" = "Report via <a href=\"https://github.com/iina/iina/issues\">GitHub issues</a>.";
 
+// Inspector Window
+"inspector.error" = "Virhe";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "Puskuroidaan… %d%%";
 "main.opening_stream" = "Avataan streamia…";

--- a/iina/fr.lproj/InspectorWindowController.strings
+++ b/iina/fr.lproj/InspectorWindowController.strings
@@ -165,3 +165,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
 "mLo-Wc-BoO.title" = "Espace colorimétrique :";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "zDk-Ie-EPs"; */
+"zDk-Ie-EPs.headerCell.title" = "Nom";
+
+/* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "x6R-q7-efY"; */
+"x6R-q7-efY.headerCell.title" = "Valeur";

--- a/iina/fr.lproj/Localizable.strings
+++ b/iina/fr.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "Debug builds are usually not optimized for performance, so it is not recommended to be used as daily drive. Debug builds do not support auto update.";
 "initial.bug_report" = "Report via <a href=\"https://github.com/iina/iina/issues\">GitHub issues</a>.";
 
+// Inspector Window
+"inspector.error" = "Erreur";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "Mise en mémoire tampon… %d%%";
 "main.opening_stream" = "Lancement du stream…";

--- a/iina/hi.lproj/InspectorWindowController.strings
+++ b/iina/hi.lproj/InspectorWindowController.strings
@@ -165,3 +165,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
 "mLo-Wc-BoO.title" = "Colorspace:";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "zDk-Ie-EPs"; */
+"zDk-Ie-EPs.headerCell.title" = "नाम";
+
+/* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "x6R-q7-efY"; */
+"x6R-q7-efY.headerCell.title" = "मूल्य";

--- a/iina/hi.lproj/Localizable.strings
+++ b/iina/hi.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "Debug builds are usually not optimized for performance, so it is not recommended to be used as daily drive. Debug builds do not support auto update.";
 "initial.bug_report" = "Report via <a href=\"https://github.com/iina/iina/issues\">GitHub issues</a>.";
 
+// Inspector Window
+"inspector.error" = "त्रुटि";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "बफरिंग… %d%%";
 "main.opening_stream" = "खुलने की धारा…";

--- a/iina/hu.lproj/InspectorWindowController.strings
+++ b/iina/hu.lproj/InspectorWindowController.strings
@@ -165,3 +165,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
 "mLo-Wc-BoO.title" = "Színtér:";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "zDk-Ie-EPs"; */
+"zDk-Ie-EPs.headerCell.title" = "Név";
+
+/* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "x6R-q7-efY"; */
+"x6R-q7-efY.headerCell.title" = "Érték";

--- a/iina/hu.lproj/Localizable.strings
+++ b/iina/hu.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "Debug builds are usually not optimized for performance, so it is not recommended to be used as daily drive. Debug builds do not support auto update.";
 "initial.bug_report" = "Report via <a href=\"https://github.com/iina/iina/issues\">GitHub issues</a>.";
 
+// Inspector Window
+"inspector.error" = "Hiba";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "Bufferelés…%d%%";
 "main.opening_stream" = "Stream megnyitása…";

--- a/iina/it.lproj/InspectorWindowController.strings
+++ b/iina/it.lproj/InspectorWindowController.strings
@@ -165,3 +165,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
 "mLo-Wc-BoO.title" = "Spazio colore:";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "zDk-Ie-EPs"; */
+"zDk-Ie-EPs.headerCell.title" = "Nome";
+
+/* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "x6R-q7-efY"; */
+"x6R-q7-efY.headerCell.title" = "Valore";

--- a/iina/it.lproj/Localizable.strings
+++ b/iina/it.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "Debug builds are usually not optimized for performance, so it is not recommended to be used as daily drive. Debug builds do not support auto update.";
 "initial.bug_report" = "Report via <a href=\"https://github.com/iina/iina/issues\">GitHub issues</a>.";
 
+// Inspector Window
+"inspector.error" = "Errore";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "Buffer… %d%%";
 "main.opening_stream" = "Apertura stream…";

--- a/iina/ja.lproj/InspectorWindowController.strings
+++ b/iina/ja.lproj/InspectorWindowController.strings
@@ -165,3 +165,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
 "mLo-Wc-BoO.title" = "カラースペース:";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "zDk-Ie-EPs"; */
+"zDk-Ie-EPs.headerCell.title" = "名前";
+
+/* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "x6R-q7-efY"; */
+"x6R-q7-efY.headerCell.title" = "値";

--- a/iina/ja.lproj/Localizable.strings
+++ b/iina/ja.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "Debug builds are usually not optimized for performance, so it is not recommended to be used as daily drive. Debug builds do not support auto update.";
 "initial.bug_report" = "Report via <a href=\"https://github.com/iina/iina/issues\">GitHub issues</a>.";
 
+// Inspector Window
+"inspector.error" = "エラー";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "バッファ中… %d%%";
 "main.opening_stream" = "ストリームを展開中…";

--- a/iina/ko.lproj/InspectorWindowController.strings
+++ b/iina/ko.lproj/InspectorWindowController.strings
@@ -165,3 +165,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
 "mLo-Wc-BoO.title" = "색 공간:";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "zDk-Ie-EPs"; */
+"zDk-Ie-EPs.headerCell.title" = "항목";
+
+/* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "x6R-q7-efY"; */
+"x6R-q7-efY.headerCell.title" = "값";

--- a/iina/ko.lproj/Localizable.strings
+++ b/iina/ko.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "디버그 빌드는 성능에 최적화되어 있지 않으므로, 일반적으로 사용하지 않는 것이 좋습니다. 디버그 빌드는 자동 업데이트를 지원하지 않습니다.";
 "initial.bug_report" = "<a href=\"https://github.com/iina/iina/issues\">GitHub 이슈</a>를 통해 오류를 보고해주십시오.";
 
+// Inspector Window
+"inspector.error" = "오류";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "버퍼링… %d%%";
 "main.opening_stream" = "스트림 여는 중…";

--- a/iina/nl.lproj/InspectorWindowController.strings
+++ b/iina/nl.lproj/InspectorWindowController.strings
@@ -165,3 +165,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
 "mLo-Wc-BoO.title" = "Colorspace:";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "zDk-Ie-EPs"; */
+"zDk-Ie-EPs.headerCell.title" = "Naam";
+
+/* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "x6R-q7-efY"; */
+"x6R-q7-efY.headerCell.title" = "Waarde";

--- a/iina/nl.lproj/Localizable.strings
+++ b/iina/nl.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "Debug builds are usually not optimized for performance, so it is not recommended to be used as daily drive. Debug builds do not support auto update.";
 "initial.bug_report" = "Report via <a href=\"https://github.com/iina/iina/issues\">GitHub issues</a>.";
 
+// Inspector Window
+"inspector.error" = "Fout";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "Bufferen… %d%%";
 "main.opening_stream" = "Stream openen…";

--- a/iina/pl.lproj/InspectorWindowController.strings
+++ b/iina/pl.lproj/InspectorWindowController.strings
@@ -165,3 +165,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
 "mLo-Wc-BoO.title" = "Przestrzeń kolorów:";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "zDk-Ie-EPs"; */
+"zDk-Ie-EPs.headerCell.title" = "Nazwa";
+
+/* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "x6R-q7-efY"; */
+"x6R-q7-efY.headerCell.title" = "Wartość";

--- a/iina/pl.lproj/Localizable.strings
+++ b/iina/pl.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "Debug builds are usually not optimized for performance, so it is not recommended to be used as daily drive. Debug builds do not support auto update.";
 "initial.bug_report" = "Report via <a href=\"https://github.com/iina/iina/issues\">GitHub issues</a>.";
 
+// Inspector Window
+"inspector.error" = "Błąd";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "Buforowanie… %d%%";
 "main.opening_stream" = "Otwieram strumień…";

--- a/iina/pt-BR.lproj/InspectorWindowController.strings
+++ b/iina/pt-BR.lproj/InspectorWindowController.strings
@@ -165,3 +165,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
 "mLo-Wc-BoO.title" = "Sistema de cor:";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "zDk-Ie-EPs"; */
+"zDk-Ie-EPs.headerCell.title" = "Nome";
+
+/* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "x6R-q7-efY"; */
+"x6R-q7-efY.headerCell.title" = "Valor";

--- a/iina/pt-BR.lproj/Localizable.strings
+++ b/iina/pt-BR.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "Debug builds are usually not optimized for performance, so it is not recommended to be used as daily drive. Debug builds do not support auto update.";
 "initial.bug_report" = "Report via <a href=\"https://github.com/iina/iina/issues\">GitHub issues</a>.";
 
+// Inspector Window
+"inspector.error" = "Erro";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "Carregando… %d%%";
 "main.opening_stream" = "Abrindo stream…";

--- a/iina/pt.lproj/InspectorWindowController.strings
+++ b/iina/pt.lproj/InspectorWindowController.strings
@@ -165,3 +165,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
 "mLo-Wc-BoO.title" = "Colorspace:";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "zDk-Ie-EPs"; */
+"zDk-Ie-EPs.headerCell.title" = "Nome";
+
+/* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "x6R-q7-efY"; */
+"x6R-q7-efY.headerCell.title" = "Valor";

--- a/iina/pt.lproj/Localizable.strings
+++ b/iina/pt.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "Debug builds are usually not optimized for performance, so it is not recommended to be used as daily drive. Debug builds do not support auto update.";
 "initial.bug_report" = "Report via <a href=\"https://github.com/iina/iina/issues\">GitHub issues</a>.";
 
+// Inspector Window
+"inspector.error" = "Erro";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "Buffer de dados… %d%%";
 "main.opening_stream" = "A abrir stream…";

--- a/iina/ro.lproj/InspectorWindowController.strings
+++ b/iina/ro.lproj/InspectorWindowController.strings
@@ -165,3 +165,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
 "mLo-Wc-BoO.title" = "Spațiu de culori:";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "zDk-Ie-EPs"; */
+"zDk-Ie-EPs.headerCell.title" = "Nume";
+
+/* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "x6R-q7-efY"; */
+"x6R-q7-efY.headerCell.title" = "Valoare";

--- a/iina/ro.lproj/Localizable.strings
+++ b/iina/ro.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "Debug builds are usually not optimized for performance, so it is not recommended to be used as daily drive. Debug builds do not support auto update.";
 "initial.bug_report" = "Report via <a href=\"https://github.com/iina/iina/issues\">GitHub issues</a>.";
 
+// Inspector Window
+"inspector.error" = "Eroare";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "Buffering...%d%%";
 "main.opening_stream" = "Se deschide streamul…";

--- a/iina/ru.lproj/InspectorWindowController.strings
+++ b/iina/ru.lproj/InspectorWindowController.strings
@@ -165,3 +165,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
 "mLo-Wc-BoO.title" = "Цветовое пространство:";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "zDk-Ie-EPs"; */
+"zDk-Ie-EPs.headerCell.title" = "Название";
+
+/* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "x6R-q7-efY"; */
+"x6R-q7-efY.headerCell.title" = "Значение";

--- a/iina/ru.lproj/Localizable.strings
+++ b/iina/ru.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "Debug builds are usually not optimized for performance, so it is not recommended to be used as daily drive. Debug builds do not support auto update.";
 "initial.bug_report" = "Report via <a href=\"https://github.com/iina/iina/issues\">GitHub issues</a>.";
 
+// Inspector Window
+"inspector.error" = "Ошибка";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "Буферизация… %d%%";
 "main.opening_stream" = "Открытие потока…";

--- a/iina/sk.lproj/InspectorWindowController.strings
+++ b/iina/sk.lproj/InspectorWindowController.strings
@@ -165,3 +165,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
 "mLo-Wc-BoO.title" = "Farebná škála:";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "zDk-Ie-EPs"; */
+"zDk-Ie-EPs.headerCell.title" = "Názov";
+
+/* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "x6R-q7-efY"; */
+"x6R-q7-efY.headerCell.title" = "Hodnota";

--- a/iina/sk.lproj/Localizable.strings
+++ b/iina/sk.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "Debug builds are usually not optimized for performance, so it is not recommended to be used as daily drive. Debug builds do not support auto update.";
 "initial.bug_report" = "Report via <a href=\"https://github.com/iina/iina/issues\">GitHub issues</a>.";
 
+// Inspector Window
+"inspector.error" = "Chyba";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "Načítava sa… %d%%";
 "main.opening_stream" = "Otváram stream…";

--- a/iina/sr-Latn.lproj/InspectorWindowController.strings
+++ b/iina/sr-Latn.lproj/InspectorWindowController.strings
@@ -165,3 +165,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
 "mLo-Wc-BoO.title" = "Colorspace:";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "zDk-Ie-EPs"; */
+"zDk-Ie-EPs.headerCell.title" = "Naziv";
+
+/* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "x6R-q7-efY"; */
+"x6R-q7-efY.headerCell.title" = "Vrednost";

--- a/iina/sr-Latn.lproj/Localizable.strings
+++ b/iina/sr-Latn.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "Debug builds are usually not optimized for performance, so it is not recommended to be used as daily drive. Debug builds do not support auto update.";
 "initial.bug_report" = "Report via <a href=\"https://github.com/iina/iina/issues\">GitHub issues</a>.";
 
+// Inspector Window
+"inspector.error" = "Grеška";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "Smeštanje u bafer… %d%%";
 "main.opening_stream" = "Otvaram strim…";

--- a/iina/sv.lproj/InspectorWindowController.strings
+++ b/iina/sv.lproj/InspectorWindowController.strings
@@ -165,3 +165,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
 "mLo-Wc-BoO.title" = "Färgrymd:";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "zDk-Ie-EPs"; */
+"zDk-Ie-EPs.headerCell.title" = "Namn";
+
+/* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "x6R-q7-efY"; */
+"x6R-q7-efY.headerCell.title" = "Värde";

--- a/iina/sv.lproj/Localizable.strings
+++ b/iina/sv.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "Debug builds are usually not optimized for performance, so it is not recommended to be used as daily drive. Debug builds do not support auto update.";
 "initial.bug_report" = "Report via <a href=\"https://github.com/iina/iina/issues\">GitHub issues</a>.";
 
+// Inspector Window
+"inspector.error" = "Fel";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "Buffrar… %d%%";
 "main.opening_stream" = "Öppnar ström…";

--- a/iina/tr.lproj/InspectorWindowController.strings
+++ b/iina/tr.lproj/InspectorWindowController.strings
@@ -165,3 +165,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
 "mLo-Wc-BoO.title" = "Renk Uzayı:";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "zDk-Ie-EPs"; */
+"zDk-Ie-EPs.headerCell.title" = "İsim";
+
+/* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "x6R-q7-efY"; */
+"x6R-q7-efY.headerCell.title" = "Değer";

--- a/iina/tr.lproj/Localizable.strings
+++ b/iina/tr.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "Debug builds are usually not optimized for performance, so it is not recommended to be used as daily drive. Debug builds do not support auto update.";
 "initial.bug_report" = "Report via <a href=\"https://github.com/iina/iina/issues\">GitHub issues</a>.";
 
+// Inspector Window
+"inspector.error" = "Hata";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "Arabelleğe alınıyor... %%%d";
 "main.opening_stream" = "Akış açılıyor...";

--- a/iina/uk.lproj/InspectorWindowController.strings
+++ b/iina/uk.lproj/InspectorWindowController.strings
@@ -165,3 +165,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
 "mLo-Wc-BoO.title" = "Колірний простір:";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "zDk-Ie-EPs"; */
+"zDk-Ie-EPs.headerCell.title" = "Назва";
+
+/* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "x6R-q7-efY"; */
+"x6R-q7-efY.headerCell.title" = "Значення";

--- a/iina/uk.lproj/Localizable.strings
+++ b/iina/uk.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "Debug builds are usually not optimized for performance, so it is not recommended to be used as daily drive. Debug builds do not support auto update.";
 "initial.bug_report" = "Report via <a href=\"https://github.com/iina/iina/issues\">GitHub issues</a>.";
 
+// Inspector Window
+"inspector.error" = "Помилка";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "Буферизація… %d%%";
 "main.opening_stream" = "Відкриття потоку…";

--- a/iina/zh-Hans.lproj/InspectorWindowController.strings
+++ b/iina/zh-Hans.lproj/InspectorWindowController.strings
@@ -165,3 +165,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
 "mLo-Wc-BoO.title" = "色彩空间:";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "zDk-Ie-EPs"; */
+"zDk-Ie-EPs.headerCell.title" = "选项";
+
+/* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "x6R-q7-efY"; */
+"x6R-q7-efY.headerCell.title" = "值";

--- a/iina/zh-Hans.lproj/Localizable.strings
+++ b/iina/zh-Hans.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "调试版本（Debug）通常没有对性能进行优化，所以不建议日常用。调试版本（Debug）不支持自动更新。";
 "initial.bug_report" = "通过<a href=\"https://github.com/iina/iina/issues\">GitHub issues</a>报告。";
 
+// Inspector Window
+"inspector.error" = "错误";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "缓冲中… %d%%";
 "main.opening_stream" = "正在打开流……";

--- a/iina/zh-Hant.lproj/InspectorWindowController.strings
+++ b/iina/zh-Hant.lproj/InspectorWindowController.strings
@@ -165,3 +165,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Colorspace:"; ObjectID = "mLo-Wc-BoO"; */
 "mLo-Wc-BoO.title" = "色彩空間：";
+
+/* Class = "NSTableColumn"; headerCell.title = "Name"; ObjectID = "zDk-Ie-EPs"; */
+"zDk-Ie-EPs.headerCell.title" = "选项";
+
+/* Class = "NSTableColumn"; headerCell.title = "Value"; ObjectID = "x6R-q7-efY"; */
+"x6R-q7-efY.headerCell.title" = "值";

--- a/iina/zh-Hant.lproj/Localizable.strings
+++ b/iina/zh-Hant.lproj/Localizable.strings
@@ -28,6 +28,9 @@
 "initial.debug.desc" = "Debug builds are usually not optimized for performance, so it is not recommended to be used as daily drive. Debug builds do not support auto update.";
 "initial.bug_report" = "Report via <a href=\"https://github.com/iina/iina/issues\">GitHub issues</a>.";
 
+// Inspector Window
+"inspector.error" = "錯誤";
+
 // MainWindowController.swift
 "main.buffering_indicator" = "緩衝處理中⋯ %d%%";
 "main.opening_stream" = "開啟串流中⋯⋯";


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4521.

---

**Description:**

**Window layout changes:**
1. Fix vertical alignment between columns in all 4 tabs, by replacing "top"/"bottom" constraints between `NSTextView`s with "firstBaseline" constraints.
2. Fix constraints which cause the height of the window to change for "General" tab.
3. Tweaked offset constraints to be consistent across all tabs and fields.
4. Re-order views in the XML for consistency, and various other constraint cleanup
5. Adjust minimum widths & heights to be consistent across tabs.

**Watch table changes:**
1. Add `Name` and `Value` column headers to the "Watch" table in the "Status" tab, and made the first tab resizable and saveable, and the second tab set to scale to the size of the window (fixing #4521).
2.  Add code to make the Name column reduce itself in width when the window is resized, so the `Value` column won't get hidden.
3. Refactor Watch table to support translucent headers while working around `NSTableView` bugs: Make table view-based, add custom column headers, reimplement background translucency. Make table expand the window vertically instead of scrolling to avoid overlapping views issue.
4. Add animations to Watch table for row insert & delete (respecting the "Reduce Motion" pref).
5. Change `Error` entries to remove brackets, add italic & grayed text.
6. Add localization entries for 3 new fields; see comments below.

**Final product:**

<img width="495" alt="SCR-20230727-ndhl" src="https://github.com/iina/iina/assets/2213815/5e5e9e8e-850a-4fe9-8082-04c5ef60bbee">
