### PR TITLE
Fix data races, #3829, #3830, #3936, #3937

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -103,6 +103,11 @@ class MPVController: NSObject {
   var mpvClientName: UnsafePointer<CChar>!
   var mpvVersion: String { getString(MPVProperty.mpvVersion)! }
 
+  /// [DispatchQueue](https://developer.apple.com/documentation/dispatch/dispatchqueue) for reading `mpv`
+  /// events.
+  ///
+  /// - Important: To avoid using locking to prevent data races the convention is that processing involving data used by the UI is
+  ///     never performed while running on this queue's thread and instead is queued for processing by the main thread .
   lazy var queue = DispatchQueue(label: "com.colliderli.iina.controller", qos: .userInitiated)
 
   unowned let player: PlayerCore
@@ -115,7 +120,7 @@ class MPVController: NSObject {
 
   var fileLoaded: Bool = false
 
-  private var hooks: [UInt64: MPVHookValue] = [:]
+  @Atomic private var hooks: [UInt64: MPVHookValue] = [:]
   private var hookCounter: UInt64 = 1
 
   let observeProperties: [String: mpv_format] = [
@@ -904,13 +909,17 @@ not applying FFmpeg 9599 workaround
   // MARK: - Hooks
 
   func addHook(_ name: MPVHook, priority: Int32 = 0, hook: MPVHookValue) {
-    mpv_hook_add(mpv, hookCounter, name.rawValue, priority)
-    hooks[hookCounter] = hook
-    hookCounter += 1
+    $hooks.withLock {
+      mpv_hook_add(mpv, hookCounter, name.rawValue, priority)
+      $0[hookCounter] = hook
+      hookCounter += 1
+    }
   }
 
   func removeHooks(withIdentifier id: String) {
-    hooks.filter { (k, v) in v.isJavascript && v.id == id }.keys.forEach { hooks.removeValue(forKey: $0) }
+    $hooks.withLock {
+      $0.filter { (k, v) in v.isJavascript && v.id == id }.keys.forEach { hooks.removeValue(forKey: $0) }
+    }
   }
 
   // MARK: - Events
@@ -990,10 +999,10 @@ not applying FFmpeg 9599 workaround
       let userData = event.pointee.reply_userdata
       let hookEvent = event.pointee.data.bindMemory(to: mpv_event_hook.self, capacity: 1).pointee
       let hookID = hookEvent.id
-      if let hook = hooks[userData] {
-        hook.call {
-          mpv_hook_continue(self.mpv, hookID)
-        }
+      let hook = $hooks.withLock { $0[userData] }
+      guard let hook = hook else { break }
+      hook.call {
+        mpv_hook_continue(self.mpv, hookID)
       }
 
     case MPV_EVENT_PROPERTY_CHANGE:
@@ -1006,67 +1015,69 @@ not applying FFmpeg 9599 workaround
     case MPV_EVENT_AUDIO_RECONFIG: break
 
     case MPV_EVENT_VIDEO_RECONFIG:
-      player.onVideoReconfig()
+      DispatchQueue.main.async { self.player.onVideoReconfig() }
 
     case MPV_EVENT_START_FILE:
-      player.info.isIdle = false
       guard let path = getString(MPVProperty.path) else { break }
-      player.fileStarted(path: path)
-      let url = player.info.currentURL
-      let message = player.info.isNetworkResource ? url?.absoluteString : url?.lastPathComponent
-      player.sendOSD(.fileStart(message ?? "-"))
+      DispatchQueue.main.async { [self] in
+        player.info.isIdle = false
+        player.fileStarted(path: path)
+        let url = player.info.currentURL
+        let message = player.info.isNetworkResource ? url?.absoluteString : url?.lastPathComponent
+        player.sendOSD(.fileStart(message ?? "-"))
+      }
 
     case MPV_EVENT_FILE_LOADED:
-      onFileLoaded()
+      DispatchQueue.main.async { self.onFileLoaded() }
 
     case MPV_EVENT_SEEK:
-      player.info.isSeeking = true
-      DispatchQueue.main.sync {
+      DispatchQueue.main.async { [self] in
+        player.info.isSeeking = true
         // When playback is paused the display link may be shutdown in order to not waste energy.
         // It must be running when seeking to avoid slowdowns caused by mpv waiting for IINA to call
         // mpv_render_report_swap.
         player.mainWindow.videoView.displayActive()
-      }
-      if needRecordSeekTime {
-        recordedSeekStartTime = CACurrentMediaTime()
-      }
-      player.syncUI(.time)
-      let osdText = (player.info.videoPosition?.stringRepresentation ?? Constants.String.videoTimePlaceholder) + " / " +
+        if needRecordSeekTime {
+          recordedSeekStartTime = CACurrentMediaTime()
+        }
+        player.syncUI(.time)
+        let osdText = (player.info.videoPosition?.stringRepresentation ?? Constants.String.videoTimePlaceholder) + " / " +
         (player.info.videoDuration?.stringRepresentation ?? Constants.String.videoTimePlaceholder)
-      let percentage = (player.info.videoPosition / player.info.videoDuration) ?? 1
-      player.sendOSD(.seek(osdText, percentage))
+        let percentage = (player.info.videoPosition / player.info.videoDuration) ?? 1
+        player.sendOSD(.seek(osdText, percentage))
+      }
 
     case MPV_EVENT_PLAYBACK_RESTART:
-      player.info.isIdle = false
-      player.info.isSeeking = false
-      DispatchQueue.main.sync {
+      DispatchQueue.main.async { [self] in
+        player.info.isIdle = false
+        player.info.isSeeking = false
         // When playback is paused the display link may be shutdown in order to not waste energy.
         // The display link will be restarted while seeking. If playback is paused shut it down
         // again.
         if player.info.isPaused {
           player.mainWindow.videoView.displayIdle()
         }
+        if needRecordSeekTime {
+          recordedSeekTimeListener?(CACurrentMediaTime() - recordedSeekStartTime)
+          recordedSeekTimeListener = nil
+        }
+        player.playbackRestarted()
+        player.syncUI(.time)
       }
-      if needRecordSeekTime {
-        recordedSeekTimeListener?(CACurrentMediaTime() - recordedSeekStartTime)
-        recordedSeekTimeListener = nil
-      }
-      player.playbackRestarted()
-      player.syncUI(.time)
 
     case MPV_EVENT_END_FILE:
       // if receive end-file when loading file, might be error
       // wait for idle
       let reason = event!.pointee.data.load(as: mpv_end_file_reason.self)
-      if player.info.fileLoading {
-        if reason != MPV_END_FILE_REASON_STOP {
-          receivedEndFileWhileLoading = true
+      DispatchQueue.main.async { [self] in
+        if player.info.fileLoading {
+          if reason != MPV_END_FILE_REASON_STOP {
+            receivedEndFileWhileLoading = true
+          }
+        } else {
+          player.info.shouldAutoLoadFiles = false
         }
-      } else {
-        player.info.shouldAutoLoadFiles = false
-      }
-      if reason == MPV_END_FILE_REASON_STOP {
-        DispatchQueue.main.async {
+        if reason == MPV_END_FILE_REASON_STOP {
           self.player.playbackStopped()
         }
       }
@@ -1086,7 +1097,7 @@ not applying FFmpeg 9599 workaround
           }
           return
         }
-        player.screenshotCallback()
+        DispatchQueue.main.async { self.player.screenshotCallback() }
       }
 
     default: break
@@ -1101,11 +1112,6 @@ not applying FFmpeg 9599 workaround
       let eventName = "mpv.\(String(cString: mpv_event_name(eventId)))"
       player.events.emit(.init(eventName))
     }
-  }
-
-  private func onVideoParamsChange(_ data: UnsafePointer<mpv_node_list>) {
-    //let params = data.pointee
-    //params.keys.
   }
 
   private func onFileLoaded() {
@@ -1138,118 +1144,148 @@ not applying FFmpeg 9599 workaround
 
   private func handlePropertyChange(_ name: String, _ property: mpv_event_property) {
 
-    var needReloadQuickSettingsView = false
-
     switch name {
 
     case MPVProperty.videoParams:
-      needReloadQuickSettingsView = true
-      onVideoParamsChange(UnsafePointer<mpv_node_list>(OpaquePointer(property.data)))
+      DispatchQueue.main.async { self.player.needReloadQuickSettingsView() }
 
     case MPVProperty.videoParamsRotate:
-      if let rotation = UnsafePointer<Int>(OpaquePointer(property.data))?.pointee {
-        player.mainWindow.rotation = rotation
+      guard let rotation = UnsafePointer<Int>(OpaquePointer(property.data))?.pointee else {
+        logPropertyValueError(MPVProperty.videoParamsRotate, property.format)
+        break
       }
+      DispatchQueue.main.async { self.player.mainWindow.rotation = rotation }
 
     case MPVProperty.videoParamsPrimaries:
       fallthrough;
 
     case MPVProperty.videoParamsGamma:
-      player.refreshEdrMode()
+      if #available(macOS 10.15, *) {
+        DispatchQueue.main.async { self.player.refreshEdrMode() }
+      }
 
     case MPVOption.TrackSelection.vid:
-      player.vidChanged()
+      DispatchQueue.main.async { self.player.vidChanged() }
 
     case MPVOption.TrackSelection.aid:
-      player.aidChanged()
+      DispatchQueue.main.async { self.player.aidChanged() }
 
     case MPVOption.TrackSelection.sid:
-      player.sidChanged()
+      DispatchQueue.main.async { self.player.sidChanged() }
 
     case MPVOption.Subtitles.secondarySid:
-      player.secondarySidChanged()
+      DispatchQueue.main.async { self.player.secondarySidChanged() }
 
     case MPVOption.PlaybackControl.pause:
-      if let paused = UnsafePointer<Bool>(OpaquePointer(property.data))?.pointee {
+      guard let paused = UnsafePointer<Bool>(OpaquePointer(property.data))?.pointee else {
+        logPropertyValueError(MPVOption.PlaybackControl.pause, property.format)
+        break
+      }
+      DispatchQueue.main.async { [self] in
         if player.info.isPaused != paused {
           player.sendOSD(paused ? .pause : .resume)
-          DispatchQueue.main.sync {
-            player.info.isPaused = paused
-            player.refreshSyncUITimer()
-            if paused {
-              player.mainWindow.videoView.displayIdle()
-            } else {
-              player.mainWindow.videoView.displayActive()
-            }
+          player.info.isPaused = paused
+          player.refreshSyncUITimer()
+          // Follow energy efficiency best practices and ensure IINA is absolutely idle when the
+          // video is paused to avoid wasting energy with needless processing. If paused shutdown
+          // the timer that synchronizes the UI and the high priority display link thread.
+          if paused {
+            player.mainWindow.videoView.displayIdle()
+          } else {
+            player.mainWindow.videoView.displayActive()
           }
         }
         if player.mainWindow.loaded && Preference.bool(for: .alwaysFloatOnTop) {
-          DispatchQueue.main.async {
-            self.player.mainWindow.setWindowFloatingOnTop(!paused)
-          }
+          player.mainWindow.setWindowFloatingOnTop(!paused)
         }
+        player.syncUI(.playButton)
       }
-      player.syncUI(.playButton)
 
     case MPVProperty.chapter:
-      player.info.chapter = Int(getInt(MPVProperty.chapter))
-      player.syncUI(.time)
-      player.syncUI(.chapterList)
-      player.postNotification(.iinaMediaTitleChanged)
+      DispatchQueue.main.async { [self] in
+        player.info.chapter = Int(getInt(MPVProperty.chapter))
+        player.syncUI(.time)
+        player.syncUI(.chapterList)
+        player.postNotification(.iinaMediaTitleChanged)
+      }
 
     case MPVOption.PlaybackControl.speed:
-      needReloadQuickSettingsView = true
-      if let data = UnsafePointer<Double>(OpaquePointer(property.data))?.pointee {
+      guard let data = UnsafePointer<Double>(OpaquePointer(property.data))?.pointee else {
+        logPropertyValueError(MPVOption.PlaybackControl.speed, property.format)
+        break
+      }
+      DispatchQueue.main.async { [self] in
         player.info.playSpeed = data
         player.sendOSD(.speed(data))
+        player.needReloadQuickSettingsView()
       }
 
     case MPVOption.PlaybackControl.loopPlaylist, MPVOption.PlaybackControl.loopFile:
-      player.syncUI(.loop)
+      DispatchQueue.main.async { self.player.syncUI(.loop) }
 
     case MPVOption.Video.deinterlace:
-      needReloadQuickSettingsView = true
-      if let data = UnsafePointer<Bool>(OpaquePointer(property.data))?.pointee {
+      guard let data = UnsafePointer<Bool>(OpaquePointer(property.data))?.pointee else {
+        logPropertyValueError(MPVOption.Video.deinterlace, property.format)
+        break
+      }
+      DispatchQueue.main.async { [self] in
         // this property will fire a change event at file start
         if player.info.deinterlace != data {
           player.info.deinterlace = data
           player.sendOSD(.deinterlace(data))
         }
+        player.needReloadQuickSettingsView()
       }
 
     case MPVOption.Video.hwdec:
-      needReloadQuickSettingsView = true
       let data = String(cString: property.data.assumingMemoryBound(to: UnsafePointer<UInt8>.self).pointee)
-      if player.info.hwdec != data {
-        player.info.hwdec = data
-        player.sendOSD(.hwdec(player.info.hwdecEnabled))
+      DispatchQueue.main.async { [self] in
+        if player.info.hwdec != data {
+          player.info.hwdec = data
+          player.sendOSD(.hwdec(player.info.hwdecEnabled))
+        }
+        player.needReloadQuickSettingsView()
       }
 
     case MPVOption.Video.videoRotate:
-      if let data = UnsafePointer<Int64>(OpaquePointer(property.data))?.pointee {
-      let intData = Int(data)
-        player.info.rotation = intData
+      guard let data = UnsafePointer<Int64>(OpaquePointer(property.data))?.pointee else {
+        logPropertyValueError(MPVOption.Video.videoRotate, property.format)
+        break
       }
+      let intData = Int(data)
+      DispatchQueue.main.async { self.player.info.rotation = intData }
 
     case MPVOption.Audio.mute:
-      player.syncUI(.muteButton)
-      if let data = UnsafePointer<Bool>(OpaquePointer(property.data))?.pointee {
+      guard let data = UnsafePointer<Bool>(OpaquePointer(property.data))?.pointee else {
+        logPropertyValueError(MPVOption.Video.videoRotate, property.format)
+        break
+      }
+      DispatchQueue.main.async { [self] in
+        player.syncUI(.muteButton)
         player.info.isMuted = data
         player.sendOSD(data ? OSDMessage.mute : OSDMessage.unMute)
       }
 
     case MPVOption.Audio.volume:
-      if let data = UnsafePointer<Double>(OpaquePointer(property.data))?.pointee {
+      guard let data = UnsafePointer<Double>(OpaquePointer(property.data))?.pointee else {
+        logPropertyValueError(MPVOption.Audio.volume, property.format)
+        break
+      }
+      DispatchQueue.main.async { [self] in
         player.info.volume = data
         player.syncUI(.volume)
         player.sendOSD(.volume(Int(data)))
       }
 
     case MPVOption.Audio.audioDelay:
-      needReloadQuickSettingsView = true
-      if let data = UnsafePointer<Double>(OpaquePointer(property.data))?.pointee {
+      guard let data = UnsafePointer<Double>(OpaquePointer(property.data))?.pointee else {
+        logPropertyValueError(MPVOption.Audio.audioDelay, property.format)
+        break
+      }
+      DispatchQueue.main.async { [self] in
         player.info.audioDelay = data
         player.sendOSD(.audioDelay(data))
+        player.needReloadQuickSettingsView()
       }
 
     case MPVOption.Subtitles.subVisibility:
@@ -1267,111 +1303,152 @@ not applying FFmpeg 9599 workaround
       }
 
     case MPVOption.Subtitles.subDelay:
-      needReloadQuickSettingsView = true
-      if let data = UnsafePointer<Double>(OpaquePointer(property.data))?.pointee {
+      guard let data = UnsafePointer<Double>(OpaquePointer(property.data))?.pointee else {
+        logPropertyValueError(MPVOption.Subtitles.subDelay, property.format)
+        break
+      }
+      DispatchQueue.main.async { [self] in
         player.info.subDelay = data
         player.sendOSD(.subDelay(data))
+        player.needReloadQuickSettingsView()
       }
 
     case MPVOption.Subtitles.subScale:
-      needReloadQuickSettingsView = true
-      if let data = UnsafePointer<Double>(OpaquePointer(property.data))?.pointee {
-        let displayValue = data >= 1 ? data : -1/data
-        let truncated = round(displayValue * 100) / 100
+      guard let data = UnsafePointer<Double>(OpaquePointer(property.data))?.pointee else {
+        logPropertyValueError(MPVOption.Subtitles.subScale, property.format)
+        break
+      }
+      let displayValue = data >= 1 ? data : -1/data
+      let truncated = round(displayValue * 100) / 100
+      DispatchQueue.main.async { [self] in
         player.sendOSD(.subScale(truncated))
+        player.needReloadQuickSettingsView()
       }
 
     case MPVOption.Subtitles.subPos:
-      needReloadQuickSettingsView = true
-      if let data = UnsafePointer<Double>(OpaquePointer(property.data))?.pointee {
+      guard let data = UnsafePointer<Double>(OpaquePointer(property.data))?.pointee else {
+        logPropertyValueError(MPVOption.Subtitles.subPos, property.format)
+        break
+      }
+      DispatchQueue.main.async { [self] in
         player.sendOSD(.subPos(data))
+        player.needReloadQuickSettingsView()
       }
 
     case MPVOption.Equalizer.contrast:
-      needReloadQuickSettingsView = true
-      if let data = UnsafePointer<Int64>(OpaquePointer(property.data))?.pointee {
-        let intData = Int(data)
+      guard let data = UnsafePointer<Int64>(OpaquePointer(property.data))?.pointee else {
+        logPropertyValueError(MPVOption.Equalizer.contrast, property.format)
+        break
+      }
+      let intData = Int(data)
+      DispatchQueue.main.async { [self] in
         player.info.contrast = intData
         player.sendOSD(.contrast(intData))
+        player.needReloadQuickSettingsView()
       }
 
     case MPVOption.Equalizer.hue:
-      needReloadQuickSettingsView = true
-      if let data = UnsafePointer<Int64>(OpaquePointer(property.data))?.pointee {
-        let intData = Int(data)
+      guard let data = UnsafePointer<Int64>(OpaquePointer(property.data))?.pointee else {
+        logPropertyValueError(MPVOption.Equalizer.hue, property.format)
+        break
+      }
+      let intData = Int(data)
+      DispatchQueue.main.async { [self] in
         player.info.hue = intData
         player.sendOSD(.hue(intData))
+        player.needReloadQuickSettingsView()
       }
 
     case MPVOption.Equalizer.brightness:
-      needReloadQuickSettingsView = true
-      if let data = UnsafePointer<Int64>(OpaquePointer(property.data))?.pointee {
-        let intData = Int(data)
+      guard let data = UnsafePointer<Int64>(OpaquePointer(property.data))?.pointee else {
+        logPropertyValueError(MPVOption.Equalizer.brightness, property.format)
+        break
+      }
+      let intData = Int(data)
+      DispatchQueue.main.async { [self] in
         player.info.brightness = intData
         player.sendOSD(.brightness(intData))
+        player.needReloadQuickSettingsView()
       }
 
     case MPVOption.Equalizer.gamma:
-      needReloadQuickSettingsView = true
-      if let data = UnsafePointer<Int64>(OpaquePointer(property.data))?.pointee {
-        let intData = Int(data)
+      guard let data = UnsafePointer<Int64>(OpaquePointer(property.data))?.pointee else {
+        logPropertyValueError(MPVOption.Equalizer.gamma, property.format)
+        break
+      }
+      let intData = Int(data)
+      DispatchQueue.main.async { [self] in
         player.info.gamma = intData
         player.sendOSD(.gamma(intData))
+        player.needReloadQuickSettingsView()
       }
 
     case MPVOption.Equalizer.saturation:
-      needReloadQuickSettingsView = true
-      if let data = UnsafePointer<Int64>(OpaquePointer(property.data))?.pointee {
-        let intData = Int(data)
+      guard let data = UnsafePointer<Int64>(OpaquePointer(property.data))?.pointee else {
+        logPropertyValueError(MPVOption.Equalizer.saturation, property.format)
+        break
+      }
+      let intData = Int(data)
+      DispatchQueue.main.async { [self] in
         player.info.saturation = intData
         player.sendOSD(.saturation(intData))
+        player.needReloadQuickSettingsView()
       }
 
     // following properties may change before file loaded
 
     case MPVProperty.playlistCount:
-      player.postNotification(.iinaPlaylistChanged)
+      DispatchQueue.main.async { self.player.postNotification(.iinaPlaylistChanged) }
 
     case MPVProperty.trackList:
-      player.trackListChanged()
+      DispatchQueue.main.async { self.player.trackListChanged() }
 
     case MPVProperty.vf:
-      needReloadQuickSettingsView = true
-      player.vfChanged()
+      DispatchQueue.main.async { [self] in
+        player.vfChanged()
+        player.needReloadQuickSettingsView()
+      }
 
     case MPVProperty.af:
-      player.afChanged()
+      DispatchQueue.main.async { self.player.afChanged() }
 
     case MPVOption.Window.fullscreen:
-      guard player.mainWindow.loaded else { break }
-      let fs = getFlag(MPVOption.Window.fullscreen)
-      if fs != player.mainWindow.fsState.isFullscreen {
-        DispatchQueue.main.async(execute: self.player.mainWindow.toggleWindowFullScreen)
+      DispatchQueue.main.async { [self] in
+        guard player.mainWindow.loaded else { return }
+        let fs = getFlag(MPVOption.Window.fullscreen)
+        if fs != player.mainWindow.fsState.isFullscreen {
+          player.mainWindow.toggleWindowFullScreen()
+        }
       }
 
     case MPVOption.Window.ontop:
-      guard player.mainWindow.loaded else { break }
-      let ontop = getFlag(MPVOption.Window.ontop)
-      if ontop != player.mainWindow.isOntop {
-        DispatchQueue.main.async {
-          self.player.mainWindow.setWindowFloatingOnTop(ontop)
+      DispatchQueue.main.async { [self] in
+        guard player.mainWindow.loaded else { return }
+        let ontop = getFlag(MPVOption.Window.ontop)
+        if ontop != player.mainWindow.isOntop {
+          player.mainWindow.setWindowFloatingOnTop(ontop)
         }
       }
 
     case MPVOption.Window.windowScale:
-      guard player.mainWindow.loaded else { break }
-      let windowScale = getDouble(MPVOption.Window.windowScale)
-      if fabs(windowScale - player.info.cachedWindowScale) > 10e-10 {
-        DispatchQueue.main.async {
-          self.player.mainWindow.setWindowScale(windowScale)
+      DispatchQueue.main.async { [self] in
+        guard player.mainWindow.loaded else { return }
+        let windowScale = getDouble(MPVOption.Window.windowScale)
+        if fabs(windowScale - player.info.cachedWindowScale) > 10e-10 {
+          player.mainWindow.setWindowScale(windowScale)
         }
       }
 
     case MPVProperty.mediaTitle:
-      player.mediaTitleChanged()
+      DispatchQueue.main.async { self.player.mediaTitleChanged() }
 
     case MPVProperty.idleActive:
-      if let idleActive = UnsafePointer<Bool>(OpaquePointer(property.data))?.pointee, idleActive {
+      guard let idleActive = UnsafePointer<Bool>(OpaquePointer(property.data))?.pointee else {
+        logPropertyValueError(MPVProperty.idleActive, property.format)
+        break
+      }
+      guard idleActive else { break }
+      DispatchQueue.main.async { [self] in
         if receivedEndFileWhileLoading && player.info.fileLoading {
           player.errorOpeningFileAndCloseMainWindow()
           player.info.fileLoading = false
@@ -1389,10 +1466,6 @@ not applying FFmpeg 9599 workaround
     default:
       // Utility.log("MPV property changed (unhandled): \(name)")
       break
-    }
-
-    if needReloadQuickSettingsView {
-      player.needReloadQuickSettingsView()
     }
 
     // This code is running in the com.colliderli.iina.controller dispatch queue. We must not run
@@ -1581,6 +1654,32 @@ not applying FFmpeg 9599 workaround
 
   private func log(_ message: String, level: Logger.Level = .debug) {
     Logger.log(message, level: level, subsystem: subsystem)
+  }
+
+  /// Log an error when a `mpv` property change event can't be processed because a property value could not be converted to the
+  /// expected type.
+  ///
+  /// A [MPV_EVENT_PROPERTY_CHANGE](https://mpv.io/manual/stable/#command-interface-mpv-event-property-change)
+  /// event contains the new value of the property. If that value could not be converted to the expected type then this method is called
+  /// to log the problem.
+  ///
+  /// _However_ the situation is not that simple. The documentation for [mpv_observe_property](https://github.com/mpv-player/mpv/blob/023d02c9504e308ba5a295cd1846f2508b3dd9c2/libmpv/client.h#L1192-L1195)
+  /// contains the following warning:
+  ///
+  /// "if a property is unavailable or retrieving it caused an error, `MPV_FORMAT_NONE` will be set in `mpv_event_property`, even
+  /// if the format parameter was set to a different value. In this case, the `mpv_event_property.data` field is invalid"
+  ///
+  /// With mpv 0.35.0 we are receiving some property change events for the video-params/rotate property that do not contain the
+  /// property value. This happens when the core starts before a file is loaded and when the core is stopping. At some point this needs
+  /// to be investigated. For now we suppress logging an error for this known case.
+  /// - Parameter property: Name of the property whose value changed.
+  /// - Parameter format: Format of the value contained in the property change event.
+  private func logPropertyValueError(_ property: String, _ format: mpv_format) {
+    guard property != MPVProperty.videoParamsRotate, format != MPV_FORMAT_NONE else { return }
+    log("""
+      Value of property \(property) in the property change event could not be converted from 
+      \(format) to the expected type
+      """, level: .error)
   }
 }
 

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -413,7 +413,7 @@ extension MainMenuActionHandler {
   }
 
   @objc func saveDownloadedSub(_ sender: NSMenuItem) {
-    let selected = player.info.subTracks.filter { $0.id == player.info.sid }
+    let selected = player.info.$subTracks.withLock { $0.filter { $0.id == player.info.sid } }
     guard selected.count > 0 else {
       Utility.showAlert("sub.no_selected")
 

--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -139,15 +139,15 @@ class PlaybackInfo {
 
   var audioTracks: [MPVTrack] = []
   var videoTracks: [MPVTrack] = []
-  var subTracks: [MPVTrack] = []
+  @Atomic var subTracks: [MPVTrack] = []
 
   var abLoopStatus: LoopStatus = .cleared
 
   /** Selected track IDs. Use these (instead of `isSelected` of a track) to check if selected */
-  var aid: Int?
-  var sid: Int?
-  var vid: Int?
-  var secondSid: Int?
+  @Atomic var aid: Int?
+  @Atomic var sid: Int?
+  @Atomic var vid: Int?
+  @Atomic var secondSid: Int?
 
   var isSubVisible = true
   var isSecondSubVisible = true
@@ -271,19 +271,21 @@ class PlaybackInfo {
     }
   }
 
-  var thumbnailsReady = false
-  var thumbnailsProgress: Double = 0
-  var thumbnails: [FFThumbnail] = []
+  @Atomic var thumbnailsReady = false
+  @Atomic var thumbnailsProgress: Double = 0
+  @Atomic var thumbnails: [FFThumbnail] = []
 
   func getThumbnail(forSecond sec: Double) -> FFThumbnail? {
-    guard !thumbnails.isEmpty else { return nil }
-    var tb = thumbnails.last!
-    for i in 0..<thumbnails.count {
-      if thumbnails[i].realTime >= sec {
-        tb = thumbnails[(i == 0 ? i : i - 1)]
-        break
+    $thumbnails.withLock {
+      guard !$0.isEmpty else { return nil }
+      var tb = $0.last!
+      for i in 0..<$0.count {
+        if $0[i].realTime >= sec {
+          tb = $0[(i == 0 ? i : i - 1)]
+          break
+        }
       }
+      return tb
     }
-    return tb
   }
 }

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1810,6 +1810,22 @@ class PlayerCore: NSObject {
     sendOSD(.track(info.currentTrack(.audio) ?? .noneAudioTrack))
   }
 
+  func chapterChanged() {
+    guard !isShuttingDown, !isShutdown else { return }
+    info.chapter = Int(mpv.getInt(MPVProperty.chapter))
+    syncUI(.time)
+    syncUI(.chapterList)
+    postNotification(.iinaMediaTitleChanged)
+  }
+
+  func fullscreenChanged() {
+    guard mainWindow.loaded, !isStopping, !isStopped, !isShuttingDown, !isShutdown else { return }
+    let fs = mpv.getFlag(MPVOption.Window.fullscreen)
+    if fs != mainWindow.fsState.isFullscreen {
+      mainWindow.toggleWindowFullScreen()
+    }
+  }
+
   func mediaTitleChanged() {
     guard !isShuttingDown, !isShutdown else { return }
     postNotification(.iinaMediaTitleChanged)
@@ -1818,6 +1834,14 @@ class PlayerCore: NSObject {
   func needReloadQuickSettingsView() {
     guard !isShuttingDown, !isShutdown else { return }
     mainWindow.quickSettingView.reload()
+  }
+
+  func ontopChanged() {
+    guard mainWindow.loaded, !isStopping, !isStopped, !isShuttingDown, !isShutdown else { return }
+    let ontop = mpv.getFlag(MPVOption.Window.ontop)
+    if ontop != mainWindow.isOntop {
+      mainWindow.setWindowFloatingOnTop(ontop)
+    }
   }
 
   func playbackRestarted() {
@@ -1921,6 +1945,14 @@ class PlayerCore: NSObject {
     info.vid = Int(mpv.getInt(MPVOption.TrackSelection.vid))
     postNotification(.iinaVIDChanged)
     sendOSD(.track(info.currentTrack(.video) ?? .noneVideoTrack))
+  }
+
+  func windowScaleChanged() {
+    guard mainWindow.loaded, !isStopping, !isStopped, !isShuttingDown, !isShutdown else { return }
+    let windowScale = mpv.getDouble(MPVOption.Window.windowScale)
+    if fabs(windowScale - info.cachedWindowScale) > 10e-10 {
+      mainWindow.setWindowScale(windowScale)
+    }
   }
 
   private func autoSearchOnlineSub() {

--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -74,8 +74,8 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
   @IBOutlet weak var addBtn: NSButton!
   @IBOutlet weak var removeBtn: NSButton!
   
-  private var playlistTotalLengthIsReady = false
-  private var playlistTotalLength: Double? = nil
+  @Atomic private var playlistTotalLengthIsReady = false
+  @Atomic private var playlistTotalLength: Double? = nil
 
   var downShift: CGFloat = 0 {
     didSet {

--- a/iina/QuickSettingViewController.swift
+++ b/iina/QuickSettingViewController.swift
@@ -568,7 +568,7 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
     } else if tableView == audioTableView {
       return player.info.audioTracks.count + 1
     } else if tableView == subTableView || tableView == secSubTableView {
-      return player.info.subTracks.count + 1
+      return player.info.$subTracks.withLock { $0.count + 1 }
     } else {
       return 0
     }


### PR DESCRIPTION
This commit will:
- Change `MPVController` to perform most event processing using the main thread
- Remove dispatching to main queue from `PlayerCore` methods now being called by `MPVController` using the main thread
- Add the `Atomic` property wrapper to the `playlistTotalLength` and `playlistTotalLengthIsReady` `PlaylistViewController` properties
- Add the `Atomic` property wrapper to the following `PlayerInfo` properties:
  - aid
  - secondSid
  - sid
   - subTracks
  - thumbnails
  - thumbnailsProgress
  - thumbnailsReady
  - vid
- Change references to `subTracks` to lock the array
- Change references to `thumbnails` to lock the array
- Add the `Atomic` property wrapper to the `hooks` `MPVController` property
- Change references to `hooks` to lock the array
- Change `PlayerCore.playbackRestarted` to re-enable the OSD by dispatching to the main thread using `async` with a delay instead of using a timer
- Add the method `logPropertyValueError` to `MPVController` to report when property values can not be converted to the expected type
- Replace `MPVController` method `reEnableOSDAfterFileLoading` with inline code

These changes will correct data races between the  main thread and the thread for the `MPVController` `com.colliderli.iina.controller` queue by changing `MPVController` to dispatch work to the main queue. This will simplify the code as in some cases work was being done on both the `controller` queue and the main queue as some processing required calling AppKit methods that must be run on the main thread.

These changes will correct the data races between the main thread and PlayerCore backgroundQueue used for loading subtitles by adding the `Atomic` property wrapper to properties shared between these threads and using the `withLock` method. Similar changes correct the data races between the main thread and PlayerCore thumbnailQueue.

These changes will also fix data races with the `playlistTotalLengthIsReady` and `playlistTotalLength` properties.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #3829, #3830, #3936, #3937.

---

**Description:**
