### PR TITLE
Refactor how AppDelegate is accessed

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -23,6 +23,9 @@ fileprivate let AlternativeMenuItemTag = 1
 @NSApplicationMain
 class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 
+  /// The `AppDelegate` singleton object.
+  static var shared: AppDelegate { NSApp.delegate as! AppDelegate }
+
   /** Whether performed some basic initialization, like bind menu items. */
   var isReady = false
   /**
@@ -363,7 +366,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 
     NSApplication.shared.servicesProvider = self
 
-    (NSApp.delegate as? AppDelegate)?.menuController?.updatePluginMenu()
+    AppDelegate.shared.menuController?.updatePluginMenu()
   }
 
   /** Show welcome window if `application(_:openFile:)` wasn't called, i.e. launched normally. */

--- a/iina/FilterWindowController.swift
+++ b/iina/FilterWindowController.swift
@@ -137,7 +137,7 @@ class FilterWindowController: NSWindowController, NSWindowDelegate {
 
   private func syncSavedFilter() {
     Preference.set(savedFilters.map { $0.toDict() }, for: filterType == MPVProperty.af ? .savedAudioFilters : .savedVideoFilters)
-    (NSApp.delegate as? AppDelegate)?.menuController?.updateSavedFilters(forType: filterType, from: savedFilters)
+    AppDelegate.shared.menuController?.updateSavedFilters(forType: filterType, from: savedFilters)
     UserDefaults.standard.synchronize()
   }
 

--- a/iina/InitialWindowController.swift
+++ b/iina/InitialWindowController.swift
@@ -461,9 +461,9 @@ class InitialWindowViewActionButton: NSView {
   override func mouseDown(with event: NSEvent) {
     self.layer?.backgroundColor = pressedBackground.cgColor
     if self.identifier == .openFile {
-      (NSApp.delegate as! AppDelegate).openFile(self)
+      AppDelegate.shared.openFile(self)
     } else if self.identifier == .openURL {
-      (NSApp.delegate as! AppDelegate).openURL(self)
+      AppDelegate.shared.openURL(self)
     } else {
       if let lastFile = Preference.url(for: .iinaLastPlayedFilePath),
         let windowController = window?.windowController as? InitialWindowController {

--- a/iina/JavascriptAPIMenu.swift
+++ b/iina/JavascriptAPIMenu.swift
@@ -72,7 +72,7 @@ class JavascriptAPIMenu: JavascriptAPI, JavascriptAPIMenuExportable {
 
   func forceUpdate() {
     Utility.executeOnMainThread {
-      (NSApp.delegate as? AppDelegate)?.menuController?.updatePluginMenu()
+      AppDelegate.shared.menuController?.updatePluginMenu()
     }
   }
 }

--- a/iina/Logger.swift
+++ b/iina/Logger.swift
@@ -207,7 +207,7 @@ class Logger: NSObject {
       if logs.isEmpty {
         DispatchQueue.main.async {
           Timer.scheduledTimer(withTimeInterval: 0.1, repeats: false) { timer in
-            (NSApp.delegate as! AppDelegate).logWindow.syncLogs()
+            AppDelegate.shared.logWindow.syncLogs()
           }
         }
       }

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -23,7 +23,7 @@ class MainMenuActionHandler: NSResponder {
   }
 
   @objc func menuShowInspector(_ sender: AnyObject) {
-    let inspector = (NSApp.delegate as! AppDelegate).inspector
+    let inspector = AppDelegate.shared.inspector
     inspector.showWindow(self)
     inspector.updateInfo()
   }
@@ -277,7 +277,8 @@ extension MainMenuActionHandler {
         }
       }
     }
-    if let vfWindow = (NSApp.delegate as? AppDelegate)?.vfWindow, vfWindow.loaded {
+    let vfWindow = AppDelegate.shared.vfWindow
+    if vfWindow.loaded {
       vfWindow.reloadTable()
     }
   }

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -241,7 +241,7 @@ class PlayerCore: NSObject {
 
   static func reloadPluginForAll(_ plugin: JavascriptPlugin) {
     playerCores.forEach { $0.reloadPlugin(plugin) }
-    (NSApp.delegate as? AppDelegate)?.menuController?.updatePluginMenu()
+    AppDelegate.shared.menuController?.updatePluginMenu()
   }
 
   func loadPlugins() {
@@ -435,7 +435,7 @@ class PlayerCore: NSObject {
       kbUniqueOrderedList.append(keyBindingsDict[key]!)
     }
 
-    (NSApp.delegate as? AppDelegate)?.menuController.updateKeyEquivalentsFrom(kbUniqueOrderedList)
+    AppDelegate.shared.menuController.updateKeyEquivalentsFrom(kbUniqueOrderedList)
 
     NotificationCenter.default.post(Notification(name: .iinaGlobalKeyBindingsChanged, object: kbUniqueOrderedList))
   }
@@ -1607,7 +1607,7 @@ class PlayerCore: NSObject {
         HistoryController.shared.add(url, duration: duration.second)
       }
       if Preference.bool(for: .recordRecentFiles) && Preference.bool(for: .trackAllFilesInRecentOpenMenu) {
-        DispatchQueue.main.sync { (NSApp.delegate as! AppDelegate).noteNewRecentDocumentURL(url) }
+        DispatchQueue.main.sync { AppDelegate.shared.noteNewRecentDocumentURL(url) }
       }
 
     }

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -507,7 +507,7 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
     if #available(macOS 10.13, *), RemoteCommandController.useSystemMediaControl {
       NowPlayingInfoManager.updateInfo(withTitle: true)
     }
-    (NSApp.delegate as? AppDelegate)?.menuController?.updatePluginMenu()
+    AppDelegate.shared.menuController?.updatePluginMenu()
 
     NotificationCenter.default.post(name: .iinaMainWindowChanged, object: true)
   }
@@ -599,12 +599,11 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
   }
 
   internal func handleIINACommand(_ cmd: IINACommand) {
-    let appDelegate = (NSApp.delegate! as! AppDelegate)
     switch cmd {
     case .openFile:
-      appDelegate.openFile(self)
+      AppDelegate.shared.openFile(self)
     case .openURL:
-      appDelegate.openURL(self)
+      AppDelegate.shared.openURL(self)
     case .flip:
       menuActionHandler.menuToggleFlip(.dummy)
     case .mirror:

--- a/iina/PrefAdvancedViewController.swift
+++ b/iina/PrefAdvancedViewController.swift
@@ -80,7 +80,7 @@ class PrefAdvancedViewController: PreferenceViewController, PreferenceWindowEmbe
   }
   
   @IBAction func showLogWindow(_ sender: AnyObject) {
-    (NSApp.delegate as! AppDelegate).logWindow.showWindow(self)
+    AppDelegate.shared.logWindow.showWindow(self)
   }
 
   @IBAction func addOptionBtnAction(_ sender: AnyObject) {

--- a/iina/PrefGeneralViewController.swift
+++ b/iina/PrefGeneralViewController.swift
@@ -58,7 +58,7 @@ class PrefGeneralViewController: PreferenceViewController, PreferenceWindowEmbed
 
   @IBAction func rememberRecentChanged(_ sender: NSButton) {
     if sender.state == .off {
-      (NSApp.delegate as! AppDelegate).clearRecentDocuments(self)
+      AppDelegate.shared.clearRecentDocuments(self)
     }
   }
 }

--- a/iina/PrefUtilsViewController.swift
+++ b/iina/PrefUtilsViewController.swift
@@ -129,7 +129,7 @@ class PrefUtilsViewController: PreferenceViewController, PreferenceWindowEmbedda
     Utility.quickAskPanel("clear_history", sheetWindow: view.window) { respond in
       guard respond == .alertFirstButtonReturn else { return }
       try? FileManager.default.removeItem(atPath: Utility.playbackHistoryURL.path)
-      (NSApp.delegate as! AppDelegate).clearRecentDocuments(self)
+      AppDelegate.shared.clearRecentDocuments(self)
       Preference.set(nil, for: .iinaLastPlayedFilePath)
       self.playHistoryClearedLabel.isHidden = false
     }

--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -318,7 +318,7 @@ class Utility {
      - callback: A closure accepting the font name.
    */
   static func quickFontPickerWindow(callback: @escaping (String?) -> Void) {
-    guard let appDelegate = NSApp.delegate as? AppDelegate else { return }
+    let appDelegate = AppDelegate.shared
     appDelegate.fontPicker.finishedPicking = callback
     appDelegate.fontPicker.showWindow(self)
   }


### PR DESCRIPTION
This commit will:
- Add a new computed property `shared` to the `AppDelegate` class for accessing the singleton instance
- Change all code that was accessing the instance using `NSApp.delegate` and downcasting it to `AppDelegate` to reference the property instead

Previously some code used the conditional cast operator and some forced the conversion. This commit effectively changes all code to force the conversion.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
