### PR TITLE
Remove unsupported codecs from hwdec-codecs

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -163,6 +163,7 @@
 		5196819A29EC963F00B05D55 /* CoreDisplay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5196819929EC963F00B05D55 /* CoreDisplay.framework */; };
 		51854CDA2A1C489300C40B78 /* FFmpegLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51854CD92A1C489300C40B78 /* FFmpegLogger.swift */; };
 		519872FF26879B9B00F84BCC /* AccessibilityPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519872FE26879B9B00F84BCC /* AccessibilityPreferences.swift */; };
+		519CCABD2BFFAEF10079DCAF /* HardwareDecodeCapabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519CCABC2BFFAEF10079DCAF /* HardwareDecodeCapabilities.swift */; };
 		51AC1CAB2A9FBF3700DF7079 /* OpenSubClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC1CAA2A9FBF3700DF7079 /* OpenSubClient.swift */; };
 		51C1BA3A291CA76700C1208A /* InfoDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C1BA39291CA76700C1208A /* InfoDictionary.swift */; };
 		51CACB9529D500290034CEE5 /* VideoPIPViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51CACB9429D500290034CEE5 /* VideoPIPViewController.swift */; };
@@ -1157,6 +1158,7 @@
 		5196819929EC963F00B05D55 /* CoreDisplay.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreDisplay.framework; path = /System/Library/Frameworks/CoreDisplay.framework; sourceTree = "<group>"; };
 		51854CD92A1C489300C40B78 /* FFmpegLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FFmpegLogger.swift; sourceTree = "<group>"; };
 		519872FE26879B9B00F84BCC /* AccessibilityPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPreferences.swift; sourceTree = "<group>"; };
+		519CCABC2BFFAEF10079DCAF /* HardwareDecodeCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HardwareDecodeCapabilities.swift; sourceTree = "<group>"; };
 		51A0F0F629FA2C8E000130CF /* Beta.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Beta.xcconfig; sourceTree = "<group>"; };
 		51AC1CAA2A9FBF3700DF7079 /* OpenSubClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSubClient.swift; sourceTree = "<group>"; };
 		51C1BA39291CA76700C1208A /* InfoDictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InfoDictionary.swift; sourceTree = "<group>"; };
@@ -2408,6 +2410,7 @@
 				E39A11FC240F176E00A67F9F /* StringEncodingName.swift */,
 				51C1BA39291CA76700C1208A /* InfoDictionary.swift */,
 				51DE55C82A6646710050AD06 /* Sysctl.swift */,
+				519CCABC2BFFAEF10079DCAF /* HardwareDecodeCapabilities.swift */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -3125,6 +3128,7 @@
 				84A886F31E26CA24008755BB /* Regex.swift in Sources */,
 				8487BEC31D76A1AF00FD17B0 /* MenuController.swift in Sources */,
 				8450403D1E0A9EE20079C194 /* InspectorWindowController.swift in Sources */,
+				519CCABD2BFFAEF10079DCAF /* HardwareDecodeCapabilities.swift in Sources */,
 				E38BA1C0253E54F2000B551D /* JavascriptAPIGlobal.swift in Sources */,
 				E39A11FD240F176E00A67F9F /* StringEncodingName.swift in Sources */,
 				E33FEEB52229A44F00B59711 /* JavascriptAPIUtils.swift in Sources */,

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -213,6 +213,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 
     Logger.log("App will launch")
 
+    // Start asynchronously gathering and caching information about the hardware decoding
+    // capabilities of this Mac.
+    HardwareDecodeCapabilities.shared.checkCapabilities()
+
     // Workaround macOS Sonoma clearing the recent documents list when the IINA code is not signed
     // with IINA's certificate as is the case for developer and nightly builds.
     restoreRecentDocuments()

--- a/iina/HardwareDecodeCapabilities.swift
+++ b/iina/HardwareDecodeCapabilities.swift
@@ -1,0 +1,103 @@
+//
+//  HardwareDecodeCapabilities.swift
+//  iina
+//
+//  Created by low-batt on 5/23/24.
+//  Copyright © 2024 lhc. All rights reserved.
+//
+
+import Foundation
+import VideoToolbox
+
+/// Cache containing information about the hardware decoding capabilities of this Mac.
+///
+/// It is desirable to cache this information because the [Video Toolbox](https://developer.apple.com/documentation/videotoolbox)
+/// method  [VTIsHardwareDecodeSupported](https://developer.apple.com/documentation/videotoolbox/vtishardwaredecodesupported(_:))
+/// is long running and should not be called on the main thread. Instead another thread is used and the information is cached for when
+/// code that is running on the main thread needs it.
+class HardwareDecodeCapabilities {
+  /// The `HardwareDecodeCapabilities` singleton object.
+  static let shared = HardwareDecodeCapabilities()
+
+  /// The hardware decoding capabilities of this Mac will be checked for the codecs in this list.
+  private let codecs = [
+    kCMVideoCodecType_AppleProRes422,
+    kCMVideoCodecType_AppleProRes422HQ,
+    kCMVideoCodecType_AppleProRes422LT,
+    kCMVideoCodecType_AppleProRes422Proxy,
+    kCMVideoCodecType_AppleProRes4444,
+    kCMVideoCodecType_AppleProRes4444XQ,
+    kCMVideoCodecType_AppleProResRAW,
+    kCMVideoCodecType_AppleProResRAWHQ,
+    kCMVideoCodecType_AV1,
+    kCMVideoCodecType_VP9]
+
+  private var initialization: DispatchWorkItem?
+  private var isInitialized = false
+
+  /// Cache containing a map from video codec to whether hardware decoding is supported.
+  private var supported: [CMVideoCodecType: Bool] = [:]
+
+  /// Check the hardware decoding capabilities of this Mac and cache the results.
+  ///
+  /// As checking the capabilities takes a long time it is performed asynchronously. See `isHardwareDecodeSupported` for details.
+  /// - Important: This method **must** be called before `isSupported` is called and only be called **once**.
+  func checkCapabilities() {
+    guard initialization == nil else {
+      // Internal error. This method must only be called once.
+      Logger.fatal("HardwareDecodeCapabilities is already initialized")
+    }
+    initialization = DispatchWorkItem() { [self] in
+      for codec in codecs {
+        supported[codec] = isHardwareDecodeSupported(codec)
+      }
+    }
+    DispatchQueue.global(qos: .userInitiated).async { self.initialization!.perform() }
+  }
+
+  /// Whether this Mac supports hardware decoding for the given video codec.
+  /// - Parameter codecType: The video codec as a
+  ///     [CMVideoCodecType](https://developer.apple.com/documentation/coremedia/cmvideocodectype).
+  /// - Returns: `true` if hardware decoding is supported;,`false` otherwise.
+  func isSupported(_ codecType: CMVideoCodecType) -> Bool {
+    if !isInitialized {
+      guard let initialization = initialization else {
+        // Internal error. The cache must be initialized before calling this method.
+        Logger.fatal("HardwareDecodeCapabilities.checkCapabilities has not been called")
+      }
+      initialization.wait()
+      isInitialized = true
+    }
+    guard let supported = supported[codecType] else {
+      // Internal error. This codec must not be in the list of codecs above.
+      Logger.fatal("HardwareDecodeCapabilities is missing support for codec \(codecType)")
+    }
+    return supported
+  }
+
+  /// Whether this Mac supports hardware decoding for the given video codec.
+  /// - Parameter codecType: The video codec as a
+  ///     [CMVideoCodecType](https://developer.apple.com/documentation/coremedia/cmvideocodectype).
+  /// - Returns: true` if hardware decoding is supported;,`false` otherwise.
+  /// - Important: This method calls
+  ///     [VTIsHardwareDecodeSupported](https://developer.apple.com/documentation/videotoolbox/vtishardwaredecodesupported(_:)),
+  ///     which if called on the main thread will cause Xcode to report: "This method should not be called on the main thread as it may
+  ///     lead to UI unresponsiveness". Use a different thread to call this method. Do not call `isHardwareDecodeSupported`
+  ///     from the main thread.
+  private func isHardwareDecodeSupported(_ codecType: CMVideoCodecType) -> Bool {
+    if #available(macOS 11.0, *) {
+      VTRegisterSupplementalVideoDecoderIfAvailable(codecType)
+    }
+    if #available(macOS 10.13, *) {
+      return VTIsHardwareDecodeSupported(codecType)
+    }
+    guard codecType != kCMVideoCodecType_AV1, codecType != kCMVideoCodecType_VP9 else {
+      // Neither of these codecs are supported in older versions of macOS.
+      return false
+    }
+    // Unable to determine. For how this information is used by IINA the safe answer is true.
+    return true
+  }
+
+  private init() {}
+}

--- a/iina/HardwareDecodeCapabilities.swift
+++ b/iina/HardwareDecodeCapabilities.swift
@@ -88,15 +88,7 @@ class HardwareDecodeCapabilities {
     if #available(macOS 11.0, *) {
       VTRegisterSupplementalVideoDecoderIfAvailable(codecType)
     }
-    if #available(macOS 10.13, *) {
-      return VTIsHardwareDecodeSupported(codecType)
-    }
-    guard codecType != kCMVideoCodecType_AV1, codecType != kCMVideoCodecType_VP9 else {
-      // Neither of these codecs are supported in older versions of macOS.
-      return false
-    }
-    // Unable to determine. For how this information is used by IINA the safe answer is true.
-    return true
+    return VTIsHardwareDecodeSupported(codecType)
   }
 
   private init() {}


### PR DESCRIPTION
This commit will:
- Add a new class `HardwareDecodeCapabilities`
- Add a call to `HardwareDecodeCapabilities.checkCapabilities` in `AppDelegate.applicationWillFinishLaunching`
- Add a new method `userOptionsContains` to `MPVController` that checks if a user has configured a `mpv` option in IINA's advanced settings
- Add a new property `mpvCodecToCodecTypes` to  `MPVController` that maps a `mpv` codec name to core media video codec types
- Add a new `adjustCodecWhiteList` method to `MPVController` that removes codecs from the `mpv` `hwdec-codecs` option if the Mac does not support hardware decoding for that codec
- Change the `applyHardwareAccelerationWorkaround` method to use the value of the `hwdec-codecs` option instead of a hardcoded value

These changes cause mpv to not attempt to use hardware decoding for a codec that is known to not be supported. This eliminates the overhead of setting up for hardware decoding only to have it fail. This is not comprehensive. This only covers the recent codecs whose support for hardware decoding varies among Macs. This merely reduces the dependence upon the FFmpeg fallback to software decoding feature in some cases.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
