### PR TITLE
fix: Failed to download subtitles from assrt.

### DIFF
--- a/iina/AssrtSubtitle.swift
+++ b/iina/AssrtSubtitle.swift
@@ -48,8 +48,12 @@ class Assrt {
     override func download() -> Promise<[URL]> {
       if let fileList = fileList {
         // download from file list
-        return when(fulfilled: fileList.map { file -> Promise<URL> in
-          Promise { resolver in
+        var fileGenerator = fileList.makeIterator()
+        let generator = AnyIterator<Promise<URL>> {
+          guard let file = fileGenerator.next() else {
+            return nil
+          }
+          return Promise<URL> { resolver in
             Just.get(file.url, asyncCompletionHandler: { response in
               guard response.ok, let data = response.content else {
                 resolver.reject(OnlineSubtitle.CommonError.networkError(response.error))
@@ -61,7 +65,9 @@ class Assrt {
               }
             })
           }
-        })
+        }
+
+        return when(fulfilled: generator, concurrently: 2)
       } else if let url = url, let filename = filename {
         // download from url
         return Promise { resolver in


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4671 .

---

**Description:**

Here I restrict the concurrency as at maximum 2 download tasks at the same time for assrt. In my test, if I change 2 to 3, it will simply return code `503`, but 2 works well.
