### PR TITLE
Close download from Open Subtitles using REST API, #3920

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		515B5E5A2A579903001FCD49 /* iina-plugin in Copy Executables */ = {isa = PBXBuildFile; fileRef = E38558872A484A2D0083772D /* iina-plugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		5196819A29EC963F00B05D55 /* CoreDisplay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5196819929EC963F00B05D55 /* CoreDisplay.framework */; };
 		519872FF26879B9B00F84BCC /* AccessibilityPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519872FE26879B9B00F84BCC /* AccessibilityPreferences.swift */; };
+		51AC1CAB2A9FBF3700DF7079 /* OpenSubClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC1CAA2A9FBF3700DF7079 /* OpenSubClient.swift */; };
 		51C1BA3A291CA76700C1208A /* InfoDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C1BA39291CA76700C1208A /* InfoDictionary.swift */; };
 		51CACB9529D500290034CEE5 /* VideoPIPViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51CACB9429D500290034CEE5 /* VideoPIPViewController.swift */; };
 		51DE55C92A6646710050AD06 /* Sysctl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DE55C82A6646710050AD06 /* Sysctl.swift */; };
@@ -898,6 +899,7 @@
 		5196819929EC963F00B05D55 /* CoreDisplay.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreDisplay.framework; path = /System/Library/Frameworks/CoreDisplay.framework; sourceTree = "<group>"; };
 		519872FE26879B9B00F84BCC /* AccessibilityPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPreferences.swift; sourceTree = "<group>"; };
 		51A0F0F629FA2C8E000130CF /* Beta.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Beta.xcconfig; sourceTree = "<group>"; };
+		51AC1CAA2A9FBF3700DF7079 /* OpenSubClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSubClient.swift; sourceTree = "<group>"; };
 		51C1BA39291CA76700C1208A /* InfoDictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InfoDictionary.swift; sourceTree = "<group>"; };
 		51CACB9429D500290034CEE5 /* VideoPIPViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPIPViewController.swift; sourceTree = "<group>"; };
 		51DE55C82A6646710050AD06 /* Sysctl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sysctl.swift; sourceTree = "<group>"; };
@@ -2272,6 +2274,7 @@
 				840AF5811E732C8F00F4AF92 /* JustXMLRPC.swift */,
 				E33BA5C5204BD9FE0069A0F6 /* SubChooseViewController.swift */,
 				1326718020852D0D000FA7E2 /* SubChooseViewController.xib */,
+				51AC1CAA2A9FBF3700DF7079 /* OpenSubClient.swift */,
 			);
 			name = Sub;
 			sourceTree = "<group>";
@@ -3003,6 +3006,7 @@
 				51DE55C92A6646710050AD06 /* Sysctl.swift in Sources */,
 				845FB0C71D39462E00C011E0 /* ControlBarView.swift in Sources */,
 				E3513AFB20F120F600F8C347 /* PreferenceViewController.swift in Sources */,
+				51AC1CAB2A9FBF3700DF7079 /* OpenSubClient.swift in Sources */,
 				E38BD4AF20054BD9007635FC /* MainWindow.swift in Sources */,
 				51E63DFB29CFB031008AFC20 /* PlaySlider.swift in Sources */,
 				84F5D4A01E44F9DB0060A838 /* KeyBindingItem.swift in Sources */,

--- a/iina/AppData.swift
+++ b/iina/AppData.swift
@@ -132,4 +132,5 @@ extension Notification.Name {
   static let iinaPlayerStopped = Notification.Name("iinaPlayerStopped")
   static let iinaPlayerShutdown = Notification.Name("iinaPlayerShutdown")
   static let iinaPlaySliderLoopKnobChanged = Notification.Name("iinaPlaySliderLoopKnobChanged")
+  static let iinaLogoutCompleted = Notification.Name("iinaLoggedOutOfSubtitleProvider")
 }

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -39,9 +39,18 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
   /** The timer for `OpenFileRepeatTime` and `application(_:openFile:)`. */
   private var openFileTimer: Timer?
 
+  private var allPlayersHaveShutdown = false
+
   private var commandLineStatus = CommandLineStatus()
 
   private var isTerminating = false
+
+  /// Longest time to wait for asynchronous shutdown tasks to finish before giving up on waiting and proceeding with termination.
+  ///
+  /// Ten seconds was chosen to provide plenty of time for termination and yet not be long enough that users start thinking they will
+  /// need to force quit IINA. As termination may involve logging out of an online subtitles provider it can take a while to complete if
+  /// the provider is slow to respond to the logout request.
+  private let terminationTimeout: TimeInterval = 10
 
   // Windows
 
@@ -393,21 +402,32 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
   @objc
   func shutdownTimedout() {
     timedOut = true
-    Logger.log("Timed out waiting for players to stop and shutdown", level: .warning)
-    // For debugging list players that have not terminated.
-    for player in PlayerCore.playerCores {
-      let label = player.label ?? "unlabeled"
-      if !player.isStopped {
-        Logger.log("Player \(label) failed to stop", level: .warning)
-      } else if !player.isShutdown {
-        Logger.log("Player \(label) failed to shutdown", level: .warning)
+    if !allPlayersHaveShutdown {
+      Logger.log("Timed out waiting for players to stop and shutdown", level: .warning)
+      // For debugging list players that have not terminated.
+      for player in PlayerCore.playerCores {
+        let label = player.label ?? "unlabeled"
+        if !player.isStopped {
+          Logger.log("Player \(label) failed to stop", level: .warning)
+        } else if !player.isShutdown {
+          Logger.log("Player \(label) failed to shutdown", level: .warning)
+        }
       }
+      // For debugging purposes we do not remove observers in case players stop or shutdown after
+      // the timeout has fired as knowing that occurred maybe useful for debugging why the
+      // termination sequence failed to complete on time.
+      Logger.log("Not waiting for players to shutdown; proceeding with application termination",
+                 level: .warning)
     }
-    // For debugging purposes we do not remove observers in case players stop or shutdown after
-    // the timeout has fired as knowing that occurred maybe useful for debugging why the
-    // termination sequence failed to complete on time.
-    Logger.log("Not waiting for players to shutdown; proceeding with application termination",
-               level: .warning)
+    if OnlineSubtitle.loggedIn {
+      // The request to log out of the online subtitles provider has not completed. This should not
+      // occur as the logout request uses a timeout that is shorter than the termination timeout to
+      // avoid this occurring. Therefore if this message is logged something has gone wrong with the
+      // shutdown code.
+      Logger.log("Timed out waiting for log out of online subtitles provider to complete",
+                 level: .warning)
+    }
+    Logger.log("Proceeding with application termination due to time out", level: .warning)
     // Tell Cocoa to proceed with termination.
     NSApp.reply(toApplicationShouldTerminate: true)
   }
@@ -434,6 +454,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
       }
     }
 
+    // The first priority was to shutdown any new input from the user. The second priority is to
+    // send a logout request if logged into an online subtitles provider as that needs time to
+    // complete.
+    if OnlineSubtitle.loggedIn {
+      // Force the logout request to timeout earlier than the overall termination timeout. This
+      // request taking too long does not represent an error in the shutdown code, whereas the
+      // intention of the overall termination timeout is to recover from some sort of hold up in the
+      // shutdown sequence that should not occur.
+      OnlineSubtitle.logout(timeout: terminationTimeout - 1)
+    }
+
     // Close all windows. When a player window is closed it will send a stop command to mpv to stop
     // playback and unload the file.
     Logger.log("Closing all windows")
@@ -446,23 +477,37 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     // player and shutdown was initiated by typing "q" in the player window. That sends a quit
     // command directly to mpv causing mpv and the player to shutdown before application
     // termination is initiated.
-    var canTerminateNow = true
+    allPlayersHaveShutdown = true
     for player in PlayerCore.playerCores {
       if !player.isShutdown {
-        canTerminateNow = false
+        allPlayersHaveShutdown = false
         break
       }
     }
+    if allPlayersHaveShutdown {
+      Logger.log("All players have shutdown")
+    } else {
+      // Shutdown of player cores involves sending the stop and quit commands to mpv. Even though
+      // these commands are sent to mpv using the synchronous API mpv executes them asynchronously.
+      // This requires IINA to wait for mpv to finish executing these commands.
+      Logger.log("Waiting for players to stop and shutdown")
+    }
+
+    // Usually will have to wait for logout request to complete if logged into an online subtitle
+    // provider.
+    var canTerminateNow = allPlayersHaveShutdown
+    if OnlineSubtitle.loggedIn {
+      canTerminateNow = false
+      Logger.log("Waiting for log out of online subtitles provider to complete")
+    }
+
+    // If the user pressed Q and mpv initiated the termination then players will already be
+    // shutdown and it may be possible to proceed with termination.
     if canTerminateNow {
-      Logger.log("All players have shutdown; proceeding with application termination")
+      Logger.log("Proceeding with application termination")
       // Tell Cocoa that it is ok to immediately proceed with termination.
       return .terminateNow
     }
-
-    // Shutdown of player cores involves sending the stop and quit commands to mpv. Even though
-    // these commands are sent to mpv using the synchronous API mpv executes them asynchronously.
-    // This requires IINA to wait for mpv to finish executing these commands.
-    Logger.log("Waiting for players to stop and shutdown")
 
     // To ensure termination completes and the user is not required to force quit IINA, impose an
     // arbitrary timeout that forces termination to complete. The expectation is that this timeout
@@ -470,13 +515,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     // investigated.
     var timer: Timer
     if #available(macOS 10.12, *) {
-      timer = Timer(timeInterval: 10, repeats: false) { _ in
+      timer = Timer(timeInterval: terminationTimeout, repeats: false) { _ in
         // Once macOS 10.11 is no longer supported the contents of the method can be inlined in this
         // closure.
         self.shutdownTimedout()
       }
     } else {
-      timer = Timer(timeInterval: TimeInterval(10), target: self,
+      timer = Timer(timeInterval: terminationTimeout, target: self,
                     selector: #selector(self.shutdownTimedout), userInfo: nil, repeats: false)
     }
     RunLoop.main.add(timer, forMode: .common)
@@ -509,6 +554,37 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     }
     observers.append(observer)
 
+    /// Proceed with termination if all outstanding shutdown tasks have completed.
+    ///
+    /// This method is called when an observer receives a notification that a player has shutdown or an online subtitles provider logout
+    /// request has completed. If there are no other termination tasks outstanding then this method will instruct AppKit to proceed with
+    /// termination.
+    func proceedWithTermination() {
+      if !allPlayersHaveShutdown {
+        // If any player has not shutdown then continue waiting.
+        for player in PlayerCore.playerCores {
+          guard player.isShutdown else { return }
+        }
+        allPlayersHaveShutdown = true
+        // All players have shutdown.
+        Logger.log("All players have shutdown")
+      }
+      guard !OnlineSubtitle.loggedIn else { return }
+      // All players have shutdown. No longer logged into an online subtitles provider.
+      Logger.log("Proceeding with application termination")
+      // No longer need the timer that forces termination to proceed.
+      timer.invalidate()
+      // No longer need the observers for players stopping and shutting down, along with the
+      // observer for logout requests completing.
+      ObjcUtils.silenced {
+        observers.forEach {
+          NotificationCenter.default.removeObserver($0)
+        }
+      }
+      // Tell AppKit to proceed with termination.
+      NSApp.reply(toApplicationShouldTerminate: true)
+    }
+
     // Establish an observer for a player core shutting down.
     observer = center.addObserver(forName: .iinaPlayerShutdown, object: nil, queue: .main) { _ in
       guard !self.timedOut else {
@@ -525,22 +601,24 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         Logger.log("Player shutdown after application termination timed out", level: .warning)
         return
       }
-      // If any player has not shutdown then continue waiting.
-      for player in PlayerCore.playerCores {
-        guard player.isShutdown else { return }
+      proceedWithTermination()
+    }
+    observers.append(observer)
+
+    // Establish an observer for logging out of the online subtitle provider.
+    observer = center.addObserver(forName: .iinaLogoutCompleted, object: nil, queue: .main) { _ in
+      guard !self.timedOut else {
+        // The request to log out of the online subtitles provider has completed after IINA already
+        // timed out, gave up waiting for players to shutdown, and told Cocoa to proceed with
+        // termination. This should not occur as the logout request uses a timeout that is shorter
+        // than the termination timeout to avoid this occurring. Therefore if this message is logged
+        // something has gone wrong with the shutdown code.
+        Logger.log(
+          "Log out of online subtitles provider completed after application termination timed out",
+          level: .warning)
+        return
       }
-      // All players have shutdown. Proceed with termination.
-      Logger.log("All players have shutdown; proceeding with application termination")
-      // No longer need the timer that forces termination to proceed.
-      timer.invalidate()
-      // No longer need the observers for players stopping and shutting down.
-      ObjcUtils.silenced {
-        observers.forEach {
-          NotificationCenter.default.removeObserver($0)
-        }
-      }
-      // Tell Cocoa to proceed with termination.
-      NSApp.reply(toApplicationShouldTerminate: true)
+      proceedWithTermination()
     }
     observers.append(observer)
 
@@ -551,7 +629,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
       }
     }
 
-    // Tell Cocoa that it is ok to proceed with termination, but wait for our reply.
+    // Tell AppKit that it is ok to proceed with termination, but wait for our reply.
     return .terminateLater
   }
 

--- a/iina/OpenSubClient.swift
+++ b/iina/OpenSubClient.swift
@@ -1,0 +1,916 @@
+//
+//  OpenSubClient.swift
+//  iina
+//
+//  Created by low-batt on 8/30/23.
+//  Copyright © 2023 lhc. All rights reserved.
+//
+
+import Foundation
+import Just
+import PromiseKit
+
+/// [Open Subtitles](https://www.opensubtitles.com/)
+/// [REST API](https://opensubtitles.stoplight.io/docs/opensubtitles-api/e3750fd63a100-getting-started/)
+/// client.
+///
+/// The [opensubtitles.org](https://www.opensubtitles.org/)
+/// [XMLRPC](https://trac.opensubtitles.org/projects/opensubtitles/wiki/XMLRPC) API is shutting down at the
+/// end of 2023 and being replaced by the [opensubtitles.com](https://www.opensubtitles.com/)
+/// [REST API](https://opensubtitles.stoplight.io/docs/opensubtitles-api/e3750fd63a100-getting-started/).
+/// Thus this is more than a switch from a XMLRPC API to a REST API, it also involves a migration from `opensubtitles.org` to
+/// `opensubtitles.com`.  This is not transparent to users with an `opensubtitles.org` account.  The Open Subtitles FAQ
+/// [How do I import my opensubtitles.org account?](https://www.opensubtitles.com/en/faq)
+/// instructs users to:
+///
+/// Go to the [user import] (https://www.opensubtitles.com/users/import) page and fill in the email registered on
+/// opensubtitles.org. You will receive an email inviting you set yourself a new password. Your previous uploads will be referenced, user
+/// right such as VIP will be imported.
+///
+/// Open Subtitles was unable to automate migrating a user's account password, so they implemented a manual account import
+/// process that requires a user to change their password. IINA needs to communicate the need to manually migrate accounts to users
+/// in order to avoid reports that login is broken.
+///
+/// This class provides a _somewhat_ generic client for the Open Subtitles REST API. The intent is to have a clear separation between
+/// the code required merely to call the REST API and code that guides how IINA uses the API. Therefore **developers must not**
+/// add code that specifically deals with IINA concerns. This class should remain a "dumb client". IINA concerns should be handled at a
+/// higher level. To avoid the work and additional complexity of a true generic client, this class is tied to IINA in a number of ways such
+/// as:
+/// - The HTTP [User-Agent](https://en.wikipedia.org/wiki/User-Agent_header) request header is hardcoded to IINA
+/// - The HTTP [Api-Key](https://opensubtitles.stoplight.io/docs/opensubtitles-api/e3750fd63a100-getting-started#api-key)
+/// request header is hardcoded to IINA's key
+/// - Only the REST API methods used by IINA are supported
+/// - Only the method features used by IINA are supported
+/// - IINA's logger is used for debug logging
+/// Intentionally not present is any support for higher level IINA operations, many of which involve multiple API calls. The purpose of this
+/// client is to make it easier for the higher level code to call individual API methods.
+class OpenSubClient {
+  
+  enum Error: Swift.Error {
+
+    /// An error that indicates the REST API call failed.
+    /// - Parameters:
+    ///   - statuscode:
+    ///     [HTTP status code](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml).
+    ///   - message: Description of the failure.
+    case callFailed(statusCode: Int?, message: String? = nil)
+    
+    /// An error that indicates the client expected the  HTTP response to contain content, but none was found.
+    /// - Parameter statuscode:
+    ///   [HTTP status code](https://www.iana.org/assignments/http-status-codes/http-status-codes.xhtml).
+    case contentMissing(statusCode: Int?)
+    
+    /// An error that indicates the REST API call failed, returning a JSON struct containing information about the faillure.
+    /// - Parameter response: An `ErrorResponse` object containing information about the failure.
+    case errorResponse(response: OpenSubClient.ErrorResponse)
+  }
+
+  /// The `OpenSubClient` singleton object.
+  static let shared = OpenSubClient()
+
+  /// `True` if currently logged in, `false` otherwise.
+  ///
+  /// This property reflects whether the client currently possesses a valid
+  /// [JSON Web Token](https://en.wikipedia.org/wiki/JSON_Web_Token) returned by the
+  /// [login](https://opensubtitles.stoplight.io/docs/opensubtitles-api/73acf79accc0a-login) method.
+  ///
+  /// - NOTE: In [Authorization JWT](https://opensubtitles.stoplight.io/docs/opensubtitles-api/e3750fd63a100-getting-started#authorization-jwt)
+  /// Open Subtitles indicates a token is valid for 24 hours. The client keeps track of when the token was obtained and will consider the
+  /// token expired before 24 hours is reached in order to reduce the chance of a request failing with a 406 `invalid token` error.
+  var loggedIn: Bool {
+    guard token != nil, let tokenExpiration = tokenExpiration else { return false }
+    guard Date() < tokenExpiration else {
+      log("User session has expired")
+      abandonUserSession()
+      return false
+    }
+    return true
+  }
+
+  // MARK: - Private Properties
+
+  /// URL to prepend to a REST API method name to form the full URL of the API endpoint.
+  ///
+  /// - Important: As discussed in the documentation for the
+  ///     [login](https://opensubtitles.stoplight.io/docs/opensubtitles-api/73acf79accc0a-login)
+  ///     method Open Subtitles may direct the client to use a different host for further API requests.
+  private var apiBaseURL: URL
+  
+  /// Hostname to initially use to access the REST API.
+  private let apiDefaultHostname = "api.opensubtitles.com"
+
+  // FIXME: Obtain official Open Subtitles API key for IINA.
+
+  /// Official IINA [Open Subtitles](https://www.opensubtitles.com/)
+  /// [API key](https://opensubtitles.stoplight.io/docs/opensubtitles-api/e3750fd63a100-getting-started#api-key).
+  ///
+  /// The API key identifies the _application_ using the
+  /// [REST API](https://opensubtitles.stoplight.io/docs/opensubtitles-api/e3750fd63a100-getting-started),
+  /// not the  [Open Subtitles](https://www.opensubtitles.com/) user.
+  private let apiKey = "FIXME FIXME FIXME"
+
+  /// [JSON decoder](https://developer.apple.com/documentation/foundation/jsondecoder) properly configured
+  /// to decode responses from API methods.
+  ///
+  /// - Note: Decoding dates requires a custom decoder because the
+  /// [ISO8601DateFormatter](https://developer.apple.com/documentation/foundation/iso8601dateformatter)
+  /// can only be configured to expect one specific format, but dates in the JSON responses from Open Subtitles sometimes contain
+  /// fractional seconds, `2023-09-01T23:59:59.000Z` and sometimes not, `2023-05-15T21:54:32Z`.
+  private let decoder: JSONDecoder = {
+    let decoder = JSONDecoder()
+    decoder.keyDecodingStrategy = .convertFromSnakeCase
+    guard #available(macOS 10.12, *) else {
+      let iso8601 = DateFormatter()
+      iso8601.calendar = Calendar(identifier: .iso8601)
+      iso8601.locale = Locale(identifier: "en_US_POSIX")
+      iso8601.timeZone = TimeZone(secondsFromGMT: 0)
+      iso8601.dateFormat = "yyyy-MM-dd'T'HH:mm:ssZ"
+      let iso8601WithFractionalSeconds = DateFormatter()
+      iso8601WithFractionalSeconds.calendar = Calendar(identifier: .iso8601)
+      iso8601WithFractionalSeconds.locale = Locale(identifier: "en_US_POSIX")
+      iso8601WithFractionalSeconds.timeZone = TimeZone(secondsFromGMT: 0)
+      iso8601WithFractionalSeconds.dateFormat = "yyyy-MM-dd'T'HH:mm:ss.SSSSZ"
+      decoder.dateDecodingStrategy = .custom({ (decoder) -> Date in
+        let container = try decoder.singleValueContainer()
+        let dateStr = try container.decode(String.self)
+        if let date = iso8601.date(from: dateStr) {
+          return date
+        }
+        if let date = iso8601WithFractionalSeconds.date(from: dateStr) {
+          return date
+        }
+        throw DecodingError.dataCorruptedError(in: container,
+                                               debugDescription: "Expected ISO 8601 date: \(dateStr)")
+      })
+      return decoder
+    }
+    let iso8601 = ISO8601DateFormatter()
+    let iso8601WithFractionalSeconds = ISO8601DateFormatter()
+    iso8601WithFractionalSeconds.formatOptions = [.withFractionalSeconds]
+    decoder.dateDecodingStrategy = .custom({ (decoder) -> Date in
+      let container = try decoder.singleValueContainer()
+      let dateStr = try container.decode(String.self)
+      if let date = iso8601.date(from: dateStr) {
+        return date
+      }
+      if let date = iso8601WithFractionalSeconds.date(from: dateStr) {
+        return date
+      }
+      throw DecodingError.dataCorruptedError(in: container,
+                                             debugDescription: "Expected ISO 8601 date: \(dateStr)")
+    })
+    return decoder
+  }()
+
+  /// Management of API request
+  /// [rate limits](https://opensubtitles.stoplight.io/docs/opensubtitles-api/6ef2e232095c7-best-practices#limits)
+  /// imposed on clients by Open Subtitles.
+  private var rateLimiter = RateLimiter()
+
+  /// Authorization [JSON Web Token](https://en.wikipedia.org/wiki/JSON_Web_Token) returned by the
+  /// [login](https://opensubtitles.stoplight.io/docs/opensubtitles-api/73acf79accc0a-login) method.
+  ///
+  /// Authentication is discussed in [Getting Started](https://opensubtitles.stoplight.io/docs/opensubtitles-api/e3750fd63a100-getting-started#authorization-jwt)
+  private var token: String?
+
+  /// Time when the JWT will be considered expired by the client.
+  private var tokenExpiration: Date?
+
+  /// Length of time a JWT is considered valid.
+  ///
+  /// As documented in
+  /// [Authorization JWT](https://opensubtitles.stoplight.io/docs/opensubtitles-api/e3750fd63a100-getting-started#authorization-jwt)
+  /// `Open Subtitles` expires logged in user sessions after 24 hours. To reduce the chance of a request failing due to an expired
+  /// token the client considers the token expired after 23 hours.
+  private let tokenLifetime: TimeInterval = 23 * 60 * 60
+
+  /// Value to send in the HTTP [User-Agent](https://en.wikipedia.org/wiki/User-Agent_header) request header.
+  ///
+  /// The value is formatted as specified in
+  /// [Important-HTTP Request Headers](https://opensubtitles.stoplight.io/docs/opensubtitles-api/e3750fd63a100-getting-started#important-http-request-headers).
+  private let userAgent: String = {
+    let (version, build) = InfoDictionary.shared.version
+    return "IINA v\(version)"
+  }()
+
+  // MARK: - REST API Methods
+  
+  /// [Download](https://opensubtitles.stoplight.io/docs/opensubtitles-api/6be7f6ae2d918-download) method.
+  ///
+  /// This method _does not_ download the subtitle file. It requests that a temporary URL be generated from which the subtitle file
+  /// contents can be downloaded. As discussed in
+  /// [Getting started](https://opensubtitles.stoplight.io/docs/opensubtitles-api/e3750fd63a100-getting-started)
+  /// this is the method that Open Subtitles uses to enforce limits on use of their service. The download quota imposed depends up
+  /// whether a user is authenticated or not and their rank. If the quota is exceeded this method will fail with a 406 (not acceptable)
+  /// status code as explained in
+  /// [Error codes](https://opensubtitles.stoplight.io/docs/opensubtitles-api/12f131ce12132-error-codes).
+  /// - Parameter fileId: File ID of the subtitle file to download (obtained from search results).
+  /// - Returns: A `DownloadResponse` containing a temporary link to the subtitle file and information such as requests
+  ///            remaining before download quota is reached.
+  func download(fileId: Int) -> Promise<DownloadResponse> {
+    return after(seconds: rateLimiter.delayBeforeCall()).then { [self] in
+      Promise { resolver in
+        let data = ["file_id": String(fileId)]
+        let url = apiURL("download")
+        Just.post(url, data: data, headers: formHeaders(), asyncCompletionHandler: { [self] result in
+          logHTTPResult(result)
+          do {
+            let response = try decodeResponse(DownloadResponse.self, from: result)
+            resolver.fulfill(response)
+          } catch {
+            resolver.reject(error)
+          }
+        })
+      }
+    }
+  }
+
+  /// Download the contents of a subtitle file.
+  ///
+  /// This is an accompanying endpoint for the
+  /// [Download](https://opensubtitles.stoplight.io/docs/opensubtitles-api/6be7f6ae2d918-download)
+  /// method. That method does not return the subtitle file contents. Instead it returns a link that can then be used with this endpoint to
+  /// download the file contents.
+  /// - Parameter url: Link to subtitle file contents returned by the `Download` method.
+  /// - Returns: A [Data](https://developer.apple.com/documentation/foundation/data) object containing the
+  ///            file contents
+  func downloadFileContents(_ url: URL) -> Promise<Data> {
+    return after(seconds: rateLimiter.delayBeforeCall()).then { [self] in
+      Promise { resolver in
+        Just.get(url, headers: formHeaders(), asyncCompletionHandler: { [self] result in
+          logHTTPResult(result)
+          if let error = result.error {
+            resolver.reject(error)
+            return
+          }
+          guard result.ok else {
+            // When downloading fails, Open Subtitles normally returns an error message as the
+            // response content. As this is not a part of the REST API, the contents is not JSON.
+            guard let text = result.text else {
+              // No error message, generate a message based on HTTP status code.
+              resolver.reject(Error.callFailed(statusCode: result.statusCode))
+              return
+            }
+            // Sometimes the response content is a HTML error page instead of a simple text message.
+            if let error = formErrorIfHtmlResponse(result) {
+              resolver.reject(error)
+              return
+            }
+            resolver.reject(Error.callFailed(statusCode: result.statusCode, message: text))
+            return
+          }
+          guard let content = result.content else {
+            resolver.reject(Error.contentMissing(statusCode: result.statusCode))
+            return
+          }
+          resolver.fulfill(content)
+        })
+      }
+    }
+  }
+
+  /// [Languages](https://opensubtitles.stoplight.io/docs/opensubtitles-api/1de776d20e873-languages)
+  /// method.
+  /// - Returns: A `LanguagesResponse` containing a list of the supported lanuage codes.
+  func languages() -> Promise<LanguagesResponse> {
+    return after(seconds: rateLimiter.delayBeforeCall()).then { [self] in
+      Promise { resolver in
+        let url = apiURL("infos/languages")
+        Just.get(url, headers: formHeaders(), asyncCompletionHandler: { [self] result in
+          logHTTPResult(result)
+          do {
+            let response = try self.decodeResponse(LanguagesResponse.self, from: result)
+            resolver.fulfill(response)
+          } catch {
+            resolver.reject(error)
+          }
+        })
+      }
+    }
+  }
+
+  /// [Login](https://opensubtitles.stoplight.io/docs/opensubtitles-api/73acf79accc0a-login) method.
+  ///
+  /// This method is used to log into [Open Subtitles](https://www.opensubtitles.com/en). A successful login returns a
+  /// [JSON Web Token](https://en.wikipedia.org/wiki/JSON_Web_Token) that is then passed in an `Authorization`
+  /// header in further requests. Based on account privileges Open Subtitles may redirect the client to use a different hostname for the
+  /// REST API endpoints in further requests.
+  /// - Important: The given username and password _must_ be for an `opensubtitles.com` account., not an
+  ///     `opensubtitles.org` account. Users with an `opensubtitles.org` account must
+  ///     [import] (https://www.opensubtitles.com/users/import) it  into `opensubtitles.com` before the
+  ///     account can be used.
+  /// - Note: Open Subtitles documents that for the login method there is set limit 1 request per 1 second to avoid flooding with
+  ///     wrong credentials. This means the rate limit response headers returned instruct the client to wait before sending another
+  ///     request. However this only applies if the client is making another request to the login method. This is referred to as the
+  ///     "throttling scope" in the
+  ///     [RateLimit header fields for HTTP](https://www.ietf.org/archive/id/draft-ietf-httpapi-ratelimit-headers-07.html)
+  ///     Internet Draft. Unfortunately at this time the draft does not define a standard header for specifying scope. This means the
+  ///     `RateLimiter`class has no understanding of scope. As a workaround the rate limiter is recreated if login is successful to
+  ///     avoid delaying the next API call.
+  /// - Parameters:
+  ///   - username: Account username.
+  ///   - password: Account password.
+  /// - Returns: account details.
+  func login(username: String, password: String) -> Promise<LoginResponse> {
+    return after(seconds: rateLimiter.delayBeforeCall()).then { [self] in
+      Promise { resolver in
+        let data = ["username": username, "password": password]
+        let url = apiURL("login")
+        Just.post(url, data: data, headers: formHeaders(), asyncCompletionHandler: { [self] result in
+          logHTTPResult(result)
+          do {
+            let response = try self.decodeResponse(LoginResponse.self, from: result)
+            resolver.fulfill(response)
+            // Use a fresh rate limiter to avoid delaying the next request.
+            rateLimiter = RateLimiter()
+            token = response.token
+            tokenExpiration = Date() + tokenLifetime
+            // Open Subtitles may direct the client to use a different host for further requests.
+            guard let hostname = response.baseUrl else {
+              return
+            }
+            guard let baseURL = OpenSubClient.formBaseURL(hostname: hostname) else {
+              // Should not occur. Malformed data returned by Open Subtitles? As login was
+              // apparently successful we will treat this as a warning.
+              log("Unable to form URL from: \(hostname)", level: .warning)
+              return
+            }
+            apiBaseURL = baseURL
+          } catch {
+            resolver.reject(error)
+          }
+        })
+      }
+    }
+  }
+
+  /// [Logout](https://opensubtitles.stoplight.io/docs/opensubtitles-api/9fe4d6d078e50-logout) method.
+  /// - Parameter timeout: The timeout to to use for the the request.
+  /// - Returns: A `LogoutResponse`
+  func logout(timeout: TimeInterval? = nil) -> Promise<LogoutResponse> {
+    return after(seconds: rateLimiter.delayBeforeCall()).then { [self] in
+      Promise { resolver in
+        let headers = formHeaders()
+        let url = apiURL("logout")
+        Just.delete(url, headers: headers, timeout: timeout, asyncCompletionHandler: { [self] result in
+          logHTTPResult(result)
+          // Whether or not the logout request was successful consider the user as having logged out.
+          abandonUserSession()
+          do {
+            let response = try self.decodeResponse(LogoutResponse.self, from: result)
+            resolver.fulfill(response)
+          } catch {
+            resolver.reject(error)
+          }
+        })
+      }
+    }
+  }
+
+  /// [Subtitles](https://opensubtitles.stoplight.io/docs/opensubtitles-api/a172317bd5ccc-search-for-subtitles)
+  /// method.
+  ///
+  /// Find available subtitles matching the query and
+  /// [hash code](https://trac.opensubtitles.org/projects/opensubtitles/wiki/HashSourceCodes)
+  /// (if available) in the given languages.
+  /// - Note: This method does not adhere to the recommended REST API
+  ///         [Best Practice](https://opensubtitles.stoplight.io/docs/opensubtitles-api/6ef2e232095c7-best-practices#performance)
+  ///         of sending parameters in alphabetical order because the `Just` parameter is an unordered Swift dictionary.
+  /// - Note: This method does not adhere to the recommended REST API
+  ///         [Best Practice](https://opensubtitles.stoplight.io/docs/opensubtitles-api/6ef2e232095c7-best-practices#performance)
+  ///         of using "+" instead "%20" for space in the URL encoding because `Just` does not provide a way to control the
+  ///         percent encoding.
+  /// - Parameters:
+  ///   - languages: Language code(s).
+  ///   - hash: Moviehash of the movie file.
+  ///   - query:File name or text search.
+  /// - Returns: A `SubtitlesResponse` object.
+  func subtitles(languages: [String], hash: String?, query: String?) -> Promise<SubtitlesResponse> {
+    return after(seconds: rateLimiter.delayBeforeCall()).then { [self] in
+      Promise { resolver in
+        // As per REST API best practices, attempt to send GET parameters in alphabetical order.
+        // Unfortunately, Just.get takes a Swift dictionary therefore order is not guaranteed.
+        var params = ["languages": languages.sorted().joined(separator: ",")]
+        if let hash = hash {
+          params["moviehash"] = hash
+        }
+        if let query = query {
+          params["query"] = query
+        }
+        let url = apiURL("subtitles")
+        Just.get(url, params: params, headers: formHeaders(), asyncCompletionHandler: { [self] result in
+          logHTTPResult(result)
+          do {
+            let response = try self.decodeResponse(SubtitlesResponse.self, from: result)
+            resolver.fulfill(response)
+          } catch {
+            resolver.reject(error)
+          }
+        })
+      }
+    }
+  }
+
+  // MARK: - Supporting Methods
+
+  /// Abandons the current the user session.
+  ///
+  /// The [JSON Web Token](https://en.wikipedia.org/wiki/JSON_Web_Token) is discarded. The host to use for API
+  /// requests is reset to the default Open Subtitles REST API server.
+  private func abandonUserSession() {
+    apiBaseURL = OpenSubClient.formBaseURL(hostname: apiDefaultHostname)!
+    token = nil
+    tokenExpiration = nil
+  }
+
+  /// Returns the REST API endpoint for the given method.
+  /// - Parameter method: Name of the REST API method.
+  /// - Returns: `URL` to send the request to.
+  private func apiURL(_ method: String) -> URL { URL(string: method, relativeTo: apiBaseURL)! }
+
+  /// Decode the result of a REST API call into a `Response` object.
+  /// - Parameters:
+  ///   - type: Type of `Response` to decode the response into.
+  ///   - result: `HTTPResult` returned by [Just](https://github.com/dduan/Just).
+  /// - Returns: Response JSON decoded into a `Response` object.
+  private func decodeResponse<T>(_ type: T.Type, from result: HTTPResult) throws -> T where T : Response {
+    if !result.headers.isEmpty {
+      rateLimiter.processRateLimitHeaders(result.headers)
+    }
+    if let error = result.error {
+      throw error
+    }
+    guard result.ok else {
+      guard let content = result.content else {
+        throw Error.callFailed(statusCode: result.statusCode, message: result.reason)
+      }
+      // Sometimes the response content is a HTML error page instead of JSON.
+      if let error = formErrorIfHtmlResponse(result) {
+        throw error
+      }
+      do {
+        let response = try self.decoder.decode(ErrorResponse.self, from: content)
+        guard let statusCode = result.statusCode, statusCode == 406,
+              response.message == "invalid token" else {
+          throw Error.errorResponse(response: response)
+        }
+        // The REST API returns a 406 (Not Acceptable) HTTP status code with an "invalid token"
+        // error message if the server determined the JSON web token representing the user session
+        // has expired. The client keeps track of when the token was acquired and attempts to reduce
+        // the chance of this error occurring, however the client must still be prepared to handle
+        // the case where the server rejects the token.
+        log("User session is no longer valid")
+        abandonUserSession()
+        throw Error.errorResponse(response: response)
+      } catch {
+        guard let text = result.text else {
+          throw error
+        }
+        log("Decoding JSON as \(String(describing: ErrorResponse.self)) failed: \(text) error thrown: \(error)", level: .error)
+        throw error
+      }
+    }
+    guard let content = result.content else {
+      throw Error.contentMissing(statusCode: result.statusCode)
+    }
+    do {
+      return try self.decoder.decode(type, from: content)
+    } catch {
+      guard let text = result.text else {
+        throw error
+      }
+      log("Decoding JSON as \(String(describing: type)) failed: \(text) error thrown: \(error)", level: .error)
+      throw error
+    }
+  }
+
+  /// Form the base URL to append a REST API method to.
+  ///
+  /// The server to send REST API requests to is not a constant. The response to a login request may instruct the client to send further
+  /// API requests to a different host.
+  /// - Parameter hostname: Host to send REST API requests to.
+  /// - Returns: Base `URL` to append a method name to.
+  private static func formBaseURL(hostname: String) -> URL? {
+    var components = URLComponents()
+    components.scheme = "https"
+    components.host = hostname
+    components.path = "/api/v1/"
+    return components.url
+  }
+
+  /// Form an error if the given API response content is HTML.
+  ///
+  /// Normally when an API request fails the content of the response returned by Open Subtitles is a JSON `ErrorResponse`
+  /// structure. However for certain types of failures the response content returned is a HTML error page. If the content is HTML the
+  /// title is extracted and a `callFailed` error is constructed using the title as the error message.
+  /// - Parameter result: `HTTPResult` returned by [Just](https://github.com/dduan/Just).
+  /// - Returns: A `callFailed` error or `nil`
+  private func formErrorIfHtmlResponse(_ result: HTTPResult) -> Error? {
+    guard let contentHeader = result.headers["Content-Type"], contentHeader.contains("text/html"),
+          let text = result.text else {
+      return nil
+    }
+    log("Found HTML instead of JSON:\n\(text.trimmingCharacters(in: .whitespacesAndNewlines))")
+    guard let start = text.range(of: "<title>"), let end = text.range(of: "</title>"),
+          start.upperBound < end.lowerBound else {
+      // Not expected to occur. All error pages seen in testing included a title.
+      return Error.callFailed(statusCode: result.statusCode, message: "HTML returned instead of JSON")
+    }
+    var message = String(text[start.upperBound..<end.lowerBound])
+    if let statusCode = result.statusCode {
+      let prefix = "\(statusCode) "
+      if message.hasPrefix(prefix) {
+        message = String(message.dropFirst(prefix.count))
+      }
+    }
+    return Error.callFailed(statusCode: result.statusCode, message: message)
+  }
+
+  /// Form a dictionary containing the common headers sent in every request.
+  ///
+  /// These are the headers shown in the [Getting Started](https://opensubtitles.stoplight.io/docs/opensubtitles-api/e3750fd63a100-getting-started)
+  /// section of the REST API documentation.
+  /// - Returns: Dictionary containing the headers.
+  private func formHeaders() -> [String: String] {
+    var headers = ["Accept": "*/*", "Api-Key": String(apiKey.reversed()),
+                   "Content-Type": "application/json", "User-Agent": userAgent]
+    guard let token = token else { return headers }
+    headers["Authorization"] = "Bearer \(token)"
+    return headers
+  }
+
+  private func log(_ message: String, level: Logger.Level = .debug) {
+    Logger.log(message, level: level, subsystem: Logger.Sub.opensubapi)
+  }
+
+  /// Log details about the result of calling a REST API.
+  ///
+  /// Both the request and the response are logged in detail. For debugging it is important to log the details of the response as the
+  /// result returned by Open Subtitles is sometimes not matching up with the REST API documentation.
+  /// - Important: This method redacts sensitive authentication and authorization data replacing it with `<private>`.
+  /// - Parameter result: `HTTPResult` returned by [Just](https://github.com/dduan/Just).
+  private func logHTTPResult(_ result: HTTPResult) {
+    let options: JSONSerialization.WritingOptions = [.prettyPrinted]
+    let privateValue = "<private>"
+    if let request = result.request {
+      var requestJson: [String: Any] = [:]
+      if let httpMethod = request.httpMethod {
+        requestJson["httpMethod"] = httpMethod
+      }
+      if let url = request.url {
+        requestJson["url"] = url.absoluteString
+      }
+      if var headers = request.allHTTPHeaderFields, !headers.isEmpty {
+        if headers["Api-Key"] != nil {
+          headers["Api-Key"] = privateValue
+        }
+        if headers["Authorization"] != nil {
+          headers["Authorization"] = privateValue
+        }
+        requestJson["headers"] = headers
+      }
+      if let data = request.httpBody, var body = try? JSONSerialization.jsonObject(with: data) as? [String:Any] {
+        if body["username"] != nil {
+          body["username"] = privateValue
+        }
+        if body["password"] != nil {
+          body["password"] = privateValue
+        }
+        requestJson["body"] = body
+      }
+      if let data = try? JSONSerialization.data(withJSONObject: requestJson, options: options),
+         let pretty = String(data: data, encoding: .utf8) {
+        log("Request: \(pretty)")
+      }
+    }
+    if let status = result.statusCode {
+      log("HTTP response status code: \(status) \(result.reason)")
+    }
+    if let error = result.error {
+      log("Error: \(error)")
+    }
+    guard var resultJson = result.json as? [String: Any] else {
+      if !result.headers.isEmpty {
+        var message = ""
+        for (header, value) in result.headers {
+          if !message.isEmpty {
+            message += "\n"
+          }
+          message += "\(header): \(value)"
+        }
+        log("HTTP response headers:\n" + message)
+      }
+      return
+    }
+    if !result.headers.isEmpty {
+      var dict: [String: String] = [:]
+      for (key, value) in result.headers {
+        dict[key] = value
+      }
+      resultJson["headers"] = dict
+    }
+    if resultJson["token"] != nil {
+      resultJson["token"] = privateValue
+    }
+    if let data = try? JSONSerialization.data(withJSONObject: resultJson, options: options),
+       let pretty = String(data: data, encoding: .utf8) {
+      log("Response: \(pretty)")
+    }
+  }
+  
+  private init() {
+    apiBaseURL = OpenSubClient.formBaseURL(hostname: apiDefaultHostname)!
+  }
+
+  // MARK: - Rate Limiter
+
+  /// REST API call rate limiter.
+  ///
+  /// This class is used to detect when the client _must_ wait before sending a REST API request in order to adhere to the request rate
+  /// limits imposed by Open Subtitles on clients. The limits currently imposed by Open Subtitles normally do not require IINA to wait
+  /// before sending a request. Possibly selecting many subtitles to download could run fast enough to require a delay, but only if the
+  /// subtitle files are tiny and the Open Subtitles servers are responding quickly. _However_  in response to overloaded servers Open
+  /// Subtitles could lower the rate limits, thus clients _must_ obey the limits returned in responses from the server.
+  ///
+  /// Rate limits are discussed in the Open Subtitles REST API documentation in the
+  /// [Best Practices](https://opensubtitles.stoplight.io/docs/opensubtitles-api/6ef2e232095c7-best-practices)
+  /// section which says:
+  ///
+  /// API requests are rate limited **5 requests per 1 second** per IP address. It means your client should follow the limits,
+  /// otherwise it will receive HTTP error:
+  ///
+  /// _429 Too Many Requests_
+  ///
+  /// The documentation goes on to say:
+  ///
+  /// On `/login` there is set limit 1 request per 1 second to avoid flooding with wrong credentials. Stop sending requests with same
+  /// credentials if user fail to authenticate.
+  ///
+  /// The [Important HTTP response headers](https://opensubtitles.stoplight.io/docs/opensubtitles-api/e3750fd63a100-getting-started#important-http-response-headers)
+  /// section contains a link to [Rate Limiting | Kong Docs](https://docs.konghq.com/hub/kong-inc/rate-limiting/).
+  /// The Kong documentation contains this example of response headers:
+  /// ```text
+  /// RateLimit-Limit: 6
+  /// RateLimit-Remaining: 4
+  /// RateLimit-Reset: 47
+  /// ```
+  /// And indicates these headers are based on the Internet-Draft [RateLimit header fields for HTTP](https://datatracker.ietf.org/doc/draft-ietf-httpapi-ratelimit-headers/).
+  class RateLimiter {
+
+    /// Number of requests remaining in the quota for the current window.
+    private var remaining = Int.max
+
+    /// Time at which the current window ends and the quota resets .
+    private var resets: TimeInterval = 0
+
+    /// Returns the time to wait before sending a request.
+    ///
+    /// If the current time is outside of the window for which the quota in `remaining` is applicable then zero is returned. Otherwise
+    /// the remaining quota is decremented and if the quota has not been exceeded then zero is returned. When the quota would be
+    /// exceeded the time remaining until the current window ends and the quota resets is calculated and returned.
+    /// - Returns: Time to wait in seconds.
+    func delayBeforeCall() -> TimeInterval {
+      // No delay needed if the current time is outside of the window for which the quota given in
+      // remaining is applicable.
+      let now = Date().timeIntervalSince1970
+      guard resets > now else { return 0 }
+      remaining -= 1
+      // No delay needed if quota has not been exceeded.
+      guard remaining < 0 else { return 0 }
+      // Must wait until outside the current window and the quota resets.
+      let delay = (resets - now).rounded(.up)
+      let delayAsString = String(format: "%.f", delay)
+      shared.log("Rate limit quota reached, waiting \(delayAsString)s before sending request")
+      return delay
+    }
+
+    /// Process rate limit headers if present in the response headers.
+    /// - Parameter headers: Response headers returned by the server.
+    func processRateLimitHeaders(_ headers: CaseInsensitiveDictionary<String, String>) {
+      // Up to the server as to whether it sends rate limit headers in the response.
+      guard let remainingString = headers["ratelimit-remaining"],
+            let resetString = headers["ratelimit-reset"] else {
+        return
+      }
+      // Have headers, parse and validate their values.
+      guard let remaining = Int(remainingString), remaining >= 0, let reset = Int(resetString),
+            reset >= 0 else {
+        // The draft RFC specifies that the values of these header fields are non-negative Integers
+        // and that "Malformed RateLimit header fields MUST be ignored". Log a warning as this
+        // should not occur and pretend no headers were received.
+        shared.log("Malformed rate limits: \(remainingString), \(resetString)", level: .warning)
+        return
+      }
+      // Save the time at which current window ends and the quota resets.
+      resets = Date().timeIntervalSince1970 + Double(reset)
+      self.remaining = remaining
+    }
+  }
+
+  // MARK: - Response Models
+
+  /// Response returned by the
+  /// [Download](https://opensubtitles.stoplight.io/docs/opensubtitles-api/6be7f6ae2d918-download) method.
+  struct DownloadResponse: Response {
+    var fileName: String
+    var link: URL
+    var message: String
+    var remaining: Int
+    var requests: Int
+    var resetTime: String
+    var resetTimeUtc: Date
+  }
+
+  struct ErrorResponse: Response {
+    var message: String
+    var remaining: Int?
+    var requests: Int?
+    var resetTime: String?
+    var resetTimeUtc: Date?
+  }
+
+  /// Part of the response returned by the
+  /// [Languages](https://opensubtitles.stoplight.io/docs/opensubtitles-api/1de776d20e873-languages)
+  /// method.
+  struct LanguageCode: Decodable {
+    var languageCode: String
+    var languageName: String
+  }
+
+  /// Response returned by the
+  /// [Languages](https://opensubtitles.stoplight.io/docs/opensubtitles-api/1de776d20e873-languages)
+  /// method.
+  struct LanguagesResponse: Response {
+    var data: [LanguageCode]
+  }
+
+  /// Response returned by the
+  /// [Login](https://opensubtitles.stoplight.io/docs/opensubtitles-api/73acf79accc0a-login) method.
+  struct LoginResponse: Response {
+    var baseUrl: String?
+    var status: Int
+    var token: String
+    var user: User
+  }
+
+  /// Response returned by the
+  /// [Logout](https://opensubtitles.stoplight.io/docs/opensubtitles-api/9fe4d6d078e50-logout) method.
+  struct LogoutResponse: Response {
+    var message: String
+    var status: Int
+  }
+
+  /// Response returned by the
+  /// [Subtitles](https://opensubtitles.stoplight.io/docs/opensubtitles-api/a172317bd5ccc-search-for-subtitles
+  /// method.
+  struct SubtitlesResponse: Response {
+    var data: [Subtitle]
+    var page: Int
+    var perPage: Int
+    var totalCount: Int
+    var totalPages: Int
+  }
+
+  /// Part of the response returned by the
+  /// [Login](https://opensubtitles.stoplight.io/docs/opensubtitles-api/73acf79accc0a-login) method.
+  struct User: Decodable {
+    var allowedDownloads: Int
+    var allowedTranslations: Int
+    var extInstalled: Bool
+    var level: String
+    var userId: Int
+    var vip: Bool
+  }
+
+  // MARK: - Subtitle Models
+
+  /// [Subtitle](https://opensubtitles.stoplight.io/docs/opensubtitles-api/573f76acc1493-subtitle) model.
+  ///
+  /// Structure modeling the JSON returned by the
+  /// [Subtitles](https://opensubtitles.stoplight.io/docs/opensubtitles-api/a172317bd5ccc-search-for-subtitles)
+  /// method representing a subtitle file.
+  /// - Important: The above referenced documentation has proven to be unreliable. Testing has encountered properties that are
+  /// documented as `required` but are being returned with `null` values in responses from Open Subtitles. This is unfortunate
+  /// because returning `null` will trigger a [DecodingError](https://developer.apple.com/documentation/swift/decodingerror)
+  /// unless an optional type is used for the property.  Many properties use optional types because we are unsure which ones can be
+  /// depended upon to always be present.
+  /// - Note: Properties not used by IINA at this time are not included in the release build to avoid the need to decode their values.
+  struct Subtitle: Decodable {
+
+    var attributes: SubtitleAttributes
+    var id: String
+    var type: String
+
+    struct SubtitleAttributes: Decodable {
+#if DEBUG
+      var aiTranslated: Bool?
+      var comments: String?
+#endif
+      var downloadCount: Int
+#if DEBUG
+      var featureDetails: SubtitleFeatureDetails
+#endif
+      var files: [SubtitleFile]
+#if DEBUG
+      var foreignPartsOnly: Bool?
+      var fps: Double?
+      var fromTrusted: Bool?
+      var hd: Bool?
+      var hearingImpaired: Bool?
+#endif
+      var language: String
+#if DEBUG
+      var legacySubtitleId: Int?
+      var machineTranslated: Bool?
+      var newDownloadCount: Int?
+      var points: Int?
+#endif
+      var ratings: Double
+#if DEBUG
+      var relatedLinks: [SubtitleRelatedLinks]?
+      var release: String?
+      var subtitleId: String?
+#endif
+      var uploadDate: Date
+#if DEBUG
+      var uploader: SubtitleUploader
+      var url: URL?
+      var votes: Int?
+#endif
+
+      /// Model containing details about the media the subtitles are for.
+      ///
+      /// This JSON structure is dynamically typed. The value of the `featureType` property determines which of the following
+      /// structures the object represents:
+      /// - [Feature-Episode](https://opensubtitles.stoplight.io/docs/opensubtitles-api/06192f1ad8378-feature-episode)
+      /// - [Feature-Movie](https://opensubtitles.stoplight.io/docs/opensubtitles-api/eb1e524fb59d6-feature-movie)
+      /// - [Feature-Tvshow](https://opensubtitles.stoplight.io/docs/opensubtitles-api/b771c5ae51786-feature-tvshow)
+      ///
+      /// To properly decode dynamically typed JSON requires using something like the
+      /// [DynamicCodableKit](https://swiftylab.github.io/DynamicCodableKit/documentation/dynamiccodablekit/)
+      /// framework. As IINA is not making use of the information in these structures, only the common properties are modeled.
+      struct SubtitleFeatureDetails: Decodable {
+        var featureId: Int
+        var featureType: String?
+        var imdbId: Int?
+        var title: String
+        var tmdbId: Int?
+        var year: Int?
+      }
+
+      struct SubtitleFile: Decodable {
+#if DEBUG
+        var cdNumber: Int?
+#endif
+        var fileId: Int
+        var fileName: String
+      }
+
+      struct SubtitleRelatedLinks: Decodable {
+        var imgUrl: URL?
+        var label: String?
+        var url: URL?
+      }
+      
+      struct SubtitleUploader: Decodable {
+        var name: String
+        var rank: String?
+        var uploaderId: Int?
+      }
+    }
+  }
+}
+
+protocol Response: Decodable {}
+
+extension OpenSubClient.Error: CustomStringConvertible, LocalizedError {
+  var description: String {
+    switch self {
+    case .callFailed(let statusCode, let message):
+      guard let message = message else {
+        guard let statusCode = statusCode else {
+          return String(describing: type(of: self))
+        }
+        return statusCodeAsString(statusCode)
+      }
+      guard let statusCode = statusCode else { return message }
+      return message + " (\(statusCodeAsString(statusCode)))"
+    case.contentMissing(let statusCode):
+      let message = "Response content is missing"
+      guard let statusCode = statusCode else { return message }
+      return message + " (\(statusCodeAsString(statusCode)))"
+    case .errorResponse(let response):
+      return response.message
+    }
+  }
+  
+  var errorDescription: String? { description }
+
+  private func statusCodeAsString(_ statusCode: Int) -> String {
+    "\(statusCode) \(HTTPURLResponse.localizedString(forStatusCode: statusCode))"
+  }
+}
+
+extension Logger.Sub {
+  static let opensubapi = Logger.makeSubsystem("opensubapi")
+}

--- a/iina/OpenSubClient.swift
+++ b/iina/OpenSubClient.swift
@@ -99,15 +99,13 @@ class OpenSubClient {
   /// Hostname to initially use to access the REST API.
   private let apiDefaultHostname = "api.opensubtitles.com"
 
-  // FIXME: Obtain official Open Subtitles API key for IINA.
-
   /// Official IINA [Open Subtitles](https://www.opensubtitles.com/)
   /// [API key](https://opensubtitles.stoplight.io/docs/opensubtitles-api/e3750fd63a100-getting-started#api-key).
   ///
   /// The API key identifies the _application_ using the
   /// [REST API](https://opensubtitles.stoplight.io/docs/opensubtitles-api/e3750fd63a100-getting-started),
   /// not the  [Open Subtitles](https://www.opensubtitles.com/) user.
-  private let apiKey = "FIXME FIXME FIXME"
+  private let apiKey = "SPX87dlUuuHpxeh5u3rd7dHekOT6oYpx"
 
   /// [JSON decoder](https://developer.apple.com/documentation/foundation/jsondecoder) properly configured
   /// to decode responses from API methods.

--- a/iina/OpenSubSubtitle.swift
+++ b/iina/OpenSubSubtitle.swift
@@ -9,55 +9,78 @@
 import Foundation
 import Just
 import PromiseKit
-import Gzip
 
+/// Downloader for [Open Subtitles](https://www.opensubtitles.com/).
+/// - Important: This code **should not** be enhanced as the plan is to remove all built-in code for downloading subtitles and
+///              replace it with plug-in implementations.
 class OpenSub {
   final class Subtitle: OnlineSubtitle {
-    var filename: String = ""
-    var langID: String
-    var authorComment: String
-    var addDate: String
-    var rating: String
-    var dlCount: String
-    var movieFPS: String
-    var subDlLink: String
-    var zipDlLink: String
 
-    init(index: Int, filename: String, langID: String, authorComment: String, addDate: String, rating: String, dlCount: String, movieFPS: String, subDlLink: String, zipDlLink: String) {
-      self.filename = filename
-      self.langID = langID
-      self.authorComment = authorComment
-      self.addDate = addDate
-      self.rating = rating
-      self.dlCount = dlCount
-      self.movieFPS = movieFPS
-      self.subDlLink = subDlLink
-      self.zipDlLink = zipDlLink
+    private static let dateFormatter = {
+      let dateFormatter = DateFormatter()
+      dateFormatter.dateStyle = .medium
+      dateFormatter.timeStyle = .medium
+      return dateFormatter
+    }()
+
+    private let subtitle: OpenSubClient.Subtitle
+
+    init(index: Int, subtitle: OpenSubClient.Subtitle) {
+      self.subtitle = subtitle
       super.init(index: index)
     }
 
+    /// Asynchronously download this subtitle.
+    ///
+    /// Downloading requires making two separate requests to [Open Subtitles](https://www.opensubtitles.com/).
+    /// Despite its name, the
+    /// [Download](https://opensubtitles.stoplight.io/docs/opensubtitles-api/6be7f6ae2d918-download)
+    /// REST API method does not return the contents subtitle file. The response from this call contains details related to the quota
+    /// imposed by `Open Subtitles` on downloads along with a link that can be used to download the subtitle file contents. Thus
+    /// a second request is required to actually download the subtitle file contents.
+    /// - Returns: A [URL](https://developer.apple.com/documentation/foundation/url) to the file containing
+    ///            the downloaded subtitle.
     override func download() -> Promise<[URL]> {
-      return Promise { resolver in
-        Just.get(subDlLink, asyncCompletionHandler: { response in
-          guard response.ok, let data = response.content, let unzipped = try? data.gunzipped() else {
-            resolver.reject(OnlineSubtitle.CommonError.networkError(response.error))
-            return
+      let fileId = subtitle.attributes.files[0].fileId
+      return OpenSubClient.shared.download(fileId: fileId).then { downloadResponse in
+        OpenSubClient.shared.downloadFileContents(downloadResponse.link).then { data in
+          Promise { resolver in
+            // This check was added after Open Subtitles returned a subtitle file of zero length.
+            // Better to catch this error early to make it obvious what the problem is rather than
+            // creating a zero length file that triggers a failure during loading.
+            if data.isEmpty {
+              resolver.reject(Error.emptyFile(
+                "Subtitle file \"\(downloadResponse.fileName)\" with ID \(fileId) is empty, no contents"))
+              return
+            }
+            let remaining = String(downloadResponse.remaining)
+            let requests = String(downloadResponse.requests)
+            log("Download #\(requests), remaining quota \(remaining), quota resets in \(downloadResponse.resetTime)")
+            let subFilename = "[\(self.index)]\(downloadResponse.fileName)"
+            guard let url = data.saveToFolder(Utility.tempDirURL, filename: subFilename) else {
+              resolver.reject(OnlineSubtitle.CommonError.fsError)
+              return
+            }
+            resolver.fulfill([url])
           }
-          let subFilename = "[\(self.index)]\(self.filename)"
-          guard let url = unzipped.saveToFolder(Utility.tempDirURL, filename: subFilename) else {
-            resolver.reject(OnlineSubtitle.CommonError.fsError)
-            return
-          }
-          resolver.fulfill([url])
-        })
+        }
       }
     }
 
+    /// Returns a description of this subtitle suitable for display to the user.
+    /// - Returns: A tuple containing the name of this subtitle and the strings to display in the two other columns shown by the
+    ///            view displayed to the user for choosing the subtitle files to download.
     override func getDescription() -> (name: String, left: String, right: String) {
-      (
+      let attributes = subtitle.attributes
+      let downloadCount = String(attributes.downloadCount)
+      let filename = attributes.files[0].fileName
+      let language = attributes.language
+      let rating = String(attributes.ratings)
+      let uploadDate = OpenSub.Subtitle.dateFormatter.string(from: attributes.uploadDate)
+      return (
         filename,
-        "\(langID) \u{2b07}\(dlCount) \u{2605}\(rating)",
-        addDate
+        "\(language) \u{2b07}\(downloadCount) \u{2605}\(rating)",
+        uploadDate
       )
     }
   }
@@ -70,34 +93,19 @@ class OpenSub {
     case fileTooSmall(Int)
     // search failed (reason)
     case searchFailed(String)
-    // lower level error
-    case wrongResponseFormat
-    case xmlRpcError(JustXMLRPC.XMLRPCError)
+    case emptyFile(String)
   }
-
 
   class Fetcher: OnlineSubtitle.DefaultFetcher, OnlineSubtitleFetcher {
     typealias Subtitle = OpenSub.Subtitle
 
-    struct FileInfo {
-      var hashValue: String
-      var fileSize: UInt64
-
-      var dictionary: [String: String] {
-        get {
-          return [
-            "moviehash": hashValue,
-            "moviebytesize": "\(fileSize)"
-          ]
-        }
-      }
-    }
-
-    typealias ResponseFilesData = [[String: Any]]
+    /// `True` if currently logged in to [Open Subtitles](https://www.opensubtitles.com), `false` otherwise.
+    override var loggedIn: Bool { OpenSubClient.shared.loggedIn }
 
     /// Minimum file size imposed by [Open Subtitles](https://www.opensubtitles.org).
     ///
-    /// Open Subtitles limits the size of movies that it supports. This is documented on the wiki page [HashSourceCodes](https://trac.opensubtitles.org/projects/opensubtitles/wiki/HashSourceCodes):
+    /// Open Subtitles limits the size of movies that it supports. This is documented on the wiki page
+    /// [HashSourceCodes](https://trac.opensubtitles.org/projects/opensubtitles/wiki/HashSourceCodes):
     ///
     /// On opensubtitles.org is movie file size limited to **9000000000 > $moviebytesize > 131072 bytes**
     ///
@@ -105,138 +113,49 @@ class OpenSub {
     private static let minimumFileSize = 131072
 
     private let chunkSize: Int = 65536
-    private let apiPath = "https://api.opensubtitles.org:443/xml-rpc"
-    private static let serviceName: NSString = "IINA OpenSubtitles Account"
-    private let xmlRpc: JustXMLRPC
 
     private let subChooseViewController = SubChooseViewController()
 
-    var language: String
-    var username: String = ""
-
-    let ua: String = {
-      let version = Bundle.main.infoDictionary!["CFBundleShortVersionString"] as! String
-      return "IINA v\(version)"
-    }()
-    var token: String!
-
-    var heartBeatTimer: Timer?
-    let heartbeatInterval = TimeInterval(800)
+    private let languages: [String]
 
     static let shared = Fetcher()
 
     required init() {
-      let userLang = Preference.string(for: .subLang) ?? ""
-      if userLang.isEmpty {
+      guard let preferredLanguages = Preference.string(for: .subLang) else {
         Utility.showAlert("sub_lang_not_set")
-        self.language = "eng"
-      } else {
-        self.language = userLang
+        self.languages = ["en"]
+        return
       }
-      self.xmlRpc = JustXMLRPC(apiPath)
+      self.languages = preferredLanguages.components(separatedBy: ",")
     }
 
     func fetch(from url: URL, withProviderID id: String, playerCore player: PlayerCore) -> Promise<[Subtitle]> {
-      return login()
-      .then { _ in
-        self.hash(url, player.info.isNetworkResource)
-      }.then { info in
-        self.requestByHashAndSize(info)
-      }.recover { error -> Promise<[Subtitle]> in
-        if case OnlineSubtitle.CommonError.noResult = error {
-          return self.requestByName(url, player.info.isNetworkResource, player.getMediaTitle())
-        } else {
-          throw error
+      return login().then { _ in
+          self.logIgnoredLanguageCodes()
+        }.then {
+          self.hash(url)
+        }.then { hash in
+          self.searchForSubtitles(url, hash, player.getMediaTitle())
+        }.then { subs in
+          self.showSubSelectWindow(with: subs)
         }
-      }.then { subs in
-        self.showSubSelectWindow(with: subs)
-      }
     }
 
-    private func findPath(_ path: [String], in data: Any) throws -> Any? {
-      var current: Any? = data
-      for arg in path {
-        guard let next = current as? [String: Any] else { throw Error.wrongResponseFormat }
-        current = next[arg]
-      }
-      return current
-    }
-
-    private func checkStatus(_ data: Any) -> Bool {
-      if let parsed = try? findPath(["status"], in: data) {
-        return (parsed as? String ?? "").hasPrefix("200")
-      } else {
-        return false
-      }
-    }
-
-    func login(testUser username: String? = nil, password: String? = nil) -> Promise<Void> {
+    /// Calculate an [Open Subtitles](https://www.opensubtitles.com/) hash code value.
+    ///
+    /// If a hash code is provided when searching for subtitles then `Open Subtitles` will return matching subtitles first in the
+    /// response.
+    ///
+    /// Calculating the hash code is described in detail in the `Open Subtitles` wiki post
+    /// [HashSourceCodes](https://trac.opensubtitles.org/projects/opensubtitles/wiki/HashSourceCodes).
+    /// - Note: If the media is being streamed then it is not possible to calculate the hash code and `nil` will be returned.
+    /// - Parameter url: Location of the media being played.
+    /// - Returns: String containing the hash code or `nil`.
+    func hash(_ url: URL) -> Promise<String?> {
       return Promise { resolver in
-        var finalUser = ""
-        var finalPw = ""
-        if let testUser = username, let testPw = password {
-          // if test login
-          finalUser = testUser
-          finalPw = testPw
-        } else {
-          // check logged in
-          if self.loggedIn {
-            resolver.fulfill(())
-            return
-          }
-          // read password
-          if let udUsername = Preference.string(for: .openSubUsername), !udUsername.isEmpty {
-            if let (_, readPassword) = try? KeychainAccess.read(username: udUsername, forService: .openSubAccount) {
-              finalUser = udUsername
-              finalPw = readPassword
-            }
-          }
-        }
-        // login
-        xmlRpc.call("LogIn", [finalUser, finalPw, "eng", ua]) { status in
-          switch status {
-          case .ok(let response):
-            // OK
-            guard let parsed = (response as? [String: Any]) else {
-              resolver.reject(Error.wrongResponseFormat)
-              return
-            }
-            // check status
-            let pStatus = parsed["status"] as! String
-            if pStatus.hasPrefix("200") {
-              self.token = parsed["token"] as? String
-              log("OpenSub: logged in as user \(finalUser)")
-              self.startHeartbeat()
-              resolver.fulfill(())
-            } else {
-              resolver.reject(Error.loginFailed(pStatus))
-            }
-          case .failure:
-            // Failure
-            resolver.reject(Error.loginFailed("Failure"))
-          case .error(let error):
-            // Error
-            if let cause = error.underlyingError {
-              if OnlineSubtitle.isConnectFailure(cause) {
-                resolver.reject(OnlineSubtitle.CommonError.cannotConnect(cause))
-                return
-              }
-              if OnlineSubtitle.isTimedOutFailure(cause) {
-                resolver.reject(OnlineSubtitle.CommonError.timedOut(cause))
-                return
-              }
-            }
-            resolver.reject(Error.xmlRpcError(error))
-          }
-        }
-      }
-    }
-
-    func hash(_ url: URL, _ isNetworkResource: Bool) -> Promise<FileInfo> {
-      return Promise { resolver in
-        guard !isNetworkResource else {
-          // Cannot create a hash when streaming. Force caller to use title instead.
-          resolver.reject(OnlineSubtitle.CommonError.noResult)
+        guard url.isFileURL else {
+          // Cannot create a hash when streaming.
+          resolver.fulfill(nil)
           return
         }
         let file: FileHandle
@@ -265,101 +184,165 @@ class OpenSub {
 
         hash += fileSize
 
-        resolver.fulfill(FileInfo(hashValue: String(format: "%016qx", hash), fileSize: fileSize))
+        resolver.fulfill(String(format: "%016qx", hash))
       }
     }
 
-    func requestByHashAndSize(_ info: FileInfo) -> Promise<[Subtitle]> {
-      log("Searching for subtitles of movies matching hash \(info.hashValue) and size \(info.fileSize)")
-      return self.request(info.dictionary)
-    }
-
-    func requestByName(_ fileURL: URL, _ isNetworkResource: Bool, _ mediaTitle: String) -> Promise<[Subtitle]> {
-       return requestIMDB(fileURL, isNetworkResource, mediaTitle).then { imdb -> Promise<[Subtitle]> in        let info = ["imdbid": imdb]
-        return self.request(info)
-      }
-    }
-
-    func requestIMDB(_ fileURL: URL, _ isNetworkResource: Bool, _ mediaTitle: String) -> Promise<String> {
-      return Promise { resolver in
-        // When streaming use the media title as frequently the URL does not reflect the title
-        // of the video.
-        let searchString = isNetworkResource ? mediaTitle : fileURL.lastPathComponent
-        log("Searching for subtitles of movies matching '\(searchString)'")
-        xmlRpc.call("GuessMovieFromString", [token as Any, [searchString]]) { status in
-          switch status {
-          case .ok(let response):
-
-            func parseResponse() throws -> String {
-              let responsePath = ["data", searchString, "BestGuess"]
-              guard let bestGuess = try self.findPath(responsePath, in: response) as? [String: Any] else {
-                return ""
-              }
-
-              guard let imdbEntry = bestGuess["IMDBEpisode"] ?? bestGuess["IDMovieIMDB"] else {
-                return ""
-              }
-              if let imdbEntry = imdbEntry as? Int {
-                return String(imdbEntry)
-              }
-              return imdbEntry as? String ?? ""
-            }
-
-            do {
-              guard self.checkStatus(response) else { throw Error.wrongResponseFormat }
-              try resolver.fulfill(parseResponse())
-            } catch let (error) {
-              resolver.reject(error)
-              return
-            }
-          case .failure:
-            resolver.reject(Error.searchFailed("Failure"))
-          case .error(let error):
-            resolver.reject(Error.xmlRpcError(error))
+    /// Log in to [Open Subtitles](https://www.opensubtitles.com/).
+    ///
+    /// The `username`/`password` parameters are used to test credentials when the user configuring the account on the
+    /// `Subtitle` tab of IINA's settings. Normally the credentials will be retrieved from the macOS `Keychain`.
+    ///
+    /// This method detects if the user is already logged in and avoids needlessly creating a new user session.
+    /// - Parameters:
+    ///   - username: User name to test or `nil`.
+    ///   - password: Password when testing credentials or `nil`.
+    func login(testUser username: String? = nil, password: String? = nil) -> Promise<Void> {
+      var finalUser: String? = username
+      var finalPw: String? = password
+      if finalUser == nil || finalPw == nil {
+        // check logged in
+        if OpenSubClient.shared.loggedIn {
+          log("Already logged in to Open Subtitles")
+          return .value
+        }
+        // read password
+        if let udUsername = Preference.string(for: .openSubUsername), !udUsername.isEmpty {
+          if let (_, readPassword) = try? KeychainAccess.read(username: udUsername, forService: .openSubAccount) {
+            finalUser = udUsername
+            finalPw = readPassword
           }
         }
       }
+      guard let finalUser = finalUser, let finalPw = finalPw else {
+        log("An Open Subtitles account has not been configured")
+        return .value
+      }
+      return OpenSubClient.shared.login(username: finalUser, password: finalPw).then { response in
+        Promise { resolver in
+          let allowedDownloads = String(response.user.allowedDownloads)
+          let vip = response.user.vip ? " as VIP" : ""
+          log("Logged in to Open Subtitles\(vip), allowed downloads: \(allowedDownloads)")
+          resolver.fulfill(())
+        }
+      }.recover { error in
+        throw Error.loginFailed(error.localizedDescription)
+      }
     }
 
-    func request(_ info: [String: String]) -> Promise<[Subtitle]> {
-      return Promise { resolver in
-        let limit = 100
-        var requestInfo = info
-        requestInfo["sublanguageid"] = self.language
-        xmlRpc.call("SearchSubtitles", [token as Any, [requestInfo], ["limit": limit]]) { status in
-          switch status {
-          case .ok(let response):
-            guard self.checkStatus(response) else { resolver.reject(Error.wrongResponseFormat); return }
-            guard let pData = try? self.findPath(["data"], in: response) as? ResponseFilesData else {
-              resolver.reject(Error.wrongResponseFormat)
-              return
+    /// Log ignored language codes.
+    ///
+    /// IINA's `Preferred language` setting is used when automatically loading local subtitle files as well as when downloading
+    /// from subtitle sites. As a result it may contian language codes not supported by Open Subtitles. When logging is enabled this
+    /// method will log the language codes in the setting that are not supported by Open Subtitles and will be ignored. This is only
+    /// done for ease of debugging.
+    func logIgnoredLanguageCodes() -> Promise<Void> {
+      guard Logger.enabled else { return .value }
+      return OpenSubClient.shared.languages().then { response in
+        Promise { resolver in
+          resolver.fulfill(())
+          var foundCode = false
+          var ignoredCodes = ""
+          let supportedCodes = response.data.map { $0.languageCode }
+          log("Preferred languages: \(self.languages.sorted().joined(separator: ","))")
+          log("Supported languages: \(supportedCodes.sorted().joined(separator: ","))")
+          for language in self.languages {
+            guard supportedCodes.contains(language) else {
+              if !ignoredCodes.isEmpty {
+                ignoredCodes += ","
+              }
+              ignoredCodes += language
+              continue
             }
-            var result: [Subtitle] = []
-            for (index, subData) in pData.enumerated() {
-              let sub = Subtitle(index: index,
-                                        filename: subData["SubFileName"] as! String,
-                                        langID: subData["SubLanguageID"] as! String,
-                                        authorComment: subData["SubAuthorComment"] as! String,
-                                        addDate: subData["SubAddDate"] as! String,
-                                        rating: subData["SubRating"] as! String,
-                                        dlCount: subData["SubDownloadsCnt"] as! String,
-                                        movieFPS: subData["MovieFPS"] as! String,
-                                        subDlLink: subData["SubDownloadLink"] as! String,
-                                        zipDlLink: subData["ZipDownloadLink"] as! String)
-              result.append(sub)
-            }
-            if result.isEmpty {
-              resolver.reject(OnlineSubtitle.CommonError.noResult)
-            } else {
-              resolver.fulfill(result)
-            }
-          case .failure:
-            // Failure
-            resolver.reject(Error.searchFailed("Failure"))
-          case .error(let error):
-            // Error
-            resolver.reject(Error.xmlRpcError(error))
+            foundCode = true
           }
+          guard foundCode else {
+            log("None of the preferred languages are supported: \(ignoredCodes)", level: .warning)
+            return
+          }
+          guard ignoredCodes.isEmpty else {
+            log("The following preferred languages will be ignored: \(ignoredCodes)")
+            return
+          }
+          log("All preferred languages are supported")
+        }
+      }.recover { error in
+        throw OnlineSubtitle.CommonError.networkError(error)
+      }
+    }
+
+    /// Logout of the user session.
+    ///
+    /// Open Subtitles requests that applications logout of of user sessions so that they can free resources. This is discussed in the
+    /// [Best Practices](https://opensubtitles.stoplight.io/docs/opensubtitles-api/6ef2e232095c7-best-practices)
+    /// section of the Open Subtitles REST API documentation.
+    /// - Parameter timeout: The timeout to to use for the the request.
+    override func logout(timeout: TimeInterval? = nil) -> Promise<Void> {
+      guard OpenSubClient.shared.loggedIn else {
+        Logger.log("Not logged in to Open Subtitles")
+        return .value
+      }
+      log("Logging out of Open Subtitles")
+      return OpenSubClient.shared.logout(timeout: timeout).asVoid().done {
+        log("Logged out of Open Subtitles")
+      }
+    }
+
+    /// Search [Open Subtitles](https://www.opensubtitles.com/) for subtitles for the given movie.
+    ///
+    /// If no subtitles are found this method will fail with the error `noResult`.
+    /// - Parameters:
+    ///   - url: A [URL](https://developer.apple.com/documentation/foundation/url) to the movie to search
+    ///          for subtitles for.
+    ///   - hash: An [Open Subtitles](https://www.opensubtitles.com/) hash code value or `nil`.
+    ///   - mediaTitle: The title of the movie.
+    /// - Returns: An array containing one or more `Subtitle` objects.
+    func searchForSubtitles(_ url: URL, _ hash: String?, _ mediaTitle: String) -> Promise<[Subtitle]> {
+      // When streaming prefer the movie's title.
+      let searchString = url.isFileURL ? url.deletingPathExtension().lastPathComponent : mediaTitle
+      if let hash = hash {
+        log("Searching for subtitles of movies with hash \(hash) and matching '\(searchString)'")
+      } else {
+        log("Searching for subtitles of movies matching '\(searchString)'")
+      }
+      return OpenSubClient.shared.subtitles(languages: languages, hash: hash, query: searchString).then { response in
+        Promise { resolver in
+          guard response.totalCount != 0 else {
+            resolver.reject(OnlineSubtitle.CommonError.noResult)
+            return
+          }
+          var result: [Subtitle] = []
+          for (index, subData) in response.data.enumerated() {
+            guard subData.type == "subtitle" else {
+              log("Ignoring result with unexpected type: \(subData.type), subtitle ID: \(subData.id)",
+                  level: .warning)
+              continue
+            }
+            guard !subData.attributes.files.isEmpty else {
+              // Should not occur according to the Open Subtitles REST API documentation which
+              // indicates this array must contain at least one entry. However results returned
+              // have sometimes violated other documented behavior so it is critical to validate
+              // the data returned.
+              log("Ignoring result missing file information, subtitle ID: \(subData.id)",
+                  level: .warning)
+              continue
+            }
+            result.append(Subtitle(index: index, subtitle: subData))
+          }
+          guard !result.isEmpty else {
+            // The normal case where no subtitles were found is caught above. The subtitles returned
+            // must have been ignored.
+            resolver.reject(OnlineSubtitle.CommonError.noResult)
+            return
+          }
+          resolver.fulfill((result))
+        }
+      }.recover { error -> Promise<[Subtitle]> in
+        switch error {
+        case OnlineSubtitle.CommonError.noResult:
+          throw error
+        default:
+          throw Error.searchFailed(error.localizedDescription)
         }
       }
     }
@@ -383,42 +366,6 @@ class OpenSub {
         PlayerCore.active.sendOSD(.foundSub(subs.count), autoHide: false, accessoryView: subChooseViewController.view)
         subChooseViewController.tableView.reloadData()
       }
-    }
-
-    private func startHeartbeat() {
-      heartBeatTimer = Timer(timeInterval: heartbeatInterval, target: self, selector: #selector(sendHeartbeat), userInfo: nil, repeats: true)
-    }
-
-    @objc private func sendHeartbeat() {
-      xmlRpc.call("NoOperation", [token as Any]) { result in
-        switch result {
-        case .ok(let value):
-          // 406 No session
-          if let pValue = value as? [String: Any], (pValue["status"] as? String ?? "").hasPrefix("406") {
-            log("heartbeat: no session", level: .warning)
-            self.token = nil
-            self.login().catch { err in
-              switch err {
-              case Error.loginFailed(let reason):
-                log("(re-login) \(reason)", level: .error)
-              case Error.xmlRpcError(let error):
-                log("(re-login) \(error.readableDescription)", level: .error)
-              default:
-                log("(re-login) \(err.localizedDescription)", level: .error)
-              }
-            }
-          } else {
-            log("OpenSub: heartbeat ok")
-          }
-        default:
-          log("OpenSub: heartbeat failed", level: .error)
-          self.token = nil
-        }
-      }
-    }
-
-    var loggedIn: Bool {
-      return token != nil
     }
   }
 

--- a/iina/PrefSubViewController.swift
+++ b/iina/PrefSubViewController.swift
@@ -116,8 +116,6 @@ class PrefSubViewController: PreferenceViewController, PreferenceWindowEmbeddabl
           switch err {
           case OpenSub.Error.loginFailed(let reason):
             message = reason
-          case OpenSub.Error.xmlRpcError(let e):
-            message = e.readableDescription
           default:
             message = "Unknown error"
           }


### PR DESCRIPTION
This commit will:
- Add a new `OpenSubClient` class
- Change the `OpenSub` class to use the new client
- Change the `OpenSub` default language from `eng` to `en`
- Change name of provider from `opensubtitles.org` to `opensubtitles.com`
- Add a new `loggedIn` property to `OnlineSubtitle`
- Add a new `logout` method to `OnlineSubtitle`
- Add a new `iinaLogoutCompleted` notification to `AppData`
- Change `AppDelegate` to log out of the online subtitle provider during termination

This is a temporary stopgap solution that updates the builtin legacy code in order to meet the end of 2023 deadline imposed by Open Subtitles for switching to the new REST API. The plan is still to replace all built-in code for downloading from online subtitle providers with plug-in implementations.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #3920.

---

**Description:**
