### PR TITLE
Fix: conflicting key bindings in default conf files (issue #4786)

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -316,6 +316,7 @@
 		B4E4470125CE3F930069F06E /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = B4E4470025CE3F930069F06E /* Sparkle */; };
 		C789872F1E34EF170005769F /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = C78987311E34EF170005769F /* InfoPlist.strings */; };
 		D17504A82918F13E005C3DD0 /* OSCToolbarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17504A72918F13E005C3DD0 /* OSCToolbarButton.swift */; };
+		D17B857B2C94C8B5002A8EDE /* movist-v2-default-input.conf in Copy Configs */ = {isa = PBXBuildFile; fileRef = D1F68E742C6ABC22003D1208 /* movist-v2-default-input.conf */; };
 		D1A4D98A2B1495270009AB4E /* LegacyMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A4D9892B1495270009AB4E /* LegacyMigration.swift */; };
 		D1B4E24E2A3AFC9100E36F1D /* MiniPlayerWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B4E24D2A3AFC9100E36F1D /* MiniPlayerWindow.swift */; };
 		D1F68E752C6ABC22003D1208 /* movist-v2-default-input.conf in Resources */ = {isa = PBXBuildFile; fileRef = D1F68E742C6ABC22003D1208 /* movist-v2-default-input.conf */; };
@@ -542,6 +543,7 @@
 			dstSubfolderSpec = 7;
 			files = (
 				846DD8CA1FB39B2500991A81 /* movist-default-input.conf in Copy Configs */,
+				D17B857B2C94C8B5002A8EDE /* movist-v2-default-input.conf in Copy Configs */,
 				846654941F4EEBE300C91B8C /* vlc-default-input.conf in Copy Configs */,
 				84A886EF1E269E67008755BB /* iina-default-input.conf in Copy Configs */,
 				844D72EF1E056E1400522E5E /* input.conf in Copy Configs */,

--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -318,6 +318,7 @@
 		D17504A82918F13E005C3DD0 /* OSCToolbarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17504A72918F13E005C3DD0 /* OSCToolbarButton.swift */; };
 		D1A4D98A2B1495270009AB4E /* LegacyMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A4D9892B1495270009AB4E /* LegacyMigration.swift */; };
 		D1B4E24E2A3AFC9100E36F1D /* MiniPlayerWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B4E24D2A3AFC9100E36F1D /* MiniPlayerWindow.swift */; };
+		D1F68E752C6ABC22003D1208 /* movist-v2-default-input.conf in Resources */ = {isa = PBXBuildFile; fileRef = D1F68E742C6ABC22003D1208 /* movist-v2-default-input.conf */; };
 		E301EFDA21312AB300BC8588 /* KeychainAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = E301EFD921312AB300BC8588 /* KeychainAccess.swift */; };
 		E30D2EBD21F5FD2600E1FF0D /* PluginOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30D2EBC21F5FD2600E1FF0D /* PluginOverlayView.swift */; };
 		E322A4F820A8442E00C67D32 /* PlaylistPlaybackProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E322A4F720A8442E00C67D32 /* PlaylistPlaybackProgressView.swift */; };
@@ -1745,6 +1746,7 @@
 		D17504A72918F13E005C3DD0 /* OSCToolbarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSCToolbarButton.swift; sourceTree = "<group>"; };
 		D1A4D9892B1495270009AB4E /* LegacyMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyMigration.swift; sourceTree = "<group>"; };
 		D1B4E24D2A3AFC9100E36F1D /* MiniPlayerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerWindow.swift; sourceTree = "<group>"; };
+		D1F68E742C6ABC22003D1208 /* movist-v2-default-input.conf */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = "movist-v2-default-input.conf"; sourceTree = "<group>"; };
 		D27556FC1EC6E1C300CAB2A4 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/HistoryWindowController.strings"; sourceTree = "<group>"; };
 		D27E35CE1E379B6D0064BE57 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/MainMenu.strings"; sourceTree = "<group>"; };
 		D27E35CF1E379B6D0064BE57 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/MainWindowController.strings"; sourceTree = "<group>"; };
@@ -2595,6 +2597,7 @@
 				84E745D81DFDE8C100588DED /* input.conf */,
 				846654921F4EEA5500C91B8C /* vlc-default-input.conf */,
 				846DD8C81FB39A9800991A81 /* movist-default-input.conf */,
+				D1F68E742C6ABC22003D1208 /* movist-v2-default-input.conf */,
 			);
 			name = config;
 			path = iina/config;
@@ -2938,6 +2941,7 @@
 			files = (
 				8400D5E71E1AB337006785F5 /* PrefKeyBindingViewController.xib in Resources */,
 				E3DBD23F218EF4F100B3AFBF /* AboutWindowContributorAvatarItem.xib in Resources */,
+				D1F68E752C6ABC22003D1208 /* movist-v2-default-input.conf in Resources */,
 				C789872F1E34EF170005769F /* InfoPlist.strings in Resources */,
 				E32712B224F2B8CA00359DAB /* ScreenshootOSDView.xib in Resources */,
 				8400D5DB1E1AB326006785F5 /* FontPickerWindowController.xib in Resources */,

--- a/iina/PrefKeyBindingViewController.swift
+++ b/iina/PrefKeyBindingViewController.swift
@@ -35,6 +35,7 @@ class PrefKeyBindingViewController: NSViewController, PreferenceWindowEmbeddable
     "mpv Default": "input",
     "VLC Default": "vlc-default-input",
     "Movist Default": "movist-default-input",
+    "Movist v2 Default": "movist-v2-default-input",
   ]
 
   let fallbackDefault = "IINA Default"

--- a/iina/config/iina-default-input.conf
+++ b/iina/config/iina-default-input.conf
@@ -48,7 +48,7 @@ Meta+2 set window-scale 2
 #@iina Meta+= bigger-window
 
 #@iina Ctrl+Meta+p toggle-pip
-#@iina Shift+Meta+R show-current-file-in-finder
+#@iina Shift+Meta+r show-current-file-in-finder
 Ctrl+Meta+f cycle fullscreen
 Ctrl+Meta+t cycle ontop
 

--- a/iina/config/input.conf
+++ b/iina/config/input.conf
@@ -30,8 +30,9 @@
 #@iina Shift+Meta+s sub-panel
 #@iina Shift+Meta+p playlist-panel
 #@iina Shift+Meta+c chapter-panel
+#@iina Shift+Meta+m toggle-music-mode
 #@iina Ctrl+Meta+p toggle-pip
-#@iina Shift+Meta+R show-current-file-in-finder
+#@iina Shift+Meta+r show-current-file-in-finder
 
 MBTN_LEFT     ignore              # don't do anything
 MBTN_LEFT_DBL cycle fullscreen    # toggle fullscreen

--- a/iina/config/movist-v2-default-input.conf
+++ b/iina/config/movist-v2-default-input.conf
@@ -1,0 +1,86 @@
+# Default keybindings of Movist Version 2
+# Note that some of the Movist keybindings are not supported by IINA
+
+#@iina Shift+Meta+v video-panel
+#@iina Shift+Meta+a audio-panel
+#@iina Shift+Meta+s sub-panel
+#@iina Shift+Meta+p playlist-panel
+#@iina Shift+Meta+c chapter-panel
+#@iina Shift+Meta+m toggle-music-mode
+#@iina Ctrl+Meta+p toggle-pip
+#@iina Shift+Meta+r show-current-file-in-finder
+
+#@iina v video-panel
+#@iina a audio-panel
+#@iina s sub-panel
+#@iina l playlist-panel
+#@iina p toggle-pip
+
+#@iina Meta+- smaller-window
+#@iina Meta+= bigger-window
+
+#@iina Meta+l playlist-panel
+#@iina Meta+p save-playlist
+Meta+RIGHT playlist-next
+Meta+LEFT playlist-prev
+Alt+Meta+s playlist-shuffle
+Alt+Meta+r cycle-values loop "inf" "no"
+Ctrl+Meta+v cycle video up
+Ctrl+Meta+V cycle video down
+SPACE cycle pause
+LEFT seek -5
+Alt+LEFT seek -30
+Shift+Alt+LEFT seek -300
+RIGHT seek 5
+Alt+RIGHT seek 30
+Shift+Alt+RIGHT seek 300
+, frame-back-step
+. frame-step
+Alt+2 set speed 2
+Alt+4 set speed 4
+Alt+1 set speed 1
+Alt+` set speed 0.5
+z set speed 1
+x multiply speed 0.9
+c multiply speed 1.1
+Ctrl+Meta+f cycle fullscreen
+ENTER cycle fullscreen
+` set window-scale 0.5
+1 set window-scale 1
+2 set window-scale 2
+#@iina 4 fit-to-screen
+- multiply window-scale 0.9
+= multiply window-scale 1.1
+Alt+s screenshot
+Ctrl+Meta+a cycle audio
+Ctrl+Meta+A cycle audio down
+Ctrl+Alt+Shift+\ set audio-delay 0
+Ctrl+Alt+Shift+RIGHT add audio-delay 0.1
+Ctrl+Alt+Shift+LEFT add audio-delay -0.1
+UP add volume 10
+Alt+UP add volume 1
+DOWN add volume -10
+Alt+DOWN add volume -1
+m cycle mute
+Ctrl+v cycle sub-visibility
+Ctrl+Meta+s cycle sub
+Ctrl+Meta+S cycle sub down
+Ctrl+| set sub-delay 0
+Ctrl+Shift+LEFT add sub-delay -0.1
+Ctrl+Shift+RIGHT add sub-delay 0.1
+Meta+t cycle ontop
+Alt+c close
+
+POWER quit
+PLAY cycle pause
+PAUSE cycle pause
+PLAYPAUSE cycle pause
+STOP quit
+FORWARD seek 60
+REWIND seek -60
+NEXT playlist-next
+PREV playlist-prev
+VOLUME_UP add volume 2
+VOLUME_DOWN add volume -2
+MUTE cycle mute
+CLOSE_WIN quit

--- a/iina/config/vlc-default-input.conf
+++ b/iina/config/vlc-default-input.conf
@@ -1,14 +1,14 @@
 # Default keybindings of VLC
 # Note that some of the VLC keybindings are not supported by IINA
 
-#@iina Alt+Meta+v video-panel
-#@iina Alt+Meta+a audio-panel
-#@iina Alt+Meta+s sub-panel
-#@iina Alt+Meta+p playlist-panel
-#@iina Alt+Meta+c chapter-panel
-#@iina Alt+Meta+m toggle-music-mode
+#@iina Shift+Meta+v video-panel
+#@iina Shift+Meta+a audio-panel
+#@iina Shift+Meta+s sub-panel
+#@iina Shift+Meta+p playlist-panel
+#@iina Shift+Meta+c chapter-panel
+#@iina Shift+Meta+m toggle-music-mode
 #@iina Ctrl+Meta+p toggle-pip
-#@iina Alt+Meta+r show-current-file-in-finder
+#@iina Shift+Meta+r show-current-file-in-finder
 
 Meta+f cycle fullscreen
 ESC set fullscreen no
@@ -51,7 +51,7 @@ Meta+2 set window-scale 2
 #@iina Alt+o bigger-window
 #@iina Alt+O smaller-window
 z cycle-values window-scale 0.25 0.5 1 2
-Meta+z cycle-values window-scale 2 1 0.5 0.25
+Z cycle-values window-scale 2 1 0.5 0.25
 a cycle-values video-aspect "-1" "16:9" "4:3" "1:1" "16:10" "2.21:1" "2.35:1" "2.39:1" "5:4"
 
 POWER quit


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4786.

---

**Description:**
Attempts to fix conflicts reported in the issue above. These are inherently subjective changes, so I took my best shot. I did look at VLC and Movist to observe their bindings, but there were no major insights there. For each conflict I generally tried to decide which command was more commonly used, and give that the easier key.

_UPDATE: As a result of feedback (below), this PR now leaves the existing Movist file untouched and instead moves all these changes into a new file, `movist-v2-default-input.conf`._

Notes / justifications for my changes:
- `movist-default` has both `bigger-window` and `multiply window-scale 1.1` (also the comparable small versions) which are somewhat similar, but not completely. The `bigger-window` menu item increases window width by 10 pixels at a time. No idea which would be more commonly used in this case, but I gave the `multiply [...]` commands the favored keys because they more closely resemble Movist commands.
- Also in `movist-default`: I noticed that those bigger / smaller commands were not mapped to complementary keys. for example: `Meta+-` → `smaller-window`, `Meta++` → `bigger-window`. But while `+` looks appropriate for "bigger" when read from text, it requires holding down `Shift` to type it. So from a typing perspective, the complement of `Meta+-` should be `Meta+=`. Likewise, the complement of  `Meta++` should be `Meta+_`. At least on a US keyboard.
- In `vlc-default`, changes a binding from `Meta+z` (which wouldn't work anyway) with `Z` to match VLC.
-#@iina Meta++ bigger-window
+#@iina Meta+= bigger-window
- `#@iina Shift+Meta+R show-current-file-in-finder` is changed to `#@iina Shift+Meta+r show-current-file-in-finder` in a couple of files. This is a style change only, so that it doesn't contrast with the format of the bindings above it.
- ~~`iina-default` and `vlc-default` had swapped keys for `ab-loop` and `cycle-values loop "inf" "no"`, respectively. This seemed wrong to me, so I changed both in `vlc-default`, using `Meta+l` (lowercase L) for `ab-loop` instead of uppercase, which matches `iina-default`.~~
- ~~I decided to leave `Meta+Shift+L` for Window > Log Viewer, and instead changed the mapping for `cycle-values loop "inf" "no"` to `Alt+Meta+l`. Maybe I should have done it the other way around, since Log Viewer will only be used by developers?~~