### PR TITLE
Expand IINA screenshot functionality to screenshot flags

### DIFF
--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -238,12 +238,18 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
       let returnValue: Int32
       // execute the command
       switch keyBinding.action.first! {
+
       case MPVCommand.abLoop.rawValue:
         abLoop()
         returnValue = 0
+
+      case MPVCommand.screenshot.rawValue:
+        return player.screenshot(fromKeyBinding: keyBinding)
+        
       default:
         returnValue = player.mpv.command(rawString: keyBinding.rawAction)
       }
+
       if returnValue == 0 {
         return true
       } else {


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4582 (or the second part of it as [mentioned here](https://github.com/iina/iina/issues/4582#issuecomment-1926200685)).

---

**Description:**

### Current functionality

IINA's `Playback` > `Take a Screenshot` menu item (I'll call it "IINA's screenshot") utilizes mpv's `screenshot` command (i.e. "mpv's screenshot") as its backbone, but differs in the following ways:
1. Displays a screenshot thumbnail using the OSD (if configured in prefs).
2. Uses the value of `screenshotIncludeSubtitle` pref (bool) to decide between `subtitles` or `video` flags to send to `screenshot`.
3. Can be configured to store to clipboard instead of file, or in addition to file, or...disabled entirely (is this good...?).

If a key binding is mapped to `screenshot` with no flags, then it is matched to the menu item, and so it will call IINA's screenshot. However, if any flags are supplied (e.g., `screenshot subtitles`), it will not match and will end up calling mpv's screenshot.

### PR functional changes

- Expands functionality of `PlayerCore.screenshot()` to take an optional key binding argument, and adds a call to it from `PlayerWindowController.handleKeyBinding` so it can handle `screenshot` actions.
- Adds logic so that if flags are specified by the key binding, they will be used (if possible - see caveat 1 below). If no flags are specified, then the value for pref key `screenshotIncludeSubtitle` will be used to determine the flags.

### Caveats

1. Does not add IINA screenshot support for `each-frame` flag. If this flag is present, mpv's screenshot will be used instead (sorry - maybe some future PR).
2. It *does* add handling for `screenshot window`, although the feature itself will continue to error out until the fix for #4822 is merged.
3. IINA's screenshot deviates slightly from the spec for mpv's screenshot, and by its nature this PR will make this unavoidable for more screenshot cases. As noted in the code comments:
    i. If the stored values for `Preference.Key.screenshotSaveToFile` and `Preference.Key.screenshotCopyToClipboard` are set to false, all screenshot commands will be ignored. It may not be obvious to the end user why their screenshot seems to be getting ignored. Although no one seems to have filed any issues about it.
    ii. When no flags are given with `screenshot`, the mpv spec says that default is `subtitles` flag. But IINA will use either `subtitles` or `video`, depending on the value for `Preference.Key.screenshotIncludeSubtitle`.