### PR TITLE
Fix a crash in mpvInitRendering, #4803

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -477,7 +477,7 @@ not applying FFmpeg 9599 workaround
         // mpv_render_param(type: MPV_RENDER_PARAM_ADVANCED_CONTROL, data: &advanced),
         mpv_render_param()
       ]
-      mpv_render_context_create(&mpvRenderContext, mpv, &params)
+      chkErr(mpv_render_context_create(&mpvRenderContext, mpv, &params))
       openGLContext = CGLGetCurrentContext()
       mpv_render_context_set_update_callback(mpvRenderContext!, mpvUpdateCallback, mutableRawPointerOf(obj: player.mainWindow.videoView.videoLayer))
     }


### PR DESCRIPTION
This commit will add a call to `chkErr` around the call to `mpv_render_context_create` in `MPVController.mpvInitRendering`. Should `mpv_render_context_create` fail a fatal alert will be raised reporting the error code returned. Before this commit a failure would cause a `nil` value to be force unwrapped causing a crash.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4803.

---

**Description:**
