### PR TITLE
Fix black out window triggers makeKeyWindow warning, #4693

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2574,7 +2574,7 @@ class MainWindowController: PlayerWindowController {
       blackWindow.level = .iinaBlackScreen
 
       blackWindows.append(blackWindow)
-      blackWindow.makeKeyAndOrderFront(nil)
+      blackWindow.orderFront(self)
     }
   }
 


### PR DESCRIPTION
This commit will change the method `blackOutOtherMonitors` in the class `MainWindowController` to call `orderFront` instead of `makeKeyAndOrderFront`.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4693.

---

**Description:**
