### PR TITLE
Revert fix discrepancies with new Open Subtitles API Results, #4749

### DIFF
--- a/iina/OpenSubClient.swift
+++ b/iina/OpenSubClient.swift
@@ -267,30 +267,6 @@ class OpenSubClient {
     }
   }
 
-  /// [Guessit](https://opensubtitles.stoplight.io/docs/opensubtitles-api/7783e082edcf7-guessit)
-  /// method.
-  ///
-  /// Extracts as much information as possible from a video filename.
-  /// - Parameter filename: Video filename to extract information from.
-  /// - Returns: A `GuessitResponse` containing the information that could be extracted from the filename.
-  func guessit(filename: String) -> Promise<GuessitResponse> {
-    return after(seconds: rateLimiter.delayBeforeCall()).then { [self] in
-      Promise { resolver in
-        let params = ["filename": filename]
-        let url = apiURL("utilities/guessit")
-        Just.get(url, params: params, headers: formHeaders(), asyncCompletionHandler: { [self] result in
-          logHTTPResult(result)
-          do {
-            let response = try self.decodeResponse(GuessitResponse.self, from: result)
-            resolver.fulfill(response)
-          } catch {
-            resolver.reject(error)
-          }
-        })
-      }
-    }
-  }
-
   /// [Languages](https://opensubtitles.stoplight.io/docs/opensubtitles-api/1de776d20e873-languages)
   /// method.
   /// - Returns: A `LanguagesResponse` containing a list of the supported lanuage codes.
@@ -404,34 +380,20 @@ class OpenSubClient {
   ///         percent encoding.
   /// - Parameters:
   ///   - languages: Language code(s).
-  ///   - info: Information extracted from the video filename.
   ///   - hash: Moviehash of the movie file.
   ///   - query:File name or text search.
   /// - Returns: A `SubtitlesResponse` object.
-  func subtitles(languages: [String], info: GuessitResponse, hash: String?, query: String?) -> Promise<SubtitlesResponse> {
+  func subtitles(languages: [String], hash: String?, query: String?) -> Promise<SubtitlesResponse> {
     return after(seconds: rateLimiter.delayBeforeCall()).then { [self] in
       Promise { resolver in
         // As per REST API best practices, attempt to send GET parameters in alphabetical order.
         // Unfortunately, Just.get takes a Swift dictionary therefore order is not guaranteed.
-        var params:[String: Any] = [:]
-        if let episode = info.episode {
-          params["episode_number"] = episode
-        }
-        params["languages"] = languages.sorted().joined(separator: ",")
+        var params = ["languages": languages.sorted().joined(separator: ",")]
         if let hash = hash {
           params["moviehash"] = hash
         }
         if let query = query {
           params["query"] = query
-        }
-        if let season = info.season {
-          params["season_number"] = season
-        }
-        if let type = info.type {
-          params["type"] = type
-        }
-        if let year = info.year {
-          params["year"] = year
         }
         let url = apiURL("subtitles")
         Just.get(url, params: params, headers: formHeaders(), asyncCompletionHandler: { [self] result in
@@ -763,38 +725,6 @@ class OpenSubClient {
     var requests: Int?
     var resetTime: String?
     var resetTimeUtc: Date?
-  }
-
-  /// Response returned by the
-  /// [Guessit](https://opensubtitles.stoplight.io/docs/opensubtitles-api/7783e082edcf7-guessit)
-  /// method.
-  struct GuessitResponse: Response {
-#if DEBUG
-    var audioChannels: String?
-    var audioCodec: String?
-    var container: String?
-#endif
-    var episode: Int?
-#if DEBUG
-    var episodeTitle: String?
-    var language: String?
-    var mimetype: String?
-    var other: String?
-    var releaseGroup: String?
-    var screenSize: String?
-#endif
-    var season: Int?
-#if DEBUG
-    var source: String?
-    var streamingService: String?
-    var subtitleLanguage: String?
-    var title: String?
-#endif
-    var type: String?
-#if DEBUG
-    var videoCodec: String?
-#endif
-    var year: Int?
   }
 
   /// Part of the response returned by the

--- a/iina/OpenSubSubtitle.swift
+++ b/iina/OpenSubSubtitle.swift
@@ -136,51 +136,12 @@ class OpenSub {
         }.then {
           self.filterLanguageCodes()
         }.then {
-          when(fulfilled: self.guessit(url, player.getMediaTitle()), self.hash(url))
-        }.then { info, hash in
-          self.searchForSubtitles(url, info, hash, player.getMediaTitle())
+          self.hash(url)
+        }.then { hash in
+          self.searchForSubtitles(url, hash, player.getMediaTitle())
         }.then { subs in
           self.showSubSelectWindow(with: subs)
         }
-    }
-
-    /// Extract information from the video filename.
-    /// - Parameters:
-    ///   - url: A [URL](https://developer.apple.com/documentation/foundation/url) to the movie to search
-    ///          for subtitles for.
-    ///   - mediaTitle: The title of the movie.
-    /// - Returns: A `GuessitResponse` containing the information that could be extracted from the filename.
-    func guessit(_ url: URL, _ mediaTitle: String) -> Promise<OpenSubClient.GuessitResponse> {
-      // When streaming prefer the movie's title.
-      let filename = url.isFileURL ? url.deletingPathExtension().lastPathComponent : mediaTitle
-      return OpenSubClient.shared.guessit(filename: filename).then { response in
-        Promise { resolver in
-          var message = ""
-          if let type = response.type {
-            message += "type \(type)"
-          }
-          if let season = response.season {
-            if !message.isEmpty { message += ", " }
-            message += "season \(season)"
-          }
-          if let episode = response.episode {
-            if !message.isEmpty { message += ", " }
-            message += "episode \(episode)"
-          }
-          if let year = response.year {
-            if !message.isEmpty { message += ", " }
-            message += "year \(year)"
-          }
-          if message.isEmpty {
-            log("Unable to extract information from video filename")
-          } else {
-            log("Information extracted from video filename: \(message)")
-          }
-          resolver.fulfill((response))
-        }
-      }.recover { error -> Promise<OpenSubClient.GuessitResponse> in
-        throw Error.searchFailed(error.localizedDescription)
-      }
     }
 
     /// Calculate an [Open Subtitles](https://www.opensubtitles.com/) hash code value.
@@ -341,12 +302,10 @@ class OpenSub {
     /// - Parameters:
     ///   - url: A [URL](https://developer.apple.com/documentation/foundation/url) to the movie to search
     ///          for subtitles for.
-    ///   - info: Information extracted from the video filename.
     ///   - hash: An [Open Subtitles](https://www.opensubtitles.com/) hash code value or `nil`.
     ///   - mediaTitle: The title of the movie.
     /// - Returns: An array containing one or more `Subtitle` objects.
-    func searchForSubtitles(_ url: URL, _ info: OpenSubClient.GuessitResponse, _ hash: String?,
-                            _ mediaTitle: String) -> Promise<[Subtitle]> {
+    func searchForSubtitles(_ url: URL, _ hash: String?, _ mediaTitle: String) -> Promise<[Subtitle]> {
       // When streaming prefer the movie's title.
       let searchString = url.isFileURL ? url.deletingPathExtension().lastPathComponent : mediaTitle
       if let hash = hash {
@@ -354,8 +313,7 @@ class OpenSub {
       } else {
         log("Searching for subtitles of movies matching '\(searchString)'")
       }
-      return OpenSubClient.shared.subtitles(languages: languages, info: info, hash: hash,
-                                            query: searchString).then { response in
+      return OpenSubClient.shared.subtitles(languages: languages, hash: hash, query: searchString).then { response in
         Promise { resolver in
           guard response.totalCount != 0 else {
             resolver.reject(OnlineSubtitle.CommonError.noResult)


### PR DESCRIPTION
This reverts commit 7f315460e90c33f721bc474a3906d1889aae6d9a.

The commit being reverted added use of the Open Subtitles Guessit API in order to guess the season and episode of a TV series based on the filename. This worked and corrected the problem. However subsequently Open Subtitles reported the root cause of the failure to restrict search results to a particular episode was due to a temporary bug in their server's guessit system that has now been corrected. Thus there is no need for the client to use guessit.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
