### PR TITLE
Make open/save dialogs block window input while open (fixes #4583)

### DIFF
--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -317,7 +317,8 @@ extension MainMenuActionHandler {
 extension MainMenuActionHandler {
   @objc func menuLoadExternalSub(_ sender: NSMenuItem) {
     let currentDir = player.info.currentURL?.deletingLastPathComponent()
-    Utility.quickOpenPanel(title: "Load external subtitle file", chooseDir: false, dir: currentDir) { url in
+    Utility.quickOpenPanel(title: "Load external subtitle file", chooseDir: false, dir: currentDir,
+                           sheetWindow: player.currentWindow) { url in
       self.player.loadExternalSubFile(url, delay: true)
     }
   }
@@ -401,8 +402,8 @@ extension MainMenuActionHandler {
     }
     let subURL = URL(fileURLWithPath: path)
     let subFileName = subURL.lastPathComponent
-    Utility.quickSavePanel(title: NSLocalizedString("alert.sub.save_downloaded.title",
-         comment: "Save Downloaded Subtitle"), filename: subFileName) { (destURL) in
+    let windowTitle = NSLocalizedString("alert.sub.save_downloaded.title", comment: "Save Downloaded Subtitle")
+    Utility.quickSavePanel(title: windowTitle, filename: subFileName, sheetWindow: player.currentWindow) { (destURL) in
       do {
         // The Save panel checks to see if a file already exists and if so asks if it should be
         // replaced. The quickSavePanel would not have called this code if the user canceled, so if

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -29,7 +29,7 @@ class MainMenuActionHandler: NSResponder {
   }
 
   @objc func menuSavePlaylist(_ sender: NSMenuItem) {
-    Utility.quickSavePanel(title: "Save to playlist", types: ["m3u8"]) { (url) in
+    Utility.quickSavePanel(title: "Save to playlist", types: ["m3u8"], sheetWindow: player.currentWindow) { (url) in
       if url.isFileURL {
         var playlist = ""
         for item in self.player.info.playlist {

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -176,6 +176,10 @@ class PlayerCore: NSObject {
     isInMiniPlayer ? miniPlayer.isPlaylistVisible : mainWindow.sideBarStatus == .playlist
   }
 
+  var currentWindow: NSWindow? {
+    return isInMiniPlayer ? miniPlayer.window : mainWindow.window
+  }
+
   /// The A loop point established by the [mpv](https://mpv.io/manual/stable/) A-B loop command.
   var abLoopA: Double {
     /// Returns the value of the A loop point, a timestamp in seconds if set, otherwise returns zero.

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -132,6 +132,10 @@ class PlayerCore: NSObject {
   var initialWindow: InitialWindowController!
   var miniPlayer: MiniPlayerWindowController!
 
+  var currentWindow: NSWindow? {
+    return isInMiniPlayer ? miniPlayer.window : mainWindow.window
+  }
+
   var mpv: MPVController!
 
   var plugins: [JavascriptPluginInstance] = []
@@ -174,10 +178,6 @@ class PlayerCore: NSObject {
 
   var isPlaylistVisible: Bool {
     isInMiniPlayer ? miniPlayer.isPlaylistVisible : mainWindow.sideBarStatus == .playlist
-  }
-
-  var currentWindow: NSWindow? {
-    return isInMiniPlayer ? miniPlayer.window : mainWindow.window
   }
 
   /// The A loop point established by the [mpv](https://mpv.io/manual/stable/) A-B loop command.

--- a/iina/QuickSettingViewController.swift
+++ b/iina/QuickSettingViewController.swift
@@ -662,7 +662,8 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
 
   @IBAction func loadExternalAudioAction(_ sender: NSButton) {
     let currentDir = player.info.currentURL?.deletingLastPathComponent()
-    Utility.quickOpenPanel(title: "Load external audio file", chooseDir: false, dir: currentDir, allowedFileTypes: Utility.supportedFileExt[.audio]) { url in
+    Utility.quickOpenPanel(title: "Load external audio file", chooseDir: false, dir: currentDir,
+                           sheetWindow: player.currentWindow, allowedFileTypes: Utility.supportedFileExt[.audio]) { url in
       self.player.loadExternalAudioFile(url)
       self.audioTableView.reloadData()
     }
@@ -722,7 +723,8 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
   @IBAction func loadExternalSubAction(_ sender: NSSegmentedControl) {
     if sender.selectedSegment == 0 {
       let currentDir = player.info.currentURL?.deletingLastPathComponent()
-      Utility.quickOpenPanel(title: "Load external subtitle", chooseDir: false, dir: currentDir, allowedFileTypes: Utility.supportedFileExt[.sub]) { url in
+      Utility.quickOpenPanel(title: "Load external subtitle", chooseDir: false, dir: currentDir,
+                             sheetWindow: player.currentWindow, allowedFileTypes: Utility.supportedFileExt[.sub]) { url in
         // set a delay
         self.player.loadExternalSubFile(url, delay: true)
         self.subTableView.reloadData()


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4583.

---

**Description:**

This fixes the use of arrow key navigation in the following open/save dialogs:
1. "Load external audio file" (Audio Settings sidebar)
2. "Load external subtitle" (Subtitles menu)
3. "Load subtitle..." (Subtitles Settings sidebar)
4. "Save downloaded subtitle" (Subtitles menu)

Some users were complaining that mpv bindings were getting activated in response to arrow keys when they wanted to use them to navigate within the file picker dialog. This ensures that they will work, but it comes at some cost. They now use Apple's tyrannical modal dialog state, which clings onto the window and won't let the user do anything with it until the dialog is dismissed. I'm not a fan, although using it is probably adheres more closely to Apple's HIG than using an independent window.
