### PR TITLE
avoid playlist refresh when no selections

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1134,6 +1134,7 @@ class PlayerCore: NSObject {
   }
 
   func playlistRemove(_ indexSet: IndexSet) {
+    guard !indexSet.isEmpty else { return }
     var count = 0
     for i in indexSet {
       _playlistRemove(i - count)


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**

If no selection in the playlist, press `-` button will trigger a tableview refresh.