### PR TITLE
Make all volume icons indicate level

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2641,6 +2641,13 @@ class MainWindowController: PlayerWindowController {
     }
   }
 
+  override func updateVolume() {
+    guard loaded else { return }
+    super.updateVolume()
+    guard !player.info.isMuted else { return }
+    muteButton.image = volumeIcon()
+  }
+
   // MARK: - IBActions
 
   @IBAction override func playButtonAction(_ sender: NSButton) {

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -281,22 +281,9 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     guard loaded else { return }
     super.updateVolume()
     volumeLabel.intValue = Int32(player.info.volume)
-    if player.info.isMuted {
-      volumeButton.image = NSImage(named: "mute")
-    } else {
-      switch volumeLabel.intValue {
-        case 0:
-          volumeButton.image = NSImage(named: "volume-0")
-        case 1...33:
-          volumeButton.image = NSImage(named: "volume-1")
-        case 34...66:
-          volumeButton.image = NSImage(named: "volume-2")
-        case 67...1000:
-          volumeButton.image = NSImage(named: "volume")
-        default:
-          break
-      }
-    }
+    let image = volumeIcon()
+    muteButton.image = image
+    volumeButton.image = image
   }
 
   func updateVideoSize() {

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -527,6 +527,23 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
     fatalError("Must implement in the subclass")
   }
   
+  func volumeIcon() -> NSImage? {
+    guard !player.info.isMuted else { return NSImage(named: "mute") }
+    switch Int(player.info.volume) {
+    case 0:
+      return NSImage(named: "volume-0")
+    case 1...33:
+      return NSImage(named: "volume-1")
+    case 34...66:
+      return NSImage(named: "volume-2")
+    case 67...1000:
+      return NSImage(named: "volume")
+    default:
+      Logger.log("Volume level \(player.info.volume) is invalid", level: .error)
+      return nil
+    }
+  }
+
   func updateVolume() {
     volumeSlider.doubleValue = player.info.volume
     muteButton.state = player.info.isMuted ? .on : .off


### PR DESCRIPTION
This commit will:
- Add a `volumeIcon` method to `PlayerWindowController` that returns the appropriate icon based on volume level
- Add an `updateVolume` method to `MainWindowController` that sets the icon on the mute button
- Change `MiniPlayerController.updateVolume` to set the icon on the mute button as well as the volume button

The mini window selects the image to use for the volume button from multiple images based on the volume level. This commit extends that functionality to the mute button in the main window and the mute button in the mini window. This makes the behavior of volume icons consistent.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
