### PR TITLE
Added functionality for pinching in touchpad settings (#4793)

### DIFF
--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -176,10 +176,16 @@ extension NSRect {
   }
 
   func centeredResize(to newSize: NSSize) -> NSRect {
-    return NSRect(x: origin.x - (newSize.width - size.width) / 2,
-                  y: origin.y - (newSize.height - size.height) / 2,
-                  width: newSize.width,
-                  height: newSize.height)
+    var newX = origin.x - (newSize.width - size.width) / 2
+    var newY = origin.y - (newSize.height - size.height) / 2
+    let screenFrame = NSScreen.main?.visibleFrame ?? NSRect.zero
+    
+    // resizes x and y values so the window always stays within a valid screenFrame
+    if screenFrame != NSRect.zero {
+      newX = max(min(newX, screenFrame.maxX - newSize.width), screenFrame.minX)
+      newY = max(min(newY, screenFrame.maxY - newSize.height), screenFrame.minY)
+    }
+    return NSRect(x: newX, y: newY, width: newSize.width, height: newSize.height)
   }
 
   func constrain(in biggerRect: NSRect) -> NSRect {

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1125,22 +1125,27 @@ class MainWindowController: PlayerWindowController {
       if recognizer.state == .began {
         // began
         lastMagnification = recognizer.magnification
-        if window.frame.height >= screenFrame.height && lastMagnification > 0 {
+        if (window.frame.height >= screenFrame.height || window.frame.width >= screenFrame.width) && lastMagnification > 0 {
           self.toggleWindowFullScreen()
           return
         }
       } else if recognizer.state == .changed {
         // changed
         let offset = recognizer.magnification - lastMagnification + 1.0
-        let newWidth = window.frame.width * offset
-        let newHeight = newWidth / window.aspectRatio.aspect
+        var newWidth = window.frame.width * offset
+        var newHeight = newWidth / window.aspectRatio.aspect
 
         //Check against max & min threshold
-        if newHeight < screenFrame.height && newHeight > minSize.height && newWidth > minSize.width {
+        if newHeight > screenFrame.height {
+          newHeight = screenFrame.height
+          newWidth = screenFrame.height * window.aspectRatio.aspect
+        }
+        if newWidth > screenFrame.width {
+          newWidth = screenFrame.width
+          newHeight = screenFrame.width / window.aspectRatio.aspect
+        }
+        if newHeight >= minSize.height && newWidth >= minSize.width {
           let newSize = NSSize(width: newWidth, height: newHeight)
-          window.setFrame(window.frame.centeredResize(to: newSize), display: true)
-        } else if newHeight >= screenFrame.height {
-          let newSize = NSSize(width: screenFrame.width, height: screenFrame.height)
           window.setFrame(window.frame.centeredResize(to: newSize), display: true)
         }
 

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1114,12 +1114,21 @@ class MainWindowController: PlayerWindowController {
         }
       }
     case .windowSize:
-      if fsState.isFullscreen { return }
+      if fsState.isFullscreen {
+        if recognizer.magnification < 0 {
+          self.toggleWindowFullScreen()
+          return
+        }
+      }
 
       // adjust window size
       if recognizer.state == .began {
         // began
         lastMagnification = recognizer.magnification
+        if window.frame.height >= screenFrame.height - window.frame.height / 50 && lastMagnification > 0 {
+          self.toggleWindowFullScreen()
+          return
+        }
       } else if recognizer.state == .changed {
         // changed
         let offset = recognizer.magnification - lastMagnification + 1.0;

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1125,19 +1125,22 @@ class MainWindowController: PlayerWindowController {
       if recognizer.state == .began {
         // began
         lastMagnification = recognizer.magnification
-        if window.frame.height >= screenFrame.height - window.frame.height / 50 && lastMagnification > 0 {
+        if window.frame.height >= screenFrame.height && lastMagnification > 0 {
           self.toggleWindowFullScreen()
           return
         }
       } else if recognizer.state == .changed {
         // changed
-        let offset = recognizer.magnification - lastMagnification + 1.0;
+        let offset = recognizer.magnification - lastMagnification + 1.0
         let newWidth = window.frame.width * offset
         let newHeight = newWidth / window.aspectRatio.aspect
 
         //Check against max & min threshold
         if newHeight < screenFrame.height && newHeight > minSize.height && newWidth > minSize.width {
-          let newSize = NSSize(width: newWidth, height: newHeight);
+          let newSize = NSSize(width: newWidth, height: newHeight)
+          window.setFrame(window.frame.centeredResize(to: newSize), display: true)
+        } else if newHeight >= screenFrame.height {
+          let newSize = NSSize(width: screenFrame.width, height: screenFrame.height)
           window.setFrame(window.frame.centeredResize(to: newSize), display: true)
         }
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4793.

---

**Description:**

When the window is within 20 pixels of its largest size, it will now switch to fullscreen if the user pinches out. Likewise, it will move out of fullscreen when pinching in while in fullscreen.

- Not sure what the threshold should be, 2% of height seemed to work fine and felt responsive on a 13in macbook screen, alternatively something like 30 pixels of wiggle room could work

- May lead to confusion for users who don't want max size to turn to fullscreen; depending on experience it might make sense to make this functionality the main "Fullscreen" option and have "Adjust window size" be the version without fullscreen toggle (and have it be renamed to "Only adjust window size")