### PR TITLE
Add ability to minimize Music Mode window

### DIFF
--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -75,7 +75,7 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
 
     guard let window = window else { return }
 
-    window.styleMask = [.fullSizeContentView, .titled, .resizable, .closable]
+    window.styleMask = [.fullSizeContentView, .titled, .resizable, .closable, .miniaturizable]
     window.isMovableByWindowBackground = true
     window.titleVisibility = .hidden
     ([.closeButton, .miniaturizeButton, .zoomButton, .documentIconButton] as [NSWindow.ButtonType]).forEach {
@@ -86,7 +86,6 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
       // to front, but it never becomes key or main window.
       // Removing the button directly will also work but it causes crash on 10.12-, so for the sake of safety we don't use that way for now.
       // FIXME: Not a perfect solution. It should respond to the first click.
-      button?.frame.size = .zero
     }
 
     setToInitialWindowSize(display: false, animate: false)


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
Allows `Window` > `Minimize` (& keyboard shortcut) to work, and removes (likely) unnecessary workaround for the standard window buttons.

Saw someone trolling a closed issue recently which complained about the lack of this. It may have been infeasible to do this in the past, but looks fine now.

About removing the line: `button?.frame.size = .zero`:
1. It seems related to the FIXME note which states that it works around a bug in MacOS 10.12 and below. However, IINA now only supports MacOS 10.13 and above. So this may no longer apply.
2. For the current release of MacOS (13.4), it is sufficient to call `button?.isHidden = true` to hide these buttons. The problem in the note still exists, but not for the reason given, and appears to have already been solved for MainWindow, which does respond to the "first click" if configured in Settings.
4. I recently encountered a "quirk", unrelated to this issue, where setting the `alpha` property of `miniaturizeButton` to `0` will cause the `Window` > `Minimize` menu item to be disabled. This unexpected discovery suggests that it may be wise to avoid changing the properties of these buttons (such as size) unless absolutely needed.