### PR TITLE
Fix phantom "B" tick in slider when AB-Loop is used, #4705

### DIFF
--- a/iina/PlaySlider.swift
+++ b/iina/PlaySlider.swift
@@ -57,14 +57,29 @@ final class PlaySlider: NSSlider {
 
   // MARK:- Drawing
 
+  /// Draw the slider.
+  ///
+  /// The [NSSlider](https://developer.apple.com/documentation/appkit/nsslider) method is being overridden
+  /// for two reasons.
+  ///
+  /// With the onscreen controller hidden and a movie playing spindumps showed time being spent drawing the slider even though it
+  /// was not visible. Apparently `NSSlider.draw` is not calling
+  /// [hiddenOrHasHiddenAncestor](https://developer.apple.com/documentation/appkit/nsview/1483473-hiddenorhashiddenancestor)
+  /// to see if drawing can be avoided.  This was noticed under macOS Monterey.  Unknown if Apple addressed this in later macOS
+  /// releases.
+  ///
+  /// The loop knobs are added as subviews to the slider. That should have resulted in the `PlaySliderLoopKnob.draw` method
+  /// being called when the slider was being drawn. Prior to macOS Sonoma that did not occur. The assumption is that the
+  /// [NSSlider](https://developer.apple.com/documentation/appkit/nsslider) `draw` method was not calling
+  /// `super.draw` and that has now been corrected. As a workaround on earlier versions of macOS the loop knob `draw` method
+  /// is called directly.
   override func draw(_ dirtyRect: NSRect) {
-    // With the onscreen controller hidden and a movie playing spindumps showed time being spent
-    // drawing the slider even though it was not visible. Apparently NSSlider is missing the
-    // following check.
     guard !isHiddenOrHasHiddenAncestor else { return }
     super.draw(dirtyRect)
-    abLoopA.draw(dirtyRect)
-    abLoopB.draw(dirtyRect)
+    if #unavailable(macOS 14) {
+      abLoopA.draw(dirtyRect)
+      abLoopB.draw(dirtyRect)
+    }
   }
 
   override func viewDidUnhide() {

--- a/iina/PlaySlider.swift
+++ b/iina/PlaySlider.swift
@@ -76,10 +76,11 @@ final class PlaySlider: NSSlider {
   override func draw(_ dirtyRect: NSRect) {
     guard !isHiddenOrHasHiddenAncestor else { return }
     super.draw(dirtyRect)
-    if #unavailable(macOS 14) {
-      abLoopA.draw(dirtyRect)
-      abLoopB.draw(dirtyRect)
-    }
+    abLoopA.needsDisplay = true
+    abLoopB.needsDisplay = true
+    guard #unavailable(macOS 14) else { return }
+    abLoopA.draw(dirtyRect)
+    abLoopB.draw(dirtyRect)
   }
 
   override func viewDidUnhide() {

--- a/iina/PlaySliderLoopKnob.swift
+++ b/iina/PlaySliderLoopKnob.swift
@@ -132,13 +132,24 @@ final class PlaySliderLoopKnob: NSView {
     }
   }
 
+  /// Draw the knob.
+  ///
+  /// If IINA is running under macOS Ventura or earlier this method is called directly by `PlaySlider.draw`. This workaround
+  /// requires this method to use the knob position within the slider as the x-coordinate when drawing. In macOS Sonoma
+  /// [NSSlider](https://developer.apple.com/documentation/appkit/nsslider) changed and the workaround is no
+  /// longer required and the drawing origin is relative to this view's frame. See `PlaySlider.draw` for more details.
   override func draw(_ dirtyRect: NSRect) {
     guard !isHiddenOrHasHiddenAncestor else { return }
     let rect = knobRect()
     // The frame is taller than the drawn knob. Adjust the y coordinate accordingly.
     let adjustedY = rect.origin.y + (rect.height - knobHeight) / 2
-    // Round the X position for cleaner drawing
-    let drawing = NSMakeRect(round(rect.origin.x), adjustedY, cell.knobWidth, knobHeight)
+    let drawing: NSRect
+    if #available(macOS 14, *) {
+      drawing = NSMakeRect(0, adjustedY, cell.knobWidth, knobHeight)
+    } else {
+      // Round the X position for cleaner drawing
+      drawing = NSMakeRect(round(rect.origin.x), adjustedY, cell.knobWidth, knobHeight)
+    }
     let path = NSBezierPath(roundedRect: drawing, xRadius: cell.knobRadius, yRadius: cell.knobRadius)
     knobColor().setFill()
     path.fill()


### PR DESCRIPTION
This commit will:
- Change `PlaySlider.draw` to not call the loop knob draw methods when drawing under macOS 10.14+
- Change `PlaySliderLoopKnob.draw` to not use the knob position within the slider as the x-coordinate when drawing under macOS 10.14+

These changes remove a workaround that was required due to `NSSlider` not drawing its subviews. As of macOS Sonoma `NSSlider` has changed and subviews are being drawn. This is good and means the workaround is no longer needed and must not be applied as it is causing the incorrect drawing of the knobs.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4705.

---

**Description:**
