### PR TITLE
Add binding for R key to IINA Default config (fixes #4823)

### DIFF
--- a/iina/config/iina-default-input.conf
+++ b/iina/config/iina-default-input.conf
@@ -93,6 +93,7 @@ Shift+PGUP seek 600
 Shift+PGDWN seek -600
 
 r add sub-pos -1
+R add sub-pos +1
 t add sub-pos +1
 
 f cycle fullscreen                     # toggle fullscreen


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4823.

---

**Description:**

Trivial: adds the following line to `IINA Default` config, to stay consistent with `mpv Default`:
```
R add sub-pos +1
```
