### PR TITLE
Log running commands and setting options and properties

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -231,7 +231,7 @@ class PlayerCore: NSObject {
 
   override init() {
     super.init()
-    self.mpv = MPVController(playerCore: self)
+    self.mpv = MPVController(playerCore: self, playerNumber: PlayerCore.playerCoreCounter)
     self.mainWindow = MainWindowController(playerCore: self)
     self.miniPlayer = MiniPlayerWindowController(playerCore: self)
     self.initialWindow = InitialWindowController(playerCore: self)


### PR DESCRIPTION
This commit will:
- Change `PlayerCore` to pass the value of `playerCoreCounter` when creating the `MPVController` object
- Change `MPVController` to use a logger subsystem name that includes the counter to identify the player the instance is associated with
- Change `MPVController` to log commands sent to mpv
- Change `MPVController` to log setting of mpv options and properties

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
