### PR TITLE
Display thumbnails in DAR instead of SAR

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2308,7 +2308,18 @@ class MainWindowController: PlayerWindowController {
       if player.info.thumbnailsReady, let image = player.info.getThumbnail(forSecond: previewTime.second)?.image {
         thumbnailPeekView.imageView.image = image.rotate(rotation)
         thumbnailPeekView.isHidden = false
-        let height = round(120 / thumbnailPeekView.imageView.image!.size.aspect)
+
+        // In some formats (like most of Japanese TV video formats), display aspect ratios (DAR) are different from the
+        // sample aspect ratio (SAR). A typical configuration is SAR 1440x1080i (4:3) w/ DAR 1920x1080 (16:9). Here we try
+        // to get the display aspect ratio from mpv to properly display the thumbnail.
+        let displayAspectRatio: CGFloat
+        if let width = player.info.displayWidth, let height = player.info.displayHeight {
+          displayAspectRatio = CGFloat(width) / CGFloat(height)
+        } else {
+          displayAspectRatio = thumbnailPeekView.imageView.image!.size.aspect
+        }
+
+        let height = round(120 / displayAspectRatio)
         let timePreviewFrameInWindow = timePreviewWhenSeek.superview!.convert(timePreviewWhenSeek.frame.origin, to: nil)
         let showAbove = canShowThumbnailAbove(timnePreviewYPos: timePreviewFrameInWindow.y, thumbnailHeight: height)
         let yPos = showAbove ? timePreviewFrameInWindow.y + timePreviewWhenSeek.frame.height : sliderFrameInWindow.y - height

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -301,7 +301,7 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
 
   func updateVideoSize() {
     guard let window = window else { return }
-    let (width, height) = player.originalVideoSize
+    let (width, height) = player.videoSizeForDisplay
     let aspect = (width == 0 || height == 0) ? 1 : CGFloat(width) / CGFloat(height)
     let currentHeight = videoView.frame.height
     let newHeight = videoView.frame.width / aspect

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -566,7 +566,7 @@ class PlayerCore: NSObject {
     miniPlayer.videoWrapperView.addSubview(videoView, positioned: .below, relativeTo: nil)
     Utility.quickConstraints(["H:|[v]|", "V:|[v]|"], ["v": videoView])
 
-    let (width, height) = originalVideoSize
+    let (width, height) = videoSizeForDisplay
     let aspect = (width == 0 || height == 0) ? 1 : CGFloat(width) / CGFloat(height)
     miniPlayer.updateVideoViewAspectConstraint(withAspect: aspect)
     miniPlayer.window?.layoutIfNeeded()

--- a/iina/ThumbnailPeekView.swift
+++ b/iina/ThumbnailPeekView.swift
@@ -23,6 +23,7 @@ class ThumbnailPeekView: NSView {
     self.imageView.wantsLayer = true
     self.imageView.layer?.cornerRadius = 4
     self.imageView.layer?.masksToBounds = true
+    self.imageView.imageScaling = .scaleAxesIndependently
   }
 
 }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)

---

**Description:**
In some formats (like most of Japanese TV video formats), display aspect ratios (DAR) are different from the sample aspect ratio (SAR). A typical configuration is SAR 1440x1080i (4:3) w/ DAR 1920x1080 (16:9). So I changed to try to get the display aspect ratio from mpv to properly display the thumbnail.

Before:
![image](https://github.com/iina/iina/assets/20237141/5bae06c3-3817-4c64-9bac-2b9d052571f2)

After:
![image](https://github.com/iina/iina/assets/20237141/3af13f07-a717-4e46-8fe8-3f593d127fe0)


Testing video: https://drive.google.com/file/d/1tKMnXhpMBGbTLUh3uxFl6F4xdiB3nBtw/view?usp=drive_link