### PR TITLE
Fix subtitle border size treated as integer, #4799

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -328,7 +328,7 @@ not applying FFmpeg 9599 workaround
     setUserOption(PK.subOverrideLevel, type: .other, forName: MPVOption.Subtitles.subAssOverride, transformer: subOverrideHandler)
 
     setUserOption(PK.subTextFont, type: .string, forName: MPVOption.Subtitles.subFont)
-    setUserOption(PK.subTextSize, type: .int, forName: MPVOption.Subtitles.subFontSize)
+    setUserOption(PK.subTextSize, type: .float, forName: MPVOption.Subtitles.subFontSize)
 
     setUserOption(PK.subTextColor, type: .color, forName: MPVOption.Subtitles.subColor)
     setUserOption(PK.subBgColor, type: .color, forName: MPVOption.Subtitles.subBackColor)
@@ -339,10 +339,10 @@ not applying FFmpeg 9599 workaround
     setUserOption(PK.subBlur, type: .float, forName: MPVOption.Subtitles.subBlur)
     setUserOption(PK.subSpacing, type: .float, forName: MPVOption.Subtitles.subSpacing)
 
-    setUserOption(PK.subBorderSize, type: .int, forName: MPVOption.Subtitles.subBorderSize)
+    setUserOption(PK.subBorderSize, type: .float, forName: MPVOption.Subtitles.subBorderSize)
     setUserOption(PK.subBorderColor, type: .color, forName: MPVOption.Subtitles.subBorderColor)
 
-    setUserOption(PK.subShadowSize, type: .int, forName: MPVOption.Subtitles.subShadowOffset)
+    setUserOption(PK.subShadowSize, type: .float, forName: MPVOption.Subtitles.subShadowOffset)
     setUserOption(PK.subShadowColor, type: .color, forName: MPVOption.Subtitles.subShadowColor)
 
     setUserOption(PK.subAlignX, type: .other, forName: MPVOption.Subtitles.subAlignX) { key in


### PR DESCRIPTION
This commit will change `MPVController.mpvInit` to treat the type of the following `mpv` options as floating point instead of integer:
- `sub-border-size`
- `sub-font-size`
- `sub-shadow-offset`

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4799.

---

**Description:**
