### PR TITLE
Fix subtitles override level not localized, #4892

### DIFF
--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -116,6 +116,10 @@
 
 "preference.enable_adv_settings" = "Enable advanced settings";
 
+"preference.sub_override_level.force" = "force";
+"preference.sub_override_level.strip" = "strip";
+"preference.sub_override_level.yes" = "yes";
+
 "menu.volume" = "Volume: %d";
 "menu.volume_muted" = "Volume: %d (Muted)";
 "menu.audio_delay" = "Audio Delay: %.2fs";

--- a/iina/PrefSubViewController.swift
+++ b/iina/PrefSubViewController.swift
@@ -183,8 +183,16 @@ class PrefSubViewController: PreferenceViewController, PreferenceWindowEmbeddabl
   }
 
   override func transformedValue(_ value: Any?) -> Any? {
-    guard let num = value as? NSNumber else { return nil }
-    return Preference.SubOverrideLevel(rawValue: num.intValue)?.string
+    guard let num = value as? NSNumber,
+          let level = Preference.SubOverrideLevel(rawValue: num.intValue) else { return nil }
+    switch level {
+    case .yes:
+      return NSLocalizedString("preference.sub_override_level.yes", value: "yes", comment: "yes")
+    case .force:
+      return NSLocalizedString("preference.sub_override_level.force", value: "force", comment: "force")
+    case .strip:
+      return NSLocalizedString("preference.sub_override_level.strip", value: "strip", comment: "strip")
+    }
   }
 
 }

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -116,6 +116,10 @@
 
 "preference.enable_adv_settings" = "Enable advanced settings";
 
+"preference.sub_override_level.force" = "force";
+"preference.sub_override_level.strip" = "strip";
+"preference.sub_override_level.yes" = "yes";
+
 "menu.volume" = "Volume: %d";
 "menu.volume_muted" = "Volume: %d (Muted)";
 "menu.audio_delay" = "Audio Delay: %.2fs";


### PR DESCRIPTION
This commit will:
- Add key-value pairs for the yes, force and strip override levels to the base and en `Localizable.strings` files
- Change the `transformedValue` method in the `ASSOverrideLevelTransformer` class to return a localized string instead of the enum value string

This localizes the value displayed for the Override level setting found in the ASS Subtitles section on the Subtitle tab in IINA's settings.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4892.

---

**Description:**
