### PR TITLE
Fix screenshot cache contains many large files, #4899

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -808,6 +808,9 @@ class PlayerCore: NSObject {
     guard let lastScreenshotURL = Utility.getLatestScreenshot(from: imageFolder) else { return }
     guard let image = NSImage(contentsOf: lastScreenshotURL) else {
       self.sendOSD(.screenshot)
+      if !saveToFile {
+        try? FileManager.default.removeItem(at: lastScreenshotURL)
+      }
       return
     }
     if saveToClipboard {
@@ -816,6 +819,9 @@ class PlayerCore: NSObject {
     }
     guard Preference.bool(for: .screenshotShowPreview) else {
       self.sendOSD(.screenshot)
+      if !saveToFile {
+        try? FileManager.default.removeItem(at: lastScreenshotURL)
+      }
       return
     }
 


### PR DESCRIPTION
This commit will change the screenshotCallback method in PlayerCore to remove the cached screenshot file when not displaying a preview.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4899.

---

**Description:**
