### PR TITLE
Sync the play button when switching to mini player

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -541,6 +541,7 @@ class PlayerCore: NSObject {
 
     miniPlayer.updateTitle()
     syncUITime()
+    syncUI(.playButton)
     // When not in the mini player the timer that updates the OSC may be stopped to conserve energy
     // when the OSC is hidden. As the OSC is always displayed in the mini player ensure the timer is
     // running if media is playing.


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [?] This implements/fixes issue #. (Not sure we have an issue for this or not)

---

**Description:**
Currently when you pause a video then enter the music mode, the play button is in the "playing" state. I've reproduced this issue even in the v1.1.0 build, so its not a bug caused by a recent change.