### PR TITLE
[#4808] Fix screenshot OSD layout issue

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -822,7 +822,7 @@ class PlayerCore: NSObject {
     DispatchQueue.main.async {
       let osdView = ScreenshootOSDView()
       osdView.setImage(image,
-                       size: image.size.shrink(toSize: NSSize(width: 300, height: 200)),
+                       size: image.size.grow(toSize: NSSize(width: 300, height: 200)),
                        fileURL: saveToFile ? lastScreenshotURL : nil)
       self.sendOSD(.screenshot, forcedTimeout: 5, accessoryView: osdView.view, context: osdView)
       if !saveToFile {


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4808.

---

IINA resizes screenshot `NSImage` before passing it to OSD for previewing with a fixed expectation size `[300, 200]`. The resizing strategy is implemented in `NSSize#shrink`, which guarantees the shrunken width or height to be given value, and decreasing the other side while keeping the image aspect.

This works in most cases except the [reported one](https://www.youtube.com/watch?v=Pf9NwWa8LQE) which has a `1:1` ratio. So by the shrinking rule, it will be resized to `[200, 200]`, which breaks the layout rule since OSD View expects a minimum width to place action buttons.

Replacing the strategy to `NSSize#grow` ensures the resized `width >= 300` and resolves layout warnings.

Grow strategy for `1:1` ratio image:

<img width="300" alt="grow" src="https://github.com/iina/iina/assets/34335406/3cfd5d3c-41be-4805-8333-559278195c84">

Shrink strategy for `1:1` ratio image:
<img width="300" alt="shrink" src="https://github.com/iina/iina/assets/34335406/d2d6ddda-5459-48f3-a182-12b2d4bd0fb8">

For those normal images close to `3:2` ratio, this fix shouldn't cause any significant visual changes.

---

Off topic: I noticed that there's a typo in Screensh***oo***tOSDView class name. Wanted to fix it but I'm a little worried that it might break the localization.