### PR TITLE
Fix can't disable pause when machine goes to sleep, #4917

### DIFF
--- a/iina/Base.lproj/PrefGeneralViewController.xib
+++ b/iina/Base.lproj/PrefGeneralViewController.xib
@@ -357,6 +357,9 @@
                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                             <font key="font" metaFont="system"/>
                                         </buttonCell>
+                                        <connections>
+                                            <binding destination="IBP-Mz-Maa" name="value" keyPath="values.pauseWhenGoesToSleep" id="Qeh-EF-RJX"/>
+                                        </connections>
                                     </button>
                                 </subviews>
                                 <constraints>


### PR DESCRIPTION
This commit will add to `PrefGeneralViewController.xib` the missing binding from the `Pause when machine goes to sleep` checkbox to the `pauseWhenGoesToSleep` user defaults value.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4917.

---

**Description:**
