### PR TITLE
Add option to enter/exit PIP when window's space is inactive/active

### DIFF
--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -143,6 +143,7 @@ struct Preference {
     static let windowBehaviorWhenPip = Key("windowBehaviorWhenPip")
     static let pauseWhenPip = Key("pauseWhenPip")
     static let togglePipByMinimizingWindow = Key("togglePipByMinimizingWindow")
+    static let togglePipWhenSwitchingSpaces = Key("togglePipWhenSwitchingSpaces")
 
     // Codec
 
@@ -764,6 +765,7 @@ struct Preference {
     .windowBehaviorWhenPip: WindowBehaviorWhenPip.doNothing.rawValue,
     .pauseWhenPip: false,
     .togglePipByMinimizingWindow: false,
+    .togglePipWhenSwitchingSpaces: true,
 
     .videoThreads: 0,
     .hardwareDecoder: HardwareDecoderOption.auto.rawValue,


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4645.

---

**Description:**

Straightforward attempt to implement this feature. So far only the feature itself is coded - still needs a checkbox in the IINA settings - so for now, the new pref key `togglePipWhenSwitchingSpaces` defaults to `true`.

There are still problems with this implementation: see comments in #4645.