### PR TITLE
Fixes & improvements to Subtitle Chooser

### DIFF
--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -88,7 +88,8 @@
 "osd.find_online_sub" = "Finding online subtitles…";
 "osd.find_online_sub.source" = "from";
 "osd.sub_not_found" = "No subtitles found";
-"osd.sub_found" = "%d subtitles found. Downloading…";
+"osd.sub_found" = "%d subtitles found.";
+"osd.sub_downloading" = "Downloading %d subtitles";
 "osd.sub_downloaded" = "Subtitle downloaded";
 "osd.sub_saved" = "Subtitle saved";
 "osd.network_error" = "Network error";

--- a/iina/Base.lproj/QuickSettingViewController.xib
+++ b/iina/Base.lproj/QuickSettingViewController.xib
@@ -1982,9 +1982,9 @@
                                                                     </view>
                                                                 </box>
                                                                 <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dXz-x4-sm5" userLabel="SubDelay Horizontal Tick Bottom Slider">
-                                                                    <rect key="frame" x="30" y="440" width="244" height="20"/>
+                                                                    <rect key="frame" x="30" y="440" width="233" height="20"/>
                                                                     <constraints>
-                                                                        <constraint firstAttribute="width" constant="240" id="Qpm-gC-Y2e"/>
+                                                                        <constraint firstAttribute="width" constant="229" id="Qpm-gC-Y2e"/>
                                                                     </constraints>
                                                                     <sliderCell key="cell" controlSize="small" continuous="YES" refusesFirstResponder="YES" state="on" alignment="left" minValue="-5" maxValue="5" tickMarkPosition="below" numberOfTickMarks="21" sliderType="linear" id="h1D-gP-Dst"/>
                                                                     <connections>
@@ -2019,7 +2019,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="r77-VA-Z1b">
-                                                                    <rect key="frame" x="253" y="430" width="21" height="11"/>
+                                                                    <rect key="frame" x="242" y="430" width="21" height="11"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="+5s" id="xfX-wr-DTJ">
                                                                         <font key="font" metaFont="label" size="9"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -2027,7 +2027,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField focusRingType="none" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eOz-bB-vzM" userLabel="CustomDelayEdit Text Field">
-                                                                    <rect key="frame" x="280" y="440" width="50" height="21"/>
+                                                                    <rect key="frame" x="269" y="440" width="50" height="21"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="ptd-kK-aWm"/>
                                                                     </constraints>
@@ -2042,7 +2042,7 @@
                                                                     </connections>
                                                                 </textField>
                                                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4U2-kT-76O">
-                                                                    <rect key="frame" x="328" y="443" width="4" height="16"/>
+                                                                    <rect key="frame" x="317" y="443" width="15" height="16"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="s" id="bsT-FB-GhF">
                                                                         <font key="font" metaFont="system"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -2050,7 +2050,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kzp-GR-Sy4">
-                                                                    <rect key="frame" x="145" y="430" width="15" height="11"/>
+                                                                    <rect key="frame" x="139" y="430" width="15" height="11"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="0s" id="LEZ-fv-buL">
                                                                         <font key="font" metaFont="label" size="9"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>

--- a/iina/Base.lproj/SubChooseViewController.xib
+++ b/iina/Base.lproj/SubChooseViewController.xib
@@ -16,30 +16,28 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY" userLabel="SubChooseView">
-            <rect key="frame" x="0.0" y="0.0" width="480" height="272"/>
+            <rect key="frame" x="0.0" y="0.0" width="480" height="200"/>
             <subviews>
-                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="CFP-kG-Ixy">
-                    <rect key="frame" x="-2" y="250" width="484" height="14"/>
-                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Please click to select subtitles to download:" id="vAl-Km-bkf">
-                        <font key="font" metaFont="controlContent" size="11"/>
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="499" translatesAutoresizingMaskIntoConstraints="NO" id="CFP-kG-Ixy">
+                    <rect key="frame" x="-2" y="184" width="484" height="16"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Please click to select subtitles to download:" id="vAl-Km-bkf">
+                        <font key="font" metaFont="system"/>
                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="37" horizontalPageScroll="10" verticalLineScroll="37" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="T82-Op-UIR">
-                    <rect key="frame" x="0.0" y="36" width="480" height="206"/>
-                    <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="Jso-OO-xRN">
-                        <rect key="frame" x="0.0" y="0.0" width="480" height="206"/>
-                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                <scrollView verticalHuggingPriority="1000" verticalCompressionResistancePriority="1" borderType="none" autohidesScrollers="YES" horizontalLineScroll="52" horizontalPageScroll="10" verticalLineScroll="52" verticalPageScroll="10" usesPredominantAxisScrolling="NO" horizontalScrollElasticity="none" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="T82-Op-UIR" userLabel="SubChooserTable Scroll View">
+                    <rect key="frame" x="0.0" y="24" width="480" height="152"/>
+                    <clipView key="contentView" ambiguous="YES" drawsBackground="NO" copiesOnScroll="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Jso-OO-xRN" userLabel="SubChooserTable Clip View">
+                        <rect key="frame" x="0.0" y="0.0" width="480" height="152"/>
                         <subviews>
-                            <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" autosaveColumns="NO" typeSelect="NO" rowHeight="35" rowSizeStyle="automatic" viewBased="YES" id="Hut-pu-9Tv">
-                                <rect key="frame" x="0.0" y="0.0" width="480" height="206"/>
-                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <tableView verticalCompressionResistancePriority="1000" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" autosaveColumns="NO" typeSelect="NO" rowHeight="50" rowSizeStyle="automatic" viewBased="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hut-pu-9Tv" userLabel="SubChooserTable Table View">
+                                <rect key="frame" x="0.0" y="0.0" width="480" height="152"/>
                                 <size key="intercellSpacing" width="3" height="2"/>
                                 <color key="backgroundColor" white="1" alpha="0.050000000000000003" colorSpace="deviceWhite"/>
                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                 <tableColumns>
-                                    <tableColumn width="448" minWidth="40" maxWidth="1000" id="vNk-Ec-Zk0">
+                                    <tableColumn width="468" minWidth="40" maxWidth="2000" id="vNk-Ec-Zk0">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
@@ -52,24 +50,13 @@
                                         <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                         <prototypeCellViews>
                                             <tableCellView identifier="SubCell" id="P97-ul-Qub">
-                                                <rect key="frame" x="11" y="1" width="457" height="35"/>
+                                                <rect key="frame" x="1" y="1" width="477" height="50"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
-                                                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ASf-cI-KhW">
-                                                        <rect key="frame" x="2" y="4" width="453" height="14"/>
-                                                        <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="Bnm-Vf-zg5">
-                                                            <font key="font" metaFont="smallSystem"/>
-                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                        </textFieldCell>
-                                                        <connections>
-                                                            <binding destination="P97-ul-Qub" name="value" keyPath="objectValue.name" id="03c-5e-AAK"/>
-                                                        </connections>
-                                                    </textField>
                                                     <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="UH9-D2-Ky7">
-                                                        <rect key="frame" x="2" y="20" width="28" height="11"/>
-                                                        <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="FW8-qy-9po">
-                                                            <font key="font" metaFont="label" size="9"/>
+                                                        <rect key="frame" x="6" y="28" width="57" height="14"/>
+                                                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Left Label" id="FW8-qy-9po">
+                                                            <font key="font" metaFont="smallSystem"/>
                                                             <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
@@ -78,9 +65,9 @@
                                                         </connections>
                                                     </textField>
                                                     <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1Sq-2N-kTU">
-                                                        <rect key="frame" x="395" y="20" width="60" height="11"/>
-                                                        <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="2000-00-00" id="qnJ-hh-Ajn">
-                                                            <font key="font" metaFont="label" size="9"/>
+                                                        <rect key="frame" x="400" y="28" width="71" height="14"/>
+                                                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="2000-00-00" id="qnJ-hh-Ajn">
+                                                            <font key="font" metaFont="smallSystem"/>
                                                             <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
@@ -88,17 +75,28 @@
                                                             <binding destination="P97-ul-Qub" name="value" keyPath="objectValue.right" id="dWx-sp-gfu"/>
                                                         </connections>
                                                     </textField>
+                                                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsExpansionToolTips="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ASf-cI-KhW" userLabel="MediaName Text Field">
+                                                        <rect key="frame" x="6" y="8" width="465" height="16"/>
+                                                        <textFieldCell key="cell" controlSize="small" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Media Name" id="Bnm-Vf-zg5" userLabel="MediaName Table View Cell">
+                                                            <font key="font" metaFont="system"/>
+                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                        </textFieldCell>
+                                                        <connections>
+                                                            <binding destination="P97-ul-Qub" name="value" keyPath="objectValue.name" id="03c-5e-AAK"/>
+                                                        </connections>
+                                                    </textField>
                                                 </subviews>
                                                 <constraints>
-                                                    <constraint firstItem="UH9-D2-Ky7" firstAttribute="top" secondItem="P97-ul-Qub" secondAttribute="top" constant="4" id="1t3-Df-wwC"/>
+                                                    <constraint firstItem="UH9-D2-Ky7" firstAttribute="top" secondItem="P97-ul-Qub" secondAttribute="top" constant="8" id="1t3-Df-wwC"/>
                                                     <constraint firstItem="1Sq-2N-kTU" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="UH9-D2-Ky7" secondAttribute="trailing" constant="8" id="FFv-ub-pFq"/>
-                                                    <constraint firstItem="ASf-cI-KhW" firstAttribute="top" secondItem="UH9-D2-Ky7" secondAttribute="bottom" constant="2" id="GhN-3s-u3F"/>
+                                                    <constraint firstItem="ASf-cI-KhW" firstAttribute="top" secondItem="UH9-D2-Ky7" secondAttribute="bottom" constant="4" id="GhN-3s-u3F"/>
                                                     <constraint firstItem="1Sq-2N-kTU" firstAttribute="firstBaseline" secondItem="UH9-D2-Ky7" secondAttribute="firstBaseline" id="NhH-DH-vfA"/>
-                                                    <constraint firstAttribute="trailing" secondItem="1Sq-2N-kTU" secondAttribute="trailing" constant="4" id="Prx-45-HCt"/>
-                                                    <constraint firstItem="UH9-D2-Ky7" firstAttribute="leading" secondItem="P97-ul-Qub" secondAttribute="leading" constant="4" id="fCW-Ci-SGz"/>
-                                                    <constraint firstAttribute="bottom" secondItem="ASf-cI-KhW" secondAttribute="bottom" constant="4" id="kCX-xn-Acw"/>
-                                                    <constraint firstAttribute="trailing" secondItem="ASf-cI-KhW" secondAttribute="trailing" constant="4" id="uMs-2X-huR"/>
-                                                    <constraint firstItem="ASf-cI-KhW" firstAttribute="leading" secondItem="P97-ul-Qub" secondAttribute="leading" constant="4" id="vlM-IS-LSD"/>
+                                                    <constraint firstAttribute="trailing" secondItem="1Sq-2N-kTU" secondAttribute="trailing" constant="8" id="Prx-45-HCt"/>
+                                                    <constraint firstItem="UH9-D2-Ky7" firstAttribute="leading" secondItem="P97-ul-Qub" secondAttribute="leading" constant="8" id="fCW-Ci-SGz"/>
+                                                    <constraint firstAttribute="bottom" secondItem="ASf-cI-KhW" secondAttribute="bottom" constant="8" id="kCX-xn-Acw"/>
+                                                    <constraint firstAttribute="trailing" secondItem="ASf-cI-KhW" secondAttribute="trailing" constant="8" id="uMs-2X-huR"/>
+                                                    <constraint firstItem="ASf-cI-KhW" firstAttribute="leading" secondItem="P97-ul-Qub" secondAttribute="leading" constant="8" id="vlM-IS-LSD"/>
                                                 </constraints>
                                                 <connections>
                                                     <outlet property="textField" destination="ASf-cI-KhW" id="tSt-fx-fBC"/>
@@ -109,9 +107,20 @@
                                 </tableColumns>
                             </tableView>
                         </subviews>
+                        <constraints>
+                            <constraint firstItem="Hut-pu-9Tv" firstAttribute="leading" secondItem="Jso-OO-xRN" secondAttribute="leading" id="IfL-tf-ekw"/>
+                            <constraint firstAttribute="bottom" secondItem="Hut-pu-9Tv" secondAttribute="bottom" id="L6D-rE-reS"/>
+                            <constraint firstItem="Hut-pu-9Tv" firstAttribute="top" secondItem="Jso-OO-xRN" secondAttribute="top" id="Lfl-0P-zlK"/>
+                            <constraint firstAttribute="trailing" secondItem="Hut-pu-9Tv" secondAttribute="trailing" id="UXp-q1-ujw"/>
+                        </constraints>
                     </clipView>
+                    <constraints>
+                        <constraint firstAttribute="bottom" secondItem="Hut-pu-9Tv" secondAttribute="bottom" priority="499" id="P1z-Ia-Pt2"/>
+                        <constraint firstItem="Hut-pu-9Tv" firstAttribute="top" secondItem="T82-Op-UIR" secondAttribute="top" id="PpT-X6-z0Y"/>
+                    </constraints>
+                    <edgeInsets key="contentInsets" left="0.0" right="0.0" top="0.0" bottom="0.0"/>
                     <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="slq-4S-gy9">
-                        <rect key="frame" x="0.0" y="190" width="480" height="16"/>
+                        <rect key="frame" x="1" y="127" width="478" height="16"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                     <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="OPY-9A-J9w">
@@ -120,7 +129,7 @@
                     </scroller>
                 </scrollView>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="i9Z-jA-8gU">
-                    <rect key="frame" x="389" y="8" width="83" height="16"/>
+                    <rect key="frame" x="397" y="0.0" width="83" height="16"/>
                     <buttonCell key="cell" type="square" title="DOWNLOAD" bezelStyle="shadowlessSquare" alignment="center" enabled="NO" inset="2" id="y68-ot-NOl">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="systemBold"/>
@@ -130,7 +139,7 @@
                     </connections>
                 </button>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tFf-9S-9GB">
-                    <rect key="frame" x="323" y="8" width="58" height="16"/>
+                    <rect key="frame" x="331" y="0.0" width="58" height="16"/>
                     <buttonCell key="cell" type="square" title="CANCEL" bezelStyle="shadowlessSquare" alignment="center" inset="2" id="pPz-om-Xit">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="systemBold"/>
@@ -144,19 +153,20 @@ Gw
                 </button>
             </subviews>
             <constraints>
-                <constraint firstAttribute="bottom" secondItem="T82-Op-UIR" secondAttribute="bottom" constant="36" id="1Js-wA-kRN"/>
+                <constraint firstItem="i9Z-jA-8gU" firstAttribute="top" secondItem="T82-Op-UIR" secondAttribute="bottom" constant="8" id="1Js-wA-kRN"/>
                 <constraint firstAttribute="trailing" secondItem="T82-Op-UIR" secondAttribute="trailing" id="3rq-7N-FxN"/>
                 <constraint firstItem="i9Z-jA-8gU" firstAttribute="leading" secondItem="tFf-9S-9GB" secondAttribute="trailing" constant="8" id="5Ic-qQ-aEq"/>
                 <constraint firstItem="T82-Op-UIR" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="6Xh-Bu-7TR"/>
                 <constraint firstItem="T82-Op-UIR" firstAttribute="top" secondItem="CFP-kG-Ixy" secondAttribute="bottom" constant="8" id="FZN-8k-JXM"/>
-                <constraint firstAttribute="width" priority="499" constant="480" id="Fm1-BD-B4h"/>
+                <constraint firstAttribute="width" priority="499" constant="600" id="Fm1-BD-B4h"/>
                 <constraint firstAttribute="trailing" secondItem="CFP-kG-Ixy" secondAttribute="trailing" id="Qnk-7D-vre"/>
                 <constraint firstItem="CFP-kG-Ixy" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="Qzc-2o-vZl"/>
-                <constraint firstAttribute="bottom" secondItem="i9Z-jA-8gU" secondAttribute="bottom" constant="8" id="RbC-52-0AG"/>
+                <constraint firstAttribute="bottom" secondItem="i9Z-jA-8gU" secondAttribute="bottom" id="RbC-52-0AG"/>
                 <constraint firstItem="tFf-9S-9GB" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Hz6-mo-xeY" secondAttribute="leading" constant="8" id="RyC-7M-R4h"/>
-                <constraint firstItem="CFP-kG-Ixy" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" constant="8" id="YJn-Hp-Fnv"/>
-                <constraint firstAttribute="trailing" secondItem="i9Z-jA-8gU" secondAttribute="trailing" constant="8" id="f09-vG-mFE"/>
+                <constraint firstItem="CFP-kG-Ixy" firstAttribute="top" secondItem="Hz6-mo-xeY" secondAttribute="top" id="YJn-Hp-Fnv"/>
+                <constraint firstAttribute="trailing" secondItem="i9Z-jA-8gU" secondAttribute="trailing" id="f09-vG-mFE"/>
                 <constraint firstItem="tFf-9S-9GB" firstAttribute="centerY" secondItem="i9Z-jA-8gU" secondAttribute="centerY" id="jDg-e5-ZRg"/>
+                <constraint firstAttribute="height" relation="greaterThanOrEqual" priority="1" constant="200" id="owS-WM-7c7"/>
             </constraints>
             <point key="canvasLocation" x="140" y="154"/>
         </customView>

--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -281,6 +281,15 @@ extension BinaryInteger {
   }
 }
 
+// Formats a number to max 2 digits after the decimal, rounded, but will omit trailing zeroes, and no commas or other formatting for large numbers
+fileprivate let fmtDecimalMaxFractionDigits2: NumberFormatter = {
+  let fmt = NumberFormatter()
+  fmt.numberStyle = .decimal
+  fmt.usesGroupingSeparator = false
+  fmt.maximumFractionDigits = 2
+  return fmt
+}()
+
 extension FloatingPoint {
   func clamped(to range: Range<Self>) -> Self {
     if self < range.lowerBound {
@@ -291,6 +300,12 @@ extension FloatingPoint {
       return self
     }
   }
+
+  /// Formats as String, rounding the number to 2 digits after the decimal
+  var stringWithMaxFractionDigits2: String {
+    return fmtDecimalMaxFractionDigits2.string(for: self)!
+  }
+
 }
 
 extension NSColor {

--- a/iina/OSDMessage.swift
+++ b/iina/OSDMessage.swift
@@ -73,6 +73,7 @@ enum OSDMessage {
 
   case startFindingSub(String)  // sub source
   case foundSub(Int)
+  case downloadingSub(Int, String)  // download count, sub source
   case downloadedSub(String)  // filename
   case savedSub
   case cannotLogin
@@ -336,8 +337,12 @@ enum OSDMessage {
     case .foundSub(let count):
       let str = count == 0 ?
         NSLocalizedString("osd.sub_not_found", comment: "No subtitles found.") :
-        String(format: NSLocalizedString("osd.sub_found", comment: "%d subtitle(s) found. Downloading..."), count)
+        String(format: NSLocalizedString("osd.sub_found", comment: "%d subtitle(s) found."), count)
       return (str, .normal)
+
+    case .downloadingSub(let count, let source):
+      let str = String(format: NSLocalizedString("osd.sub_downloading", comment: "Downloading %d subtitles"), count)
+      return (str, .withText(NSLocalizedString("osd.find_online_sub.source", comment: "from") + " " + source))
 
     case .downloadedSub(let filename):
       return (

--- a/iina/OnlineSubtitle.swift
+++ b/iina/OnlineSubtitle.swift
@@ -145,11 +145,11 @@ class OnlineSubtitle: NSObject {
 
     func fetchSubtitles(url: URL, player: PlayerCore) -> Promise<[URL]> {
       return getFetcher().fetch(from: url, withProviderID: providerID, playerCore: player)
-      .get { subtitles in
+      .get { [self] subtitles in
         if subtitles.isEmpty {
           throw OnlineSubtitle.CommonError.noResult
         } else {
-          player.sendOSD(.foundSub(subtitles.count))
+          player.sendOSD(.downloadingSub(subtitles.count, name))
         }
       }.thenFlatMap { subtitle in
         subtitle.download()

--- a/iina/OpenSubClient.swift
+++ b/iina/OpenSubClient.swift
@@ -805,9 +805,7 @@ class OpenSubClient {
       var comments: String?
 #endif
       var downloadCount: Int
-#if DEBUG
       var featureDetails: SubtitleFeatureDetails
-#endif
       var files: [SubtitleFile]
 #if DEBUG
       var foreignPartsOnly: Bool?

--- a/iina/OpenSubSubtitle.swift
+++ b/iina/OpenSubSubtitle.swift
@@ -19,7 +19,7 @@ class OpenSub {
     private static let dateFormatter: DateFormatter = {
       let dateFormatter = DateFormatter()
       dateFormatter.dateStyle = .medium
-      dateFormatter.timeStyle = .medium
+      dateFormatter.timeStyle = .none
       return dateFormatter
     }()
 
@@ -72,22 +72,25 @@ class OpenSub {
     ///            view displayed to the user for choosing the subtitle files to download.
     override func getDescription() -> (name: String, left: String, right: String) {
       let attributes = subtitle.attributes
-      let downloadCount = String(attributes.downloadCount)
-      let filename = attributes.files[0].fileName
-      let framesPerSecond: String
-      if let fps = attributes.fps, fps != 0 {
-        framesPerSecond = " \(String(Int(fps.rounded(.up)))) fps"
-      } else {
-        framesPerSecond = ""
+      var tokens: [String] = []
+
+      tokens.append(attributes.language)
+
+      if let releaseYear = attributes.featureDetails.year, releaseYear > 0 {
+        tokens.append("(\(releaseYear))")
       }
-      let language = attributes.language
-      let rating = String(attributes.ratings)
+
+      if let fps = attributes.fps, fps != 0 {
+        tokens.append("\(fps.stringWithMaxFractionDigits2) fps")
+      }
+
+      let downloadCount = "\u{2b07}\(attributes.downloadCount)"
+      tokens.append(downloadCount)
+
+      let fileName = attributes.files[0].fileName
+      let description = tokens.joined(separator: "  ")
       let uploadDate = OpenSub.Subtitle.dateFormatter.string(from: attributes.uploadDate)
-      return (
-        filename,
-        "\(language)\(framesPerSecond) \u{2b07}\(downloadCount) \u{2605}\(rating)",
-        uploadDate
-      )
+      return (fileName, description, uploadDate)
     }
   }
 

--- a/iina/SubChooseViewController.swift
+++ b/iina/SubChooseViewController.swift
@@ -26,6 +26,11 @@ class SubChooseViewController: NSViewController {
   override func viewDidLoad() {
     super.viewDidLoad()
 
+    if let scrollView = tableView.enclosingScrollView {
+      scrollView.wantsLayer = true
+      scrollView.layer?.cornerRadius = 6
+    }
+
     tableView.delegate = self
     tableView.dataSource = self
 

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -88,7 +88,8 @@
 "osd.find_online_sub" = "Finding online subtitles…";
 "osd.find_online_sub.source" = "from";
 "osd.sub_not_found" = "No subtitles found";
-"osd.sub_found" = "%d subtitles found. Downloading…";
+"osd.sub_found" = "%d subtitles found.";
+"osd.sub_downloading" = "Downloading %d subtitles";
 "osd.sub_downloaded" = "Subtitle downloaded";
 "osd.sub_saved" = "Subtitle saved";
 "osd.network_error" = "Network error";


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4057.

---

**Description:**
Like #4825 but makes additional changes:
- The message `osd.sub_found`, previously set to `%d subtitles found. Downloading…`, was not exactly appropriate as the heading for the list of subtitles to download. It looks like this was done because it was used both for the subtitle list & for the actual "downloading" message. So I changed the existing `osd.sub_found` message to remove the ` Downloading…` part, added a new `osd.sub_downloading` message whose English version is `Downloading %d subtitles`, and changed the "downloading" message to use this key instead.
- Improve text size of sub-heading and table items slightly.
- Change table style & border so it looks like [this mock-up](https://github.com/iina/iina/issues/4057#issuecomment-1949629135) from @Iiii-I-I-I. Also implemented some other changes to displayed attributes based on said mock-up:
- Remove time from upload date (seems rare that subtitles are uploaded more than once a day).
- Remove rating (seems to be 0.0 most of the time?) - am open to bringing this back.
- Add release year in parentheses.
- Add up to 2 fraction digits to `fps` attribute's displayed value.