### PR TITLE
Fix Open Recent menu cleared with each new build, #4688

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1545,6 +1545,9 @@ class PlayerCore: NSObject {
       }
       if Preference.bool(for: .recordRecentFiles) && Preference.bool(for: .trackAllFilesInRecentOpenMenu) {
         NSDocumentController.shared.noteNewRecentDocumentURL(url)
+#if DEBUG
+        DispatchQueue.main.async { (NSApp.delegate as? AppDelegate)?.saveRecentDocuments() }
+#endif
       }
 
     }

--- a/iina/PrefGeneralViewController.swift
+++ b/iina/PrefGeneralViewController.swift
@@ -59,6 +59,9 @@ class PrefGeneralViewController: PreferenceViewController, PreferenceWindowEmbed
   @IBAction func rememberRecentChanged(_ sender: NSButton) {
     if sender.state == .off {
       NSDocumentController.shared.clearRecentDocuments(self)
+#if DEBUG
+      (NSApp.delegate as? AppDelegate)?.saveRecentDocuments()
+#endif
     }
   }
 }

--- a/iina/PrefUtilsViewController.swift
+++ b/iina/PrefUtilsViewController.swift
@@ -130,6 +130,9 @@ class PrefUtilsViewController: PreferenceViewController, PreferenceWindowEmbedda
       guard respond == .alertFirstButtonReturn else { return }
       try? FileManager.default.removeItem(atPath: Utility.playbackHistoryURL.path)
       NSDocumentController.shared.clearRecentDocuments(self)
+#if DEBUG
+      (NSApp.delegate as? AppDelegate)?.saveRecentDocuments()
+#endif
       Preference.set(nil, for: .iinaLastPlayedFilePath)
       self.playHistoryClearedLabel.isHidden = false
     }

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -293,6 +293,9 @@ struct Preference {
     static let suppressCannotPreventDisplaySleep = Key("suppressCannotPreventDisplaySleep")
 
     static let iinaEnablePluginSystem = Key("iinaEnablePluginSystem")
+
+    /** Workaround for issue [#4688](https://github.com/iina/iina/issues/4688) */
+    static let recentDocuments = Key("recentDocuments")
   }
 
   // MARK: - Enums
@@ -869,7 +872,9 @@ struct Preference {
     .savedVideoFilters: [SavedFilter](),
     .savedAudioFilters: [SavedFilter](),
 
-    .suppressCannotPreventDisplaySleep: false
+    .suppressCannotPreventDisplaySleep: false,
+
+    .recentDocuments: [Any]()
   ]
 
 


### PR DESCRIPTION
This commit will:
- Add a `recentDocuments` setting to `Preference`
- Add the method `saveRecentDocuments` to `AppDelegate`
- Add a call to `saveRecentDocuments` in:
  - `AppDelegate.openFile`
  - `PlayerCore.fileLoaded`
  - `PrefGeneralViewController.rememberRecentChanged`
  - `PrefUtilsViewController.clearHistoryBtnAction`
- Add the method `restoreRecentDocuments` to `AppDelegate`
- Add a call to `restoreRecentDocuments` in `AppDelegate.applicationWillFinishLaunching`

Other than the adding the `recentDocuments` preference, all changes are only included in debug builds as this is a workaround that is only intended to provide a better experience for developers.

The workaround saves the list of recently opened files as an IINA setting so that the list can be restored when `sharedfilelistd` clears the list due to the ad hoc certificate used in developer builds.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4688.

---

**Description:**
