### PR TITLE
Fix missing Chinese localization in UI settings, #4644

### DIFF
--- a/iina/en.lproj/PrefUIViewController.strings
+++ b/iina/en.lproj/PrefUIViewController.strings
@@ -103,6 +103,9 @@
 /* Class = "NSButtonCell"; title = "Always float on top while playing"; ObjectID = "SFX-ct-8MB"; */
 "SFX-ct-8MB.title" = "Always float on top while playing";
 
+/* Class = "NSButtonCell"; title = "Always show float on top status in the title bar"; ObjectID = "ih8-5a-PYY"; */
+"ih8-5a-PYY.title" = "Always show float on top status in the title bar";
+
 /* Class = "NSMenuItem"; title = "Speed"; ObjectID = "TWq-Xb-8Ee"; */
 "TWq-Xb-8Ee.title" = "Speed";
 


### PR DESCRIPTION
This commit will add the missing English translation for the setting "Always show float on top status in the title bar" to enable the ability to add Chinese and other translations in Crowdin.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4644.

---

**Description:**
