### PR TITLE
Add support for Spatial Audio, #3444

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -447,7 +447,7 @@ not applying FFmpeg 9599 workaround
     // As mpv support for audio using the AVFoundation framework is new we enable it before applying
     // user's settings. This allows a user to roll back to the Core Audio framework should a problem
     // be encountered with the new code.
-    chkErr(mpv_set_property_string(mpv, MPVOption.Audio.ao, "avfoundation"))
+    chkErr(setOptionString(MPVOption.Audio.ao, "avfoundation", level: .verbose))
 
     // Set user defined conf dir.
     if Preference.bool(for: .enableAdvancedSettings),

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -444,6 +444,11 @@ not applying FFmpeg 9599 workaround
     chkErr(setOptionString(MPVOption.ProgramBehavior.resetOnNextFile,
             "\(MPVOption.PlaybackControl.abLoopA),\(MPVOption.PlaybackControl.abLoopB)", level: .verbose))
 
+    // As mpv support for audio using the AVFoundation framework is new we enable it before applying
+    // user's settings. This allows a user to roll back to the Core Audio framework should a problem
+    // be encountered with the new code.
+    chkErr(mpv_set_property_string(mpv, MPVOption.Audio.ao, "avfoundation"))
+
     // Set user defined conf dir.
     if Preference.bool(for: .enableAdvancedSettings),
        Preference.bool(for: .useUserDefinedConfDir),


### PR DESCRIPTION
This commit will add setting the `mpv` `ao` option to `avfoundation` in the `mpvInit` method of the `MPVController` class. This causes IINA to use the [AVFoundation](https://developer.apple.com/av-foundation/) framework for audio (which supports spatial audio) instead of the [Core Audio](https://developer.apple.com/documentation/coreaudio) framework.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #3444.

---

**Description:**
