### PR TITLE
Remove default of mpv playlist title metadata for playlist items (fixes #4682)

### DIFF
--- a/iina/MPVPlaylistItem.swift
+++ b/iina/MPVPlaylistItem.swift
@@ -15,7 +15,7 @@ class MPVPlaylistItem: NSObject {
 
   /** Title or the real filename */
   var filenameForDisplay: String {
-    return title ?? (isNetworkResource ? filename : NSString(string: filename).lastPathComponent)
+    return (isNetworkResource ? filename : NSString(string: filename).lastPathComponent)
   }
 
   var isCurrent: Bool


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4682.

---

**Description:**
* Currently the displayed playlist items are querying mpv for the property `playlist/N/title` and using that as their title. But this doesn't work consistently, and most files don't have it, and often when they do the data is not useful.
* This change ensures that `playlist/N/filename` is used consistently.
* Note that this doesn't affect the logic for displaying artist & track names for audio files.