### PR TITLE
Improve UI of Filters windows (fixes #4894)

### DIFF
--- a/iina/AppData.swift
+++ b/iina/AppData.swift
@@ -106,6 +106,10 @@ struct Constants {
   struct Time {
     static let infinite = VideoTime(999, 0, 0)
   }
+  struct WindowAutosaveName {
+    static let videoFilters = "VideoFilters"
+    static let audioFilters = "AudioFilters"
+  }
   struct FilterName {
     static let crop = "iina_crop"
     static let flip = "iina_flip"

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -66,14 +66,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
   lazy var logWindow: LogWindowController = LogWindowController()
 
   lazy var vfWindow: FilterWindowController = {
-    let w = FilterWindowController()
-    w.filterType = MPVProperty.vf
+    let w = FilterWindowController(filterType: MPVProperty.vf, autosaveName: Constants.WindowAutosaveName.videoFilters)
     return w
   }()
 
   lazy var afWindow: FilterWindowController = {
-    let w = FilterWindowController()
-    w.filterType = MPVProperty.af
+    let w = FilterWindowController(filterType: MPVProperty.af, autosaveName: Constants.WindowAutosaveName.audioFilters)
     return w
   }()
 

--- a/iina/Base.lproj/FilterWindowController.xib
+++ b/iina/Base.lproj/FilterWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14313.13.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14313.13.2"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22690"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -31,24 +31,24 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Filters" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="F0z-JX-Cv5">
+        <window title="Filters" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="F0z-JX-Cv5" userLabel="Filters Window">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="608" y="562" width="480" height="382"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
+            <rect key="contentRect" x="608" y="562" width="640" height="382"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1728" height="1079"/>
             <view key="contentView" wantsLayer="YES" id="se5-gp-TjO">
-                <rect key="frame" x="0.0" y="0.0" width="480" height="382"/>
+                <rect key="frame" x="0.0" y="0.0" width="640" height="382"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <splitView dividerStyle="thin" translatesAutoresizingMaskIntoConstraints="NO" id="cMp-LA-Nma">
-                        <rect key="frame" x="0.0" y="0.0" width="480" height="382"/>
+                        <rect key="frame" x="0.0" y="0.0" width="640" height="382"/>
                         <subviews>
                             <customView fixedFrame="YES" id="ICv-pW-MWK">
-                                <rect key="frame" x="0.0" y="0.0" width="480" height="191"/>
+                                <rect key="frame" x="0.0" y="0.0" width="640" height="191"/>
                                 <autoresizingMask key="autoresizingMask"/>
                             </customView>
                             <customView fixedFrame="YES" id="K51-DY-Jpf">
-                                <rect key="frame" x="0.0" y="192" width="480" height="190"/>
+                                <rect key="frame" x="0.0" y="192" width="640" height="190"/>
                                 <autoresizingMask key="autoresizingMask"/>
                             </customView>
                         </subviews>
@@ -70,296 +70,24 @@
             </connections>
             <point key="canvasLocation" x="139" y="217"/>
         </window>
-        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="8Eh-v2-bbh">
-            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
-            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="283" y="305" width="440" height="302"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
-            <view key="contentView" id="RNP-NG-UVn">
-                <rect key="frame" x="0.0" y="0.0" width="440" height="302"/>
-                <autoresizingMask key="autoresizingMask"/>
-                <subviews>
-                    <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="15J-Tp-Ccx">
-                        <rect key="frame" x="12" y="44" width="140" height="246"/>
-                        <clipView key="contentView" id="evP-Km-Po1">
-                            <rect key="frame" x="1" y="1" width="138" height="244"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                            <subviews>
-                                <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="n0t-vk-dME">
-                                    <rect key="frame" x="0.0" y="0.0" width="138" height="244"/>
-                                    <autoresizingMask key="autoresizingMask"/>
-                                    <size key="intercellSpacing" width="3" height="2"/>
-                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                    <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
-                                    <tableColumns>
-                                        <tableColumn width="135" minWidth="40" maxWidth="1000" id="Wak-3T-72M">
-                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
-                                                <font key="font" metaFont="smallSystem"/>
-                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
-                                            </tableHeaderCell>
-                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" title="Text Cell" id="GXg-4l-PJC">
-                                                <font key="font" metaFont="system"/>
-                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                            <prototypeCellViews>
-                                                <tableCellView id="WlY-5X-SEi">
-                                                    <rect key="frame" x="1" y="1" width="135" height="17"/>
-                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                    <subviews>
-                                                        <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MAd-sY-Hvg">
-                                                            <rect key="frame" x="0.0" y="0.0" width="135" height="17"/>
-                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" flexibleMinY="YES"/>
-                                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="Kve-RD-QwY">
-                                                                <font key="font" metaFont="system"/>
-                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                            </textFieldCell>
-                                                            <connections>
-                                                                <binding destination="WlY-5X-SEi" name="value" keyPath="objectValue" id="CPm-ly-m1u"/>
-                                                            </connections>
-                                                        </textField>
-                                                    </subviews>
-                                                    <connections>
-                                                        <outlet property="textField" destination="MAd-sY-Hvg" id="m6f-Sx-xb4"/>
-                                                    </connections>
-                                                </tableCellView>
-                                            </prototypeCellViews>
-                                        </tableColumn>
-                                    </tableColumns>
-                                </tableView>
-                            </subviews>
-                        </clipView>
-                        <constraints>
-                            <constraint firstAttribute="width" constant="140" id="oFm-NQ-6ro"/>
-                        </constraints>
-                        <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="Zhg-GM-4UI">
-                            <rect key="frame" x="1" y="271" width="138" height="16"/>
-                            <autoresizingMask key="autoresizingMask"/>
-                        </scroller>
-                        <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="zJA-Ld-fbA">
-                            <rect key="frame" x="224" y="17" width="15" height="102"/>
-                            <autoresizingMask key="autoresizingMask"/>
-                        </scroller>
-                    </scrollView>
-                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="THV-Yh-VnK">
-                        <rect key="frame" x="369" y="5" width="65" height="32"/>
-                        <buttonCell key="cell" type="push" title="Add" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="w2g-wR-hPu">
-                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                            <font key="font" metaFont="system"/>
-                            <string key="keyEquivalent" base64-UTF8="YES">
-DQ
-</string>
-                        </buttonCell>
-                        <connections>
-                            <action selector="sheetAddBtnAction:" target="bda-X5-kCJ" id="RHg-OM-dU2"/>
-                        </connections>
-                    </button>
-                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fIw-KJ-Onk">
-                        <rect key="frame" x="287" y="5" width="82" height="32"/>
-                        <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="9Au-ZV-KXN">
-                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                            <font key="font" metaFont="system"/>
-                            <string key="keyEquivalent" base64-UTF8="YES">
-Gw
-</string>
-                        </buttonCell>
-                        <connections>
-                            <action selector="sheetCancelBtnAction:" target="bda-X5-kCJ" id="6np-Pb-cA2"/>
-                        </connections>
-                    </button>
-                    <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B0m-Ni-LVx">
-                        <rect key="frame" x="160" y="45" width="268" height="244"/>
-                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="ig8-nk-a17">
-                            <rect key="frame" x="0.0" y="0.0" width="268" height="244"/>
-                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                            <subviews>
-                                <view fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZHP-RK-Ly4" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="0.0" width="268" height="244"/>
-                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                </view>
-                            </subviews>
-                        </clipView>
-                        <scroller key="horizontalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="QWZ-kz-uCm">
-                            <rect key="frame" x="0.0" y="228" width="268" height="16"/>
-                            <autoresizingMask key="autoresizingMask"/>
-                        </scroller>
-                        <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="XFr-qq-P3o">
-                            <rect key="frame" x="252" y="0.0" width="16" height="244"/>
-                            <autoresizingMask key="autoresizingMask"/>
-                        </scroller>
-                    </scrollView>
-                </subviews>
-                <constraints>
-                    <constraint firstItem="fIw-KJ-Onk" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="RNP-NG-UVn" secondAttribute="leading" constant="20" symbolic="YES" id="21c-Fi-Ddw"/>
-                    <constraint firstItem="B0m-Ni-LVx" firstAttribute="bottom" secondItem="n0t-vk-dME" secondAttribute="bottom" id="5Pt-oe-qS5"/>
-                    <constraint firstAttribute="trailing" secondItem="B0m-Ni-LVx" secondAttribute="trailing" constant="12" id="9gr-IB-GDr"/>
-                    <constraint firstAttribute="bottom" secondItem="15J-Tp-Ccx" secondAttribute="bottom" constant="44" id="DTb-US-5Yy"/>
-                    <constraint firstItem="fIw-KJ-Onk" firstAttribute="centerY" secondItem="THV-Yh-VnK" secondAttribute="centerY" id="UKK-mU-pJ6"/>
-                    <constraint firstItem="B0m-Ni-LVx" firstAttribute="top" secondItem="n0t-vk-dME" secondAttribute="top" id="Wkv-JK-daM"/>
-                    <constraint firstItem="B0m-Ni-LVx" firstAttribute="leading" secondItem="15J-Tp-Ccx" secondAttribute="trailing" constant="8" id="Xos-4x-Eq2"/>
-                    <constraint firstAttribute="bottom" secondItem="THV-Yh-VnK" secondAttribute="bottom" constant="12" id="f2S-i2-Ubu"/>
-                    <constraint firstItem="15J-Tp-Ccx" firstAttribute="top" secondItem="RNP-NG-UVn" secondAttribute="top" constant="12" id="gve-pZ-230"/>
-                    <constraint firstItem="15J-Tp-Ccx" firstAttribute="leading" secondItem="RNP-NG-UVn" secondAttribute="leading" constant="12" id="ksy-rD-gqr"/>
-                    <constraint firstAttribute="trailing" secondItem="THV-Yh-VnK" secondAttribute="trailing" constant="12" id="rY0-bo-ihO"/>
-                    <constraint firstItem="THV-Yh-VnK" firstAttribute="leading" secondItem="fIw-KJ-Onk" secondAttribute="trailing" constant="12" id="xZZ-dm-0yL"/>
-                </constraints>
-            </view>
-            <point key="canvasLocation" x="687" y="240"/>
-        </window>
-        <viewController id="bda-X5-kCJ" customClass="NewFilterSheetViewController" customModule="IINA" customModuleProvider="target">
-            <connections>
-                <outlet property="addButton" destination="THV-Yh-VnK" id="GeO-qk-FbF"/>
-                <outlet property="filterWindow" destination="-2" id="Pjr-CT-nJA"/>
-                <outlet property="scrollContentView" destination="ZHP-RK-Ly4" id="NhJ-gL-sPY"/>
-                <outlet property="tableView" destination="n0t-vk-dME" id="IBk-xT-LkA"/>
-                <outlet property="view" destination="RNP-NG-UVn" id="IxR-CL-PuL"/>
-            </connections>
-        </viewController>
-        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="hsA-Hq-fPV">
-            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
-            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
-            <rect key="contentRect" x="163" y="199" width="403" height="230"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
-            <view key="contentView" id="Af9-J4-L1C">
-                <rect key="frame" x="0.0" y="0.0" width="403" height="230"/>
-                <autoresizingMask key="autoresizingMask"/>
-                <subviews>
-                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qz5-V0-iH0">
-                        <rect key="frame" x="12" y="115" width="379" height="22"/>
-                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="tIJ-Qx-EGw">
-                            <font key="font" metaFont="system"/>
-                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                        </textFieldCell>
-                    </textField>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VVZ-yu-5X9">
-                        <rect key="frame" x="10" y="141" width="38" height="14"/>
-                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Name:" id="IYf-IE-5cL">
-                            <font key="font" metaFont="smallSystem"/>
-                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                        </textFieldCell>
-                    </textField>
-                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="Tl9-qS-Ybu" customClass="KeyRecordView" customModule="IINA" customModuleProvider="target">
-                        <rect key="frame" x="12" y="41" width="379" height="48"/>
-                        <subviews>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oDS-CG-efd">
-                                <rect key="frame" x="107" y="16" width="165" height="17"/>
-                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Press any button to record" id="jJk-0R-KQo">
-                                    <font key="font" metaFont="system"/>
-                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                </textFieldCell>
-                            </textField>
-                        </subviews>
-                        <constraints>
-                            <constraint firstItem="oDS-CG-efd" firstAttribute="centerY" secondItem="Tl9-qS-Ybu" secondAttribute="centerY" id="Yha-he-Gjl"/>
-                            <constraint firstItem="oDS-CG-efd" firstAttribute="centerX" secondItem="Tl9-qS-Ybu" secondAttribute="centerX" id="mdJ-S2-8he"/>
-                            <constraint firstAttribute="height" constant="48" id="mrk-CK-nJr"/>
-                        </constraints>
-                    </customView>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IRi-nC-VIB">
-                        <rect key="frame" x="12" y="93" width="75" height="14"/>
-                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Shortcut key:" id="M9z-ss-1Ma">
-                            <font key="font" metaFont="smallSystem"/>
-                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                        </textFieldCell>
-                    </textField>
-                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3zR-Ud-A5J">
-                        <rect key="frame" x="332" y="5" width="65" height="32"/>
-                        <buttonCell key="cell" type="push" title="Add" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ljR-R1-mo7">
-                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                            <font key="font" metaFont="system"/>
-                            <string key="keyEquivalent" base64-UTF8="YES">
-DQ
-</string>
-                        </buttonCell>
-                        <connections>
-                            <action selector="addSavedFilterAction:" target="-2" id="wfX-ZZ-9Fv"/>
-                        </connections>
-                    </button>
-                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0dV-KP-u1a">
-                        <rect key="frame" x="250" y="5" width="82" height="32"/>
-                        <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="6fq-yx-3dE">
-                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                            <font key="font" metaFont="system"/>
-                            <string key="keyEquivalent" base64-UTF8="YES">
-Gw
-</string>
-                        </buttonCell>
-                        <connections>
-                            <action selector="cancelSavingFilterAction:" target="-2" id="OEO-0e-lfN"/>
-                        </connections>
-                    </button>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="THb-Ky-Cnh">
-                        <rect key="frame" x="10" y="201" width="72" height="17"/>
-                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Save Filter" id="KGV-G1-A2l">
-                            <font key="font" metaFont="systemBold"/>
-                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                        </textFieldCell>
-                    </textField>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="494-9n-dCn">
-                        <rect key="frame" x="10" y="163" width="383" height="34"/>
-                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="By saving a filter, you can enable or disable it conveniently and even assign a shortcut key to it." id="8JN-kb-kGF">
-                            <font key="font" metaFont="system"/>
-                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                        </textFieldCell>
-                    </textField>
-                </subviews>
-                <constraints>
-                    <constraint firstAttribute="trailing" secondItem="494-9n-dCn" secondAttribute="trailing" constant="12" id="8W5-bf-DQZ"/>
-                    <constraint firstItem="THb-Ky-Cnh" firstAttribute="top" secondItem="Af9-J4-L1C" secondAttribute="top" constant="12" id="8xg-Pc-eJY"/>
-                    <constraint firstItem="3zR-Ud-A5J" firstAttribute="top" secondItem="Tl9-qS-Ybu" secondAttribute="bottom" constant="8" id="99O-Yo-Tua"/>
-                    <constraint firstAttribute="trailing" secondItem="Tl9-qS-Ybu" secondAttribute="trailing" constant="12" id="AlG-0d-EPY"/>
-                    <constraint firstItem="0dV-KP-u1a" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Af9-J4-L1C" secondAttribute="leading" constant="20" symbolic="YES" id="Cxw-eO-pjH"/>
-                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="VVZ-yu-5X9" secondAttribute="trailing" constant="12" id="Dgv-Ke-N55"/>
-                    <constraint firstAttribute="bottom" secondItem="3zR-Ud-A5J" secondAttribute="bottom" constant="12" id="Dzw-gl-bm9"/>
-                    <constraint firstItem="VVZ-yu-5X9" firstAttribute="leading" secondItem="Af9-J4-L1C" secondAttribute="leading" constant="12" id="GWH-4d-U5D"/>
-                    <constraint firstItem="IRi-nC-VIB" firstAttribute="leading" secondItem="Af9-J4-L1C" secondAttribute="leading" constant="14" id="K1r-yi-TbH"/>
-                    <constraint firstItem="Tl9-qS-Ybu" firstAttribute="leading" secondItem="Af9-J4-L1C" secondAttribute="leading" constant="12" id="MSF-Jj-2fE"/>
-                    <constraint firstItem="THb-Ky-Cnh" firstAttribute="leading" secondItem="Af9-J4-L1C" secondAttribute="leading" constant="12" id="N4i-xV-nYI"/>
-                    <constraint firstItem="494-9n-dCn" firstAttribute="top" secondItem="THb-Ky-Cnh" secondAttribute="bottom" constant="4" id="O2K-aA-ZeZ"/>
-                    <constraint firstItem="494-9n-dCn" firstAttribute="leading" secondItem="Af9-J4-L1C" secondAttribute="leading" constant="12" id="UG1-qT-Nis"/>
-                    <constraint firstAttribute="trailing" secondItem="qz5-V0-iH0" secondAttribute="trailing" constant="12" id="V4I-Ho-7F2"/>
-                    <constraint firstItem="VVZ-yu-5X9" firstAttribute="top" secondItem="494-9n-dCn" secondAttribute="bottom" constant="8" id="X1v-tH-TUQ"/>
-                    <constraint firstItem="qz5-V0-iH0" firstAttribute="leading" secondItem="Af9-J4-L1C" secondAttribute="leading" constant="12" id="XxV-6d-Kcm"/>
-                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="IRi-nC-VIB" secondAttribute="trailing" constant="12" id="Z9r-Bn-bpy"/>
-                    <constraint firstItem="IRi-nC-VIB" firstAttribute="top" secondItem="qz5-V0-iH0" secondAttribute="bottom" constant="8" id="ZK0-St-dK7"/>
-                    <constraint firstItem="0dV-KP-u1a" firstAttribute="centerY" secondItem="3zR-Ud-A5J" secondAttribute="centerY" id="Zfg-Wf-6FG"/>
-                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="THb-Ky-Cnh" secondAttribute="trailing" constant="12" id="Zyi-Cb-q8D"/>
-                    <constraint firstAttribute="trailing" secondItem="3zR-Ud-A5J" secondAttribute="trailing" constant="12" id="cyc-cE-PRo"/>
-                    <constraint firstItem="Tl9-qS-Ybu" firstAttribute="top" secondItem="IRi-nC-VIB" secondAttribute="bottom" constant="4" id="gPR-mI-MFK"/>
-                    <constraint firstItem="qz5-V0-iH0" firstAttribute="top" secondItem="VVZ-yu-5X9" secondAttribute="bottom" constant="4" id="gQ6-Gc-iVl"/>
-                    <constraint firstItem="3zR-Ud-A5J" firstAttribute="leading" secondItem="0dV-KP-u1a" secondAttribute="trailing" constant="12" id="vRK-MA-je7"/>
-                </constraints>
-            </view>
-            <point key="canvasLocation" x="393.5" y="658.5"/>
-        </window>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="tI1-4J-bvZ">
-            <rect key="frame" x="0.0" y="0.0" width="480" height="194"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="tI1-4J-bvZ" userLabel="Active Filters View">
+            <rect key="frame" x="0.0" y="0.0" width="638" height="143"/>
             <subviews>
-                <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="brl-j0-vbe">
-                    <rect key="frame" x="-1" y="19" width="482" height="176"/>
+                <scrollView autohidesScrollers="YES" horizontalLineScroll="26" horizontalPageScroll="10" verticalLineScroll="26" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="brl-j0-vbe">
+                    <rect key="frame" x="-1" y="19" width="640" height="125"/>
                     <clipView key="contentView" id="Hbi-ga-FRu">
-                        <rect key="frame" x="1" y="0.0" width="480" height="175"/>
+                        <rect key="frame" x="1" y="1" width="638" height="123"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" headerView="ESY-lT-CzV" viewBased="YES" id="iTp-t4-bao">
-                                <rect key="frame" x="0.0" y="0.0" width="480" height="150"/>
-                                <autoresizingMask key="autoresizingMask"/>
+                            <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" tableStyle="fullWidth" alternatingRowBackgroundColors="YES" columnReordering="NO" autosaveName="FilterTable" rowHeight="24" rowSizeStyle="systemDefault" headerView="ESY-lT-CzV" viewBased="YES" id="iTp-t4-bao">
+                                <rect key="frame" x="0.0" y="0.0" width="638" height="98"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <size key="intercellSpacing" width="3" height="2"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                 <tableColumns>
-                                    <tableColumn identifier="Key" editable="NO" width="45" minWidth="40" maxWidth="1000" id="amK-Iz-lu8">
+                                    <tableColumn identifier="Key" editable="NO" width="40" minWidth="40" maxWidth="40" id="amK-Iz-lu8" userLabel="Key Column (#)">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="#">
-                                            <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                         </tableHeaderCell>
@@ -374,10 +102,10 @@ Gw
                                                 <rect key="frame" x="1" y="1" width="45" height="17"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
-                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="cLl-pZ-KNW">
-                                                        <rect key="frame" x="0.0" y="0.0" width="45" height="17"/>
-                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="WAS-rj-5Np">
-                                                            <font key="font" metaFont="system"/>
+                                                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="cLl-pZ-KNW">
+                                                        <rect key="frame" x="0.0" y="1" width="41" height="16"/>
+                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="right" title="Table View Cell" id="WAS-rj-5Np">
+                                                            <font key="font" usesAppearanceFont="YES"/>
                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
@@ -387,9 +115,9 @@ Gw
                                                     </textField>
                                                 </subviews>
                                                 <constraints>
+                                                    <constraint firstAttribute="trailing" secondItem="cLl-pZ-KNW" secondAttribute="trailing" constant="6" id="EmY-Bt-gh6"/>
                                                     <constraint firstItem="cLl-pZ-KNW" firstAttribute="leading" secondItem="bMU-ho-Dvg" secondAttribute="leading" constant="2" id="JiO-9J-K5y"/>
                                                     <constraint firstItem="cLl-pZ-KNW" firstAttribute="centerY" secondItem="bMU-ho-Dvg" secondAttribute="centerY" id="Zy0-LN-Gjp"/>
-                                                    <constraint firstItem="cLl-pZ-KNW" firstAttribute="centerX" secondItem="bMU-ho-Dvg" secondAttribute="centerX" id="zOd-Qy-8il"/>
                                                 </constraints>
                                                 <connections>
                                                     <outlet property="textField" destination="cLl-pZ-KNW" id="nYk-qj-eXE"/>
@@ -397,9 +125,8 @@ Gw
                                             </tableCellView>
                                         </prototypeCellViews>
                                     </tableColumn>
-                                    <tableColumn identifier="Value" width="320" minWidth="40" maxWidth="1000" id="4g6-LW-373">
+                                    <tableColumn identifier="Value" width="527.5" minWidth="40" maxWidth="2000" id="4g6-LW-373" userLabel="Value Column (Filter String)">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Filter String">
-                                            <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                         </tableHeaderCell>
@@ -411,13 +138,13 @@ Gw
                                         <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                         <prototypeCellViews>
                                             <tableCellView id="lPY-eq-bPA">
-                                                <rect key="frame" x="49" y="1" width="320" height="17"/>
+                                                <rect key="frame" x="49" y="1" width="527" height="17"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
-                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="AfO-KW-cSw">
-                                                        <rect key="frame" x="0.0" y="0.0" width="320" height="17"/>
+                                                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="AfO-KW-cSw">
+                                                        <rect key="frame" x="0.0" y="1" width="528" height="16"/>
                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" title="Table View Cell" id="gtr-Iv-kcK">
-                                                            <font key="font" metaFont="system"/>
+                                                            <font key="font" usesAppearanceFont="YES"/>
                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
@@ -437,9 +164,8 @@ Gw
                                             </tableCellView>
                                         </prototypeCellViews>
                                     </tableColumn>
-                                    <tableColumn width="95" minWidth="10" maxWidth="3.4028234663852886e+38" id="lka-OZ-XXJ">
+                                    <tableColumn width="45.5" minWidth="45" maxWidth="100" id="lka-OZ-XXJ" userLabel="Save Column">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                            <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                         </tableHeaderCell>
@@ -451,12 +177,12 @@ Gw
                                         <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                         <prototypeCellViews>
                                             <tableCellView id="6Ia-1U-G2V">
-                                                <rect key="frame" x="372" y="1" width="95" height="17"/>
+                                                <rect key="frame" x="579" y="1" width="49" height="17"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3dk-bb-Au2">
-                                                        <rect key="frame" x="2" y="0.0" width="40" height="17"/>
-                                                        <buttonCell key="cell" type="roundRect" title="Save" bezelStyle="roundedRect" alignment="center" controlSize="small" borderStyle="border" inset="2" id="tPs-K2-ZPz">
+                                                        <rect key="frame" x="-4" y="-6" width="54" height="27"/>
+                                                        <buttonCell key="cell" type="push" title="Save" bezelStyle="rounded" alignment="center" controlSize="small" borderStyle="border" inset="2" id="tPs-K2-ZPz">
                                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                             <font key="font" metaFont="smallSystem"/>
                                                         </buttonCell>
@@ -485,27 +211,27 @@ Gw
                     <constraints>
                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="120" id="VTD-Sc-iBR"/>
                     </constraints>
-                    <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="fYA-q7-Cne">
-                        <rect key="frame" x="1" y="305" width="438" height="16"/>
+                    <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="fYA-q7-Cne">
+                        <rect key="frame" x="1" y="108" width="638" height="16"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                     <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="QAU-je-m7n">
                         <rect key="frame" x="-15" y="0.0" width="16" height="0.0"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
-                    <tableHeaderView key="headerView" id="ESY-lT-CzV">
-                        <rect key="frame" x="0.0" y="0.0" width="480" height="25"/>
+                    <tableHeaderView key="headerView" wantsLayer="YES" id="ESY-lT-CzV">
+                        <rect key="frame" x="0.0" y="0.0" width="638" height="25"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </tableHeaderView>
                 </scrollView>
                 <box boxType="custom" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="G4c-Vf-UqH">
-                    <rect key="frame" x="-1" y="-1" width="482" height="22"/>
-                    <view key="contentView" id="RLZ-UD-oYg">
-                        <rect key="frame" x="1" y="1" width="480" height="20"/>
+                    <rect key="frame" x="-1" y="-1" width="640" height="22"/>
+                    <view key="contentView" id="RLZ-UD-oYg" userLabel="Box View">
+                        <rect key="frame" x="1" y="1" width="638" height="20"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="La1-eJ-8B2">
-                                <rect key="frame" x="0.0" y="0.0" width="20" height="20"/>
+                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="La1-eJ-8B2" userLabel="Add Filter Button">
+                                <rect key="frame" x="0.0" y="0.5" width="20.5" height="20"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" inset="2" id="skC-wc-wWf">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -515,8 +241,8 @@ Gw
                                     <action selector="addFilterAction:" target="-2" id="joq-SS-0iv"/>
                                 </connections>
                             </button>
-                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fCm-Dl-yIc">
-                                <rect key="frame" x="20" y="0.0" width="20" height="20"/>
+                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fCm-Dl-yIc" userLabel="Remove Filter Button">
+                                <rect key="frame" x="20" y="0.0" width="20.5" height="20"/>
                                 <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" inset="2" id="DRr-Vt-evM">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
@@ -544,27 +270,34 @@ Gw
                 <constraint firstItem="brl-j0-vbe" firstAttribute="top" secondItem="tI1-4J-bvZ" secondAttribute="top" constant="-1" id="bkI-IP-vh3"/>
                 <constraint firstItem="brl-j0-vbe" firstAttribute="leading" secondItem="tI1-4J-bvZ" secondAttribute="leading" constant="-1" id="tux-kP-U9v"/>
             </constraints>
-            <point key="canvasLocation" x="-457" y="395"/>
+            <point key="canvasLocation" x="-564" y="71"/>
         </customView>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="itW-qD-XDg">
-            <rect key="frame" x="0.0" y="0.0" width="480" height="163"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="itW-qD-XDg" userLabel="Saved Filters View">
+            <rect key="frame" x="0.0" y="0.0" width="640" height="171"/>
             <subviews>
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cIf-90-odO">
+                    <rect key="frame" x="6" y="153" width="79" height="16"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Saved filters" id="m5X-Zl-aOj">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
                 <scrollView autohidesScrollers="YES" horizontalLineScroll="40" horizontalPageScroll="10" verticalLineScroll="40" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rnV-6H-I6Z">
-                    <rect key="frame" x="-1" y="-1" width="482" height="146"/>
+                    <rect key="frame" x="-1" y="-1" width="642" height="152"/>
                     <clipView key="contentView" id="xDQ-TM-9KQ">
-                        <rect key="frame" x="1" y="1" width="480" height="144"/>
+                        <rect key="frame" x="1" y="1" width="640" height="150"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" alternatingRowBackgroundColors="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="38" rowSizeStyle="automatic" viewBased="YES" id="cw6-pW-oMs">
-                                <rect key="frame" x="0.0" y="0.0" width="480" height="144"/>
-                                <autoresizingMask key="autoresizingMask"/>
+                            <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" alternatingRowBackgroundColors="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="38" rowSizeStyle="automatic" viewBased="YES" id="cw6-pW-oMs">
+                                <rect key="frame" x="0.0" y="0.0" width="640" height="150"/>
+                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <size key="intercellSpacing" width="3" height="2"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                 <tableColumns>
-                                    <tableColumn width="477" minWidth="40" maxWidth="1000" id="TbO-kN-XQm">
+                                    <tableColumn width="628" minWidth="40" maxWidth="2000" id="TbO-kN-XQm">
                                         <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
-                                            <font key="font" metaFont="smallSystem"/>
                                             <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                             <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                         </tableHeaderCell>
@@ -576,11 +309,11 @@ Gw
                                         <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                         <prototypeCellViews>
                                             <tableCellView id="VRo-34-gOI">
-                                                <rect key="frame" x="1" y="1" width="477" height="38"/>
+                                                <rect key="frame" x="1" y="1" width="637" height="38"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
-                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Lbk-r9-gQj">
-                                                        <rect key="frame" x="30" y="19" width="96" height="17"/>
+                                                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Lbk-r9-gQj">
+                                                        <rect key="frame" x="30" y="20" width="96" height="16"/>
                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="EXM-Xm-pvG">
                                                             <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -590,10 +323,10 @@ Gw
                                                             <binding destination="VRo-34-gOI" name="value" keyPath="objectValue.name" id="AOt-1Q-XQy"/>
                                                         </connections>
                                                     </textField>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="748" translatesAutoresizingMaskIntoConstraints="NO" id="MIx-kF-Ju3">
-                                                        <rect key="frame" x="30" y="3" width="33" height="14"/>
+                                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="748" translatesAutoresizingMaskIntoConstraints="NO" id="MIx-kF-Ju3">
+                                                        <rect key="frame" x="30" y="2" width="37" height="16"/>
                                                         <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" title="Label" id="09q-ZP-mpK">
-                                                            <font key="font" metaFont="smallSystem"/>
+                                                            <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                                         </textFieldCell>
@@ -602,50 +335,50 @@ Gw
                                                         </connections>
                                                     </textField>
                                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="56K-2H-lTw">
-                                                        <rect key="frame" x="455" y="12" width="14" height="14"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="14" id="5Ua-Wm-PBx"/>
-                                                            <constraint firstAttribute="width" constant="14" id="fXx-LD-vcD"/>
-                                                        </constraints>
+                                                        <rect key="frame" x="611" y="7" width="18" height="24"/>
                                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSStopProgressFreestandingTemplate" imagePosition="overlaps" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="e3h-Ed-KyL">
                                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                             <font key="font" metaFont="system"/>
                                                         </buttonCell>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" secondItem="56K-2H-lTw" secondAttribute="height" multiplier="1:1" id="2V5-qV-ASQ"/>
+                                                            <constraint firstAttribute="height" constant="18" id="5Ua-Wm-PBx"/>
+                                                        </constraints>
                                                         <connections>
                                                             <action selector="deleteSavedFilterAction:" target="-2" id="dRe-NB-f1C"/>
                                                         </connections>
                                                     </button>
                                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="ZJo-ef-lfp">
-                                                        <rect key="frame" x="433" y="12" width="14" height="14"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="width" constant="14" id="B7C-IN-gxD"/>
-                                                            <constraint firstAttribute="height" constant="14" id="ESC-VN-aRY"/>
-                                                        </constraints>
+                                                        <rect key="frame" x="585" y="7" width="18" height="24"/>
                                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSActionTemplate" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="y2D-Dj-SFr">
                                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                             <font key="font" metaFont="system"/>
                                                         </buttonCell>
+                                                        <constraints>
+                                                            <constraint firstAttribute="width" constant="18" id="B7C-IN-gxD"/>
+                                                            <constraint firstAttribute="height" constant="18" id="ESC-VN-aRY"/>
+                                                        </constraints>
                                                         <connections>
                                                             <action selector="editSavedFilterAction:" target="-2" id="8gU-l1-Yw3"/>
                                                         </connections>
                                                     </button>
                                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JHq-zl-TrB">
                                                         <rect key="frame" x="6" y="10" width="18" height="18"/>
-                                                        <constraints>
-                                                            <constraint firstAttribute="height" constant="14" id="3i6-Vm-I65"/>
-                                                            <constraint firstAttribute="width" constant="14" id="Yz3-zO-jhs"/>
-                                                        </constraints>
                                                         <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="only" state="on" inset="2" id="p7t-d6-y1M">
                                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                             <font key="font" metaFont="system"/>
                                                         </buttonCell>
+                                                        <constraints>
+                                                            <constraint firstAttribute="height" constant="14" id="3i6-Vm-I65"/>
+                                                            <constraint firstAttribute="width" constant="14" id="Yz3-zO-jhs"/>
+                                                        </constraints>
                                                         <connections>
                                                             <action selector="toggleSavedFilterAction:" target="-2" id="k1Y-BZ-hG1"/>
                                                             <binding destination="VRo-34-gOI" name="value" keyPath="objectValue.isEnabled" id="ZuN-gB-olx"/>
                                                         </connections>
                                                     </button>
-                                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="b2Y-ob-c1P">
-                                                        <rect key="frame" x="421" y="11" width="4" height="17"/>
+                                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="b2Y-ob-c1P">
+                                                        <rect key="frame" x="573" y="11" width="4" height="16"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="9xR-IJ-UkJ">
                                                             <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -691,7 +424,7 @@ Gw
                         <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="120" id="rKj-fy-rqf"/>
                     </constraints>
                     <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="esw-5n-JqU">
-                        <rect key="frame" x="1" y="119" width="223" height="15"/>
+                        <rect key="frame" x="1" y="135" width="640" height="16"/>
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                     <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="eRO-nL-o5k">
@@ -699,14 +432,6 @@ Gw
                         <autoresizingMask key="autoresizingMask"/>
                     </scroller>
                 </scrollView>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cIf-90-odO">
-                    <rect key="frame" x="6" y="147" width="70" height="14"/>
-                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Saved filters" id="m5X-Zl-aOj">
-                        <font key="font" metaFont="smallSystem"/>
-                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
-                </textField>
             </subviews>
             <constraints>
                 <constraint firstItem="rnV-6H-I6Z" firstAttribute="top" secondItem="cIf-90-odO" secondAttribute="bottom" constant="2" id="7e0-eN-AZx"/>
@@ -717,43 +442,322 @@ Gw
                 <constraint firstItem="cIf-90-odO" firstAttribute="top" secondItem="itW-qD-XDg" secondAttribute="top" constant="2" id="kBC-XD-Pm7"/>
                 <constraint firstAttribute="bottom" secondItem="rnV-6H-I6Z" secondAttribute="bottom" constant="-1" id="xeo-PZ-Zhr"/>
             </constraints>
-            <point key="canvasLocation" x="-457" y="129"/>
+            <point key="canvasLocation" x="-563" y="281"/>
         </customView>
-        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" id="Zxl-uQ-3ud">
+        <window title="New Filter" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="NewFilterWindow" animationBehavior="default" id="8Eh-v2-bbh" userLabel="New Filter Window">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="283" y="305" width="620" height="400"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1728" height="1079"/>
+            <value key="minSize" type="size" width="320" height="200"/>
+            <view key="contentView" ambiguous="YES" translatesAutoresizingMaskIntoConstraints="NO" id="RNP-NG-UVn" userLabel="Window Content View">
+                <rect key="frame" x="0.0" y="0.0" width="450" height="200"/>
+                <subviews>
+                    <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="15J-Tp-Ccx" userLabel="Left Bordered Scroll View">
+                        <rect key="frame" x="12" y="40" width="200" height="148"/>
+                        <clipView key="contentView" id="evP-Km-Po1" userLabel="Left Clip View">
+                            <rect key="frame" x="1" y="1" width="198" height="146"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <subviews>
+                                <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" translatesAutoresizingMaskIntoConstraints="NO" id="n0t-vk-dME" userLabel="FilterPresets Table View">
+                                    <rect key="frame" x="-1" y="0.0" width="198" height="146"/>
+                                    <size key="intercellSpacing" width="3" height="2"/>
+                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
+                                    <tableColumns>
+                                        <tableColumn editable="NO" width="157" minWidth="40" maxWidth="1000" id="Wak-3T-72M" userLabel="FilterPresetsTable Column">
+                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
+                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                            </tableHeaderCell>
+                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" title="Text Cell" id="GXg-4l-PJC">
+                                                <font key="font" metaFont="system"/>
+                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                            <prototypeCellViews>
+                                                <tableCellView id="WlY-5X-SEi">
+                                                    <rect key="frame" x="1" y="1" width="166" height="17"/>
+                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                    <subviews>
+                                                        <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="MAd-sY-Hvg">
+                                                            <rect key="frame" x="0.0" y="0.0" width="166" height="17"/>
+                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="Kve-RD-QwY">
+                                                                <font key="font" metaFont="system"/>
+                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                            <connections>
+                                                                <binding destination="WlY-5X-SEi" name="value" keyPath="objectValue" id="CPm-ly-m1u"/>
+                                                            </connections>
+                                                        </textField>
+                                                    </subviews>
+                                                    <connections>
+                                                        <outlet property="textField" destination="MAd-sY-Hvg" id="m6f-Sx-xb4"/>
+                                                    </connections>
+                                                </tableCellView>
+                                            </prototypeCellViews>
+                                        </tableColumn>
+                                    </tableColumns>
+                                </tableView>
+                            </subviews>
+                            <constraints>
+                                <constraint firstItem="n0t-vk-dME" firstAttribute="top" secondItem="evP-Km-Po1" secondAttribute="top" id="0Xm-Vy-HSK"/>
+                            </constraints>
+                        </clipView>
+                        <constraints>
+                            <constraint firstItem="n0t-vk-dME" firstAttribute="leading" secondItem="15J-Tp-Ccx" secondAttribute="leading" id="UgT-GR-h0J"/>
+                            <constraint firstAttribute="trailing" secondItem="n0t-vk-dME" secondAttribute="trailing" id="Us1-M1-eIt"/>
+                            <constraint firstAttribute="width" constant="200" id="oFm-NQ-6ro"/>
+                        </constraints>
+                        <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="Zhg-GM-4UI">
+                            <rect key="frame" x="1" y="271" width="138" height="16"/>
+                            <autoresizingMask key="autoresizingMask"/>
+                        </scroller>
+                        <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="zJA-Ld-fbA">
+                            <rect key="frame" x="224" y="17" width="15" height="102"/>
+                            <autoresizingMask key="autoresizingMask"/>
+                        </scroller>
+                    </scrollView>
+                    <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B0m-Ni-LVx" userLabel="Right Scroll View - Flipped View">
+                        <rect key="frame" x="220" y="40" width="218" height="148"/>
+                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="ig8-nk-a17" userLabel="Right Clip View">
+                            <rect key="frame" x="0.0" y="0.0" width="218" height="148"/>
+                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                            <subviews>
+                                <view fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZHP-RK-Ly4" userLabel="Right Flipped View" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
+                                    <rect key="frame" x="0.0" y="0.0" width="218" height="148"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                </view>
+                            </subviews>
+                        </clipView>
+                        <scroller key="horizontalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="QWZ-kz-uCm">
+                            <rect key="frame" x="0.0" y="132" width="218" height="16"/>
+                            <autoresizingMask key="autoresizingMask"/>
+                        </scroller>
+                        <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="XFr-qq-P3o">
+                            <rect key="frame" x="202" y="0.0" width="16" height="148"/>
+                            <autoresizingMask key="autoresizingMask"/>
+                        </scroller>
+                    </scrollView>
+                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fIw-KJ-Onk">
+                        <rect key="frame" x="312" y="5" width="76" height="32"/>
+                        <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="9Au-ZV-KXN">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                            <string key="keyEquivalent" base64-UTF8="YES">
+Gw
+</string>
+                        </buttonCell>
+                        <connections>
+                            <action selector="sheetCancelBtnAction:" target="bda-X5-kCJ" id="6np-Pb-cA2"/>
+                        </connections>
+                    </button>
+                    <button horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="THV-Yh-VnK">
+                        <rect key="frame" x="386" y="5" width="59" height="32"/>
+                        <buttonCell key="cell" type="push" title="Add" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="w2g-wR-hPu">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                            <string key="keyEquivalent" base64-UTF8="YES">
+DQ
+</string>
+                        </buttonCell>
+                        <connections>
+                            <action selector="sheetAddBtnAction:" target="bda-X5-kCJ" id="RHg-OM-dU2"/>
+                        </connections>
+                    </button>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="fIw-KJ-Onk" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="RNP-NG-UVn" secondAttribute="leading" constant="20" symbolic="YES" id="21c-Fi-Ddw"/>
+                    <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="501" constant="450" id="DKb-QT-lTf"/>
+                    <constraint firstAttribute="height" relation="greaterThanOrEqual" priority="501" constant="200" id="FcW-r4-O57"/>
+                    <constraint firstItem="B0m-Ni-LVx" firstAttribute="leading" secondItem="15J-Tp-Ccx" secondAttribute="trailing" constant="8" id="Ijb-qQ-k2l"/>
+                    <constraint firstItem="B0m-Ni-LVx" firstAttribute="top" secondItem="RNP-NG-UVn" secondAttribute="top" constant="12" id="JO7-zl-b0n"/>
+                    <constraint firstItem="THV-Yh-VnK" firstAttribute="trailing" secondItem="B0m-Ni-LVx" secondAttribute="trailing" id="Li7-mx-p6M"/>
+                    <constraint firstItem="B0m-Ni-LVx" firstAttribute="bottom" secondItem="15J-Tp-Ccx" secondAttribute="bottom" id="Psb-yU-Sqe"/>
+                    <constraint firstItem="B0m-Ni-LVx" firstAttribute="height" secondItem="15J-Tp-Ccx" secondAttribute="height" id="Q9b-lL-9CS"/>
+                    <constraint firstAttribute="width" relation="lessThanOrEqual" priority="499" constant="450" id="STN-GI-eKO"/>
+                    <constraint firstAttribute="trailing" secondItem="B0m-Ni-LVx" secondAttribute="trailing" constant="12" id="YcU-xC-2wB"/>
+                    <constraint firstItem="THV-Yh-VnK" firstAttribute="bottom" secondItem="fIw-KJ-Onk" secondAttribute="bottom" id="bj8-WV-xwA"/>
+                    <constraint firstItem="THV-Yh-VnK" firstAttribute="top" secondItem="B0m-Ni-LVx" secondAttribute="bottom" constant="8" id="ecM-0g-P89"/>
+                    <constraint firstAttribute="bottom" secondItem="THV-Yh-VnK" secondAttribute="bottom" constant="12" id="f2S-i2-Ubu"/>
+                    <constraint firstItem="15J-Tp-Ccx" firstAttribute="leading" secondItem="RNP-NG-UVn" secondAttribute="leading" constant="12" id="ksy-rD-gqr"/>
+                    <constraint firstItem="THV-Yh-VnK" firstAttribute="top" secondItem="fIw-KJ-Onk" secondAttribute="top" id="lYB-i1-KwA"/>
+                    <constraint firstAttribute="height" relation="lessThanOrEqual" priority="499" constant="200" id="oAy-l9-t8y"/>
+                    <constraint firstItem="THV-Yh-VnK" firstAttribute="leading" secondItem="fIw-KJ-Onk" secondAttribute="trailing" constant="12" id="xZZ-dm-0yL"/>
+                </constraints>
+            </view>
+            <point key="canvasLocation" x="317" y="617"/>
+        </window>
+        <viewController id="bda-X5-kCJ" customClass="NewFilterSheetViewController" customModule="IINA" customModuleProvider="target">
+            <connections>
+                <outlet property="addButton" destination="THV-Yh-VnK" id="GeO-qk-FbF"/>
+                <outlet property="filterWindow" destination="-2" id="Pjr-CT-nJA"/>
+                <outlet property="scrollContentView" destination="ZHP-RK-Ly4" id="NhJ-gL-sPY"/>
+                <outlet property="tableView" destination="n0t-vk-dME" id="IBk-xT-LkA"/>
+                <outlet property="view" destination="RNP-NG-UVn" id="IxR-CL-PuL"/>
+            </connections>
+        </viewController>
+        <window title="Save Filter" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="SaveFilterWindow" animationBehavior="default" id="hsA-Hq-fPV" userLabel="Save Filter Window">
+            <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
+            <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
+            <rect key="contentRect" x="163" y="199" width="403" height="230"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1728" height="1079"/>
+            <view key="contentView" id="Af9-J4-L1C">
+                <rect key="frame" x="0.0" y="0.0" width="403" height="225"/>
+                <autoresizingMask key="autoresizingMask"/>
+                <subviews>
+                    <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qz5-V0-iH0">
+                        <rect key="frame" x="12" y="114" width="379" height="21"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="tIJ-Qx-EGw">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="VVZ-yu-5X9">
+                        <rect key="frame" x="10" y="139" width="38" height="14"/>
+                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Name:" id="IYf-IE-5cL">
+                            <font key="font" metaFont="smallSystem"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="Tl9-qS-Ybu" customClass="KeyRecordView" customModule="IINA" customModuleProvider="target">
+                        <rect key="frame" x="12" y="40" width="379" height="48"/>
+                        <subviews>
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oDS-CG-efd">
+                                <rect key="frame" x="107" y="16" width="165" height="16"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Press any button to record" id="jJk-0R-KQo">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="oDS-CG-efd" firstAttribute="centerY" secondItem="Tl9-qS-Ybu" secondAttribute="centerY" id="Yha-he-Gjl"/>
+                            <constraint firstItem="oDS-CG-efd" firstAttribute="centerX" secondItem="Tl9-qS-Ybu" secondAttribute="centerX" id="mdJ-S2-8he"/>
+                            <constraint firstAttribute="height" constant="48" id="mrk-CK-nJr"/>
+                        </constraints>
+                    </customView>
+                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IRi-nC-VIB">
+                        <rect key="frame" x="12" y="92" width="74" height="14"/>
+                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Shortcut key:" id="M9z-ss-1Ma">
+                            <font key="font" metaFont="smallSystem"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3zR-Ud-A5J">
+                        <rect key="frame" x="339" y="5" width="59" height="32"/>
+                        <buttonCell key="cell" type="push" title="Add" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ljR-R1-mo7">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                            <string key="keyEquivalent" base64-UTF8="YES">
+DQ
+</string>
+                        </buttonCell>
+                        <connections>
+                            <action selector="addSavedFilterAction:" target="-2" id="wfX-ZZ-9Fv"/>
+                        </connections>
+                    </button>
+                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="0dV-KP-u1a">
+                        <rect key="frame" x="265" y="5" width="76" height="32"/>
+                        <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="6fq-yx-3dE">
+                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                            <font key="font" metaFont="system"/>
+                            <string key="keyEquivalent" base64-UTF8="YES">
+Gw
+</string>
+                        </buttonCell>
+                        <connections>
+                            <action selector="cancelSavingFilterAction:" target="-2" id="OEO-0e-lfN"/>
+                        </connections>
+                    </button>
+                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="THb-Ky-Cnh">
+                        <rect key="frame" x="10" y="197" width="72" height="16"/>
+                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Save Filter" id="KGV-G1-A2l">
+                            <font key="font" metaFont="systemBold"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="494-9n-dCn">
+                        <rect key="frame" x="10" y="161" width="383" height="32"/>
+                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" title="By saving a filter, you can enable or disable it conveniently and even assign a shortcut key to it." id="8JN-kb-kGF">
+                            <font key="font" metaFont="system"/>
+                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                        </textFieldCell>
+                    </textField>
+                </subviews>
+                <constraints>
+                    <constraint firstAttribute="trailing" secondItem="494-9n-dCn" secondAttribute="trailing" constant="12" id="8W5-bf-DQZ"/>
+                    <constraint firstItem="THb-Ky-Cnh" firstAttribute="top" secondItem="Af9-J4-L1C" secondAttribute="top" constant="12" id="8xg-Pc-eJY"/>
+                    <constraint firstItem="3zR-Ud-A5J" firstAttribute="top" secondItem="Tl9-qS-Ybu" secondAttribute="bottom" constant="8" id="99O-Yo-Tua"/>
+                    <constraint firstAttribute="trailing" secondItem="Tl9-qS-Ybu" secondAttribute="trailing" constant="12" id="AlG-0d-EPY"/>
+                    <constraint firstItem="0dV-KP-u1a" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Af9-J4-L1C" secondAttribute="leading" constant="20" symbolic="YES" id="Cxw-eO-pjH"/>
+                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="VVZ-yu-5X9" secondAttribute="trailing" constant="12" id="Dgv-Ke-N55"/>
+                    <constraint firstAttribute="bottom" secondItem="3zR-Ud-A5J" secondAttribute="bottom" constant="12" id="Dzw-gl-bm9"/>
+                    <constraint firstItem="VVZ-yu-5X9" firstAttribute="leading" secondItem="Af9-J4-L1C" secondAttribute="leading" constant="12" id="GWH-4d-U5D"/>
+                    <constraint firstItem="IRi-nC-VIB" firstAttribute="leading" secondItem="Af9-J4-L1C" secondAttribute="leading" constant="14" id="K1r-yi-TbH"/>
+                    <constraint firstItem="Tl9-qS-Ybu" firstAttribute="leading" secondItem="Af9-J4-L1C" secondAttribute="leading" constant="12" id="MSF-Jj-2fE"/>
+                    <constraint firstItem="THb-Ky-Cnh" firstAttribute="leading" secondItem="Af9-J4-L1C" secondAttribute="leading" constant="12" id="N4i-xV-nYI"/>
+                    <constraint firstItem="494-9n-dCn" firstAttribute="top" secondItem="THb-Ky-Cnh" secondAttribute="bottom" constant="4" id="O2K-aA-ZeZ"/>
+                    <constraint firstItem="494-9n-dCn" firstAttribute="leading" secondItem="Af9-J4-L1C" secondAttribute="leading" constant="12" id="UG1-qT-Nis"/>
+                    <constraint firstAttribute="trailing" secondItem="qz5-V0-iH0" secondAttribute="trailing" constant="12" id="V4I-Ho-7F2"/>
+                    <constraint firstItem="VVZ-yu-5X9" firstAttribute="top" secondItem="494-9n-dCn" secondAttribute="bottom" constant="8" id="X1v-tH-TUQ"/>
+                    <constraint firstItem="qz5-V0-iH0" firstAttribute="leading" secondItem="Af9-J4-L1C" secondAttribute="leading" constant="12" id="XxV-6d-Kcm"/>
+                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="IRi-nC-VIB" secondAttribute="trailing" constant="12" id="Z9r-Bn-bpy"/>
+                    <constraint firstItem="IRi-nC-VIB" firstAttribute="top" secondItem="qz5-V0-iH0" secondAttribute="bottom" constant="8" id="ZK0-St-dK7"/>
+                    <constraint firstItem="0dV-KP-u1a" firstAttribute="centerY" secondItem="3zR-Ud-A5J" secondAttribute="centerY" id="Zfg-Wf-6FG"/>
+                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="THb-Ky-Cnh" secondAttribute="trailing" constant="12" id="Zyi-Cb-q8D"/>
+                    <constraint firstAttribute="trailing" secondItem="3zR-Ud-A5J" secondAttribute="trailing" constant="12" id="cyc-cE-PRo"/>
+                    <constraint firstItem="Tl9-qS-Ybu" firstAttribute="top" secondItem="IRi-nC-VIB" secondAttribute="bottom" constant="4" id="gPR-mI-MFK"/>
+                    <constraint firstItem="qz5-V0-iH0" firstAttribute="top" secondItem="VVZ-yu-5X9" secondAttribute="bottom" constant="4" id="gQ6-Gc-iVl"/>
+                    <constraint firstItem="3zR-Ud-A5J" firstAttribute="leading" secondItem="0dV-KP-u1a" secondAttribute="trailing" constant="12" id="vRK-MA-je7"/>
+                </constraints>
+            </view>
+            <point key="canvasLocation" x="-735" y="618"/>
+        </window>
+        <window title="Edit Filter" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="EditFilterWindow" animationBehavior="default" id="Zxl-uQ-3ud" userLabel="Edit Filter Window">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="163" y="199" width="393" height="240"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="1440" height="877"/>
-            <view key="contentView" id="knb-gb-GnG">
-                <rect key="frame" x="0.0" y="0.0" width="393" height="240"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1728" height="1079"/>
+            <view key="contentView" id="knb-gb-GnG" userLabel="Content View">
+                <rect key="frame" x="0.0" y="0.0" width="393" height="236"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="E7J-3Z-sWo">
-                        <rect key="frame" x="10" y="211" width="67" height="17"/>
+                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="E7J-3Z-sWo">
+                        <rect key="frame" x="10" y="208" width="67" height="16"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Edit Filter" id="Dab-w9-6TY">
                             <font key="font" metaFont="systemBold"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="O0s-TH-UaJ">
-                        <rect key="frame" x="12" y="163" width="369" height="22"/>
+                    <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="O0s-TH-UaJ">
+                        <rect key="frame" x="12" y="161" width="369" height="21"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="cXe-Ng-Vqb">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="L4P-KI-bQL">
-                        <rect key="frame" x="12" y="115" width="369" height="22"/>
+                    <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="L4P-KI-bQL">
+                        <rect key="frame" x="12" y="114" width="369" height="21"/>
                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="OdQ-xm-1k0">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KIF-JE-AL9">
-                        <rect key="frame" x="10" y="189" width="38" height="14"/>
+                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KIF-JE-AL9">
+                        <rect key="frame" x="10" y="186" width="38" height="14"/>
                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Name:" id="9k2-lm-YGD">
                             <font key="font" metaFont="smallSystem"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -761,10 +765,10 @@ Gw
                         </textFieldCell>
                     </textField>
                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="dAY-w3-zCx" customClass="KeyRecordView" customModule="IINA" customModuleProvider="target">
-                        <rect key="frame" x="12" y="41" width="369" height="48"/>
+                        <rect key="frame" x="12" y="40" width="369" height="48"/>
                         <subviews>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="B5v-za-vBd">
-                                <rect key="frame" x="102" y="16" width="165" height="17"/>
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="B5v-za-vBd">
+                                <rect key="frame" x="102" y="16" width="165" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Press any button to record" id="dL4-so-Qss">
                                     <font key="font" metaFont="system"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -778,8 +782,8 @@ Gw
                             <constraint firstItem="B5v-za-vBd" firstAttribute="centerY" secondItem="dAY-w3-zCx" secondAttribute="centerY" id="nLv-EY-pnm"/>
                         </constraints>
                     </customView>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3lk-uI-Pxk">
-                        <rect key="frame" x="10" y="141" width="68" height="14"/>
+                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3lk-uI-Pxk">
+                        <rect key="frame" x="10" y="139" width="68" height="14"/>
                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Filter string:" id="t9F-EU-fKj">
                             <font key="font" metaFont="smallSystem"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -787,7 +791,7 @@ Gw
                         </textFieldCell>
                     </textField>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4tq-jE-rDe">
-                        <rect key="frame" x="317" y="5" width="70" height="32"/>
+                        <rect key="frame" x="324" y="5" width="64" height="32"/>
                         <buttonCell key="cell" type="push" title="Save" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="02L-0u-zae">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -800,7 +804,7 @@ DQ
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="oZ1-MZ-myx">
-                        <rect key="frame" x="235" y="5" width="82" height="32"/>
+                        <rect key="frame" x="250" y="5" width="76" height="32"/>
                         <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Xqd-Ft-hTS">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -812,8 +816,8 @@ Gw
                             <action selector="cancelEditingFilterAction:" target="-2" id="q92-39-s9z"/>
                         </connections>
                     </button>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="An7-v8-Wy4">
-                        <rect key="frame" x="10" y="93" width="75" height="14"/>
+                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="An7-v8-Wy4">
+                        <rect key="frame" x="10" y="92" width="74" height="14"/>
                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Shortcut key:" id="Nzk-zW-mIL">
                             <font key="font" metaFont="smallSystem"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -853,13 +857,13 @@ Gw
                     <constraint firstItem="KIF-JE-AL9" firstAttribute="top" secondItem="E7J-3Z-sWo" secondAttribute="bottom" constant="8" id="veT-s6-Eul"/>
                 </constraints>
             </view>
-            <point key="canvasLocation" x="-207.5" y="670.5"/>
+            <point key="canvasLocation" x="-211" y="663"/>
         </window>
     </objects>
     <resources>
-        <image name="NSActionTemplate" width="14" height="14"/>
-        <image name="NSAddTemplate" width="11" height="11"/>
-        <image name="NSRemoveTemplate" width="11" height="11"/>
-        <image name="NSStopProgressFreestandingTemplate" width="14" height="14"/>
+        <image name="NSActionTemplate" width="20" height="20"/>
+        <image name="NSAddTemplate" width="18" height="17"/>
+        <image name="NSRemoveTemplate" width="18" height="5"/>
+        <image name="NSStopProgressFreestandingTemplate" width="20" height="20"/>
     </resources>
 </document>

--- a/iina/Base.lproj/FilterWindowController.xib
+++ b/iina/Base.lproj/FilterWindowController.xib
@@ -72,16 +72,16 @@
             <point key="canvasLocation" x="139" y="217"/>
         </window>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="tI1-4J-bvZ" userLabel="Active Filters View">
-            <rect key="frame" x="0.0" y="0.0" width="638" height="143"/>
+            <rect key="frame" x="0.0" y="0.0" width="638" height="75"/>
             <subviews>
                 <scrollView autohidesScrollers="YES" horizontalLineScroll="26" horizontalPageScroll="10" verticalLineScroll="26" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="brl-j0-vbe">
-                    <rect key="frame" x="-1" y="19" width="640" height="125"/>
+                    <rect key="frame" x="-1" y="21" width="640" height="55"/>
                     <clipView key="contentView" id="Hbi-ga-FRu">
-                        <rect key="frame" x="1" y="1" width="638" height="123"/>
+                        <rect key="frame" x="1" y="1" width="638" height="53"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" tableStyle="fullWidth" alternatingRowBackgroundColors="YES" columnReordering="NO" autosaveName="FilterTable" rowHeight="24" rowSizeStyle="systemDefault" headerView="ESY-lT-CzV" viewBased="YES" id="iTp-t4-bao">
-                                <rect key="frame" x="0.0" y="0.0" width="638" height="98"/>
+                                <rect key="frame" x="0.0" y="0.0" width="638" height="28"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <size key="intercellSpacing" width="3" height="2"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -210,7 +210,7 @@
                         </subviews>
                     </clipView>
                     <constraints>
-                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="120" id="VTD-Sc-iBR"/>
+                        <constraint firstAttribute="height" relation="greaterThanOrEqual" constant="40" id="EIQ-xX-FNj"/>
                     </constraints>
                     <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="YES" id="fYA-q7-Cne">
                         <rect key="frame" x="1" y="108" width="638" height="16"/>
@@ -225,53 +225,63 @@
                         <autoresizingMask key="autoresizingMask"/>
                     </tableHeaderView>
                 </scrollView>
-                <box boxType="custom" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="G4c-Vf-UqH">
-                    <rect key="frame" x="-1" y="-1" width="640" height="22"/>
+                <box boxType="custom" borderType="line" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="G4c-Vf-UqH">
+                    <rect key="frame" x="0.0" y="-1" width="638" height="22"/>
                     <view key="contentView" id="RLZ-UD-oYg" userLabel="Box View">
-                        <rect key="frame" x="1" y="1" width="638" height="20"/>
+                        <rect key="frame" x="1" y="1" width="636" height="20"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="La1-eJ-8B2" userLabel="Add Filter Button">
-                                <rect key="frame" x="0.0" y="0.5" width="20.5" height="20"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                            <button translatesAutoresizingMaskIntoConstraints="NO" id="La1-eJ-8B2" userLabel="Add Filter Button">
+                                <rect key="frame" x="1" y="-1.5" width="20.5" height="24"/>
                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" inset="2" id="skC-wc-wWf">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="20" id="dDK-xH-yZu"/>
+                                    <constraint firstAttribute="width" secondItem="La1-eJ-8B2" secondAttribute="height" multiplier="1:1" id="keE-YU-o14"/>
+                                </constraints>
                                 <connections>
                                     <action selector="addFilterAction:" target="-2" id="joq-SS-0iv"/>
                                 </connections>
                             </button>
-                            <button fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="fCm-Dl-yIc" userLabel="Remove Filter Button">
-                                <rect key="frame" x="20" y="0.0" width="20.5" height="20"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+                            <button translatesAutoresizingMaskIntoConstraints="NO" id="fCm-Dl-yIc" userLabel="Remove Filter Button">
+                                <rect key="frame" x="21" y="3" width="20.5" height="15"/>
                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" inset="2" id="DRr-Vt-evM">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="20" id="I7K-vd-6jo"/>
+                                    <constraint firstAttribute="width" constant="20" id="JHw-2Y-UQh"/>
+                                </constraints>
                                 <connections>
                                     <action selector="removeFilterAction:" target="-2" id="9at-jv-q44"/>
                                 </connections>
                             </button>
                         </subviews>
+                        <constraints>
+                            <constraint firstItem="fCm-Dl-yIc" firstAttribute="top" secondItem="La1-eJ-8B2" secondAttribute="top" id="3dk-aK-j1E"/>
+                            <constraint firstItem="fCm-Dl-yIc" firstAttribute="leading" secondItem="La1-eJ-8B2" secondAttribute="trailing" id="5L5-Ux-XOj"/>
+                            <constraint firstItem="La1-eJ-8B2" firstAttribute="leading" secondItem="RLZ-UD-oYg" secondAttribute="leading" constant="1" id="fdY-bb-gZI"/>
+                            <constraint firstAttribute="bottom" secondItem="La1-eJ-8B2" secondAttribute="bottom" id="iPG-Nw-Ghh"/>
+                        </constraints>
                     </view>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="22" id="lIS-W3-u4k"/>
-                    </constraints>
                     <color key="borderColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                     <color key="fillColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                 </box>
             </subviews>
             <constraints>
-                <constraint firstAttribute="bottom" secondItem="G4c-Vf-UqH" secondAttribute="bottom" constant="-1" id="7nU-fM-4kX"/>
+                <constraint firstItem="G4c-Vf-UqH" firstAttribute="top" secondItem="tI1-4J-bvZ" secondAttribute="bottom" constant="-21" id="7nU-fM-4kX"/>
                 <constraint firstAttribute="trailing" secondItem="brl-j0-vbe" secondAttribute="trailing" constant="-1" id="KHV-eM-yke"/>
-                <constraint firstItem="RLZ-UD-oYg" firstAttribute="top" secondItem="brl-j0-vbe" secondAttribute="bottom" constant="-1" id="NV7-Fu-Z1r"/>
-                <constraint firstItem="G4c-Vf-UqH" firstAttribute="leading" secondItem="tI1-4J-bvZ" secondAttribute="leading" constant="-1" id="T9M-bt-KYX"/>
-                <constraint firstAttribute="trailing" secondItem="G4c-Vf-UqH" secondAttribute="trailing" constant="-1" id="bNf-qM-1OQ"/>
+                <constraint firstItem="G4c-Vf-UqH" firstAttribute="leading" secondItem="tI1-4J-bvZ" secondAttribute="leading" id="T9M-bt-KYX"/>
+                <constraint firstAttribute="trailing" secondItem="G4c-Vf-UqH" secondAttribute="trailing" id="bNf-qM-1OQ"/>
                 <constraint firstItem="brl-j0-vbe" firstAttribute="top" secondItem="tI1-4J-bvZ" secondAttribute="top" constant="-1" id="bkI-IP-vh3"/>
+                <constraint firstAttribute="bottom" secondItem="brl-j0-vbe" secondAttribute="bottom" constant="21" id="cvr-nZ-qjB"/>
                 <constraint firstItem="brl-j0-vbe" firstAttribute="leading" secondItem="tI1-4J-bvZ" secondAttribute="leading" constant="-1" id="tux-kP-U9v"/>
+                <constraint firstAttribute="bottom" secondItem="G4c-Vf-UqH" secondAttribute="bottom" constant="-1" id="vJ2-67-9t3"/>
             </constraints>
-            <point key="canvasLocation" x="-564" y="71"/>
+            <point key="canvasLocation" x="-564" y="25.5"/>
         </customView>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="itW-qD-XDg" userLabel="Saved Filters View">
             <rect key="frame" x="0.0" y="0.0" width="640" height="168"/>
@@ -462,7 +472,7 @@
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" translatesAutoresizingMaskIntoConstraints="NO" id="n0t-vk-dME" userLabel="FilterPresets Table View">
-                                    <rect key="frame" x="-1" y="0.0" width="160" height="146"/>
+                                    <rect key="frame" x="-1" y="0.0" width="158" height="146"/>
                                     <size key="intercellSpacing" width="3" height="2"/>
                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>

--- a/iina/Base.lproj/FilterWindowController.xib
+++ b/iina/Base.lproj/FilterWindowController.xib
@@ -177,7 +177,7 @@
                                         <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                         <prototypeCellViews>
                                             <tableCellView id="6Ia-1U-G2V">
-                                                <rect key="frame" x="579" y="1" width="49" height="17"/>
+                                                <rect key="frame" x="579.5" y="1" width="49" height="17"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3dk-bb-Au2">
@@ -273,24 +273,24 @@
             <point key="canvasLocation" x="-564" y="71"/>
         </customView>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="itW-qD-XDg" userLabel="Saved Filters View">
-            <rect key="frame" x="0.0" y="0.0" width="640" height="171"/>
+            <rect key="frame" x="0.0" y="0.0" width="640" height="168"/>
             <subviews>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cIf-90-odO">
-                    <rect key="frame" x="6" y="153" width="79" height="16"/>
+                    <rect key="frame" x="6" y="150" width="79" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Saved filters" id="m5X-Zl-aOj">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <scrollView autohidesScrollers="YES" horizontalLineScroll="40" horizontalPageScroll="10" verticalLineScroll="40" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rnV-6H-I6Z">
-                    <rect key="frame" x="-1" y="-1" width="642" height="152"/>
+                <scrollView autohidesScrollers="YES" horizontalLineScroll="44" horizontalPageScroll="10" verticalLineScroll="44" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="rnV-6H-I6Z">
+                    <rect key="frame" x="-1" y="-1" width="642" height="149"/>
                     <clipView key="contentView" id="xDQ-TM-9KQ">
-                        <rect key="frame" x="1" y="1" width="640" height="150"/>
+                        <rect key="frame" x="1" y="1" width="640" height="147"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" alternatingRowBackgroundColors="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="38" rowSizeStyle="automatic" viewBased="YES" id="cw6-pW-oMs">
-                                <rect key="frame" x="0.0" y="0.0" width="640" height="150"/>
+                            <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" alternatingRowBackgroundColors="YES" multipleSelection="NO" autosaveColumns="NO" rowHeight="42" rowSizeStyle="automatic" viewBased="YES" id="cw6-pW-oMs">
+                                <rect key="frame" x="0.0" y="0.0" width="640" height="147"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <size key="intercellSpacing" width="3" height="2"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -309,11 +309,11 @@
                                         <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                         <prototypeCellViews>
                                             <tableCellView id="VRo-34-gOI">
-                                                <rect key="frame" x="1" y="1" width="637" height="38"/>
+                                                <rect key="frame" x="1" y="1" width="637" height="42"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Lbk-r9-gQj">
-                                                        <rect key="frame" x="30" y="20" width="96" height="16"/>
+                                                        <rect key="frame" x="30" y="24" width="96" height="16"/>
                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="EXM-Xm-pvG">
                                                             <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -324,7 +324,7 @@
                                                         </connections>
                                                     </textField>
                                                     <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="748" translatesAutoresizingMaskIntoConstraints="NO" id="MIx-kF-Ju3">
-                                                        <rect key="frame" x="30" y="2" width="37" height="16"/>
+                                                        <rect key="frame" x="30" y="6" width="37" height="16"/>
                                                         <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" title="Label" id="09q-ZP-mpK">
                                                             <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -335,35 +335,35 @@
                                                         </connections>
                                                     </textField>
                                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="56K-2H-lTw">
-                                                        <rect key="frame" x="611" y="7" width="18" height="24"/>
+                                                        <rect key="frame" x="613" y="10" width="16" height="22"/>
                                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSStopProgressFreestandingTemplate" imagePosition="overlaps" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="e3h-Ed-KyL">
                                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                             <font key="font" metaFont="system"/>
                                                         </buttonCell>
                                                         <constraints>
                                                             <constraint firstAttribute="width" secondItem="56K-2H-lTw" secondAttribute="height" multiplier="1:1" id="2V5-qV-ASQ"/>
-                                                            <constraint firstAttribute="height" constant="18" id="5Ua-Wm-PBx"/>
+                                                            <constraint firstAttribute="height" constant="16" id="5Ua-Wm-PBx"/>
                                                         </constraints>
                                                         <connections>
                                                             <action selector="deleteSavedFilterAction:" target="-2" id="dRe-NB-f1C"/>
                                                         </connections>
                                                     </button>
                                                     <button translatesAutoresizingMaskIntoConstraints="NO" id="ZJo-ef-lfp">
-                                                        <rect key="frame" x="585" y="7" width="18" height="24"/>
+                                                        <rect key="frame" x="589" y="10" width="16" height="22"/>
                                                         <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSActionTemplate" imagePosition="only" alignment="center" imageScaling="proportionallyUpOrDown" inset="2" id="y2D-Dj-SFr">
                                                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                             <font key="font" metaFont="system"/>
                                                         </buttonCell>
                                                         <constraints>
-                                                            <constraint firstAttribute="width" constant="18" id="B7C-IN-gxD"/>
-                                                            <constraint firstAttribute="height" constant="18" id="ESC-VN-aRY"/>
+                                                            <constraint firstAttribute="width" constant="16" id="B7C-IN-gxD"/>
+                                                            <constraint firstAttribute="height" constant="16" id="ESC-VN-aRY"/>
                                                         </constraints>
                                                         <connections>
                                                             <action selector="editSavedFilterAction:" target="-2" id="8gU-l1-Yw3"/>
                                                         </connections>
                                                     </button>
                                                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JHq-zl-TrB">
-                                                        <rect key="frame" x="6" y="10" width="18" height="18"/>
+                                                        <rect key="frame" x="6" y="12" width="18" height="18"/>
                                                         <buttonCell key="cell" type="check" bezelStyle="regularSquare" imagePosition="only" state="on" inset="2" id="p7t-d6-y1M">
                                                             <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                             <font key="font" metaFont="system"/>
@@ -378,7 +378,7 @@
                                                         </connections>
                                                     </button>
                                                     <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="b2Y-ob-c1P">
-                                                        <rect key="frame" x="573" y="11" width="4" height="16"/>
+                                                        <rect key="frame" x="577" y="13" width="4" height="16"/>
                                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="9xR-IJ-UkJ">
                                                             <font key="font" metaFont="system"/>
                                                             <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -392,15 +392,16 @@
                                                 </subviews>
                                                 <constraints>
                                                     <constraint firstItem="b2Y-ob-c1P" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Lbk-r9-gQj" secondAttribute="trailing" constant="8" symbolic="YES" id="3y8-p2-2R8"/>
-                                                    <constraint firstItem="ZJo-ef-lfp" firstAttribute="centerY" secondItem="VRo-34-gOI" secondAttribute="centerY" id="IXG-Ag-Y3l"/>
+                                                    <constraint firstItem="ZJo-ef-lfp" firstAttribute="centerY" secondItem="JHq-zl-TrB" secondAttribute="centerY" id="CBV-mt-m4t"/>
                                                     <constraint firstItem="b2Y-ob-c1P" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="MIx-kF-Ju3" secondAttribute="trailing" constant="8" symbolic="YES" id="JBz-o8-bAP"/>
                                                     <constraint firstItem="MIx-kF-Ju3" firstAttribute="leading" secondItem="VRo-34-gOI" secondAttribute="leading" constant="32" id="Ms8-A6-OYO"/>
                                                     <constraint firstItem="Lbk-r9-gQj" firstAttribute="top" secondItem="VRo-34-gOI" secondAttribute="top" constant="2" id="O6R-KR-lOV"/>
                                                     <constraint firstAttribute="trailing" secondItem="56K-2H-lTw" secondAttribute="trailing" constant="8" id="QU2-tI-IcU"/>
                                                     <constraint firstItem="JHq-zl-TrB" firstAttribute="centerY" secondItem="VRo-34-gOI" secondAttribute="centerY" id="RCg-NA-ik6"/>
                                                     <constraint firstItem="ZJo-ef-lfp" firstAttribute="leading" secondItem="b2Y-ob-c1P" secondAttribute="trailing" constant="10" id="T5C-lN-JuE"/>
-                                                    <constraint firstItem="56K-2H-lTw" firstAttribute="centerY" secondItem="VRo-34-gOI" secondAttribute="centerY" id="aRS-kY-p9p"/>
                                                     <constraint firstItem="MIx-kF-Ju3" firstAttribute="top" secondItem="Lbk-r9-gQj" secondAttribute="bottom" constant="2" id="ihR-Y7-KcU"/>
+                                                    <constraint firstItem="56K-2H-lTw" firstAttribute="centerY" secondItem="JHq-zl-TrB" secondAttribute="centerY" id="pBZ-di-ol9"/>
+                                                    <constraint firstAttribute="bottom" secondItem="MIx-kF-Ju3" secondAttribute="bottom" constant="5.5" id="qiz-Kb-S6d"/>
                                                     <constraint firstItem="JHq-zl-TrB" firstAttribute="leading" secondItem="VRo-34-gOI" secondAttribute="leading" constant="8" id="tST-AK-ace"/>
                                                     <constraint firstItem="Lbk-r9-gQj" firstAttribute="leading" secondItem="VRo-34-gOI" secondAttribute="leading" constant="32" id="twF-5W-qbY"/>
                                                     <constraint firstItem="56K-2H-lTw" firstAttribute="leading" secondItem="ZJo-ef-lfp" secondAttribute="trailing" constant="8" id="uyX-VM-0KJ"/>

--- a/iina/Base.lproj/FilterWindowController.xib
+++ b/iina/Base.lproj/FilterWindowController.xib
@@ -75,13 +75,13 @@
             <rect key="frame" x="0.0" y="0.0" width="638" height="75"/>
             <subviews>
                 <scrollView autohidesScrollers="YES" horizontalLineScroll="26" horizontalPageScroll="10" verticalLineScroll="26" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="brl-j0-vbe">
-                    <rect key="frame" x="-1" y="21" width="640" height="55"/>
+                    <rect key="frame" x="-1" y="20" width="640" height="56"/>
                     <clipView key="contentView" id="Hbi-ga-FRu">
-                        <rect key="frame" x="1" y="1" width="638" height="53"/>
+                        <rect key="frame" x="1" y="1" width="638" height="54"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" tableStyle="fullWidth" alternatingRowBackgroundColors="YES" columnReordering="NO" autosaveName="FilterTable" rowHeight="24" rowSizeStyle="systemDefault" headerView="ESY-lT-CzV" viewBased="YES" id="iTp-t4-bao">
-                                <rect key="frame" x="0.0" y="0.0" width="638" height="28"/>
+                                <rect key="frame" x="0.0" y="0.0" width="638" height="29"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <size key="intercellSpacing" width="3" height="2"/>
                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -226,9 +226,9 @@
                     </tableHeaderView>
                 </scrollView>
                 <box boxType="custom" borderType="line" title="Box" translatesAutoresizingMaskIntoConstraints="NO" id="G4c-Vf-UqH">
-                    <rect key="frame" x="0.0" y="-1" width="638" height="22"/>
+                    <rect key="frame" x="-1" y="-1" width="640" height="23"/>
                     <view key="contentView" id="RLZ-UD-oYg" userLabel="Box View">
-                        <rect key="frame" x="1" y="1" width="636" height="20"/>
+                        <rect key="frame" x="1" y="1" width="638" height="21"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="La1-eJ-8B2" userLabel="Add Filter Button">
@@ -272,12 +272,12 @@
                 </box>
             </subviews>
             <constraints>
-                <constraint firstItem="G4c-Vf-UqH" firstAttribute="top" secondItem="tI1-4J-bvZ" secondAttribute="bottom" constant="-21" id="7nU-fM-4kX"/>
+                <constraint firstItem="G4c-Vf-UqH" firstAttribute="top" secondItem="tI1-4J-bvZ" secondAttribute="bottom" constant="-22" id="7nU-fM-4kX"/>
                 <constraint firstAttribute="trailing" secondItem="brl-j0-vbe" secondAttribute="trailing" constant="-1" id="KHV-eM-yke"/>
-                <constraint firstItem="G4c-Vf-UqH" firstAttribute="leading" secondItem="tI1-4J-bvZ" secondAttribute="leading" id="T9M-bt-KYX"/>
-                <constraint firstAttribute="trailing" secondItem="G4c-Vf-UqH" secondAttribute="trailing" id="bNf-qM-1OQ"/>
+                <constraint firstItem="G4c-Vf-UqH" firstAttribute="leading" secondItem="tI1-4J-bvZ" secondAttribute="leading" constant="-1" id="T9M-bt-KYX"/>
+                <constraint firstItem="G4c-Vf-UqH" firstAttribute="trailing" secondItem="tI1-4J-bvZ" secondAttribute="trailing" constant="1" id="bNf-qM-1OQ"/>
                 <constraint firstItem="brl-j0-vbe" firstAttribute="top" secondItem="tI1-4J-bvZ" secondAttribute="top" constant="-1" id="bkI-IP-vh3"/>
-                <constraint firstAttribute="bottom" secondItem="brl-j0-vbe" secondAttribute="bottom" constant="21" id="cvr-nZ-qjB"/>
+                <constraint firstAttribute="bottom" secondItem="brl-j0-vbe" secondAttribute="bottom" constant="20" id="cvr-nZ-qjB"/>
                 <constraint firstItem="brl-j0-vbe" firstAttribute="leading" secondItem="tI1-4J-bvZ" secondAttribute="leading" constant="-1" id="tux-kP-U9v"/>
                 <constraint firstAttribute="bottom" secondItem="G4c-Vf-UqH" secondAttribute="bottom" constant="-1" id="vJ2-67-9t3"/>
             </constraints>
@@ -471,7 +471,7 @@
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" translatesAutoresizingMaskIntoConstraints="NO" id="n0t-vk-dME" userLabel="FilterPresets Table View">
-                                    <rect key="frame" x="-1" y="0.0" width="158" height="146"/>
+                                    <rect key="frame" x="-1" y="0.0" width="160" height="146"/>
                                     <size key="intercellSpacing" width="3" height="2"/>
                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>

--- a/iina/Base.lproj/FilterWindowController.xib
+++ b/iina/Base.lproj/FilterWindowController.xib
@@ -139,7 +139,7 @@
                                         <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                         <prototypeCellViews>
                                             <tableCellView id="lPY-eq-bPA">
-                                                <rect key="frame" x="49" y="1" width="527" height="17"/>
+                                                <rect key="frame" x="49" y="1" width="528" height="17"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
                                                     <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="AfO-KW-cSw">
@@ -456,18 +456,18 @@
                 <rect key="frame" x="0.0" y="0.0" width="450" height="200"/>
                 <subviews>
                     <scrollView autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="15J-Tp-Ccx" userLabel="Left Bordered Scroll View">
-                        <rect key="frame" x="12" y="40" width="200" height="148"/>
+                        <rect key="frame" x="12" y="40" width="160" height="148"/>
                         <clipView key="contentView" id="evP-Km-Po1" userLabel="Left Clip View">
-                            <rect key="frame" x="1" y="1" width="198" height="146"/>
+                            <rect key="frame" x="1" y="1" width="158" height="146"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
-                                <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" translatesAutoresizingMaskIntoConstraints="NO" id="n0t-vk-dME" userLabel="FilterPresets Table View">
-                                    <rect key="frame" x="-1" y="0.0" width="198" height="146"/>
+                                <tableView verticalHuggingPriority="750" allowsExpansionToolTips="YES" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" translatesAutoresizingMaskIntoConstraints="NO" id="n0t-vk-dME" userLabel="FilterPresets Table View">
+                                    <rect key="frame" x="-1" y="0.0" width="160" height="146"/>
                                     <size key="intercellSpacing" width="3" height="2"/>
                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                     <tableColumns>
-                                        <tableColumn editable="NO" width="157" minWidth="40" maxWidth="1000" id="Wak-3T-72M" userLabel="FilterPresetsTable Column">
+                                        <tableColumn editable="NO" width="146" minWidth="40" maxWidth="1000" id="Wak-3T-72M" userLabel="FilterPresetsTable Column">
                                             <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border">
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
@@ -480,11 +480,11 @@
                                             <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
                                             <prototypeCellViews>
                                                 <tableCellView id="WlY-5X-SEi">
-                                                    <rect key="frame" x="1" y="1" width="166" height="17"/>
+                                                    <rect key="frame" x="1" y="1" width="155" height="17"/>
                                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                     <subviews>
                                                         <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" id="MAd-sY-Hvg">
-                                                            <rect key="frame" x="0.0" y="0.0" width="166" height="17"/>
+                                                            <rect key="frame" x="0.0" y="0.0" width="155" height="17"/>
                                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                             <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="Kve-RD-QwY">
                                                                 <font key="font" metaFont="system"/>
@@ -512,10 +512,10 @@
                         <constraints>
                             <constraint firstItem="n0t-vk-dME" firstAttribute="leading" secondItem="15J-Tp-Ccx" secondAttribute="leading" id="UgT-GR-h0J"/>
                             <constraint firstAttribute="trailing" secondItem="n0t-vk-dME" secondAttribute="trailing" id="Us1-M1-eIt"/>
-                            <constraint firstAttribute="width" constant="200" id="oFm-NQ-6ro"/>
+                            <constraint firstAttribute="width" constant="160" id="oFm-NQ-6ro"/>
                         </constraints>
                         <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="Zhg-GM-4UI">
-                            <rect key="frame" x="1" y="271" width="138" height="16"/>
+                            <rect key="frame" x="1" y="131" width="158" height="16"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
                         <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="zJA-Ld-fbA">
@@ -524,23 +524,23 @@
                         </scroller>
                     </scrollView>
                     <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="B0m-Ni-LVx" userLabel="Right Scroll View - Flipped View">
-                        <rect key="frame" x="220" y="40" width="218" height="148"/>
+                        <rect key="frame" x="180" y="40" width="258" height="148"/>
                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="ig8-nk-a17" userLabel="Right Clip View">
-                            <rect key="frame" x="0.0" y="0.0" width="218" height="148"/>
+                            <rect key="frame" x="0.0" y="0.0" width="258" height="148"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <view fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZHP-RK-Ly4" userLabel="Right Flipped View" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
-                                    <rect key="frame" x="0.0" y="0.0" width="218" height="148"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="258" height="148"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 </view>
                             </subviews>
                         </clipView>
                         <scroller key="horizontalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="QWZ-kz-uCm">
-                            <rect key="frame" x="0.0" y="132" width="218" height="16"/>
+                            <rect key="frame" x="0.0" y="132" width="258" height="16"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
                         <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="XFr-qq-P3o">
-                            <rect key="frame" x="202" y="0.0" width="16" height="148"/>
+                            <rect key="frame" x="242" y="0.0" width="16" height="148"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
                     </scrollView>
@@ -597,6 +597,7 @@ DQ
             <connections>
                 <outlet property="addButton" destination="THV-Yh-VnK" id="GeO-qk-FbF"/>
                 <outlet property="filterWindow" destination="-2" id="Pjr-CT-nJA"/>
+                <outlet property="presetsClipViewWidthConstraint" destination="oFm-NQ-6ro" id="Uag-2b-npq"/>
                 <outlet property="scrollContentView" destination="ZHP-RK-Ly4" id="NhJ-gL-sPY"/>
                 <outlet property="tableView" destination="n0t-vk-dME" id="IBk-xT-LkA"/>
                 <outlet property="view" destination="RNP-NG-UVn" id="IxR-CL-PuL"/>

--- a/iina/Base.lproj/FilterWindowController.xib
+++ b/iina/Base.lproj/FilterWindowController.xib
@@ -36,6 +36,7 @@
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="608" y="562" width="640" height="382"/>
             <rect key="screenRect" x="0.0" y="0.0" width="1728" height="1079"/>
+            <value key="minSize" type="size" width="240" height="300"/>
             <view key="contentView" wantsLayer="YES" id="se5-gp-TjO">
                 <rect key="frame" x="0.0" y="0.0" width="640" height="382"/>
                 <autoresizingMask key="autoresizingMask"/>

--- a/iina/Base.lproj/FilterWindowController.xib
+++ b/iina/Base.lproj/FilterWindowController.xib
@@ -412,7 +412,6 @@
                                                     <constraint firstItem="ZJo-ef-lfp" firstAttribute="leading" secondItem="b2Y-ob-c1P" secondAttribute="trailing" constant="10" id="T5C-lN-JuE"/>
                                                     <constraint firstItem="MIx-kF-Ju3" firstAttribute="top" secondItem="Lbk-r9-gQj" secondAttribute="bottom" constant="2" id="ihR-Y7-KcU"/>
                                                     <constraint firstItem="56K-2H-lTw" firstAttribute="centerY" secondItem="JHq-zl-TrB" secondAttribute="centerY" id="pBZ-di-ol9"/>
-                                                    <constraint firstAttribute="bottom" secondItem="MIx-kF-Ju3" secondAttribute="bottom" constant="5.5" id="qiz-Kb-S6d"/>
                                                     <constraint firstItem="JHq-zl-TrB" firstAttribute="leading" secondItem="VRo-34-gOI" secondAttribute="leading" constant="8" id="tST-AK-ace"/>
                                                     <constraint firstItem="Lbk-r9-gQj" firstAttribute="leading" secondItem="VRo-34-gOI" secondAttribute="leading" constant="32" id="twF-5W-qbY"/>
                                                     <constraint firstItem="56K-2H-lTw" firstAttribute="leading" secondItem="ZJo-ef-lfp" secondAttribute="trailing" constant="8" id="uyX-VM-0KJ"/>

--- a/iina/FilterWindowController.swift
+++ b/iina/FilterWindowController.swift
@@ -46,6 +46,17 @@ class FilterWindowController: NSWindowController, NSWindowDelegate {
   private var currentFilter: MPVFilter?
   private var currentSavedFilter: SavedFilter?
 
+  init(filterType: String, autosaveName: String) {
+    self.filterType = filterType
+    super.init(window: nil)
+    self.windowFrameAutosaveName = autosaveName
+    Logger.log("Init \(windowFrameAutosaveName)", level: .verbose)
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
   override func windowDidLoad() {
     super.windowDidLoad()
     loaded = true
@@ -66,6 +77,9 @@ class FilterWindowController: NSWindowController, NSWindowDelegate {
 
     keyRecordView.delegate = self
     editFilterKeyRecordView.delegate = self
+
+    // Double-click saved filter to edit
+    savedFiltersTableView.doubleAction = #selector(self.editSavedFilterAction(_:))
 
     updateButtonStatus()
 
@@ -251,7 +265,15 @@ class FilterWindowController: NSWindowController, NSWindowDelegate {
   }
 
   @IBAction func editSavedFilterAction(_ sender: NSButton) {
-    let row = savedFiltersTableView.row(for: sender)
+    var row = savedFiltersTableView.clickedRow  // if double-clicking
+    if row < 0 {
+      row = savedFiltersTableView.row(for: sender)  // If using Edit button
+    }
+    guard row >= 0 && row < savedFiltersTableView.numberOfRows else {
+      Logger.log("Cannot edit saved filter! Invalid row: \(row)", level: .verbose)
+      return
+    }
+    Logger.log("Editing saved filter for row \(row)", level: .verbose)
     currentSavedFilter = savedFilters[row]
     editFilterNameTextField.stringValue = currentSavedFilter!.name
     editFilterStringTextField.stringValue = currentSavedFilter!.filterString
@@ -374,6 +396,11 @@ class NewFilterSheetViewController: NSViewController, NSTableViewDelegate, NSTab
     tableView.dataSource = self
     tableView.delegate = self
     presets = filterWindow.filterType == MPVProperty.vf ? FilterPreset.vfPresets : FilterPreset.afPresets
+
+    // Select first filter preset in table if nothing already selected
+    if tableView.selectedRowIndexes.isEmpty {
+      tableView.selectRowIndexes(IndexSet(integer: 0), byExtendingSelection: false)
+    }
   }
 
   func numberOfRows(in tableView: NSTableView) -> Int {

--- a/iina/FilterWindowController.swift
+++ b/iina/FilterWindowController.swift
@@ -382,12 +382,14 @@ extension FilterWindowController {
 
 
 class NewFilterSheetViewController: NSViewController, NSTableViewDelegate, NSTableViewDataSource {
+  private static let textAndTableWidthDifference = 20.0
 
   @IBOutlet weak var filterWindow: FilterWindowController!
   @IBOutlet weak var tableView: NSTableView!
   @IBOutlet weak var scrollContentView: NSView!
   @IBOutlet weak var addButton: NSButton!
-  
+  @IBOutlet weak var presetsClipViewWidthConstraint: NSLayoutConstraint!
+
   private var currentPreset: FilterPreset?
   private var currentBindings: [String: NSControl] = [:]
   private var presets: [FilterPreset] = []
@@ -396,6 +398,20 @@ class NewFilterSheetViewController: NSViewController, NSTableViewDelegate, NSTab
     tableView.dataSource = self
     tableView.delegate = self
     presets = filterWindow.filterType == MPVProperty.vf ? FilterPreset.vfPresets : FilterPreset.afPresets
+
+    // Different locales have different text width requirements. Examine all content and fit table to widest item.
+    var maxWidth = 0.0
+    for preset in presets {
+      let presetString = NSMutableAttributedString(string: preset.localizedName)
+      let fontSize = NSFont.systemFontSize(for: .regular)
+      let textFont = NSFont.systemFont(ofSize: fontSize)
+      presetString.addAttribute(.font, value: textFont, range: NSRange(location: 0, length: presetString.length))
+      let textWidth = presetString.size().width
+      if textWidth > maxWidth {
+        maxWidth = textWidth
+      }
+    }
+    presetsClipViewWidthConstraint.constant = maxWidth + NewFilterSheetViewController.textAndTableWidthDifference
 
     // Select first filter preset in table if nothing already selected
     if tableView.selectedRowIndexes.isEmpty {


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issues:
  - #4894 
  - #1098

---

**Description:**

Makes the following fixes/improvements to the `Video Filters` & `Audio Filters` windows:
• Increase size of text & icons
• Add save of window sizes & positions between launches
• Add double-click in Saved Filters table to edit saved filter

Also makes the following changes to the "Add Filter" sheet:
• Ensure Filter Presets table always has exactly 1 row selected, so that the sheet's Add button can no longer be clicked when nothing is selected
• Save size of sheet between launches
• Fix multiple layout issues which prevented the sheet from resizing correctly
• Set width of Filter Presets table at first load to fit its widest localized text (issues #1098, #4894).
