### PR TITLE
Fix #4156 (OSD stealing mouse clicks from OSC even while hidden), #4612: (OSC responds to mouse hover when behind OSD)

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2018,6 +2018,7 @@ class MainWindowController: PlayerWindowController {
     }) {
       if self.osdAnimationState == .willHide {
         self.osdAnimationState = .hidden
+        self.osdVisualEffectView.isHidden = true
         self.osdStackView.views(in: .bottom).forEach { self.osdStackView.removeView($0) }
       }
     }

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1056,8 +1056,7 @@ class MainWindowController: PlayerWindowController {
         timePreviewWhenSeek.isHidden = false
         thumbnailPeekView.isHidden = !player.info.thumbnailsReady
       }
-      let mousePos = playSlider.convert(event.locationInWindow, from: nil)
-      updateTimeLabel(mousePos.x, originalPos: event.locationInWindow)
+      refreshSeekTimeAndThumnail(from: event)
     }
   }
 
@@ -1078,18 +1077,15 @@ class MainWindowController: PlayerWindowController {
       // slider
       isMouseInSlider = false
       timePreviewWhenSeek.isHidden = true
-      let mousePos = playSlider.convert(event.locationInWindow, from: nil)
-      updateTimeLabel(mousePos.x, originalPos: event.locationInWindow)
+      refreshSeekTimeAndThumnail(from: event)
       thumbnailPeekView.isHidden = true
     }
   }
 
   override func mouseMoved(with event: NSEvent) {
     guard !isInInteractiveMode else { return }
-    let mousePos = playSlider.convert(event.locationInWindow, from: nil)
-    if isMouseInSlider {
-      updateTimeLabel(mousePos.x, originalPos: event.locationInWindow)
-    }
+
+    refreshSeekTimeAndThumnail(from: event)
     if isMouseInWindow {
       showUI()
     }
@@ -2263,6 +2259,16 @@ class MainWindowController: PlayerWindowController {
       self.bottomView.isHidden = true
       self.showUI()
       then()
+    }
+  }
+
+  private func refreshSeekTimeAndThumnail(from event: NSEvent) {
+    let isCoveredByOSD = !osdVisualEffectView.isHidden && isMouseEvent(event, inAnyOf: [osdVisualEffectView])
+    let mousePos = playSlider.convert(event.locationInWindow, from: nil)
+    if isMouseInSlider && !isCoveredByOSD {
+      updateTimeLabel(mousePos.x, originalPos: event.locationInWindow)
+    } else {
+      thumbnailPeekView.isHidden = true
     }
   }
 

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1056,7 +1056,7 @@ class MainWindowController: PlayerWindowController {
         timePreviewWhenSeek.isHidden = false
         thumbnailPeekView.isHidden = !player.info.thumbnailsReady
       }
-      refreshSeekTimeAndThumnail(from: event)
+      refreshSeekTimeAndThumbnail(from: event)
     }
   }
 
@@ -1077,7 +1077,7 @@ class MainWindowController: PlayerWindowController {
       // slider
       isMouseInSlider = false
       timePreviewWhenSeek.isHidden = true
-      refreshSeekTimeAndThumnail(from: event)
+      refreshSeekTimeAndThumbnail(from: event)
       thumbnailPeekView.isHidden = true
     }
   }
@@ -1085,7 +1085,7 @@ class MainWindowController: PlayerWindowController {
   override func mouseMoved(with event: NSEvent) {
     guard !isInInteractiveMode else { return }
 
-    refreshSeekTimeAndThumnail(from: event)
+    refreshSeekTimeAndThumbnail(from: event)
     if isMouseInWindow {
       showUI()
     }
@@ -2262,11 +2262,11 @@ class MainWindowController: PlayerWindowController {
     }
   }
 
-  private func refreshSeekTimeAndThumnail(from event: NSEvent) {
+  private func refreshSeekTimeAndThumbnail(from event: NSEvent) {
     let isCoveredByOSD = !osdVisualEffectView.isHidden && isMouseEvent(event, inAnyOf: [osdVisualEffectView])
-    let mousePos = playSlider.convert(event.locationInWindow, from: nil)
-    if isMouseInSlider && !isCoveredByOSD {
-      updateTimeLabel(mousePos.x, originalPos: event.locationInWindow)
+    let isCoveredBySidebar = !sideBarView.isHidden && isMouseEvent(event, inAnyOf: [sideBarView])
+    if isMouseInSlider, !isCoveredByOSD, !isCoveredBySidebar {
+      updateTimeLabel(event.locationInWindow)
     } else {
       thumbnailPeekView.isHidden = true
     }
@@ -2297,7 +2297,8 @@ class MainWindowController: PlayerWindowController {
   }
 
   /** Display time label when mouse over slider */
-  private func updateTimeLabel(_ mouseXPos: CGFloat, originalPos: NSPoint) {
+  private func updateTimeLabel(_ posInWindow: NSPoint) {
+    let mouseXPos = playSlider.convert(posInWindow, from: nil).x
     let timeLabelXPos = round(mouseXPos + playSlider.frame.origin.x - timePreviewWhenSeek.frame.width / 2)
     let timeLabelYPos = playSlider.frame.origin.y + playSlider.frame.height
     timePreviewWhenSeek.frame.origin = NSPoint(x: timeLabelXPos, y: timeLabelYPos)
@@ -2320,7 +2321,7 @@ class MainWindowController: PlayerWindowController {
         let showAbove = canShowThumbnailAbove(timnePreviewYPos: timePreviewFrameInWindow.y, thumbnailHeight: height)
         let yPos = showAbove ? timePreviewFrameInWindow.y + timePreviewWhenSeek.frame.height : sliderFrameInWindow.y - height
         thumbnailPeekView.frame.size = NSSize(width: 120, height: height)
-        thumbnailPeekView.frame.origin = NSPoint(x: round(originalPos.x - thumbnailPeekView.frame.width / 2), y: yPos)
+        thumbnailPeekView.frame.origin = NSPoint(x: round(posInWindow.x - thumbnailPeekView.frame.width / 2), y: yPos)
       } else {
         thumbnailPeekView.isHidden = true
       }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issues:
  - #4156 
  - #4612.

---

**Description:**

Could not have been a more straightforward fix. When the OSD was hidden, its alpha was set to 0, but `isHidden` was never set to `true` (looks deleted or forgot to include).

Update: added a fix for #4612, since it needed the original fix as a prerequisite.