### PR TITLE
Fix playback history window doesn't respect reduce motion, #4870

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		49542982216C34950058F680 /* ToolbarItemIcon.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 49542981216C34950058F680 /* ToolbarItemIcon.pdf */; };
 		49542986216C34950058F680 /* OpenInIINA.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 49542973216C34950058F680 /* OpenInIINA.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		496B19921E2968530035AF10 /* PIP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 496B19911E2968530035AF10 /* PIP.framework */; };
+		512B8FDD2BC2376E00AF41BF /* OutlineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512B8FDC2BC2376E00AF41BF /* OutlineView.swift */; };
 		513A4FFA29B53F8100A8EA7D /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513A4FF929B53F8100A8EA7D /* Atomic.swift */; };
 		515B5E5A2A579903001FCD49 /* iina-plugin in Copy Executables */ = {isa = PBXBuildFile; fileRef = E38558872A484A2D0083772D /* iina-plugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		5196819A29EC963F00B05D55 /* CoreDisplay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5196819929EC963F00B05D55 /* CoreDisplay.framework */; };
@@ -880,6 +881,7 @@
 		4964988E2919E47900CD61A5 /* OpenInIINA.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = OpenInIINA.xcconfig; sourceTree = "<group>"; };
 		496B19911E2968530035AF10 /* PIP.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PIP.framework; path = /System/Library/PrivateFrameworks/PIP.framework; sourceTree = "<group>"; };
 		49F7E3BF2920D65C002DA28E /* Availability.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Availability.xcconfig; sourceTree = "<group>"; };
+		512B8FDC2BC2376E00AF41BF /* OutlineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutlineView.swift; sourceTree = "<group>"; };
 		513A4FF929B53F8100A8EA7D /* Atomic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
 		51537C7229FA26DD00F9A472 /* Nightly.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Nightly.xcconfig; sourceTree = "<group>"; };
 		5158FAB429F881B000F626E6 /* mem.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = mem.h; sourceTree = "<group>"; };
@@ -2385,6 +2387,7 @@
 				E32712B424F2B8CA00359DAB /* ScreenshootOSDView.xib */,
 				E3958563253133E80096811F /* SidebarTabView.swift */,
 				E3958564253133E80096811F /* SidebarTabView.xib */,
+				512B8FDC2BC2376E00AF41BF /* OutlineView.swift */,
 			);
 			name = Accessories;
 			sourceTree = "<group>";
@@ -2993,6 +2996,7 @@
 				841B14281E941DFF00744AB8 /* TimeLabelOverflowedStackView.swift in Sources */,
 				E33BA5C7204BD9FE0069A0F6 /* SubChooseViewController.swift in Sources */,
 				51CACB9529D500290034CEE5 /* VideoPIPViewController.swift in Sources */,
+				512B8FDD2BC2376E00AF41BF /* OutlineView.swift in Sources */,
 				8460FBA91D6497490081841B /* PlaylistViewController.swift in Sources */,
 				8450404A1E0B13230079C194 /* CropBoxView.swift in Sources */,
 				84F7258F1D486185000DEF1B /* MPVProperty.swift in Sources */,

--- a/iina/AccessibilityPreferences.swift
+++ b/iina/AccessibilityPreferences.swift
@@ -10,24 +10,30 @@ import Foundation
 
 struct AccessibilityPreferences {
 
-  /// Adjusts an animation to be instantaneous if the macOS System Preference Reduce motion is enabled.
+  /// Adjusts an animation to be instantaneous if the IINA setting `Enable animations` is disabled.
   /// - Parameter duration: Desired animation duration.
-  /// - Returns: `0` if reduce motion is enabled; otherwise the given duration.
+  /// - Returns: `0` if animations have been disabled; otherwise the given duration.
   static func adjustedDuration(_ duration: TimeInterval) -> TimeInterval {
-    return motionReductionEnabled ? 0 : duration
+    return Preference.bool(for: PK.enableAnimations) ? duration : 0
   }
 
-  /// Reflects whether the macOS System Preference accessibility option to retuce motion is in an enabled state.
+  /// Reflects whether the macOS accessibility setting to reduce motion is in an enabled state.
   ///
-  /// This property provides a wrapper around the `NSWorkspace` property so that code that needs to check this preference setting
-  /// does not need to concern itself with this preference not being available until macOS Sierra.
+  /// This property provides a wrapper around the `NSWorkspace` property so that code that needs to check this setting does not
+  /// need to concern itself with this setting not being available until macOS Sierra.
   ///
-  /// Proper handling of the Reduce motion preference setting is covered in the
-  /// [Apple Human Interface Guidelines under Appearance Effects and Motion](https://developer.apple.com/design/human-interface-guidelines/accessibility/overview/appearance-effects/).
+  /// Proper handling of the Reduce motion setting is covered in the Apple [Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/) under
+  /// [Accessibility - Motion](https://developer.apple.com/design/human-interface-guidelines/accessibility#Motion).
   ///
-  /// To change this preference, choose Apple menu > System Preferences, click Accessibility, click Display, then click Display and
-  /// check or uncheck Reduce motion.
-  ///
+  /// To enable the
+  /// [Reduced motion](https://support.apple.com/guide/mac-help/stop-or-reduce-onscreen-motion-mchlc03f57a1/mac)
+  /// setting:
+  /// - Click on `System Settings…` under the  menu
+  /// - The `System Settings` window appears
+  /// - On the left side of the window click on `Accessibility`
+  /// - On the right side of the window click on `Display`
+  /// - In the `Display` section look for the `Reduced motion` setting
+  /// - Slide the toggle button to be on (blue)
   /// - Returns: `true` if reduce motion is enabled; otherwise `false`.
   static var motionReductionEnabled: Bool {
     if #available(macOS 10.12, *) {

--- a/iina/AccessibilityPreferences.swift
+++ b/iina/AccessibilityPreferences.swift
@@ -10,11 +10,11 @@ import Foundation
 
 struct AccessibilityPreferences {
 
-  /// Adjusts an animation to be instantaneous if the IINA setting `Enable animations` is disabled.
+  /// Adjusts an animation to be instantaneous if the IINA setting `Disable animations` is enabled.
   /// - Parameter duration: Desired animation duration.
   /// - Returns: `0` if animations have been disabled; otherwise the given duration.
   static func adjustedDuration(_ duration: TimeInterval) -> TimeInterval {
-    return Preference.bool(for: PK.enableAnimations) ? duration : 0
+    return Preference.bool(for: PK.disableAnimations) ? 0 : duration
   }
 
   /// Reflects whether the macOS accessibility setting to reduce motion is in an enabled state.

--- a/iina/AppData.swift
+++ b/iina/AppData.swift
@@ -62,6 +62,7 @@ struct AppData {
   static let toneMappingHelpLink = "https://en.wikipedia.org/wiki/Tone_mapping"
   static let targetPeakHelpLink = "https://mpv.io/manual/stable/#options-target-peak"
   static let algorithmHelpLink = "https://mpv.io/manual/stable/#options-tone-mapping"
+  static let disableAnimationsHelpLink = "https://developer.apple.com/design/human-interface-guidelines/accessibility#Motion"
 
   static let widthWhenNoVideo = 640
   static let heightWhenNoVideo = 360

--- a/iina/Base.lproj/HistoryWindowController.xib
+++ b/iina/Base.lproj/HistoryWindowController.xib
@@ -93,7 +93,7 @@
                             <rect key="frame" x="1" y="1" width="598" height="266"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
-                                <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" tableStyle="fullWidth" columnReordering="NO" autosaveName="HistoryWindowTable" rowHeight="22" headerView="MiB-ow-W6T" viewBased="YES" indentationPerLevel="12" indentationMarkerFollowsCell="NO" outlineTableColumn="DIC-tR-R2F" id="6jR-CS-fgx" userLabel="PlaybackHistoryTable Outline View">
+                                <outlineView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="firstColumnOnly" tableStyle="fullWidth" columnReordering="NO" autosaveName="HistoryWindowTable" rowHeight="22" headerView="MiB-ow-W6T" viewBased="YES" indentationPerLevel="12" indentationMarkerFollowsCell="NO" outlineTableColumn="DIC-tR-R2F" id="6jR-CS-fgx" userLabel="PlaybackHistoryTable Outline View" customClass="OutlineView" customModule="IINA" customModuleProvider="target">
                                     <rect key="frame" x="0.0" y="0.0" width="606" height="243"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <size key="intercellSpacing" width="8" height="2"/>

--- a/iina/Base.lproj/PrefUIViewController.xib
+++ b/iina/Base.lproj/PrefUIViewController.xib
@@ -14,6 +14,7 @@
                 <outlet property="pipDoNothing" destination="o7N-Tm-Aly" id="xg5-HZ-Usj"/>
                 <outlet property="pipHideWindow" destination="BMA-ed-2gf" id="UJv-H3-HDi"/>
                 <outlet property="pipMinimizeWindow" destination="YWw-1J-3Gr" id="5eN-rl-utd"/>
+                <outlet property="sectionAnimationsView" destination="k9o-rY-z6u" id="p0I-TR-Sv6"/>
                 <outlet property="sectionAppearanceView" destination="M9c-Ak-HmK" id="96r-w6-H5K"/>
                 <outlet property="sectionOSCView" destination="gjB-It-iFS" id="cbg-O0-qMd"/>
                 <outlet property="sectionOSDView" destination="c8m-G4-or8" id="e6Y-FN-x1t"/>
@@ -703,6 +704,7 @@
                     <constraints>
                         <constraint firstAttribute="width" constant="18" id="DIC-cT-8P0"/>
                         <constraint firstAttribute="width" secondItem="2Fc-2d-hIJ" secondAttribute="height" multiplier="1:1" id="IBQ-ee-CQV"/>
+                        <constraint firstAttribute="width" secondItem="2Fc-2d-hIJ" secondAttribute="height" multiplier="1:1" id="JSO-Tj-v8X"/>
                     </constraints>
                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="speed" id="PCr-gs-9Yc"/>
                 </imageView>
@@ -774,7 +776,6 @@
                 <constraint firstItem="HgG-px-UUt" firstAttribute="leading" secondItem="jbc-22-59W" secondAttribute="leading" id="GnR-7V-SWW"/>
                 <constraint firstItem="jbc-22-59W" firstAttribute="top" secondItem="4XH-GU-VhV" secondAttribute="top" id="H5x-dR-Abd"/>
                 <constraint firstAttribute="bottom" secondItem="rft-T0-lds" secondAttribute="bottom" constant="8" id="HLQ-xF-5Qa"/>
-                <constraint firstItem="2Fc-2d-hIJ" firstAttribute="width" secondItem="2Fc-2d-hIJ" secondAttribute="height" multiplier="1:1" id="JSO-Tj-v8X"/>
                 <constraint firstItem="omS-tS-OVJ" firstAttribute="leading" secondItem="q8D-b2-H0y" secondAttribute="trailing" constant="8" id="Kvt-R8-Efd"/>
                 <constraint firstItem="omS-tS-OVJ" firstAttribute="leading" secondItem="bYj-5g-zYO" secondAttribute="leading" id="LgY-kh-ww0"/>
                 <constraint firstItem="gVR-so-xgt" firstAttribute="baseline" secondItem="q8D-b2-H0y" secondAttribute="baseline" id="OEQ-c0-3H3"/>
@@ -1243,6 +1244,40 @@ Picture:</string>
                 <constraint firstItem="eTQ-fy-fNJ" firstAttribute="leading" secondItem="l21-mq-zWd" secondAttribute="leading" id="xog-r6-yIL"/>
             </constraints>
             <point key="canvasLocation" x="14" y="907"/>
+        </customView>
+        <customView id="k9o-rY-z6u" userLabel="Prefs &gt; UI &gt; Animations">
+            <rect key="frame" x="0.0" y="0.0" width="493" height="32"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+            <subviews>
+                <textField identifier="SectionTitleThumb" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="M1d-6z-urt">
+                    <rect key="frame" x="-2" y="8" width="82" height="16"/>
+                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Animations:" id="AYW-Xu-ySw">
+                        <font key="font" metaFont="systemBold"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <button translatesAutoresizingMaskIntoConstraints="NO" id="6DX-Ep-AbS">
+                    <rect key="frame" x="118" y="7" width="137" height="18"/>
+                    <buttonCell key="cell" type="check" title="Enable animations" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="mjs-jg-wm1">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="lH7-Vv-0M1" name="value" keyPath="values.enableAnimations" id="MBb-V5-ZRW"/>
+                    </connections>
+                </button>
+            </subviews>
+            <constraints>
+                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="M1d-6z-urt" secondAttribute="bottom" constant="8" id="0Zd-Hq-Kal"/>
+                <constraint firstItem="M1d-6z-urt" firstAttribute="leading" secondItem="k9o-rY-z6u" secondAttribute="leading" id="5UK-qs-t0Z"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="6DX-Ep-AbS" secondAttribute="trailing" id="cOu-Iy-NWl"/>
+                <constraint firstItem="M1d-6z-urt" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="k9o-rY-z6u" secondAttribute="leading" constant="120" id="j0m-fh-NoW"/>
+                <constraint firstItem="6DX-Ep-AbS" firstAttribute="top" secondItem="M1d-6z-urt" secondAttribute="top" id="j8G-1a-rlS"/>
+                <constraint firstItem="M1d-6z-urt" firstAttribute="top" secondItem="k9o-rY-z6u" secondAttribute="top" constant="8" id="nbs-Tz-GDd"/>
+                <constraint firstItem="6DX-Ep-AbS" firstAttribute="leading" secondItem="k9o-rY-z6u" secondAttribute="leading" constant="120" id="ray-E7-Kek"/>
+            </constraints>
+            <point key="canvasLocation" x="21" y="1020"/>
         </customView>
     </objects>
     <resources>

--- a/iina/Base.lproj/PrefUIViewController.xib
+++ b/iina/Base.lproj/PrefUIViewController.xib
@@ -1245,39 +1245,63 @@ Picture:</string>
             </constraints>
             <point key="canvasLocation" x="14" y="907"/>
         </customView>
-        <customView id="k9o-rY-z6u" userLabel="Prefs &gt; UI &gt; Animations">
-            <rect key="frame" x="0.0" y="0.0" width="493" height="32"/>
+        <customView misplaced="YES" id="k9o-rY-z6u" userLabel="Prefs &gt; UI &gt; Accessibility">
+            <rect key="frame" x="0.0" y="0.0" width="550" height="90"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField identifier="SectionTitleThumb" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="M1d-6z-urt">
-                    <rect key="frame" x="-2" y="8" width="82" height="16"/>
-                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Animations:" id="AYW-Xu-ySw">
+                <textField identifier="SectionTitleThumb" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="M1d-6z-urt" userLabel="Accessibility">
+                    <rect key="frame" x="-2" y="70" width="91" height="16"/>
+                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Accessibility:" id="AYW-Xu-ySw">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <button translatesAutoresizingMaskIntoConstraints="NO" id="6DX-Ep-AbS">
-                    <rect key="frame" x="118" y="7" width="137" height="18"/>
-                    <buttonCell key="cell" type="check" title="Enable animations" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="mjs-jg-wm1">
+                <button translatesAutoresizingMaskIntoConstraints="NO" id="6DX-Ep-AbS" userLabel="Disable animations">
+                    <rect key="frame" x="118" y="69" width="141" height="18"/>
+                    <buttonCell key="cell" type="check" title="Disable animations" bezelStyle="regularSquare" imagePosition="left" inset="2" id="mjs-jg-wm1">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                     <connections>
-                        <binding destination="lH7-Vv-0M1" name="value" keyPath="values.enableAnimations" id="MBb-V5-ZRW"/>
+                        <binding destination="lH7-Vv-0M1" name="value" keyPath="values.disableAnimations" id="C94-f2-ocl"/>
                     </connections>
                 </button>
+                <button horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4QU-uL-rQD" userLabel="Disable animations Help Button">
+                    <rect key="frame" x="264" y="64" width="25" height="25"/>
+                    <buttonCell key="cell" type="help" bezelStyle="helpButton" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="tqd-k0-pR0">
+                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="disableAnimationsHelpAction:" target="-2" id="3Su-2O-LKG"/>
+                    </connections>
+                </button>
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="TmI-kk-Nbj">
+                    <rect key="frame" x="118" y="8" width="434" height="56"/>
+                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" id="9IR-Sf-wMq">
+                        <font key="font" metaFont="label" size="11"/>
+                        <string key="title">When the macOS Reduce Motion accessibility setting is enabled IINA will reduce user interface animations that are known to cause problems for those with vestibular disorders. Should that be insufficient, this setting can be used to reduce motion further by eliminating user interface animations.</string>
+                        <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
             </subviews>
             <constraints>
-                <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="M1d-6z-urt" secondAttribute="bottom" constant="8" id="0Zd-Hq-Kal"/>
+                <constraint firstItem="TmI-kk-Nbj" firstAttribute="leading" secondItem="6DX-Ep-AbS" secondAttribute="leading" id="0an-by-LUR"/>
                 <constraint firstItem="M1d-6z-urt" firstAttribute="leading" secondItem="k9o-rY-z6u" secondAttribute="leading" id="5UK-qs-t0Z"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="6DX-Ep-AbS" secondAttribute="trailing" id="cOu-Iy-NWl"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="4QU-uL-rQD" secondAttribute="trailing" id="ECi-04-TXI"/>
+                <constraint firstAttribute="bottom" secondItem="TmI-kk-Nbj" secondAttribute="bottom" constant="8" id="FdL-T8-5LI"/>
+                <constraint firstItem="4QU-uL-rQD" firstAttribute="leading" secondItem="6DX-Ep-AbS" secondAttribute="trailing" constant="8" id="MER-sj-cma"/>
+                <constraint firstItem="4QU-uL-rQD" firstAttribute="centerY" secondItem="6DX-Ep-AbS" secondAttribute="centerY" id="Nng-vM-pUe"/>
+                <constraint firstItem="TmI-kk-Nbj" firstAttribute="top" secondItem="4QU-uL-rQD" secondAttribute="bottom" constant="4" id="T9B-vQ-mWt"/>
                 <constraint firstItem="M1d-6z-urt" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="k9o-rY-z6u" secondAttribute="leading" constant="120" id="j0m-fh-NoW"/>
                 <constraint firstItem="6DX-Ep-AbS" firstAttribute="top" secondItem="M1d-6z-urt" secondAttribute="top" id="j8G-1a-rlS"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="TmI-kk-Nbj" secondAttribute="trailing" id="mgO-TO-KgH"/>
                 <constraint firstItem="M1d-6z-urt" firstAttribute="top" secondItem="k9o-rY-z6u" secondAttribute="top" constant="8" id="nbs-Tz-GDd"/>
                 <constraint firstItem="6DX-Ep-AbS" firstAttribute="leading" secondItem="k9o-rY-z6u" secondAttribute="leading" constant="120" id="ray-E7-Kek"/>
             </constraints>
-            <point key="canvasLocation" x="21" y="1020"/>
+            <point key="canvasLocation" x="49" y="1061.5"/>
         </customView>
     </objects>
     <resources>

--- a/iina/Base.lproj/PrefUIViewController.xib
+++ b/iina/Base.lproj/PrefUIViewController.xib
@@ -14,7 +14,7 @@
                 <outlet property="pipDoNothing" destination="o7N-Tm-Aly" id="xg5-HZ-Usj"/>
                 <outlet property="pipHideWindow" destination="BMA-ed-2gf" id="UJv-H3-HDi"/>
                 <outlet property="pipMinimizeWindow" destination="YWw-1J-3Gr" id="5eN-rl-utd"/>
-                <outlet property="sectionAnimationsView" destination="k9o-rY-z6u" id="p0I-TR-Sv6"/>
+                <outlet property="sectionAccessibilityView" destination="k9o-rY-z6u" id="p0I-TR-Sv6"/>
                 <outlet property="sectionAppearanceView" destination="M9c-Ak-HmK" id="96r-w6-H5K"/>
                 <outlet property="sectionOSCView" destination="gjB-It-iFS" id="cbg-O0-qMd"/>
                 <outlet property="sectionOSDView" destination="c8m-G4-or8" id="e6Y-FN-x1t"/>

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2054,7 +2054,10 @@ class MainWindowController: PlayerWindowController {
     sidebarAnimationState = .willShow
     let width = type.width()
     sideBarWidthConstraint.constant = width
-    if AccessibilityPreferences.motionReductionEnabled {
+    // The macOS setting could change at any point in time. Remember which type of animation is
+    // being used.
+    let useFade = AccessibilityPreferences.motionReductionEnabled
+    if useFade {
       sideBarRightConstraint.constant = 0
     } else {
       sideBarRightConstraint.constant = -width
@@ -2072,7 +2075,7 @@ class MainWindowController: PlayerWindowController {
     NSAnimationContext.runAnimationGroup({ (context) in
       context.duration = AccessibilityPreferences.adjustedDuration(SideBarAnimationDuration)
       context.timingFunction = CAMediaTimingFunction(name: .easeIn)
-      if AccessibilityPreferences.motionReductionEnabled {
+      if useFade {
         sideBarView.animator().isHidden = false
       } else {
         sideBarRightConstraint.animator().constant = 0
@@ -2086,10 +2089,13 @@ class MainWindowController: PlayerWindowController {
   func hideSideBar(animate: Bool = true, after: @escaping () -> Void = { }) {
     sidebarAnimationState = .willHide
     let currWidth = sideBarWidthConstraint.constant
+    // The macOS setting could change at any point in time. Remember which type of animation is
+    // being used.
+    let useFade = AccessibilityPreferences.motionReductionEnabled
     NSAnimationContext.runAnimationGroup({ (context) in
       context.duration = animate ? AccessibilityPreferences.adjustedDuration(SideBarAnimationDuration) : 0
       context.timingFunction = CAMediaTimingFunction(name: .easeIn)
-      if AccessibilityPreferences.motionReductionEnabled {
+      if useFade {
         sideBarView.animator().alphaValue = 0
       } else {
         sideBarRightConstraint.animator().constant = -currWidth
@@ -2105,7 +2111,7 @@ class MainWindowController: PlayerWindowController {
         // with the edge of the window. When reduce motion is not enabled the sidebar slides out of
         // the window. But when the sidebar fades out of view, the constraint must be adjusted to
         // put the sidebar outside of the window once it is hidden.
-        if AccessibilityPreferences.motionReductionEnabled {
+        if useFade {
           self.sideBarRightConstraint.constant = -currWidth
           self.sideBarView.alphaValue = 1
         }

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1176,9 +1176,10 @@ class MainWindowController: PlayerWindowController {
     }
 
     if shouldApplyInitialWindowSize, let wfg = windowFrameFromGeometry(newSize: AppData.sizeWhenNoVideo, screen: screen) {
-      window!.setFrame(wfg, display: true, animate: Preference.bool(for: PK.enableAnimations))
+      window!.setFrame(wfg, display: true, animate: !Preference.bool(for: PK.disableAnimations))
     } else {
-      window!.setFrame(AppData.sizeWhenNoVideo.centeredRect(in: screen.visibleFrame), display: true, animate: Preference.bool(for: PK.enableAnimations))
+      window!.setFrame(AppData.sizeWhenNoVideo.centeredRect(in: screen.visibleFrame), display: true,
+                       animate: !Preference.bool(for: PK.disableAnimations))
     }
 
     videoView.videoLayer.draw(forced: true)
@@ -1260,7 +1261,7 @@ class MainWindowController: PlayerWindowController {
   func window(_ window: NSWindow, startCustomAnimationToEnterFullScreenOn screen: NSScreen, withDuration duration: TimeInterval) {
     NSAnimationContext.runAnimationGroup({ context in
       context.duration = duration
-      window.animator().setFrame(screen.frame, display: true, animate: Preference.bool(for: PK.enableAnimations))
+      window.animator().setFrame(screen.frame, display: true, animate: !Preference.bool(for: PK.disableAnimations))
     }, completionHandler: nil)
 
   }
@@ -1273,7 +1274,7 @@ class MainWindowController: PlayerWindowController {
 
     NSAnimationContext.runAnimationGroup({ context in
       context.duration = duration
-      window.animator().setFrame(priorWindowedFrame, display: true, animate: Preference.bool(for: PK.enableAnimations))
+      window.animator().setFrame(priorWindowedFrame, display: true, animate: !Preference.bool(for: PK.disableAnimations))
     }, completionHandler: nil)
 
     NSMenu.setMenuBarVisible(true)
@@ -1408,7 +1409,7 @@ class MainWindowController: PlayerWindowController {
   }
 
   func windowDidExitFullScreen(_ notification: Notification) {
-    if !Preference.bool(for: PK.enableAnimations) {
+    if Preference.bool(for: PK.disableAnimations) {
       // When animation is not used exiting full screen does not restore the previous size of the
       // window. Restore it now.
       window!.setFrame(fsState.priorWindowedFrame!, display: true, animate: false)
@@ -1528,7 +1529,7 @@ class MainWindowController: PlayerWindowController {
   private func setWindowFrameForLegacyFullScreen() {
     guard let window = self.window else { return }
     let screen = window.screen ?? NSScreen.main!
-    window.setFrame(screen.frame, display: true, animate: Preference.bool(for: PK.enableAnimations))
+    window.setFrame(screen.frame, display: true, animate: !Preference.bool(for: PK.disableAnimations))
     guard let unusable = screen.cameraHousingHeight else { return }
     // This screen contains an embedded camera. Shorten the height of the window's content view's
     // frame to avoid having part of the window obscured by the camera housing.
@@ -2039,7 +2040,7 @@ class MainWindowController: PlayerWindowController {
   ///
   /// Normally the sidebar is revealed by sliding it into view. However if the macOS [System Settings](https://support.apple.com/guide/mac-help/change-system-settings-mh15217/mac)
   /// [reduce motion](https://support.apple.com/guide/mac-help/stop-or-reduce-onscreen-motion-mchlc03f57a1/mac)
-  /// setting is enabled then instead the sidebar will fade in. If the user disables the IINA `Enable animations` setting then the
+  /// setting is enabled then instead the sidebar will fade in. If the user enables the IINA `Disable animations` setting then the
   /// duration of the animation will be set to zero making the sidebar appear instantly.
   /// - Parameters:
   ///   - viewController: View controller for the sidebar to show.

--- a/iina/OutlineView.swift
+++ b/iina/OutlineView.swift
@@ -1,0 +1,45 @@
+//
+//  OutlineView.swift
+//  iina
+//
+//  Created by low-batt on 4/6/24.
+//  Copyright © 2024 lhc. All rights reserved.
+//
+
+import Cocoa
+
+/// A [NSOutlineView](https://developer.apple.com/documentation/appkit/nsoutlineview) that adjusts animation
+/// behavior based on the macOS [Reduce motion](https://support.apple.com/guide/mac-help/stop-or-reduce-onscreen-motion-mchlc03f57a1/mac)
+/// setting.
+///
+/// If the macOS [System Settings](https://support.apple.com/en-gb/guide/mac-help/mh15217/mac) accessibility
+/// option [Reduce motion](https://support.apple.com/en-gb/guide/mac-help/mchlc03f57a1/mac) is enabled then
+/// when the [Disclosure triangles](https://developer.apple.com/design/human-interface-guidelines/disclosure-controls#Disclosure-triangles) in the outline view are
+/// used to expand or collapse a row the sliding animation will be changed to be instantaneous.
+///
+/// Proper handling of the Reduce motion preference setting is covered in the
+/// [Apple Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/accessibility#Motion).
+class OutlineView: NSOutlineView {
+
+  override func collapseItem(_ item: Any?, collapseChildren: Bool) {
+    guard AccessibilityPreferences.motionReductionEnabled else {
+      super.collapseItem(item, collapseChildren: collapseChildren)
+      return
+    }
+    NSAnimationContext.beginGrouping()
+    defer { NSAnimationContext.endGrouping() }
+    NSAnimationContext.current.duration = 0.0
+    super.collapseItem(item, collapseChildren: collapseChildren)
+  }
+
+  override func expandItem(_ item: Any?, expandChildren: Bool) {
+    guard AccessibilityPreferences.motionReductionEnabled else {
+      super.expandItem(item, expandChildren: expandChildren)
+      return
+    }
+    NSAnimationContext.beginGrouping()
+    defer { NSAnimationContext.endGrouping() }
+    NSAnimationContext.current.duration = 0.0
+    super.expandItem(item, expandChildren: expandChildren)
+  }
+}

--- a/iina/OutlineView.swift
+++ b/iina/OutlineView.swift
@@ -8,21 +8,15 @@
 
 import Cocoa
 
-/// A [NSOutlineView](https://developer.apple.com/documentation/appkit/nsoutlineview) that adjusts animation
-/// behavior based on the macOS [Reduce motion](https://support.apple.com/guide/mac-help/stop-or-reduce-onscreen-motion-mchlc03f57a1/mac)
-/// setting.
+/// A custom [NSOutlineView](https://developer.apple.com/documentation/appkit/nsoutlineview).
 ///
-/// If the macOS [System Settings](https://support.apple.com/en-gb/guide/mac-help/mh15217/mac) accessibility
-/// option [Reduce motion](https://support.apple.com/en-gb/guide/mac-help/mchlc03f57a1/mac) is enabled then
-/// when the [Disclosure triangles](https://developer.apple.com/design/human-interface-guidelines/disclosure-controls#Disclosure-triangles) in the outline view are
-/// used to expand or collapse a row the sliding animation will be changed to be instantaneous.
-///
-/// Proper handling of the Reduce motion preference setting is covered in the
-/// [Apple Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/accessibility#Motion).
+/// If the IINA `Enable animations` setting is disabled then when the
+/// [Disclosure triangles](https://developer.apple.com/design/human-interface-guidelines/disclosure-controls#Disclosure-triangles)
+/// in the outline view are used to expand or collapse a row the sliding animation will be suppressed.
 class OutlineView: NSOutlineView {
 
   override func collapseItem(_ item: Any?, collapseChildren: Bool) {
-    guard AccessibilityPreferences.motionReductionEnabled else {
+    guard !Preference.bool(for: PK.enableAnimations) else {
       super.collapseItem(item, collapseChildren: collapseChildren)
       return
     }
@@ -33,7 +27,7 @@ class OutlineView: NSOutlineView {
   }
 
   override func expandItem(_ item: Any?, expandChildren: Bool) {
-    guard AccessibilityPreferences.motionReductionEnabled else {
+    guard !Preference.bool(for: PK.enableAnimations) else {
       super.expandItem(item, expandChildren: expandChildren)
       return
     }

--- a/iina/OutlineView.swift
+++ b/iina/OutlineView.swift
@@ -10,13 +10,13 @@ import Cocoa
 
 /// A custom [NSOutlineView](https://developer.apple.com/documentation/appkit/nsoutlineview).
 ///
-/// If the IINA `Enable animations` setting is disabled then when the
+/// If the IINA `Disable animations` setting is enabled then when the
 /// [Disclosure triangles](https://developer.apple.com/design/human-interface-guidelines/disclosure-controls#Disclosure-triangles)
 /// in the outline view are used to expand or collapse a row the sliding animation will be suppressed.
 class OutlineView: NSOutlineView {
 
   override func collapseItem(_ item: Any?, collapseChildren: Bool) {
-    guard !Preference.bool(for: PK.enableAnimations) else {
+    guard Preference.bool(for: PK.disableAnimations) else {
       super.collapseItem(item, collapseChildren: collapseChildren)
       return
     }
@@ -27,7 +27,7 @@ class OutlineView: NSOutlineView {
   }
 
   override func expandItem(_ item: Any?, expandChildren: Bool) {
-    guard !Preference.bool(for: PK.enableAnimations) else {
+    guard Preference.bool(for: PK.disableAnimations) else {
       super.expandItem(item, expandChildren: expandChildren)
       return
     }

--- a/iina/PrefUIViewController.swift
+++ b/iina/PrefUIViewController.swift
@@ -39,7 +39,7 @@ class PrefUIViewController: PreferenceViewController, PreferenceWindowEmbeddable
   }
 
   override var sectionViews: [NSView] {
-    return [sectionAppearanceView, sectionWindowView, sectionOSCView, sectionOSDView, sectionThumbnailView, sectionPictureInPictureView]
+    return [sectionAppearanceView, sectionWindowView, sectionOSCView, sectionOSDView, sectionThumbnailView, sectionPictureInPictureView, sectionAnimationsView]
   }
 
   private let toolbarSettingsSheetController = PrefOSCToolbarSettingsSheetController()
@@ -50,7 +50,8 @@ class PrefUIViewController: PreferenceViewController, PreferenceWindowEmbeddable
   @IBOutlet var sectionOSDView: NSView!
   @IBOutlet var sectionThumbnailView: NSView!
   @IBOutlet var sectionPictureInPictureView: NSView!
-    
+  @IBOutlet var sectionAnimationsView: NSView!
+
   @IBOutlet weak var themeMenu: NSMenu!
   @IBOutlet weak var oscPreviewImageView: NSImageView!
   @IBOutlet weak var oscPositionPopupButton: NSPopUpButton!

--- a/iina/PrefUIViewController.swift
+++ b/iina/PrefUIViewController.swift
@@ -235,6 +235,10 @@ class PrefUIViewController: PreferenceViewController, PreferenceWindowEmbeddable
   private func setSubViews(of view: NSBox, enabled: Bool) {
     view.contentView?.subviews.forEach { ($0 as? NSControl)?.isEnabled = enabled }
   }
+
+  @IBAction func disableAnimationsHelpAction(_ sender: Any) {
+    NSWorkspace.shared.open(URL(string: AppData.disableAnimationsHelpLink)!)
+  }
 }
 
 @objc(ResizeTimingTransformer) class ResizeTimingTransformer: ValueTransformer {

--- a/iina/PrefUIViewController.swift
+++ b/iina/PrefUIViewController.swift
@@ -39,7 +39,7 @@ class PrefUIViewController: PreferenceViewController, PreferenceWindowEmbeddable
   }
 
   override var sectionViews: [NSView] {
-    return [sectionAppearanceView, sectionWindowView, sectionOSCView, sectionOSDView, sectionThumbnailView, sectionPictureInPictureView, sectionAnimationsView]
+    return [sectionAppearanceView, sectionWindowView, sectionOSCView, sectionOSDView, sectionThumbnailView, sectionPictureInPictureView, sectionAccessibilityView]
   }
 
   private let toolbarSettingsSheetController = PrefOSCToolbarSettingsSheetController()
@@ -50,7 +50,7 @@ class PrefUIViewController: PreferenceViewController, PreferenceWindowEmbeddable
   @IBOutlet var sectionOSDView: NSView!
   @IBOutlet var sectionThumbnailView: NSView!
   @IBOutlet var sectionPictureInPictureView: NSView!
-  @IBOutlet var sectionAnimationsView: NSView!
+  @IBOutlet var sectionAccessibilityView: NSView!
 
   @IBOutlet weak var themeMenu: NSMenu!
   @IBOutlet weak var oscPreviewImageView: NSImageView!

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -144,6 +144,8 @@ struct Preference {
     static let pauseWhenPip = Key("pauseWhenPip")
     static let togglePipByMinimizingWindow = Key("togglePipByMinimizingWindow")
 
+    static let enableAnimations = Key("enableAnimations")
+
     // Codec
 
     static let videoThreads = Key("videoThreads")
@@ -770,6 +772,7 @@ struct Preference {
     .windowBehaviorWhenPip: WindowBehaviorWhenPip.doNothing.rawValue,
     .pauseWhenPip: false,
     .togglePipByMinimizingWindow: false,
+    .enableAnimations: true,
 
     .videoThreads: 0,
     .hardwareDecoder: HardwareDecoderOption.auto.rawValue,

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -144,7 +144,7 @@ struct Preference {
     static let pauseWhenPip = Key("pauseWhenPip")
     static let togglePipByMinimizingWindow = Key("togglePipByMinimizingWindow")
 
-    static let enableAnimations = Key("enableAnimations")
+    static let disableAnimations = Key("disableAnimations")
 
     // Codec
 
@@ -772,7 +772,7 @@ struct Preference {
     .windowBehaviorWhenPip: WindowBehaviorWhenPip.doNothing.rawValue,
     .pauseWhenPip: false,
     .togglePipByMinimizingWindow: false,
-    .enableAnimations: true,
+    .disableAnimations: false,
 
     .videoThreads: 0,
     .hardwareDecoder: HardwareDecoderOption.auto.rawValue,

--- a/iina/en.lproj/PrefUIViewController.strings
+++ b/iina/en.lproj/PrefUIViewController.strings
@@ -31,6 +31,9 @@
 /* Class = "NSMenuItem"; title = "% of screen"; ObjectID = "AE4-BD-wZi"; */
 "AE4-BD-wZi.title" = "% of screen";
 
+/* Class = "NSTextFieldCell"; title = "Animations:"; ObjectID = "AYW-Xu-ySw"; */
+"AYW-Xu-ySw.title" = "Animations:";
+
 /* Class = "NSTextFieldCell"; title = "Window:"; ObjectID = "AmS-Sl-b2h"; */
 "AmS-Sl-b2h.title" = "Window:";
 
@@ -174,6 +177,9 @@
 
 /* Class = "NSButtonCell"; title = "Snap to center when dragging"; ObjectID = "mdD-if-Wqw"; */
 "mdD-if-Wqw.title" = "Snap to center when dragging";
+
+/* Class = "NSButtonCell"; title = "Enable animations"; ObjectID = "mjs-jg-wm1"; */
+"mjs-jg-wm1.title" = "Enable animations";
 
 /* Class = "NSMenuItem"; title = "Previous / Next Media"; ObjectID = "oJ8-74-L3z"; */
 "oJ8-74-L3z.title" = "Previous / Next Media";

--- a/iina/en.lproj/PrefUIViewController.strings
+++ b/iina/en.lproj/PrefUIViewController.strings
@@ -28,11 +28,14 @@
 /* Class = "NSMenuItem"; title = "bottom"; ObjectID = "92n-Uq-o4G"; */
 "92n-Uq-o4G.title" = "bottom";
 
+/* Class = "NSTextFieldCell"; title = "When the macOS Reduce Motion accessibility setting is enabled IINA will reduce user interface animations that are known to cause problems for those with vestibular disorders. Should that be insufficient, this setting can be used to reduce motion further by eliminating user interface animations."; ObjectID = "9IR-Sf-wMq"; */
+"9IR-Sf-wMq.title" = "When the macOS Reduce Motion accessibility setting is enabled IINA will reduce user interface animations that are known to cause problems for those with vestibular disorders. Should that be insufficient, this setting can be used to reduce motion further by eliminating user interface animations.";
+
 /* Class = "NSMenuItem"; title = "% of screen"; ObjectID = "AE4-BD-wZi"; */
 "AE4-BD-wZi.title" = "% of screen";
 
-/* Class = "NSTextFieldCell"; title = "Animations:"; ObjectID = "AYW-Xu-ySw"; */
-"AYW-Xu-ySw.title" = "Animations:";
+/* Class = "NSTextFieldCell"; title = "Accessibility:"; ObjectID = "AYW-Xu-ySw"; */
+"AYW-Xu-ySw.title" = "Accessibility:";
 
 /* Class = "NSTextFieldCell"; title = "Window:"; ObjectID = "AmS-Sl-b2h"; */
 "AmS-Sl-b2h.title" = "Window:";
@@ -178,8 +181,8 @@
 /* Class = "NSButtonCell"; title = "Snap to center when dragging"; ObjectID = "mdD-if-Wqw"; */
 "mdD-if-Wqw.title" = "Snap to center when dragging";
 
-/* Class = "NSButtonCell"; title = "Enable animations"; ObjectID = "mjs-jg-wm1"; */
-"mjs-jg-wm1.title" = "Enable animations";
+/* Class = "NSButtonCell"; title = "Disable animations"; ObjectID = "mjs-jg-wm1"; */
+"mjs-jg-wm1.title" = "Disable animations";
 
 /* Class = "NSMenuItem"; title = "Previous / Next Media"; ObjectID = "oJ8-74-L3z"; */
 "oJ8-74-L3z.title" = "Previous / Next Media";


### PR DESCRIPTION
This commit will change IINA to adhere to the Apple [Human Interface Guidelines](https://developer.apple.com/design/human-interface-guidelines/) with respects to the macOS [Reduced motion](https://developer.apple.com/design/human-interface-guidelines/accessibility#Motion) setting. With these changes IINA will reduce, not eliminate, animations when the macOS [Reduced motion](https://support.apple.com/guide/mac-help/stop-or-reduce-onscreen-motion-mchlc03f57a1/mac)  setting is enabled. When this setting is enabled IINA will fade in the sidebar instead of sliding it into view. All other changes to animation behavior, such as how IINA transitions in and out of full screen mode, are provide by AppKit.

For users who are hyper sensitive to motion this commit adds a `Disable animations` setting to the `UI` settings tab in a new `Accessibility` section at the bottom of the panel. Enabling this setting will eliminate many, but not all, animated transition effects.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4870.

---

**Description:**
