### PR TITLE
Fix reversed check in AppDelegate.restoreRecentDocuments

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -1017,7 +1017,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
       NSDocumentController.shared.noteNewRecentDocumentURL(bookmark)
     }
     Logger.log("Restored list of recent documents")
-    guard !foundStale else { return }
+    guard foundStale else { return }
     Logger.log("Found stale bookmarks in saved recent documents")
     // Save the recent documents in order to refresh stale bookmarks.
     saveRecentDocuments()


### PR DESCRIPTION
This commit will correct the expression in the `guard` statement in `restoreRecentDocuments` that checks if stale bookmarks were found.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
