### PR TITLE
Fix Buffering indicator not showing/hiding unless OSC was shown

### DIFF
--- a/iina/DurationDisplayTextField.swift
+++ b/iina/DurationDisplayTextField.swift
@@ -93,9 +93,7 @@ class DurationDisplayTextField: NSTextField {
     DurationDisplayTextField.precision = precision
     Preference.set(Int(precision), for: .timeDisplayPrecision)
     PlayerCore.playerCores.forEach { core in
-      if core.syncPlayTimeTimer != nil {
-        core.createSyncUITimer()
-      }
+      core.refreshSyncUITimer()
     }
   }
 }

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -1082,15 +1082,11 @@ not applying FFmpeg 9599 workaround
           player.sendOSD(paused ? .pause : .resume)
           DispatchQueue.main.sync {
             player.info.isPaused = paused
-            // Follow energy efficiency best practices and ensure IINA is absolutely idle when the
-            // video is paused to avoid wasting energy with needless processing. If paused shutdown
-            // the timer that synchronizes the UI and the high priority display link thread.
+            player.refreshSyncUITimer()
             if paused {
-              player.invalidateTimer()
               player.mainWindow.videoView.displayIdle()
             } else {
               player.mainWindow.videoView.displayActive()
-              player.createSyncUITimer()
             }
           }
         }

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1780,22 +1780,8 @@ class MainWindowController: PlayerWindowController {
       return
     }
 
-    // Follow energy efficiency best practices and stop the timer that updates the OSC while it is
-    // hidden. However the timer can't be stopped if the mini player is being used as it always
-    // displays the the OSC or the timer is also updating the information being displayed in the
-    // touch bar. Does this host have a touch bar? Is the touch bar configured to show app controls?
-    // Is the touch bar awake? Is the host being operated in closed clamshell mode? This is the kind
-    // of information needed to avoid running the timer and updating controls that are not visible.
-    // Unfortunately in the documentation for NSTouchBar Apple indicates "There’s no need, and no
-    // API, for your app to know whether or not there’s a Touch Bar available". So this code keys
-    // off whether AppKit has requested that a NSTouchBar object be created. This avoids running the
-    // timer on Macs that do not have a touch bar. It also may avoid running the timer when a
-    // MacBook with a touch bar is being operated in closed clameshell mode.
-    if !player.isInMiniPlayer && !player.needsTouchBar {
-      player.invalidateTimer()
-    }
-
     animationState = .willHide
+    player.refreshSyncUITimer()
     fadeableViews.forEach { (v) in
       v.isHidden = false
     }
@@ -1830,10 +1816,7 @@ class MainWindowController: PlayerWindowController {
     }
     // The OSC may not have been updated while it was hidden to avoid wasting energy. Make sure it
     // is up to date.
-    player.syncUITime()
-    if !player.info.isPaused {
-      player.createSyncUITimer()
-    }
+    player.refreshSyncUITimer()
     standardWindowButtons.forEach { $0.isEnabled = true }
     NSAnimationContext.runAnimationGroup({ (context) in
       context.duration = UIAnimationDuration


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issues #4064, 
  - #4470.

---

**Description:**

This might look like more changes than necessary to fix the above bugs, but I think once acquainted with the new code, I think one will find it's a lot easier to understand & debug than the code it's replacing. I back-merged this code from [my fork](https://github.com/svobs/iina/tree/advance-develop), where I was use this as a foundation to finally add live refresh of the OSD. Will submit that in a separate PR.

There were a couple of problems which were contributing to the issues linked to above. The 2 commits in this PR address each of them respectively, with extra effort to hopefully prevent similar issues in the future.
1. IINA receives `MPV_EVENT_SEEK` and `MPV_EVENT_PLAYBACK_RESTART` messages from mpv at the same time the buffering state changes, but they were calling `player.syncUI(.time)`, which did not include code for network streams. They should have been calling `player.syncUITime()` instead, because that would check whether to call `player.syncUI(.time)` or `player.syncUI(.timeAndCache)`. But both `.time` and `.timeAndCache` had nearly identical logic which was easy to consolidate. Also, `syncUITime()` alone had logic to set `additionalInfo`, which was another landmine. Much better to combine all 3. Will prevent confusion/misuse, and a couple extra boolean checks will have essentially zero impact on performance. 
2. The `syncUITimer`, by calling `syncUITime()` repeatedly, is in charge of keeping the UI up-to-date, including the Buffering indicator. But it was set up to start and stop almost exclusively for use with "fadeableViews" (OSC and title bar), so if they weren't being updated, the Buffering indicator would not update. So to add support for Buffering's lifecycle, it was necessary to add even more complexity to the timer. This would have gotten too difficult unless the timer was refactored to use a more streamlined approach, which is to group all the complexity of the timer logic together. I created a new `refreshSyncUITimer()` method to do this which replaces both the `invalidateTimer()` and `createSyncUITimer()` methods. See the comments in the code for how it works. It makes the logic a lot easier to follow because it's all in one place. And it's also very lightweight, being just a handful of boolean checks & if statements. It also avoids restarting the timer unless it absolutely needs to, which should save a lot more cycles and possible hiccups.

### Test note:
How to test that Buffering indicator shows up in the middle of the video:

1. Open IINA, go to `File` > `Open URL in New Window...`, and enter this Apple test video URL: https://devstreaming-cdn.apple.com/videos/streaming/examples/bipbop_4x3/bipbop_4x3_variant.m3u8
2. Once the video starts playing, kill the network connection. If on WiFi, this is as easy as hitting the toggle switch for WiFi in the Control Center or in System Settings.
3. Using the OSC, click on the play bar to seek to just before the end of the downloaded part of the video. Then make sure the mouse is outside the window. Make sure you leave enough time to get the mouse out of the window, so that the OSC & title bar disappear but the video is still playing.
4. Wait for buffer to run out and the video to hang.
5. Does it show the Buffering indicator when it hangs? _(Correct behavior is "yes")_

### Timer logic (pseudocode):

```Swift

/// Call this when `syncUITimer` may need to be started, stopped, or needs its interval changed. It will figure out the correct action.
/// Just need to make sure that any state variables (e.g., `info.isPaused`, `isInMiniPlayer`,  etc.) are set *before* calling this method,
/// not after, so that it makes the correct decisions.
func refreshSyncUITimer() {
  if isStopping OR isShuttingDown {
    useTimer = false
  } else if info.isPaused {
    useTimer = false
  } else if needsTouchBar OR isInMiniPlayer {
    useTimer = true
  } else if info.isNetworkResource {
    // May need to show, hide, or update buffering indicator at any time
    useTimer = true
  } else {
    // Need if fadeable views are visible
    useTimer = true if fadeableViews are visible else false
  }

  let timeInterval = DurationDisplayTextField.precision >= 2 ? 0.04 : 0.1

  if syncUITimer is still running {
    if useTimer is false, OR timeInterval is different than existing {
      Invalidate existing timer
    } else if no change needed to timer {
      return
    } 
  }

  if useTimer is true {
    If syncUITimer was not running {
      Sync UI now
    }
    Start new syncUITimer
  }
}
```