### PR TITLE
Add log message containing Xcode version

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -135,10 +135,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
   /// - The git branch
   /// - The git commit
   private func logBuildDetails() {
+    guard let date = InfoDictionary.shared.buildDate,
+          let sdk = InfoDictionary.shared.buildSDK,
+          let xcode = InfoDictionary.shared.buildXcode else { return }
+    Logger.log("Built using Xcode \(xcode) and macOS SDK \(sdk) on \(date)")
     guard let branch = InfoDictionary.shared.buildBranch,
-          let commit = InfoDictionary.shared.buildCommit,
-          let date = InfoDictionary.shared.buildDate else { return }
-    Logger.log("Built \(date) from branch \(branch), commit \(commit)")
+          let commit = InfoDictionary.shared.buildCommit else { return }
+    Logger.log("From branch \(branch), commit \(commit)")
   }
 
   /// Log details about the Mac IINA is running on.

--- a/iina/Info.plist
+++ b/iina/Info.plist
@@ -1362,5 +1362,9 @@
 	<string>$(CONFIGURATION)</string>
 	<key>com.colliderli.iina.build.date</key>
 	<string>IINA_BUILD_DATE</string>
+	<key>com.colliderli.iina.build.sdk</key>
+	<string>$(SDK_VERSION)</string>
+	<key>com.colliderli.iina.build.xcode</key>
+	<string>$(XCODE_VERSION_ACTUAL)</string>
 </dict>
 </plist>

--- a/iina/InfoDictionary.swift
+++ b/iina/InfoDictionary.swift
@@ -50,6 +50,11 @@ struct InfoDictionary {
     bundleIdentifier + ".build"
   }
 
+  /// The version of the macOS SDK the application was built with.
+  ///
+  /// This is the value of the Xcode `SDK_VERSION` build setting.
+  var buildSDK: String? { dictionary["\(buildKeyPrefix).sdk"] as? String }
+
   /// The type of build used to generate this IINA executable.
   ///
   /// This corresponds to the Xcode build configuration.
@@ -63,6 +68,33 @@ struct InfoDictionary {
   /// IINA's convention is that if there is no indication of the type of build then it is a release build. Therefore this property is `nil` if
   /// this executable was built using the release configuration. Otherwise this property contains a string suitable for display to the user.
   var buildTypeIdentifier: String? { buildType == .release ? nil : buildType.description }
+
+  /// The version of Xcode the application was built with.
+  ///
+  /// For the SDK Xcode provides a setting with the version in human readable form. Unfortunately that is not the case for the Xcode
+  /// version, so the `XCODE_VERSION_ACTUAL` build setting is used which provides the version number in a four character format
+  /// that must be parsed and turned into a human readable form.
+  var buildXcode: String? {
+    guard let asFourChars = dictionary["\(buildKeyPrefix).xcode"] as? String else {
+      return nil
+    }
+    guard asFourChars.count == 4 else { return asFourChars }
+    let major: String.SubSequence
+    if asFourChars.first == "0" {
+      let index = asFourChars.index(asFourChars.startIndex, offsetBy: 1)
+      major = asFourChars[index...index]
+    } else {
+      major = asFourChars.prefix(2)
+    }
+    let minor: String.SubSequence
+    if asFourChars.last == "0" {
+      let index = asFourChars.index(asFourChars.endIndex, offsetBy: -2)
+      minor = asFourChars[index...index]
+    } else {
+      minor = asFourChars.suffix(2)
+    }
+    return "\(major).\(minor)"
+  }
 
   var bundleIdentifier: String { dictionary["CFBundleIdentifier"] as! String }
 


### PR DESCRIPTION
This commit will:
- Add a key `com.colliderli.iina.build.sdk` to `Info.plist` with a value giving the macOS SDK version used when generating the executable
- Add a key `com.colliderli.iina.build.xcode` to `Info.plist` with a value giving the Xcode version used when generating the executable
- Add `buildSDK` and `buildXcode` properties to `InfoDictionary` to provide access to this information
- Add logging of the Xcode and macOS SDK versions to `logBuildDetails` in `AppDelegate`

This information is useful as AppKit behavior can change based on the version of the macOS SDK an application was built with.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
