### PR TITLE
Fix noticeable wobble if video is playing while window is resized (issue #4667)

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -518,6 +518,7 @@ not applying FFmpeg 9599 workaround
 
   func shouldRenderUpdateFrame() -> Bool {
     guard let mpvRenderContext = mpvRenderContext else { return false }
+    guard !player.isStopping && !player.isShuttingDown else { return false }
     let flags: UInt64 = mpv_render_context_update(mpvRenderContext)
     return flags & UInt64(MPV_RENDER_UPDATE_FRAME.rawValue) > 0
   }

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -213,7 +213,14 @@ class VideoView: NSView {
       Logger.fatal("Cannot Create display link!")
     }
     guard !CVDisplayLinkIsRunning(link) else { return }
+
+    /// Set this to `true` to enable video redraws to match the timing of the view redraw during animations.
+    /// This fixes a situation where the layer size may not match the size of its superview at each redraw,
+    /// which would cause noticable clipping or wobbling during animations.
+    videoLayer.isAsynchronous = true
+
     updateDisplayLink()
+
     checkResult(CVDisplayLinkSetOutputCallback(link, displayLinkCallback, mutableRawPointerOf(obj: self)),
                 "CVDisplayLinkSetOutputCallback")
     checkResult(CVDisplayLinkStart(link), "CVDisplayLinkStart")
@@ -221,6 +228,11 @@ class VideoView: NSView {
 
   @objc func stopDisplayLink() {
     guard let link = link, CVDisplayLinkIsRunning(link) else { return }
+
+    /// If this is set to `true` while the video is paused, there is some degree of busy-waiting as the
+    /// layer is polled at a high rate about whether it needs to draw. Disable this to save CPU while idle.
+    videoLayer.isAsynchronous = false
+
     checkResult(CVDisplayLinkStop(link), "CVDisplayLinkStop")
   }
 

--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -26,7 +26,7 @@ class ViewLayer: CAOpenGLLayer {
     super.init()
 
     isOpaque = true
-    isAsynchronous = false
+    isAsynchronous = true
 
     autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
   }

--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -26,7 +26,6 @@ class ViewLayer: CAOpenGLLayer {
     super.init()
 
     isOpaque = true
-    isAsynchronous = true
 
     autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
   }

--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -94,6 +94,12 @@ class ViewLayer: CAOpenGLLayer {
 
   override func draw(inCGLContext ctx: CGLContextObj, pixelFormat pf: CGLPixelFormatObj, forLayerTime t: CFTimeInterval, displayTime ts: UnsafePointer<CVTimeStamp>?) {
     let mpv = videoView.player.mpv!
+
+    CGLLockContext(ctx)
+    defer {
+      CGLUnlockContext(ctx)
+    }
+    
     needsMPVRender = false
 
     glClear(GLbitfield(GL_COLOR_BUFFER_BIT))


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4667.

---

**Description:**

1. Sets `isAsynchronous` flag on `videoLayer`, which allows video redraw requests to be initiated asynchronously by the view (and altering the DisplayLink interval slightly) when needed.
2. Adds new checks to prevent crash during quit.

For more info, see the comments for issue #4667.