### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
             deployment_target: ""
     runs-on:  macos-13
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install dependencies
         run: ./other/download_libs.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - xcode: "15.0"
+          - xcode: "15.2"
             deployment_target: ""
     runs-on:  macos-13
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         include:
           - xcode: "15.3"
-            deployment_target: "MACOSX_DEPLOYMENT_TARGET=10.15"
+            deployment_target: ""
     runs-on:  macos-14-large
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - xcode: "15.3"
+          - xcode: "15.0"
             deployment_target: ""
-    runs-on:  macos-14-large
+    runs-on:  macos-13
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - xcode: "15.4"
+          - xcode: "15.3"
             deployment_target: "MACOSX_DEPLOYMENT_TARGET=10.15"
     runs-on:  macos-14-large
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         run: tar cvJf ~/iina.tar.xz -C /Users/runner/Library/Developer/Xcode/DerivedData/iina-csbkugdtxazzqogjnydbothqrvib/Build/Products/Debug IINA.app 
 
       - name: Save artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: IINA
           path: ~/iina.tar.xz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,11 +11,9 @@ jobs:
     strategy:
       matrix:
         include:
-          #- xcode: "13.4.1"
-          #  deployment_target: "MACOSX_DEPLOYMENT_TARGET=10.11"
-          - xcode: "14.2"
-            deployment_target: ""
-    runs-on:  macos-12
+          - xcode: "15.4"
+            deployment_target: "MACOSX_DEPLOYMENT_TARGET=10.15"
+    runs-on:  macos-14-large
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
~~Update the runner to macOS 14 and Xcode 15.4~~
It seems we cannot use `macos-14-large` for some reason; use `macos-13` and Xcode 15 instead.

Also updates actions from v3 to v4 as v3 actions are deprecated.