### PR TITLE
Close add subtitles FPS label on found subs list, #4763

### DIFF
--- a/iina/OpenSubClient.swift
+++ b/iina/OpenSubClient.swift
@@ -881,7 +881,9 @@ class OpenSubClient {
       var files: [SubtitleFile]
 #if DEBUG
       var foreignPartsOnly: Bool?
+#endif
       var fps: Double?
+#if DEBUG
       var fromTrusted: Bool?
       var hd: Bool?
       var hearingImpaired: Bool?

--- a/iina/OpenSubSubtitle.swift
+++ b/iina/OpenSubSubtitle.swift
@@ -74,12 +74,18 @@ class OpenSub {
       let attributes = subtitle.attributes
       let downloadCount = String(attributes.downloadCount)
       let filename = attributes.files[0].fileName
+      let framesPerSecond: String
+      if let fps = attributes.fps, fps != 0 {
+        framesPerSecond = " \(String(Int(fps.rounded(.up)))) fps"
+      } else {
+        framesPerSecond = ""
+      }
       let language = attributes.language
       let rating = String(attributes.ratings)
       let uploadDate = OpenSub.Subtitle.dateFormatter.string(from: attributes.uploadDate)
       return (
         filename,
-        "\(language) \u{2b07}\(downloadCount) \u{2605}\(rating)",
+        "\(language)\(framesPerSecond) \u{2b07}\(downloadCount) \u{2605}\(rating)",
         uploadDate
       )
     }


### PR DESCRIPTION
This commit will:
- Change the `Subtitle` struct in `OpenSubClient` to always include the `fps` property
- Change the `getDescription` method in `OpenSub` to include the fps in the subtitle chooser if Open Subtitles provided a value

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4763.

---

**Description:**
