### PR TITLE
Don't occupy main thread when emitting logs

### DIFF
--- a/iina/LogWindowController.swift
+++ b/iina/LogWindowController.swift
@@ -39,6 +39,9 @@ class LogWindowController: NSWindowController, NSMenuDelegate {
     }
     levelPopUpButton.selectItem(withTag: Logger.Level.preferred.rawValue)
     subsystemPopUpButton.menu!.delegate = self
+
+    Timer.scheduledTimer(timeInterval: 0.1, target: self, selector: #selector(syncLogs), userInfo: nil, repeats: true)
+    syncLogs()
   }
 
   fileprivate static func indicatorIcon(withColor color: NSColor) -> NSImage {
@@ -116,6 +119,24 @@ class LogWindowController: NSWindowController, NSMenuDelegate {
     let pasteboard = NSPasteboard.general
     pasteboard.clearContents()
     pasteboard.setString(string, forType: .string)
+  }
+
+  // MARK: - Logs
+
+  @objc private func syncLogs()
+  {
+    guard !Logger.logs.isEmpty else { return }
+    var scroll = false
+    let range = logTableView.rows(in: logTableView.visibleRect)
+    if range.location + range.length == logs.count {
+      scroll = true
+    }
+
+    logs.append(contentsOf: Logger.logs)
+    Logger.logs.removeAll()
+    if scroll {
+      logTableView.scrollRowToVisible(logs.count - 1)
+    }
   }
 }
 

--- a/iina/Logger.swift
+++ b/iina/Logger.swift
@@ -41,6 +41,8 @@ class Logger: NSObject {
     }
   }
 
+  static var logs: [Logger.Log] = []
+
   class Subsystem: RawRepresentable {
     let rawValue: String
     var added = false
@@ -201,9 +203,7 @@ class Logger: NSObject {
     let date = Date()
     let string = formatMessage(message, level, subsystem, true, date)
     let log = Log(subsystem: subsystem.rawValue, level: level.rawValue, message: message, date: dateFormatter.string(from: date), logString: string)
-    DispatchQueue.main.async {
-      (NSApp.delegate as? AppDelegate)?.logWindow.logs.append(log)
-    }
+    logs.append(log)
 
     print(string, terminator: "")
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)

---

**Description:**
- Logs are stored in `Logger.logs` temporarily
- When Log Viewer is shown, the logs will be synced every 0.1s
- The Log Viewer will follow the latest log if previously the latest is shown
- The Log Viewer will not scroll when a new log is fetched if previously the latest log is not shown
