### PR TITLE
Fix bug when triggering some key bindings: raw mpv commands executed instead of calling IINA code

### DIFF
--- a/iina/Base.lproj/MainMenu.xib
+++ b/iina/Base.lproj/MainMenu.xib
@@ -142,6 +142,10 @@
                                     <action selector="performClose:" target="-1" id="HmO-Ls-i7Q"/>
                                 </connections>
                             </menuItem>
+                            <menuItem title="Other Actions From Key Bindings" hidden="YES" id="w2L-0L-eUk">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                                <menu key="submenu" title="Other Actions From Key Bindings" id="Yf9-Ns-n9l"/>
+                            </menuItem>
                         </items>
                     </menu>
                 </menuItem>
@@ -745,6 +749,7 @@ CA
                 <outlet property="openAlternative" destination="z9W-ga-j3b" id="RRI-7o-x9o"/>
                 <outlet property="openURL" destination="0m7-3r-twH" id="BOj-Zv-hzW"/>
                 <outlet property="openURLAlternative" destination="bfB-bn-KeM" id="I7a-cV-JUC"/>
+                <outlet property="otherKeyBindingsMenu" destination="Yf9-Ns-n9l" id="SVX-M0-MuL"/>
                 <outlet property="pause" destination="UOE-MJ-8ku" id="74t-ZU-dXD"/>
                 <outlet property="pictureInPicture" destination="mND-N8-z6o" id="mrn-ku-bqH"/>
                 <outlet property="playbackMenu" destination="GEO-Iw-cKr" id="Ji3-Wv-EE5"/>


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [] This implements/fixes issue #.

---

**Description:**

Fixes longstanding bug: when multiple key bindings qualify for IINA code actions, only the first match actually invokes the action. All other matches will invoke the mpv command directly instead of invoking IINA code. For some commands this will result in differences and/or missing behavior.

This is pretty deep in the trenches... See [my comment here](https://github.com/iina/iina/issues/4562#issuecomment-1667107157) for some more explanation.

Most prominent example is the `cycle pause` action:
<img width="391" alt="SCR-20230806-qwfg" src="https://github.com/iina/iina/assets/2213815/8fb20ff5-3458-4d86-9943-83be8bc4627b">

Although this bug affected all menu items, it looks like "pause/resume" was the only one in which a difference was noticed, probably because it is the only one which deviates from mpv's behavior when executing IINA code compared to the undecorated mpv command.

EDIT: Also affects `screenshot` (see below).