### PR TITLE
Fix regression: could not use DEL or BS keys to remove from playlist

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -855,6 +855,20 @@ class MainWindowController: PlayerWindowController {
 
   // MARK: - Mouse / Trackpad events
 
+  override func keyDown(with event: NSEvent) {
+    if sideBarStatus == .playlist {
+      // Special case for playlist delete
+      let key = KeyCodeHelper.mpvKeyCode(from: event)
+      if key == "DEL" || key == "BS" {
+        let deletedSomething = playlistView.deleteSelectedRows()
+        if deletedSomething {
+          return
+        }
+      }
+    }
+    super.keyDown(with: event)
+  }
+
   @discardableResult
   override func handleKeyBinding(_ keyBinding: KeyMapping) -> Bool {
     let success = super.handleKeyBinding(keyBinding)

--- a/iina/MiniPlayerWindow.swift
+++ b/iina/MiniPlayerWindow.swift
@@ -15,6 +15,16 @@ class MiniPlayerWindow: NSWindow {
     /// This allows `ESC` & `TAB` key bindings to work, instead of getting swallowed by
     /// MacOS keyboard focus navigation (which we don't use).
     if let controller = windowController as? MiniPlayerWindowController {
+      // Special case for playlist delete
+      if controller.isPlaylistVisible {
+        let key = KeyCodeHelper.mpvKeyCode(from: event)
+        if key == "DEL" || key == "BS" {
+          let deletedSomething = controller.player.mainWindow.playlistView.deleteSelectedRows()
+          if deletedSomething {
+            return
+          }
+        }
+      }
       controller.keyDown(with: event)
     }
   }

--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -368,9 +368,18 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
     pasteFromPasteboard(playlistTableView, row: dest, from: .general)
   }
 
-
   @objc func delete(_ sender: NSMenuItem) {
-    player.playlistRemove(playlistTableView.selectedRowIndexes)
+    deleteSelectedRows()
+  }
+
+  @discardableResult
+  func deleteSelectedRows() -> Bool {
+    let selectedRows = playlistTableView.selectedRowIndexes
+    if !selectedRows.isEmpty {
+      player.playlistRemove(selectedRows)
+      return true
+    }
+    return false
   }
 
   // MARK: - private methods


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4538.

---

**Description:**

Using the easiest route to fix this, which is to add a special check for Backspace and Delete when the playlist is open and row(s) are selected.

Had to duplicate the code for Music Mode.