### PR TITLE
Revert change to folder filtering + add special handling for shuffle arg instead (fixes regression: #4548)

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -438,6 +438,12 @@ not applying FFmpeg 9599 workaround
     // Request tick event.
     // chkErr(mpv_request_event(mpv, MPV_EVENT_TICK, 1))
 
+    addHook(MPVHook.onLoad, hook: MPVHookValue(withBlock: { [self] next in
+      Logger.log("Callback triggered for mpv 'on-load' hook", level: .verbose, subsystem: player.subsystem)
+      player.fileWillLoad()
+      next()
+    }))
+
     // Set a custom function that should be called when there are new events.
     mpv_set_wakeup_callback(self.mpv, { (ctx) in
       let mpvController = unsafeBitCast(ctx, to: MPVController.self)

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -439,9 +439,11 @@ not applying FFmpeg 9599 workaround
     // chkErr(mpv_request_event(mpv, MPV_EVENT_TICK, 1))
 
     addHook(MPVHook.onLoad, hook: MPVHookValue(withBlock: { [self] next in
-      Logger.log("Callback triggered for mpv 'on-load' hook", level: .verbose, subsystem: player.subsystem)
-      player.fileWillLoad()
-      next()
+      DispatchQueue.main.async { [self] in
+        Logger.log("Processing mpv 'on_load' hook", level: .verbose, subsystem: player.subsystem)
+        player.fileWillLoad()
+        next()
+      }
     }))
 
     // Set a custom function that should be called when there are new events.

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -438,14 +438,6 @@ not applying FFmpeg 9599 workaround
     // Request tick event.
     // chkErr(mpv_request_event(mpv, MPV_EVENT_TICK, 1))
 
-    addHook(MPVHook.onBeforeStartFile, hook: MPVHookValue(withBlock: { [self] next in
-      DispatchQueue.main.async { [self] in
-        Logger.log("Processing mpv 'on_before_start_file' hook", level: .verbose, subsystem: player.subsystem)
-        player.fileWillStart()
-        next()
-      }
-    }))
-
     // Set a custom function that should be called when there are new events.
     mpv_set_wakeup_callback(self.mpv, { (ctx) in
       let mpvController = unsafeBitCast(ctx, to: MPVController.self)
@@ -826,7 +818,7 @@ not applying FFmpeg 9599 workaround
   func removeHooks(withIdentifier id: String) {
     hooks.filter { (k, v) in v.isJavascript && v.id == id }.keys.forEach { hooks.removeValue(forKey: $0) }
   }
-
+  
   // MARK: - Events
 
   // Read event and handle it async

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -438,10 +438,10 @@ not applying FFmpeg 9599 workaround
     // Request tick event.
     // chkErr(mpv_request_event(mpv, MPV_EVENT_TICK, 1))
 
-    addHook(MPVHook.onLoad, hook: MPVHookValue(withBlock: { [self] next in
+    addHook(MPVHook.onBeforeStartFile, hook: MPVHookValue(withBlock: { [self] next in
       DispatchQueue.main.async { [self] in
-        Logger.log("Processing mpv 'on_load' hook", level: .verbose, subsystem: player.subsystem)
-        player.fileWillLoad()
+        Logger.log("Processing mpv 'on_before_start_file' hook", level: .verbose, subsystem: player.subsystem)
+        player.fileWillStart()
         next()
       }
     }))

--- a/iina/MPVHook.swift
+++ b/iina/MPVHook.swift
@@ -15,6 +15,7 @@ struct MPVHook: RawRepresentable {
   init(_ string: String) { self.rawValue = string }
   init?(rawValue: RawValue) { self.rawValue = rawValue }
 
+  static let onBeforeStartFile = MPVHook("on_before_start_file")
   static let onLoad = MPVHook("on_load")
   static let onLoadFail = MPVHook("on_load_fail")
   static let onPreLoaded = MPVHook("on_preloaded")

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1498,6 +1498,18 @@ class PlayerCore: NSObject {
 
   // MARK: - Listeners
 
+  /// Called via mpv hook `on_before_start_file`, prior to file start sequence.
+  func fileWillStart() {
+    /// Currently this method is only used to honor `--shuffle` arg via iina-cli
+    guard shufflePending else { return }
+    shufflePending = false
+
+    Logger.log("Shuffling playlist", subsystem: subsystem)
+    mpv.command(.playlistShuffle)
+    /// will cancel this file load sequence (so `fileLoaded` will not be called), then will start loading item at index 0
+    mpv.command(.playlistPlayIndex, args: ["0"])
+  }
+
   func fileStarted(path: String) {
     Logger.log("File started", subsystem: subsystem)
     info.justStartedFile = true
@@ -1556,18 +1568,6 @@ class PlayerCore: NSObject {
       self.autoSearchOnlineSub()
     }
     events.emit(.fileStarted)
-  }
-
-  /// Called via mpv hook `on_load`, right before file is loaded.
-  func fileWillLoad() {
-    /// Currently this method is only used to honor `--shuffle` arg via iina-cli
-    guard shufflePending else { return }
-    shufflePending = false
-
-    Logger.log("Shuffling playlist", subsystem: subsystem)
-    mpv.command(.playlistShuffle)
-    /// will cancel this file load sequence (so `fileLoaded` will not be called), then will start loading item at index 0
-    mpv.command(.playlistPlayIndex, args: ["0"])
   }
 
   /** This function is called right after file loaded. Should load all meta info here. */


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4548.

---

**Description:**

- Backs out the change which send single folder args to mpv directly, which broke file filtering
- Implements alternate fix for #4434: intercepts `shuffle yes` (or equivalent) from command-line & converts it to `playlist-shuffle` after playlist is populated.