### PR TITLE
Add G and F key bindings to IINA Default config (closes #4824)

### DIFF
--- a/iina/config/iina-default-input.conf
+++ b/iina/config/iina-default-input.conf
@@ -92,6 +92,9 @@ m cycle mute
 Shift+PGUP seek 600
 Shift+PGDWN seek -600
 
+G add sub-scale +0.1                   # increase the subtitle font size
+F add sub-scale -0.1                   # decrease the subtitle font size
+
 r add sub-pos -1
 t add sub-pos +1
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4824.

---

**Description:**
Adds Shift+G and Shift+F key bindings to `iina-default-input.conf` to control subtitle scale, consistent with the mpv defaults.

Note that I used `G` and `F` instead of `Shift+g` and `Shift+f`, respectively, so that it was not a straight copy+paste from the `mpv Default` config. I did this so that they are in the "normalized mpv" form we agreed some time back to facilitate comparison between key bindings. The mpv project isn't consistent with which form it uses from line to line in its default config file, which seems suboptimal to me.