### PR TITLE
Fix  cursor disappears after clicking, #4748

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -883,7 +883,7 @@ class MainWindowController: PlayerWindowController {
   /// This erroneous behavior has been reported to Apple as: "Regression in NSCursor.setHiddenUntilMouseMoves"
   /// Feedback number FB11963121
   private func workaroundCursorDefect() {
-    guard #available(macOS 11, *) else { return }
+    guard #available(macOS 11, *), animationState == .hidden else { return }
     NSCursor.setHiddenUntilMouseMoves(true)
   }
 
@@ -1008,7 +1008,7 @@ class MainWindowController: PlayerWindowController {
     case .fullscreen:
       toggleWindowFullScreen()
     case .hideOSC:
-      hideUI()
+      hideUIAndCursor()
     case .togglePIP:
       if #available(macOS 10.12, *) {
         menuTogglePIP(.dummy)


### PR DESCRIPTION
This commit will:
- Change `MainWindowController.workaroundCursorDefect` to only hide the cursor if animationState is set to hidden
- Change `MainWindowController.performMouseAction` to call `hideUIAndCursor` instead of `hideUI`

This corrects the workaround for the AppKit method `NSCursor.setHiddenUntilMouseMoves` malfunctioning to only hide the cursor when the OSC is hidden.

This commit also changes the behavior when mouse clicks are configured to hide the OSC to include hiding the cursor to match up with the behavior when the OSC is automatically hidden after a delay.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4748.

---

**Description:**
