### PR TITLE
Make audio track picker accept video files

### DIFF
--- a/iina/QuickSettingViewController.swift
+++ b/iina/QuickSettingViewController.swift
@@ -662,8 +662,13 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
 
   @IBAction func loadExternalAudioAction(_ sender: NSButton) {
     let currentDir = player.info.currentURL?.deletingLastPathComponent()
-    Utility.quickOpenPanel(title: "Load external audio file", chooseDir: false, dir: currentDir,
-                           sheetWindow: player.currentWindow, allowedFileTypes: Utility.supportedFileExt[.audio]) { url in
+    Utility.quickOpenPanel(
+      title: "Load external audio file",
+      chooseDir: false,
+      dir: currentDir,
+      sheetWindow: player.currentWindow,
+      allowedFileTypes: Utility.playableFileExt
+    ) { url in
       self.player.loadExternalAudioFile(url)
       self.audioTableView.reloadData()
     }


### PR DESCRIPTION
issue #3259

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #3259.

---

**Description:**
I've added union of video and audio types to allowedFileTypes in "Load external audio file". Selecting video file works out of the box for years in IINA, and was allowed until 1.0.7 (on 1.0.7 it works, but on newer versions doesn't).
It's time to fix it! 💛