### PR TITLE
Fix RTL language causes history indicator to flip, #4906

### DIFF
--- a/iina/HistoryWindowController.swift
+++ b/iina/HistoryWindowController.swift
@@ -349,4 +349,10 @@ class HistoryProgressCellView: NSTableCellView {
 
   @IBOutlet var indicator: NSProgressIndicator!
 
+  /// Prepares the receiver for service after it has been loaded from an Interface Builder archive, or nib file.
+  /// - Important: As per Apple's [Internationalization and Localization Guide](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/SupportingRight-To-LeftLanguages/SupportingRight-To-LeftLanguages.html)
+  ///     timeline indicators should not flip in a right-to-left language. This can not be set in the XIB.
+  override func awakeFromNib() {
+    indicator.userInterfaceLayoutDirection = .leftToRight
+  }
 }


### PR DESCRIPTION
This commit will add an `awakeFromNib` method to the `HistoryProgressCellView` class that sets the progress indicator property `userInterfaceLayoutDirection` to be `leftToRight`. This prevents the indicator from reversing direction when a RTL language is configured.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4906.

---

**Description:**
