### PR TITLE
Tweak settings sidebar to make it more consistent with previous design

### DIFF
--- a/iina/Base.lproj/PreferenceWindowController.xib
+++ b/iina/Base.lproj/PreferenceWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22505" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22154" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22505"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22154"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -27,7 +27,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="820" height="480"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="3008" height="1667"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1415"/>
             <value key="minSize" type="size" width="820" height="320"/>
             <view key="contentView" wantsLayer="YES" id="se5-gp-TjO" userLabel="PrefWindow Content View">
                 <rect key="frame" x="0.0" y="0.0" width="820" height="480"/>
@@ -36,7 +36,7 @@
                     <visualEffectView blendingMode="behindWindow" material="sidebar" state="followsWindowActiveState" translatesAutoresizingMaskIntoConstraints="NO" id="AO2-1e-7F6" userLabel="PrefNavPanel Visual Effect View">
                         <rect key="frame" x="0.0" y="0.0" width="200" height="480"/>
                         <subviews>
-                            <searchField wantsLayer="YES" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rKj-eM-MTH">
+                            <searchField wantsLayer="YES" focusRingType="none" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rKj-eM-MTH">
                                 <rect key="frame" x="9" y="420" width="182" height="30"/>
                                 <searchFieldCell key="cell" controlSize="large" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" refusesFirstResponder="YES" borderStyle="bezel" usesSingleLineMode="YES" bezelStyle="round" id="ZLM-z2-CyT">
                                     <font key="font" metaFont="system"/>
@@ -86,7 +86,7 @@
                                                                         <binding destination="Cky-oa-sEY" name="value" keyPath="objectValue.image" id="C2q-6f-8qZ"/>
                                                                     </connections>
                                                                 </imageView>
-                                                                <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="XDU-ud-pYc">
+                                                                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="XDU-ud-pYc">
                                                                     <rect key="frame" x="24" y="10" width="138" height="16"/>
                                                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Table View Cell" id="Ukj-Vg-wHf" customClass="PrefTabTitleLabelCell" customModule="IINA" customModuleProvider="target">
                                                                         <font key="font" metaFont="systemBold"/>
@@ -106,7 +106,6 @@
                                                                 <constraint firstItem="XDU-ud-pYc" firstAttribute="centerY" secondItem="Cky-oa-sEY" secondAttribute="centerY" id="h97-II-d9Q"/>
                                                             </constraints>
                                                             <connections>
-                                                                <outlet property="image" destination="5Yr-Dy-tXq" id="XsY-WS-4e9"/>
                                                                 <outlet property="imageView" destination="5Yr-Dy-tXq" id="AEl-yO-dwj"/>
                                                                 <outlet property="leadingConstraint" destination="ekq-kA-abF" id="enZ-7g-e32"/>
                                                                 <outlet property="textField" destination="XDU-ud-pYc" id="NpG-es-Dgj"/>
@@ -225,7 +224,7 @@
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="XXu-SH-FYF" userLabel="Completion Popover">
             <rect key="frame" x="0.0" y="0.0" width="340" height="180"/>
             <subviews>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0yO-bT-GQW">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0yO-bT-GQW">
                     <rect key="frame" x="137" y="82" width="67" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="No Result" id="jUU-3A-jLW">
                         <font key="font" metaFont="systemBold"/>
@@ -237,7 +236,7 @@
                     <rect key="frame" x="0.0" y="0.0" width="340" height="180"/>
                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="oMs-Q9-XbP">
                         <rect key="frame" x="0.0" y="0.0" width="340" height="180"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <autoresizingMask key="autoresizingMask"/>
                         <subviews>
                             <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowHeight="40" rowSizeStyle="automatic" viewBased="YES" id="MUI-pR-u00">
                                 <rect key="frame" x="0.0" y="0.0" width="340" height="180"/>
@@ -268,7 +267,7 @@
                                                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="MoT-Tv-Eut">
                                                                 <rect key="frame" x="0.0" y="13" width="86" height="17"/>
                                                                 <subviews>
-                                                                    <textField horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WvU-OP-qKD">
+                                                                    <textField focusRingType="none" horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WvU-OP-qKD">
                                                                         <rect key="frame" x="0.0" y="0.0" width="37" height="17"/>
                                                                         <constraints>
                                                                             <constraint firstAttribute="height" constant="17" id="GnV-ad-Nfb"/>
@@ -297,7 +296,7 @@
                                                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="OxQ-u7-hBa">
                                                                         <rect key="frame" x="0.0" y="0.0" width="41" height="11"/>
                                                                         <subviews>
-                                                                            <textField horizontalHuggingPriority="751" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="uYa-E5-kPM">
+                                                                            <textField focusRingType="none" horizontalHuggingPriority="751" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="uYa-E5-kPM">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="28" height="11"/>
                                                                                 <textFieldCell key="cell" controlSize="mini" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Label" drawsBackground="YES" id="Yqs-iT-EDU">
                                                                                     <font key="font" metaFont="label" size="9"/>
@@ -308,7 +307,7 @@
                                                                                     <binding destination="PUp-P1-eMl" name="value" keyPath="objectValue.tab" id="bag-hs-AJQ"/>
                                                                                 </connections>
                                                                             </textField>
-                                                                            <textField horizontalHuggingPriority="751" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ch8-7m-EVc">
+                                                                            <textField focusRingType="none" horizontalHuggingPriority="751" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="ch8-7m-EVc">
                                                                                 <rect key="frame" x="30" y="0.0" width="11" height="11"/>
                                                                                 <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="»" drawsBackground="YES" id="hIj-J9-06Z">
                                                                                     <font key="font" metaFont="label" size="9"/>
@@ -328,7 +327,7 @@
                                                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="jkh-bf-K5S">
                                                                         <rect key="frame" x="45" y="0.0" width="41" height="11"/>
                                                                         <subviews>
-                                                                            <textField horizontalHuggingPriority="751" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wYV-pe-vBk">
+                                                                            <textField focusRingType="none" horizontalHuggingPriority="751" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="wYV-pe-vBk">
                                                                                 <rect key="frame" x="30" y="0.0" width="11" height="11"/>
                                                                                 <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="»" drawsBackground="YES" id="KCo-fS-6w5">
                                                                                     <font key="font" metaFont="label" size="9"/>
@@ -336,7 +335,7 @@
                                                                                     <color key="backgroundColor" white="1" alpha="0.0" colorSpace="deviceWhite"/>
                                                                                 </textFieldCell>
                                                                             </textField>
-                                                                            <textField horizontalHuggingPriority="751" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Oir-KU-ax2">
+                                                                            <textField focusRingType="none" horizontalHuggingPriority="751" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Oir-KU-ax2">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="28" height="11"/>
                                                                                 <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" drawsBackground="YES" id="nPh-AY-eX8">
                                                                                     <font key="font" metaFont="label" size="9"/>

--- a/iina/Base.lproj/PreferenceWindowController.xib
+++ b/iina/Base.lproj/PreferenceWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22505" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -27,17 +27,17 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="820" height="480"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="3440" height="1415"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="3008" height="1667"/>
             <value key="minSize" type="size" width="820" height="320"/>
             <view key="contentView" wantsLayer="YES" id="se5-gp-TjO" userLabel="PrefWindow Content View">
                 <rect key="frame" x="0.0" y="0.0" width="820" height="480"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
                     <visualEffectView blendingMode="behindWindow" material="sidebar" state="followsWindowActiveState" translatesAutoresizingMaskIntoConstraints="NO" id="AO2-1e-7F6" userLabel="PrefNavPanel Visual Effect View">
-                        <rect key="frame" x="0.0" y="0.0" width="220" height="480"/>
+                        <rect key="frame" x="0.0" y="0.0" width="200" height="480"/>
                         <subviews>
                             <searchField wantsLayer="YES" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rKj-eM-MTH">
-                                <rect key="frame" x="9" y="420" width="202" height="30"/>
+                                <rect key="frame" x="9" y="420" width="182" height="30"/>
                                 <searchFieldCell key="cell" controlSize="large" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" refusesFirstResponder="YES" borderStyle="bezel" usesSingleLineMode="YES" bezelStyle="round" id="ZLM-z2-CyT">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -48,18 +48,18 @@
                                 </connections>
                             </searchField>
                             <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="38" horizontalPageScroll="10" verticalLineScroll="38" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="Isy-K8-od9" userLabel="PrefNavPanelTable Scroll View">
-                                <rect key="frame" x="0.0" y="0.0" width="220" height="420"/>
+                                <rect key="frame" x="0.0" y="0.0" width="200" height="420"/>
                                 <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="H3G-ed-YHx" userLabel="PrefNavPanel Clip View">
-                                    <rect key="frame" x="0.0" y="0.0" width="220" height="420"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="200" height="420"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
                                         <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="sourceList" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" typeSelect="NO" autosaveName="" rowHeight="36" rowSizeStyle="automatic" viewBased="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vde-uJ-0ge" userLabel="PrefNavPanel Table View">
-                                            <rect key="frame" x="0.0" y="0.0" width="220" height="420"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="200" height="420"/>
                                             <size key="intercellSpacing" width="0.0" height="2"/>
                                             <color key="backgroundColor" name="_sourceListBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                             <tableColumns>
-                                                <tableColumn width="188" minWidth="100" maxWidth="1000" id="s8e-nX-tcx">
+                                                <tableColumn width="168" minWidth="100" maxWidth="1000" id="s8e-nX-tcx">
                                                     <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
                                                         <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
@@ -71,12 +71,12 @@
                                                     </textFieldCell>
                                                     <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                                     <prototypeCellViews>
-                                                        <tableCellView id="Cky-oa-sEY">
-                                                            <rect key="frame" x="10" y="1" width="200" height="36"/>
+                                                        <tableCellView id="Cky-oa-sEY" customClass="CustomCellView" customModule="IINA" customModuleProvider="target">
+                                                            <rect key="frame" x="10" y="1" width="180" height="36"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <subviews>
                                                                 <imageView wantsLayer="YES" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="5Yr-Dy-tXq">
-                                                                    <rect key="frame" x="20" y="9" width="18" height="18"/>
+                                                                    <rect key="frame" x="0.0" y="9" width="18" height="18"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" secondItem="5Yr-Dy-tXq" secondAttribute="height" multiplier="1:1" id="ITq-jp-a8v"/>
                                                                         <constraint firstAttribute="width" constant="18" id="W2O-qT-W0s"/>
@@ -87,7 +87,7 @@
                                                                     </connections>
                                                                 </imageView>
                                                                 <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="XDU-ud-pYc">
-                                                                    <rect key="frame" x="44" y="10" width="138" height="16"/>
+                                                                    <rect key="frame" x="24" y="10" width="138" height="16"/>
                                                                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="Table View Cell" id="Ukj-Vg-wHf" customClass="PrefTabTitleLabelCell" customModule="IINA" customModuleProvider="target">
                                                                         <font key="font" metaFont="systemBold"/>
                                                                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -102,11 +102,13 @@
                                                                 <constraint firstAttribute="trailing" secondItem="XDU-ud-pYc" secondAttribute="trailing" constant="20" id="GBQ-e5-LaX"/>
                                                                 <constraint firstItem="XDU-ud-pYc" firstAttribute="leading" secondItem="5Yr-Dy-tXq" secondAttribute="trailing" constant="8" id="N2o-JC-vPx"/>
                                                                 <constraint firstItem="5Yr-Dy-tXq" firstAttribute="centerY" secondItem="Cky-oa-sEY" secondAttribute="centerY" id="eBq-gK-JL2"/>
-                                                                <constraint firstItem="5Yr-Dy-tXq" firstAttribute="leading" secondItem="Cky-oa-sEY" secondAttribute="leading" constant="20" id="ekq-kA-abF"/>
+                                                                <constraint firstItem="5Yr-Dy-tXq" firstAttribute="leading" secondItem="Cky-oa-sEY" secondAttribute="leading" id="ekq-kA-abF"/>
                                                                 <constraint firstItem="XDU-ud-pYc" firstAttribute="centerY" secondItem="Cky-oa-sEY" secondAttribute="centerY" id="h97-II-d9Q"/>
                                                             </constraints>
                                                             <connections>
+                                                                <outlet property="image" destination="5Yr-Dy-tXq" id="XsY-WS-4e9"/>
                                                                 <outlet property="imageView" destination="5Yr-Dy-tXq" id="AEl-yO-dwj"/>
+                                                                <outlet property="leadingConstraint" destination="ekq-kA-abF" id="enZ-7g-e32"/>
                                                                 <outlet property="textField" destination="XDU-ud-pYc" id="NpG-es-Dgj"/>
                                                             </connections>
                                                         </tableCellView>
@@ -137,7 +139,7 @@
                             <constraint firstAttribute="trailing" secondItem="Isy-K8-od9" secondAttribute="trailing" id="J3l-Oa-DHc"/>
                             <constraint firstAttribute="bottom" secondItem="Isy-K8-od9" secondAttribute="bottom" id="RC5-qu-3AY"/>
                             <constraint firstItem="rKj-eM-MTH" firstAttribute="top" secondItem="AO2-1e-7F6" secondAttribute="top" constant="30" id="h6P-ZA-Btd"/>
-                            <constraint firstAttribute="width" constant="220" id="kCX-dz-r0u"/>
+                            <constraint firstAttribute="width" constant="200" id="kCX-dz-r0u"/>
                             <constraint firstItem="Isy-K8-od9" firstAttribute="top" secondItem="rKj-eM-MTH" secondAttribute="bottom" identifier="navTableSearchFieldSpacingConstraint" id="nOO-7o-aOI"/>
                             <constraint firstItem="rKj-eM-MTH" firstAttribute="leading" secondItem="AO2-1e-7F6" secondAttribute="leading" constant="9" id="szD-ja-pwz"/>
                             <constraint firstAttribute="trailing" secondItem="rKj-eM-MTH" secondAttribute="trailing" constant="9" id="uph-Ge-Lqq"/>
@@ -145,22 +147,22 @@
                         </constraints>
                     </visualEffectView>
                     <box horizontalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="anY-kd-ix3" userLabel="Vertical Divider Line">
-                        <rect key="frame" x="217" y="0.0" width="5" height="480"/>
+                        <rect key="frame" x="197" y="0.0" width="5" height="480"/>
                     </box>
                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="mpW-1b-ztU" userLabel="PrefSearchResult Mask View" customClass="PrefSearchResultMaskView" customModule="IINA" customModuleProvider="target">
-                        <rect key="frame" x="220" y="0.0" width="600" height="480"/>
+                        <rect key="frame" x="200" y="0.0" width="620" height="480"/>
                     </customView>
                     <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="VYU-tb-v3l" userLabel="PrefDetailPanel Scroll View">
-                        <rect key="frame" x="220" y="0.0" width="600" height="480"/>
+                        <rect key="frame" x="200" y="0.0" width="620" height="480"/>
                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="fAk-o1-RBn" userLabel="PrefDetailPanel Clip View">
-                            <rect key="frame" x="0.0" y="0.0" width="600" height="480"/>
+                            <rect key="frame" x="0.0" y="0.0" width="620" height="480"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <view translatesAutoresizingMaskIntoConstraints="NO" id="5R5-77-bmq" userLabel="PrefDetailPanel Flipped Content View" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="424" width="600" height="56"/>
+                                    <rect key="frame" x="0.0" y="424" width="620" height="56"/>
                                     <subviews>
                                         <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="16" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="250" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="evY-SZ-c3s" userLabel="PrefSections Vertical Stack View">
-                                            <rect key="frame" x="28" y="28" width="544" height="0.0"/>
+                                            <rect key="frame" x="28" y="28" width="564" height="0.0"/>
                                         </stackView>
                                     </subviews>
                                     <constraints>

--- a/iina/PreferenceWindowController.swift
+++ b/iina/PreferenceWindowController.swift
@@ -40,15 +40,14 @@ extension PreferenceWindowEmbeddable {
 }
 
 class CustomCellView: NSTableCellView {
-    @IBOutlet weak var image: NSImageView!
-    @IBOutlet weak var leadingConstraint: NSLayoutConstraint!
-    
-    override func viewWillDraw() {
-        if #unavailable (macOS 11.0) {
-            leadingConstraint.constant = 20
-        }
-        super.viewWillDraw()
+  @IBOutlet weak var leadingConstraint: NSLayoutConstraint!
+
+  override func viewWillDraw() {
+    if #unavailable (macOS 11.0) {
+      leadingConstraint.constant = 20
     }
+    super.viewWillDraw()
+  }
 }
 
 

--- a/iina/PreferenceWindowController.swift
+++ b/iina/PreferenceWindowController.swift
@@ -39,6 +39,19 @@ extension PreferenceWindowEmbeddable {
   }
 }
 
+class CustomCellView: NSTableCellView {
+    @IBOutlet weak var image: NSImageView!
+    @IBOutlet weak var leadingConstraint: NSLayoutConstraint!
+    
+    override func viewWillDraw() {
+        if #unavailable (macOS 11.0) {
+            leadingConstraint.constant = 20
+        }
+        super.viewWillDraw()
+    }
+}
+
+
 class PreferenceWindowController: NSWindowController {
 
   class Trie {


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)

---

**Description:**
This commit:
- For macOS 10.11+, make the leading space of the icon to 0, so that the icon can align with the search icon
- Reduce the width of sidebar from 220 to 200

A remake of #4292. This time, I subclassed `NSTableCellView` to manipulate the constraint. The constraint in xib is changed to 0, revert back to 20 on 10.15- systems.

@low-batt Please help to test this on 10.15 machine if you still have one :)