### PR TITLE
Support installing plugins from GitHub releases & directly opening iinaplgz files

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -4308,7 +4308,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 496498882919E47900CD61A5 /* iina.xcconfig */;
 			buildSettings = {
-				CURRENT_PROJECT_VERSION = 134;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.video";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2017-2023\nCollider LI, et al.\nReleased under GPLv3.";
 				INFOPLIST_KEY_NSMainNibFile = MainMenu;
@@ -4317,7 +4316,6 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/deps/lib",
 				);
-				MARKETING_VERSION = 1.3.2;
 			};
 			name = Debug;
 		};
@@ -4325,7 +4323,6 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 496498882919E47900CD61A5 /* iina.xcconfig */;
 			buildSettings = {
-				CURRENT_PROJECT_VERSION = 134;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.video";
 				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2017-2023\nCollider LI, et al.\nReleased under GPLv3.";
 				INFOPLIST_KEY_NSMainNibFile = MainMenu;
@@ -4334,7 +4331,6 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/deps/lib",
 				);
-				MARKETING_VERSION = 1.3.2;
 			};
 			name = Release;
 		};

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -65,7 +65,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     return w
   }()
 
-  lazy var preferenceWindowController: NSWindowController = {
+  lazy var preferenceWindowController: PreferenceWindowController = {
     var list: [NSViewController & PreferenceWindowEmbeddable] = [
       PrefGeneralViewController(),
       PrefUIViewController(),
@@ -594,9 +594,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
       shouldIgnoreOpenFile = false
       return
     }
-    // open pending files
     let urls = pendingFilesForOpenFile.map { URL(fileURLWithPath: $0) }
+    
+    // if installing a plugin package
+    if let pluginPackageURL = urls.first(where: { $0.pathExtension == "iinaplgz" }) {
+      showPreferences(self)
+      preferenceWindowController.performAction(.installPlugin(url: pluginPackageURL))
+      return
+    }
 
+    // open pending files
     pendingFilesForOpenFile.removeAll()
     if PlayerCore.activeOrNew.openURLs(urls) == 0 {
       Utility.showAlert("nothing_to_open")

--- a/iina/JavascriptPlugin.swift
+++ b/iina/JavascriptPlugin.swift
@@ -266,7 +266,7 @@ class JavascriptPlugin: NSObject {
         try downloadResponse.content?.write(to: destURL)
         return try create(fromPackageURL: destURL)
       } catch {
-        // ignore any error
+        Logger.log("Cannot find an iinaplgz file in the latest release, installing from source.", level: .debug)
       }
     }
     

--- a/iina/PrefPluginViewController.swift
+++ b/iina/PrefPluginViewController.swift
@@ -412,6 +412,12 @@ class PrefPluginViewController: NSViewController, PreferenceWindowEmbeddable {
       }
     }
   }
+  
+  @objc func installPluginAction(localPackageURL url: URL) {
+    self.queue.async {
+      self.installPlugin(fromLocalPackageURL: url)
+    }
+  }
 
   @IBAction func endSheet(_ sender: NSButton) {
     view.window!.endSheet(sender.window!)

--- a/iina/PreferenceWindowController.swift
+++ b/iina/PreferenceWindowController.swift
@@ -126,7 +126,7 @@ class PreferenceWindowController: NSWindowController {
   private let indexingQueue = DispatchQueue(label: "IINAPreferenceIndexingTask", qos: .userInitiated)
   private var isIndexing: Bool = true
   
-  enum PendingAction {
+  enum Action {
     case installPlugin(url: URL)
   }
 
@@ -353,7 +353,7 @@ class PreferenceWindowController: NSWindowController {
     return nil
   }
 
-  func performAction(_ action: PendingAction) {
+  func performAction(_ action: Action) {
     switch action {
     case .installPlugin(url: let url):
       guard let idx = viewControllers.firstIndex(where: { $0 is PrefPluginViewController }) else {

--- a/iina/PreferenceWindowController.swift
+++ b/iina/PreferenceWindowController.swift
@@ -361,7 +361,8 @@ class PreferenceWindowController: NSWindowController {
       }
       loadTab(at: idx)
       let vc = viewControllers[idx] as! PrefPluginViewController
-      vc.perform(#selector(vc.installPluginAction(localPackageURL:)), with: url, afterDelay: 0.25)
+      vc.installPluginAction(localPackageURL: url)
+      // vc.perform(#selector(vc.installPluginAction(localPackageURL:)), with: url, afterDelay: 0.25)
     }
   }
 }

--- a/iina/PreferenceWindowController.swift
+++ b/iina/PreferenceWindowController.swift
@@ -158,24 +158,24 @@ class PreferenceWindowController: NSWindowController {
 
   override func windowDidLoad() {
     super.windowDidLoad()
-    
+
     window?.titlebarAppearsTransparent = true
     window?.titleVisibility = .hidden
     window?.isMovableByWindowBackground = true
-    
+
     tableView.delegate = self
     tableView.dataSource = self
     completionTableView.delegate = self
     completionTableView.dataSource = self
-    
+
     detailViewBottomConstraint = prefDetailContentView.bottomAnchor.constraint(equalTo: prefDetailContentView.superview!.bottomAnchor)
-    
+
     // NSTableView's "Source List" style is only available with MacOS 11.0+ and includes a built-in 10pt offset for its highlights.
     // But for older MacOS versions, the style will default to "full width" with no highlight offset, which will touch the Search field.
     if #unavailable(macOS 11.0) {
       navTableSearchFieldSpacingConstraint.constant = 10.0
     }
-    
+
     var viewMap = [
       ["general", "PrefGeneralViewController"],
       ["ui", "PrefUIViewController"],
@@ -193,7 +193,7 @@ class PreferenceWindowController: NSWindowController {
     }
     let labelDict = [String: [String: [String]]](
       uniqueKeysWithValues: viewMap.map { (NSLocalizedString("preference.\($0[0])", comment: ""), self.getLabelDict(inNibNamed: $0[1])) })
-    
+
     indexingQueue.async{
       self.isIndexing = true
       self.makeTries(labelDict)

--- a/iina/PreferenceWindowController.swift
+++ b/iina/PreferenceWindowController.swift
@@ -125,6 +125,10 @@ class PreferenceWindowController: NSWindowController {
 
   private let indexingQueue = DispatchQueue(label: "IINAPreferenceIndexingTask", qos: .userInitiated)
   private var isIndexing: Bool = true
+  
+  enum PendingAction {
+    case installPlugin(url: URL)
+  }
 
   @IBOutlet weak var searchField: NSSearchField!
   @IBOutlet weak var tableView: NSTableView!
@@ -154,24 +158,24 @@ class PreferenceWindowController: NSWindowController {
 
   override func windowDidLoad() {
     super.windowDidLoad()
-
+    
     window?.titlebarAppearsTransparent = true
     window?.titleVisibility = .hidden
     window?.isMovableByWindowBackground = true
-
+    
     tableView.delegate = self
     tableView.dataSource = self
     completionTableView.delegate = self
     completionTableView.dataSource = self
-
+    
     detailViewBottomConstraint = prefDetailContentView.bottomAnchor.constraint(equalTo: prefDetailContentView.superview!.bottomAnchor)
-
+    
     // NSTableView's "Source List" style is only available with MacOS 11.0+ and includes a built-in 10pt offset for its highlights.
     // But for older MacOS versions, the style will default to "full width" with no highlight offset, which will touch the Search field.
     if #unavailable(macOS 11.0) {
       navTableSearchFieldSpacingConstraint.constant = 10.0
     }
-
+    
     var viewMap = [
       ["general", "PrefGeneralViewController"],
       ["ui", "PrefUIViewController"],
@@ -189,13 +193,12 @@ class PreferenceWindowController: NSWindowController {
     }
     let labelDict = [String: [String: [String]]](
       uniqueKeysWithValues: viewMap.map { (NSLocalizedString("preference.\($0[0])", comment: ""), self.getLabelDict(inNibNamed: $0[1])) })
-
+    
     indexingQueue.async{
       self.isIndexing = true
       self.makeTries(labelDict)
       self.isIndexing = false
     }
-
   }
 
   override func mouseDown(with event: NSEvent) {
@@ -350,6 +353,17 @@ class PreferenceWindowController: NSWindowController {
     return nil
   }
 
+  func performAction(_ action: PendingAction) {
+    switch action {
+    case .installPlugin(url: let url):
+      guard let idx = viewControllers.firstIndex(where: { $0 is PrefPluginViewController }) else {
+        return
+      }
+      loadTab(at: idx)
+      let vc = viewControllers[idx] as! PrefPluginViewController
+      vc.perform(#selector(vc.installPluginAction(localPackageURL:)), with: url, afterDelay: 0.25)
+    }
+  }
 }
 
 extension PreferenceWindowController: NSTableViewDelegate, NSTableViewDataSource {


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**

This PR implements two critical features for the upcoming release of the plugin system:

- Support installing a `iinaplgz` file by directly opening it
- Previously, when installing from GitHub, IINA could only download the source code, therefore required the built files to be included in the repo. However, this is a terrible choice, especially for a large project with megabytes of transpiled files. Now IINA will try to find an `iinaplgz` file from the latest release and only install from the source when failed.

How to test

- Use the `iina-plugin` CLI to generate `iinaplgz` packages.
- Double click, or drag & drop a `iinaplgz` file to see if IINA can install it correctly.
- Install `iina/plugin-userscript` from GitHub to see if IINA can install from the `iinaplgz` release.