### PR TITLE
Log libass version

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -296,8 +296,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     }
 
     JavascriptPlugin.loadGlobalInstances()
-    let _ = PlayerCore.first
-    Logger.log("Using \(PlayerCore.active.mpv.mpvVersion!)")
+
+    let mpv = PlayerCore.active.mpv!
+    Logger.log("Using \(mpv.mpvVersion) and libass \(mpv.libassVersion)")
 
     if #available(macOS 10.13, *) {
       if RemoteCommandController.useSystemMediaControl {

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -84,6 +84,17 @@ class MPVController: NSObject {
     static let screenshot: UInt64 = 1000000
   }
 
+  /// Version number of the libass library.
+  ///
+  /// The mpv libass version property returns an integer encoded as a hex binary-coded decimal.
+  var libassVersion: String {
+    let version = getInt(MPVProperty.libassVersion)
+    let major = String(version >> 28 & 0xF, radix: 16)
+    let minor = String(version >> 20 & 0xFF, radix: 16)
+    let patch = String(version >> 12 & 0xFF, radix: 16)
+    return "\(major).\(minor).\(patch)"
+  }
+
   // The mpv_handle
   var mpv: OpaquePointer!
   var mpvRenderContext: OpaquePointer?
@@ -91,7 +102,7 @@ class MPVController: NSObject {
   private var openGLContext: CGLContextObj! = nil
 
   var mpvClientName: UnsafePointer<CChar>!
-  var mpvVersion: String!
+  var mpvVersion: String { getString(MPVProperty.mpvVersion)! }
 
   lazy var queue = DispatchQueue(label: "com.colliderli.iina.controller", qos: .userInitiated)
 
@@ -457,9 +468,6 @@ not applying FFmpeg 9599 workaround
     chkErr(mpv_set_property_string(mpv, MPVOption.Video.vo, "libmpv"))
     chkErr(mpv_set_property_string(mpv, MPVOption.Window.keepaspect, "no"))
     chkErr(mpv_set_property_string(mpv, MPVOption.Video.gpuHwdecInterop, "auto"))
-
-    // get version
-    mpvVersion = getString(MPVProperty.mpvVersion)
   }
 
   func mpvInitRendering() {


### PR DESCRIPTION
This commit will:
- Add a new `libassVersion` computed property to `MPVController`
- Change the `MPVController` `mpvVersion` property to be a computed property
- Change `AppDelegate.applicationDidFinishLaunching` to include the libass version when logging the mpv version

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
