### PR TITLE
Fix giant Sonoma egg in Subtitles sidebar (bug #4638)

### DIFF
--- a/iina/RoundedColorWell.swift
+++ b/iina/RoundedColorWell.swift
@@ -18,7 +18,7 @@ class RoundedColorWell: NSColorWell {
   }
 
   override func draw(_ dirtyRect: NSRect) {
-    let circleRect = NSInsetRect(dirtyRect, 3, 3)
+    let circleRect = NSInsetRect(bounds, 3, 3)
 
     // darker if is pressing mouse button
     if self.isMouseDown {


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4638.

---

**Description:**
Changes code to use `bounds` instead of `dirtyRect`, which should be much more reliable, and gets rid of the egg.