### PR TITLE
Fixes to Subtitle Chooser layout

### DIFF
--- a/iina/Base.lproj/SubChooseViewController.xib
+++ b/iina/Base.lproj/SubChooseViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="16097" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22505" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="16097"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22505"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -15,11 +15,10 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView id="Hz6-mo-xeY">
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY" userLabel="SubChooseView">
             <rect key="frame" x="0.0" y="0.0" width="480" height="272"/>
-            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="CFP-kG-Ixy">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="CFP-kG-Ixy">
                     <rect key="frame" x="-2" y="250" width="484" height="14"/>
                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Please click to select subtitles to download:" id="vAl-Km-bkf">
                         <font key="font" metaFont="controlContent" size="11"/>
@@ -40,7 +39,7 @@
                                 <color key="backgroundColor" white="1" alpha="0.050000000000000003" colorSpace="deviceWhite"/>
                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                 <tableColumns>
-                                    <tableColumn width="477" minWidth="40" maxWidth="1000" id="vNk-Ec-Zk0">
+                                    <tableColumn width="448" minWidth="40" maxWidth="1000" id="vNk-Ec-Zk0">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
@@ -53,13 +52,13 @@
                                         <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                         <prototypeCellViews>
                                             <tableCellView identifier="SubCell" id="P97-ul-Qub">
-                                                <rect key="frame" x="1" y="1" width="477" height="35"/>
+                                                <rect key="frame" x="11" y="1" width="457" height="35"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
-                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="ASf-cI-KhW">
-                                                        <rect key="frame" x="2" y="4" width="473" height="14"/>
+                                                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ASf-cI-KhW">
+                                                        <rect key="frame" x="2" y="4" width="453" height="14"/>
                                                         <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="Bnm-Vf-zg5">
-                                                            <font key="font" metaFont="system" size="11"/>
+                                                            <font key="font" metaFont="smallSystem"/>
                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
@@ -67,7 +66,7 @@
                                                             <binding destination="P97-ul-Qub" name="value" keyPath="objectValue.name" id="03c-5e-AAK"/>
                                                         </connections>
                                                     </textField>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UH9-D2-Ky7">
+                                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UH9-D2-Ky7">
                                                         <rect key="frame" x="2" y="20" width="28" height="11"/>
                                                         <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="FW8-qy-9po">
                                                             <font key="font" metaFont="label" size="9"/>
@@ -78,8 +77,8 @@
                                                             <binding destination="P97-ul-Qub" name="value" keyPath="objectValue.left" id="vqh-LZ-Hz5"/>
                                                         </connections>
                                                     </textField>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1Sq-2N-kTU">
-                                                        <rect key="frame" x="415" y="22" width="60" height="11"/>
+                                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1Sq-2N-kTU">
+                                                        <rect key="frame" x="395" y="20" width="60" height="11"/>
                                                         <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="2000-00-00" id="qnJ-hh-Ajn">
                                                             <font key="font" metaFont="label" size="9"/>
                                                             <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -92,10 +91,11 @@
                                                 </subviews>
                                                 <constraints>
                                                     <constraint firstItem="UH9-D2-Ky7" firstAttribute="top" secondItem="P97-ul-Qub" secondAttribute="top" constant="4" id="1t3-Df-wwC"/>
+                                                    <constraint firstItem="1Sq-2N-kTU" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="UH9-D2-Ky7" secondAttribute="trailing" constant="8" id="FFv-ub-pFq"/>
                                                     <constraint firstItem="ASf-cI-KhW" firstAttribute="top" secondItem="UH9-D2-Ky7" secondAttribute="bottom" constant="2" id="GhN-3s-u3F"/>
+                                                    <constraint firstItem="1Sq-2N-kTU" firstAttribute="firstBaseline" secondItem="UH9-D2-Ky7" secondAttribute="firstBaseline" id="NhH-DH-vfA"/>
                                                     <constraint firstAttribute="trailing" secondItem="1Sq-2N-kTU" secondAttribute="trailing" constant="4" id="Prx-45-HCt"/>
                                                     <constraint firstItem="UH9-D2-Ky7" firstAttribute="leading" secondItem="P97-ul-Qub" secondAttribute="leading" constant="4" id="fCW-Ci-SGz"/>
-                                                    <constraint firstItem="1Sq-2N-kTU" firstAttribute="top" secondItem="P97-ul-Qub" secondAttribute="top" constant="2" id="hjk-G1-0qz"/>
                                                     <constraint firstAttribute="bottom" secondItem="ASf-cI-KhW" secondAttribute="bottom" constant="4" id="kCX-xn-Acw"/>
                                                     <constraint firstAttribute="trailing" secondItem="ASf-cI-KhW" secondAttribute="trailing" constant="4" id="uMs-2X-huR"/>
                                                     <constraint firstItem="ASf-cI-KhW" firstAttribute="leading" secondItem="P97-ul-Qub" secondAttribute="leading" constant="4" id="vlM-IS-LSD"/>
@@ -111,7 +111,7 @@
                         </subviews>
                     </clipView>
                     <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="slq-4S-gy9">
-                        <rect key="frame" x="1" y="255" width="478" height="16"/>
+                        <rect key="frame" x="0.0" y="190" width="480" height="16"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                     <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="OPY-9A-J9w">
@@ -146,9 +146,11 @@
                 <constraint firstItem="i9Z-jA-8gU" firstAttribute="leading" secondItem="tFf-9S-9GB" secondAttribute="trailing" constant="8" id="5Ic-qQ-aEq"/>
                 <constraint firstItem="T82-Op-UIR" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="6Xh-Bu-7TR"/>
                 <constraint firstItem="T82-Op-UIR" firstAttribute="top" secondItem="CFP-kG-Ixy" secondAttribute="bottom" constant="8" id="FZN-8k-JXM"/>
+                <constraint firstAttribute="width" priority="499" constant="480" id="Fm1-BD-B4h"/>
                 <constraint firstAttribute="trailing" secondItem="CFP-kG-Ixy" secondAttribute="trailing" id="Qnk-7D-vre"/>
                 <constraint firstItem="CFP-kG-Ixy" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="Qzc-2o-vZl"/>
                 <constraint firstAttribute="bottom" secondItem="i9Z-jA-8gU" secondAttribute="bottom" constant="8" id="RbC-52-0AG"/>
+                <constraint firstItem="tFf-9S-9GB" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="8" id="RyC-7M-R4h"/>
                 <constraint firstItem="CFP-kG-Ixy" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="8" id="YJn-Hp-Fnv"/>
                 <constraint firstAttribute="trailing" secondItem="i9Z-jA-8gU" secondAttribute="trailing" constant="8" id="f09-vG-mFE"/>
                 <constraint firstItem="tFf-9S-9GB" firstAttribute="centerY" secondItem="i9Z-jA-8gU" secondAttribute="centerY" id="jDg-e5-ZRg"/>


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4057.

---

**Description:**

- Allow expansion tooltips (as suggested in [this comment](https://github.com/iina/iina/issues/4057#issuecomment-1949629135))
- Set a preferred width of 480 to that it doesn't collapse to size of `osdLabel`. Uses a priority of 499 so that it will still shrink if there is not enough space.
- Fixes vertical text alignment for each table item's left & right labels
- Fix layout warning