### PR TITLE
Include fix for Open Recent menu in release builds, #4688

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1607,7 +1607,7 @@ class PlayerCore: NSObject {
         HistoryController.shared.add(url, duration: duration.second)
       }
       if Preference.bool(for: .recordRecentFiles) && Preference.bool(for: .trackAllFilesInRecentOpenMenu) {
-        DispatchQueue.main.sync { (NSApp.delegate as? AppDelegate)?.noteNewRecentDocumentURL(url) }
+        DispatchQueue.main.sync { (NSApp.delegate as! AppDelegate).noteNewRecentDocumentURL(url) }
       }
 
     }

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1607,10 +1607,7 @@ class PlayerCore: NSObject {
         HistoryController.shared.add(url, duration: duration.second)
       }
       if Preference.bool(for: .recordRecentFiles) && Preference.bool(for: .trackAllFilesInRecentOpenMenu) {
-        NSDocumentController.shared.noteNewRecentDocumentURL(url)
-#if DEBUG
-        DispatchQueue.main.async { (NSApp.delegate as? AppDelegate)?.saveRecentDocuments() }
-#endif
+        DispatchQueue.main.sync { (NSApp.delegate as? AppDelegate)?.noteNewRecentDocumentURL(url) }
       }
 
     }

--- a/iina/PrefGeneralViewController.swift
+++ b/iina/PrefGeneralViewController.swift
@@ -58,7 +58,7 @@ class PrefGeneralViewController: PreferenceViewController, PreferenceWindowEmbed
 
   @IBAction func rememberRecentChanged(_ sender: NSButton) {
     if sender.state == .off {
-      (NSApp.delegate as? AppDelegate)?.clearRecentDocuments(self)
+      (NSApp.delegate as! AppDelegate).clearRecentDocuments(self)
     }
   }
 }

--- a/iina/PrefGeneralViewController.swift
+++ b/iina/PrefGeneralViewController.swift
@@ -58,10 +58,7 @@ class PrefGeneralViewController: PreferenceViewController, PreferenceWindowEmbed
 
   @IBAction func rememberRecentChanged(_ sender: NSButton) {
     if sender.state == .off {
-      NSDocumentController.shared.clearRecentDocuments(self)
-#if DEBUG
-      (NSApp.delegate as? AppDelegate)?.saveRecentDocuments()
-#endif
+      (NSApp.delegate as? AppDelegate)?.clearRecentDocuments(self)
     }
   }
 }

--- a/iina/PrefUtilsViewController.swift
+++ b/iina/PrefUtilsViewController.swift
@@ -129,10 +129,7 @@ class PrefUtilsViewController: PreferenceViewController, PreferenceWindowEmbedda
     Utility.quickAskPanel("clear_history", sheetWindow: view.window) { respond in
       guard respond == .alertFirstButtonReturn else { return }
       try? FileManager.default.removeItem(atPath: Utility.playbackHistoryURL.path)
-      NSDocumentController.shared.clearRecentDocuments(self)
-#if DEBUG
-      (NSApp.delegate as? AppDelegate)?.saveRecentDocuments()
-#endif
+      (NSApp.delegate as? AppDelegate)?.clearRecentDocuments(self)
       Preference.set(nil, for: .iinaLastPlayedFilePath)
       self.playHistoryClearedLabel.isHidden = false
     }

--- a/iina/PrefUtilsViewController.swift
+++ b/iina/PrefUtilsViewController.swift
@@ -129,7 +129,7 @@ class PrefUtilsViewController: PreferenceViewController, PreferenceWindowEmbedda
     Utility.quickAskPanel("clear_history", sheetWindow: view.window) { respond in
       guard respond == .alertFirstButtonReturn else { return }
       try? FileManager.default.removeItem(atPath: Utility.playbackHistoryURL.path)
-      (NSApp.delegate as? AppDelegate)?.clearRecentDocuments(self)
+      (NSApp.delegate as! AppDelegate).clearRecentDocuments(self)
       Preference.set(nil, for: .iinaLastPlayedFilePath)
       self.playHistoryClearedLabel.isHidden = false
     }


### PR DESCRIPTION
This commit will:
- Add `clearRecentDocuments` and `noteNewRecentDocumentURL` methods to `AppDelegate`
- Change `PrefGeneralViewController` and `PrefUtilsViewController` to call `AppDelegate.clearRecentDocuments` instead of the `NSDocumentController` method
- Change `AppDelegate.openFile` and `PlayerCore.fileLoaded` to call `AppDelegate.noteNewRecentDocumentURL` instead of the `NSDocumentController` method
- Change `saveRecentDocuments` to not include a check for the `recordRecentFiles` preference
- Remove the compiler directives that only included this code in debug builds

These changes enhance the workaround for macOS Sonoma clearing the open recent menu to cover the case where the user clears the list and also removes conditionalization that restricted this workaround to debug builds.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4688.

---

**Description:**
