### PR TITLE
Remove unused strings in localization

### DIFF
--- a/iina/Base.lproj/LogWindowController.xib
+++ b/iina/Base.lproj/LogWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22690"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -28,12 +28,12 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="608" height="350"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="5120" height="1415"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1415"/>
             <view key="contentView" wantsLayer="YES" id="EiT-Mj-1SZ">
                 <rect key="frame" x="0.0" y="0.0" width="600" height="335"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="b3D-Hi-aSl">
+                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="b3D-Hi-aSl">
                         <rect key="frame" x="6" y="311" width="40" height="16"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" title="Level:" id="vaz-WH-G1w">
                             <font key="font" usesAppearanceFont="YES"/>
@@ -61,7 +61,7 @@
                             <action selector="subsystemUpdated:" target="-2" id="BbS-NQ-JId"/>
                         </connections>
                     </popUpButton>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QNX-uw-ybL">
+                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="QNX-uw-ybL">
                         <rect key="frame" x="148" y="311" width="75" height="16"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" title="Subsystem:" id="91n-Sw-RQj">
                             <font key="font" usesAppearanceFont="YES"/>
@@ -87,8 +87,8 @@
                         </connections>
                     </popUpButton>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UoZ-gj-OUA">
-                        <rect key="frame" x="507" y="301" width="92" height="32"/>
-                        <buttonCell key="cell" type="push" title="Save as..." bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="1si-iG-tju">
+                        <rect key="frame" x="508" y="301" width="91" height="32"/>
+                        <buttonCell key="cell" type="push" title="Save as…" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="1si-iG-tju">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
                         </buttonCell>
@@ -158,7 +158,7 @@
                                                     <rect key="frame" x="33" y="0.0" width="90" height="19"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
-                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="ALf-Zx-b75">
+                                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="ALf-Zx-b75">
                                                             <rect key="frame" x="0.0" y="6" width="90" height="13"/>
                                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="G3v-tE-ZhU">
                                                                 <font key="font" size="11" name="Menlo-Regular"/>
@@ -198,7 +198,7 @@
                                                     <rect key="frame" x="140" y="0.0" width="100" height="19"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
-                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="5yd-17-5pO">
+                                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="5yd-17-5pO">
                                                             <rect key="frame" x="0.0" y="6" width="100" height="13"/>
                                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="J8Q-uC-tUM">
                                                                 <font key="font" size="11" name="Menlo-Regular"/>
@@ -238,7 +238,7 @@
                                                     <rect key="frame" x="257" y="0.0" width="335" height="13"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
-                                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="D1p-II-0Iw">
+                                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="1000" horizontalCompressionResistancePriority="250" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="D1p-II-0Iw">
                                                             <rect key="frame" x="0.0" y="0.0" width="335" height="13"/>
                                                             <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Table View Cell" id="b9E-HK-qN8">
                                                                 <font key="font" size="11" name="Menlo-Regular"/>

--- a/iina/en.lproj/GuideWindowController.strings
+++ b/iina/en.lproj/GuideWindowController.strings
@@ -1,7 +1,4 @@
 
-/* Class = "NSWindow"; title = "Window"; ObjectID = "F0z-JX-Cv5"; */
-"F0z-JX-Cv5.title" = "Window";
-
 /* Class = "NSButtonCell"; title = "Website"; ObjectID = "FJS-b9-ATj"; */
 "FJS-b9-ATj.title" = "Website";
 
@@ -10,6 +7,3 @@
 
 /* Class = "NSButtonCell"; title = "Continue"; ObjectID = "pRW-Nk-MIQ"; */
 "pRW-Nk-MIQ.title" = "Continue";
-
-/* Class = "NSBox"; title = "Box"; ObjectID = "vEa-x6-5Uc"; */
-"vEa-x6-5Uc.title" = "Box";

--- a/iina/en.lproj/HistoryWindowController.strings
+++ b/iina/en.lproj/HistoryWindowController.strings
@@ -34,9 +34,6 @@
 /* Class = "NSMenuItem"; title = "Filename"; ObjectID = "Wkp-Vn-JoJ"; */
 "Wkp-Vn-JoJ.title" = "Filename";
 
-/* Class = "NSMenu"; title = "Context Menu"; ObjectID = "lR3-1E-Rwr"; */
-"lR3-1E-Rwr.title" = "Context Menu";
-
 /* Class = "NSMenuItem"; title = "Play in New Window"; ObjectID = "mXt-wb-fgT"; */
 "mXt-wb-fgT.title" = "Play in New Window";
 

--- a/iina/en.lproj/InfoPlist.strings
+++ b/iina/en.lproj/InfoPlist.strings
@@ -1,1 +1,1 @@
-
+NSHumanReadableCopyright = "Copyright © 2017-2024\nCollider LI, et al.\nReleased under GPLv3.";

--- a/iina/en.lproj/LogWindowController.strings
+++ b/iina/en.lproj/LogWindowController.strings
@@ -1,6 +1,6 @@
 
-/* Class = "NSButtonCell"; title = "Save as..."; ObjectID = "1si-iG-tju"; */
-"1si-iG-tju.title" = "Save as...";
+/* Class = "NSButtonCell"; title = "Save as…"; ObjectID = "1si-iG-tju"; */
+"1si-iG-tju.title" = "Save as…";
 
 /* Class = "NSTextFieldCell"; title = "Subsystem:"; ObjectID = "91n-Sw-RQj"; */
 "91n-Sw-RQj.title" = "Subsystem:";
@@ -11,14 +11,8 @@
 /* Class = "NSMenuItem"; title = "Error"; ObjectID = "FGm-HY-5ln"; */
 "FGm-HY-5ln.title" = "Error";
 
-/* Class = "NSTextFieldCell"; title = "Table View Cell"; ObjectID = "G3v-tE-ZhU"; */
-"G3v-tE-ZhU.title" = "Table View Cell";
-
 /* Class = "NSTableColumn"; headerCell.title = "Subsystem"; ObjectID = "GRp-Ls-7Bw"; */
 "GRp-Ls-7Bw.headerCell.title" = "Subsystem";
-
-/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "I7k-Y3-RgJ"; */
-"I7k-Y3-RgJ.title" = "Text Cell";
 
 /* Class = "NSMenuItem"; title = "Debug"; ObjectID = "IAO-ta-GnL"; */
 "IAO-ta-GnL.title" = "Debug";
@@ -26,20 +20,8 @@
 /* Class = "NSTableColumn"; headerCell.title = "Message"; ObjectID = "ISx-4s-GjQ"; */
 "ISx-4s-GjQ.headerCell.title" = "Message";
 
-/* Class = "NSTextFieldCell"; title = "Table View Cell"; ObjectID = "J8Q-uC-tUM"; */
-"J8Q-uC-tUM.title" = "Table View Cell";
-
-/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "L92-i2-eTp"; */
-"L92-i2-eTp.title" = "Text Cell";
-
 /* Class = "NSWindow"; title = "Log Viewer"; ObjectID = "QvC-M9-y7g"; */
 "QvC-M9-y7g.title" = "Log Viewer";
-
-/* Class = "NSTextFieldCell"; title = "Table View Cell"; ObjectID = "b9E-HK-qN8"; */
-"b9E-HK-qN8.title" = "Table View Cell";
-
-/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "cib-lC-cNh"; */
-"cib-lC-cNh.title" = "Text Cell";
 
 /* Class = "NSMenuItem"; title = "Verbose"; ObjectID = "dFU-NP-aIl"; */
 "dFU-NP-aIl.title" = "Verbose";
@@ -49,9 +31,6 @@
 
 /* Class = "NSTextFieldCell"; title = "Level:"; ObjectID = "vaz-WH-G1w"; */
 "vaz-WH-G1w.title" = "Level:";
-
-/* Class = "NSTextFieldCell"; title = "Text Cell"; ObjectID = "xko-rY-ufQ"; */
-"xko-rY-ufQ.title" = "Text Cell";
 
 /* Class = "NSMenuItem"; title = "Warning"; ObjectID = "zVH-tI-Wo0"; */
 "zVH-tI-Wo0.title" = "Warning";

--- a/iina/en.lproj/PrefGeneralViewController.strings
+++ b/iina/en.lproj/PrefGeneralViewController.strings
@@ -20,9 +20,6 @@
 /* Class = "NSButtonCell"; title = "Enable \"Open Recent\" menu"; ObjectID = "55O-ik-ql6"; */
 "55O-ik-ql6.title" = "Enable \"Open Recent\" menu";
 
-/* Class = "NSBox"; title = "Box"; ObjectID = "5RN-PV-pOZ"; */
-"5RN-PV-pOZ.title" = "Box";
-
 /* Class = "NSButtonCell"; title = "Minimized/un-minimized"; ObjectID = "5Y9-bX-K0f"; */
 "5Y9-bX-K0f.title" = "Minimized/un-minimized";
 
@@ -37,9 +34,6 @@
 
 /* Class = "NSButtonCell"; title = "Track all played files in \"Open Recent\" menu"; ObjectID = "Ci8-j2-QS3"; */
 "Ci8-j2-QS3.title" = "Track all played files in \"Open Recent\" menu";
-
-/* Class = "NSBox"; title = "Box"; ObjectID = "DZT-7n-S4M"; */
-"DZT-7n-S4M.title" = "Box";
 
 /* Class = "NSMenuItem"; title = "Daily"; ObjectID = "Ez8-qY-WAZ"; */
 "Ez8-qY-WAZ.title" = "Daily";

--- a/iina/en.lproj/PrefSubViewController.strings
+++ b/iina/en.lproj/PrefSubViewController.strings
@@ -10,9 +10,6 @@
 /* Class = "NSButtonCell"; title = "Display subtitles in letterboxes while in full screen"; ObjectID = "2XY-Un-0Fg"; */
 "2XY-Un-0Fg.title" = "Display subtitles in letterboxes while in full screen";
 
-/* Class = "NSTextFieldCell"; title = "strip"; ObjectID = "3H8-Ei-cTm"; */
-"3H8-Ei-cTm.title" = "strip";
-
 /* Class = "NSTextFieldCell"; title = "Position:"; ObjectID = "4Tb-Yh-PdP"; */
 "4Tb-Yh-PdP.title" = "Position:";
 

--- a/iina/en.lproj/PrefUtilsViewController.strings
+++ b/iina/en.lproj/PrefUtilsViewController.strings
@@ -37,6 +37,9 @@
 /* Class = "NSButtonCell"; title = "Set IINA as the Default Application…"; ObjectID = "e1p-Aa-WFG"; */
 "e1p-Aa-WFG.title" = "Set IINA as the Default Application…";
 
+/* Class = "NSButtonCell"; title = "Firefox"; ObjectID = "f9i-sS-MJN"; */
+"f9i-sS-MJN.title" = "Firefox";
+
 /* Class = "NSButtonCell"; title = "Clear Thumbnail Cache…"; ObjectID = "hsG-JB-TT9"; */
 "hsG-JB-TT9.title" = "Clear Thumbnail Cache…";
 
@@ -69,6 +72,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Please select the media types that you want to make IINA as the default Application for."; ObjectID = "uvK-Y1-dZr"; */
 "uvK-Y1-dZr.title" = "Please select the media types that you want to make IINA as the default Application for.";
+
+/* Class = "NSButtonCell"; title = "Chrome"; ObjectID = "yuw-2i-ICd"; */
+"yuw-2i-ICd.title" = "Chrome";
 
 /* Class = "NSTextFieldCell"; title = "Get Browser Extensions for IINA"; ObjectID = "zCe-1f-tkF"; */
 "zCe-1f-tkF.title" = "Get Browser Extensions for IINA";

--- a/iina/en.lproj/PrefUtilsViewController.strings
+++ b/iina/en.lproj/PrefUtilsViewController.strings
@@ -37,9 +37,6 @@
 /* Class = "NSButtonCell"; title = "Set IINA as the Default Application…"; ObjectID = "e1p-Aa-WFG"; */
 "e1p-Aa-WFG.title" = "Set IINA as the Default Application…";
 
-/* Class = "NSButtonCell"; title = "Firefox"; ObjectID = "f9i-sS-MJN"; */
-"f9i-sS-MJN.title" = "Firefox";
-
 /* Class = "NSButtonCell"; title = "Clear Thumbnail Cache…"; ObjectID = "hsG-JB-TT9"; */
 "hsG-JB-TT9.title" = "Clear Thumbnail Cache…";
 
@@ -72,9 +69,6 @@
 
 /* Class = "NSTextFieldCell"; title = "Please select the media types that you want to make IINA as the default Application for."; ObjectID = "uvK-Y1-dZr"; */
 "uvK-Y1-dZr.title" = "Please select the media types that you want to make IINA as the default Application for.";
-
-/* Class = "NSButtonCell"; title = "Chrome"; ObjectID = "yuw-2i-ICd"; */
-"yuw-2i-ICd.title" = "Chrome";
 
 /* Class = "NSTextFieldCell"; title = "Get Browser Extensions for IINA"; ObjectID = "zCe-1f-tkF"; */
 "zCe-1f-tkF.title" = "Get Browser Extensions for IINA";


### PR DESCRIPTION
**Description:**
- Removed strings like "Box", "Text Cell" which will not displayed in the UI
- Removed Chrome and Firefox in the localization
- Removed "strip" in `PrefSubViewController`, which will be replaced in in UI in runtime (https://github.com/iina/iina/pull/4893#issuecomment-2078584610)
- Added `NSHumanReadableCopyright` in `InfoPlist.strings` (https://github.com/iina/iina/pull/4922#discussion_r1610635167)
