### PR TITLE
fix: avoid double percent-encode for url scheme

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -360,8 +360,26 @@ class PlayerCore: NSObject {
     if str.first == "/" {
       openURL(URL(fileURLWithPath: str))
     } else {
-      guard let url = URL(string: str) else {
-        Logger.log("Cannot parse url for \(str)", level: .error, subsystem: subsystem)
+      // For apps built with Xcode 15 or later the behavior of the URL initializer has changed when
+      // running under macOS Sonoma or later. The behavior now matches URLComponents and will
+      // automatically percent encode characters. Must not apply percent encoding to the string
+      // passed to the URL initializer if the new new behavior is active.
+      var performPercentEncoding = true
+#if compiler(>=5.9)
+      if #available(macOS 14, *) {
+        performPercentEncoding = false
+      }
+#endif
+      var pstr = str
+      if performPercentEncoding {
+        guard let encoded = str.addingPercentEncoding(withAllowedCharacters: .urlAllowed) else {
+          print("Cannot add percent encoding for \(str)")
+          return
+        }
+        pstr = encoded
+      }
+      guard let url = URL(string: pstr) else {
+        Logger.log("Cannot parse url for \(pstr)", level: .error, subsystem: subsystem)
         return
       }
       openURL(url)

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -360,8 +360,8 @@ class PlayerCore: NSObject {
     if str.first == "/" {
       openURL(URL(fileURLWithPath: str))
     } else {
-      guard let pstr = str.addingPercentEncoding(withAllowedCharacters: .urlAllowed), let url = URL(string: pstr) else {
-        Logger.log("Cannot add percent encoding for \(str)", level: .error, subsystem: subsystem)
+      guard let url = URL(string: str) else {
+        Logger.log("Cannot parse url for \(str)", level: .error, subsystem: subsystem)
         return
       }
       openURL(url)


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #.

---

**Description:**

Remove manual percent-encoding for URL opened in URL scheme. This will make URLs with special characters no longer be encoded twice and thus openable.

Due to a recent change in Apple `URL.init`, URL will be encoded automatically, see: <https://developer.apple.com/documentation/foundation/url/3126806-init>

Therefore, if the URL is percent-encoded beforehand, it will be encoded a second time if `URL` is constructed.

```
URL Scheme:
iina://weblink?url=https://******/d/Anime/no%20Subarashii%20Sekai%20ni%20Bakuen%20wo!.mkv
Log:
16:01:57.099 [player0][d] Open URL: https://******/d/Anime/Kono%2520Subarashii%2520Sekai%2520ni%2520Bakuen%2520wo!.mkv
URL-decoded:
16:01:57.099 [player0][d] Open URL: https://******/d/Anime/Kono%20Subarashii%20Sekai%20ni%20Bakuen%20wo!.mkv

Intended URL:
16:01:19.708 [player0][d] Open URL: https://******/d/Anime/Kono Subarashii Sekai ni Bakuen wo!.mkv
```

This PR removes the first manual percent-encoding, which makes URL correct.
