### PR TITLE
Refactor logs and use more .warning and .verbose leveled logs

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -305,6 +305,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 
     let mpv = PlayerCore.active.mpv!
     Logger.log("Using \(mpv.mpvVersion) and libass \(mpv.libassVersion)")
+    Logger.log("Configuration when building mpv: \(mpv.getString(MPVProperty.mpvConfiguration)!)", level: .verbose)
 
     if #available(macOS 10.13, *) {
       if RemoteCommandController.useSystemMediaControl {

--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -638,7 +638,7 @@ extension NSScreen {
   /// - parameter screen: The `NSScreen` object to log.
   static func log(_ label: String, _ screen: NSScreen?) {
     guard let screen = screen else {
-      Logger.log("\(label): nil")
+      Logger.log("\(label): nil", level: .warning)
       return
     }
     // Unfortunately localizedName is not available until macOS Catalina.

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -577,7 +577,7 @@ not applying FFmpeg 9599 workaround
   // Send arbitrary mpv command.
   func command(_ command: MPVCommand, args: [String?] = [], checkError: Bool = true, returnValueCallback: ((Int32) -> Void)? = nil) {
     guard mpv != nil else { return }
-    log("Run command: \(command.rawValue) \(args.compactMap{$0}.joined(separator: " "))")
+    log("Run command: \(command.rawValue) \(args.compactMap{$0}.joined(separator: " "))", level: .verbose)
     var cargs = makeCArgs(command, args).map { $0.flatMap { UnsafePointer<CChar>(strdup($0)) } }
     defer {
       for ptr in cargs {
@@ -595,13 +595,13 @@ not applying FFmpeg 9599 workaround
   }
 
   func command(rawString: String) -> Int32 {
-    log("Run command: \(rawString)")
+    log("Run command: \(rawString)", level: .verbose)
     return mpv_command_string(mpv, rawString)
   }
 
   func asyncCommand(_ command: MPVCommand, args: [String?] = [], checkError: Bool = true, replyUserdata: UInt64) {
     guard mpv != nil else { return }
-    log("Asynchronously run command: \(command.rawValue) \(args.compactMap{$0}.joined(separator: " "))")
+    log("Asynchronously run command: \(command.rawValue) \(args.compactMap{$0}.joined(separator: " "))", level: .verbose)
     var cargs = makeCArgs(command, args).map { $0.flatMap { UnsafePointer<CChar>(strdup($0)) } }
     defer {
       for ptr in cargs {
@@ -622,19 +622,19 @@ not applying FFmpeg 9599 workaround
 
   // Set property
   func setFlag(_ name: String, _ flag: Bool) {
-    log("Set property: \(name)=\(flag)")
+    log("Set property: \(name)=\(flag)", level: .verbose)
     var data: Int = flag ? 1 : 0
     mpv_set_property(mpv, name, MPV_FORMAT_FLAG, &data)
   }
 
   func setInt(_ name: String, _ value: Int) {
-    log("Set property: \(name)=\(value)")
+    log("Set property: \(name)=\(value)", level: .verbose)
     var data = Int64(value)
     mpv_set_property(mpv, name, MPV_FORMAT_INT64, &data)
   }
 
   func setDouble(_ name: String, _ value: Double) {
-    log("Set property: \(name)=\(value)")
+    log("Set property: \(name)=\(value)", level: .verbose)
     var data = value
     mpv_set_property(mpv, name, MPV_FORMAT_DOUBLE, &data)
   }
@@ -656,7 +656,7 @@ not applying FFmpeg 9599 workaround
 
   @discardableResult
   func setString(_ name: String, _ value: String) -> Int32 {
-    log("Set property: \(name)=\(value)")
+    log("Set property: \(name)=\(value)", level: .verbose)
     return mpv_set_property_string(mpv, name, value)
   }
 
@@ -828,7 +828,7 @@ not applying FFmpeg 9599 workaround
       log("setNode: cannot encode value for \(name)", level: .error)
       return
     }
-    log("Set property: \(name)=<a mpv node>")
+    log("Set property: \(name)=<a mpv node>", level: .verbose)
     mpv_set_property(mpv, name, MPV_FORMAT_NODE, &node)
     MPVNode.free(node)
   }
@@ -1371,20 +1371,20 @@ not applying FFmpeg 9599 workaround
   private var optionObservers: [String: [OptionObserverInfo]] = [:]
 
   private func setOptionFloat(_ name: String, _ value: Float) -> Int32 {
-    log("Set option: \(name)=\(value)")
+    log("Set option: \(name)=\(value)", level: .verbose)
     var data = Double(value)
     return mpv_set_option(mpv, name, MPV_FORMAT_DOUBLE, &data)
   }
 
   private func setOptionInt(_ name: String, _ value: Int) -> Int32 {
-    log("Set option: \(name)=\(value)")
+    log("Set option: \(name)=\(value)", level: .verbose)
     var data = Int64(value)
     return mpv_set_option(mpv, name, MPV_FORMAT_INT64, &data)
   }
 
   @discardableResult
   private func setOptionString(_ name: String, _ value: String) -> Int32 {
-    log("Set option: \(name)=\(value)")
+    log("Set option: \(name)=\(value)", level: .verbose)
     return mpv_set_option_string(mpv, name, value)
   }
 

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -577,7 +577,7 @@ not applying FFmpeg 9599 workaround
   // Send arbitrary mpv command.
   func command(_ command: MPVCommand, args: [String?] = [], checkError: Bool = true, returnValueCallback: ((Int32) -> Void)? = nil) {
     guard mpv != nil else { return }
-    log("Run command: \(command.rawValue) \(args.compactMap{$0}.joined(separator: " "))", level: .verbose)
+    log("Run command: \(command.rawValue) \(args.compactMap{$0}.joined(separator: " "))")
     var cargs = makeCArgs(command, args).map { $0.flatMap { UnsafePointer<CChar>(strdup($0)) } }
     defer {
       for ptr in cargs {
@@ -595,13 +595,13 @@ not applying FFmpeg 9599 workaround
   }
 
   func command(rawString: String) -> Int32 {
-    log("Run command: \(rawString)", level: .verbose)
+    log("Run command: \(rawString)")
     return mpv_command_string(mpv, rawString)
   }
 
   func asyncCommand(_ command: MPVCommand, args: [String?] = [], checkError: Bool = true, replyUserdata: UInt64) {
     guard mpv != nil else { return }
-    log("Asynchronously run command: \(command.rawValue) \(args.compactMap{$0}.joined(separator: " "))", level: .verbose)
+    log("Asynchronously run command: \(command.rawValue) \(args.compactMap{$0}.joined(separator: " "))")
     var cargs = makeCArgs(command, args).map { $0.flatMap { UnsafePointer<CChar>(strdup($0)) } }
     defer {
       for ptr in cargs {
@@ -622,19 +622,19 @@ not applying FFmpeg 9599 workaround
 
   // Set property
   func setFlag(_ name: String, _ flag: Bool) {
-    log("Set property: \(name)=\(flag)", level: .verbose)
+    log("Set property: \(name)=\(flag)")
     var data: Int = flag ? 1 : 0
     mpv_set_property(mpv, name, MPV_FORMAT_FLAG, &data)
   }
 
   func setInt(_ name: String, _ value: Int) {
-    log("Set property: \(name)=\(value)", level: .verbose)
+    log("Set property: \(name)=\(value)")
     var data = Int64(value)
     mpv_set_property(mpv, name, MPV_FORMAT_INT64, &data)
   }
 
   func setDouble(_ name: String, _ value: Double) {
-    log("Set property: \(name)=\(value)", level: .verbose)
+    log("Set property: \(name)=\(value)")
     var data = value
     mpv_set_property(mpv, name, MPV_FORMAT_DOUBLE, &data)
   }
@@ -656,7 +656,7 @@ not applying FFmpeg 9599 workaround
 
   @discardableResult
   func setString(_ name: String, _ value: String) -> Int32 {
-    log("Set property: \(name)=\(value)", level: .verbose)
+    log("Set property: \(name)=\(value)")
     return mpv_set_property_string(mpv, name, value)
   }
 
@@ -828,7 +828,7 @@ not applying FFmpeg 9599 workaround
       log("setNode: cannot encode value for \(name)", level: .error)
       return
     }
-    log("Set property: \(name)=<a mpv node>", level: .verbose)
+    log("Set property: \(name)=<a mpv node>")
     mpv_set_property(mpv, name, MPV_FORMAT_NODE, &node)
     MPVNode.free(node)
   }
@@ -1371,20 +1371,20 @@ not applying FFmpeg 9599 workaround
   private var optionObservers: [String: [OptionObserverInfo]] = [:]
 
   private func setOptionFloat(_ name: String, _ value: Float) -> Int32 {
-    log("Set option: \(name)=\(value)", level: .verbose)
+    log("Set option: \(name)=\(value)")
     var data = Double(value)
     return mpv_set_option(mpv, name, MPV_FORMAT_DOUBLE, &data)
   }
 
   private func setOptionInt(_ name: String, _ value: Int) -> Int32 {
-    log("Set option: \(name)=\(value)", level: .verbose)
+    log("Set option: \(name)=\(value)")
     var data = Int64(value)
     return mpv_set_option(mpv, name, MPV_FORMAT_INT64, &data)
   }
 
   @discardableResult
   private func setOptionString(_ name: String, _ value: String) -> Int32 {
-    log("Set option: \(name)=\(value)", level: .verbose)
+    log("Set option: \(name)=\(value)")
     return mpv_set_option_string(mpv, name, value)
   }
 

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1073,7 +1073,7 @@ class MainWindowController: PlayerWindowController {
   override func mouseExited(with event: NSEvent) {
     guard !isInInteractiveMode else { return }
     guard let obj = event.trackingArea?.userInfo?["obj"] as? Int else {
-      Logger.log("No data for tracking area", level: .warning)
+      Logger.log("No data for tracking area", level: .warning, subsystem: player.subsystem)
       return
     }
     mouseExitEnterCount += 1

--- a/iina/OpenSubSubtitle.swift
+++ b/iina/OpenSubSubtitle.swift
@@ -293,7 +293,7 @@ class OpenSub {
     /// - Parameter timeout: The timeout to to use for the the request.
     override func logout(timeout: TimeInterval? = nil) -> Promise<Void> {
       guard OpenSubClient.shared.loggedIn else {
-        Logger.log("Not logged in to Open Subtitles")
+        log("Not logged in to Open Subtitles")
         return .value
       }
       log("Logging out of Open Subtitles")

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -230,7 +230,7 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
         handleIINACommand(iinaCommand)
         return true
       } else {
-        Logger.log("Unknown iina command \(keyBinding.rawAction)", level: .error)
+        Logger.log("Unknown iina command \(keyBinding.rawAction)", level: .error, subsystem: player.subsystem)
         return false
       }
     } else {
@@ -253,7 +253,7 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
       if returnValue == 0 {
         return true
       } else {
-        Logger.log("Return value \(returnValue) when executing key command \(keyBinding.rawAction)", level: .error)
+        Logger.log("Return value \(returnValue) when executing key command \(keyBinding.rawAction)", level: .error, subsystem: player.subsystem)
         return false
       }
     }
@@ -545,7 +545,7 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
     case 67...1000:
       return NSImage(named: "volume")
     default:
-      Logger.log("Volume level \(player.info.volume) is invalid", level: .error)
+      Logger.log("Volume level \(player.info.volume) is invalid", level: .error, subsystem: player.subsystem)
       return nil
     }
   }
@@ -563,11 +563,11 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
     // The mpv documentation for the duration property indicates mpv is not always able to determine
     // the video duration in which case the property is not available.
     guard let duration = player.info.videoDuration else {
-      Logger.log("Video duration not available")
+      Logger.log("Video duration not available", level: .warning, subsystem: player.subsystem)
       return
     }
     guard let pos = player.info.videoPosition else {
-      Logger.log("Video position not available")
+      Logger.log("Video position not available", level: .warning, subsystem: player.subsystem)
       return
     }
     [leftLabel, rightLabel].forEach { $0.updateText(with: duration, given: pos) }

--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -331,7 +331,7 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
           player.playlistMove(oldIndex, to: row + newIndexOffset)
           newIndexOffset += 1
         }
-        Logger.log("Playlist Drag & Drop from \(oldIndex) to \(row)")
+        Logger.log("Playlist Drag & Drop from \(oldIndex) to \(row)", subsystem: player.subsystem)
       }
       player.postNotification(.iinaPlaylistChanged)
       return true
@@ -656,14 +656,14 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
 
   @IBAction func contextMenuDeleteFile(_ sender: NSMenuItem) {
     guard let selectedRows = selectedRows else { return }
-    Logger.log("User chose to delete files from playlist at indexes: \(selectedRows.map{$0})")
+    Logger.log("User chose to delete files from playlist at indexes: \(selectedRows.map{$0})", subsystem: player.subsystem)
 
     var successes = IndexSet()
     for index in selectedRows {
       guard !player.info.playlist[index].isNetworkResource else { continue }
       let url = URL(fileURLWithPath: player.info.playlist[index].filename)
       do {
-        Logger.log("Trashing row \(index): \(url.standardizedFileURL)")
+        Logger.log("Trashing row \(index): \(url.standardizedFileURL)", subsystem: player.subsystem)
         try FileManager.default.trashItem(at: url, resultingItemURL: nil)
         successes.insert(index)
       } catch let error {

--- a/iina/Sysctl.swift
+++ b/iina/Sysctl.swift
@@ -28,13 +28,13 @@ struct Sysctl {
     var size = 0
     // Get the size of the string.
     guard sysctlbyname(name, nil, &size, nil, 0) == EXIT_SUCCESS else {
-      Logger.log("Call to sysctlbyname for \(name) failed: \(String(cString: strerror(errno))) (\(errno))")
+      Logger.log("Call to sysctlbyname for \(name) failed: \(String(cString: strerror(errno))) (\(errno))", level: .warning)
       return nil
     }
     // Now get the named kernel state as a string.
     var value = [CChar](repeating: 0,  count: Int(size))
     guard sysctlbyname(name, &value, &size, nil, 0) == EXIT_SUCCESS else {
-      Logger.log("Call to sysctlbyname for \(name) failed: \(String(cString: strerror(errno))) (\(errno))")
+      Logger.log("Call to sysctlbyname for \(name) failed: \(String(cString: strerror(errno))) (\(errno))", level: .warning)
       return nil
     }
     return String(cString: value)

--- a/iina/ThumbnailCache.swift
+++ b/iina/ThumbnailCache.swift
@@ -22,6 +22,10 @@ class ThumbnailCache {
   private static let imageProperties: [NSBitmapImageRep.PropertyKey: Any] = [
     .compressionFactor: 0.75
   ]
+  
+  private static func log(_ message: String, level: Logger.Level = .debug) {
+    Logger.log(message, level: level, subsystem: subsystem)
+  }
 
   static func fileExists(forName name: String) -> Bool {
     return FileManager.default.fileExists(atPath: urlFor(name).path)
@@ -29,19 +33,19 @@ class ThumbnailCache {
 
   static func fileIsCached(forName name: String, forVideo videoPath: URL?) -> Bool {
     guard let fileAttr = try? FileManager.default.attributesOfItem(atPath: videoPath!.path) else {
-      Logger.log("Cannot get video file attributes", level: .error, subsystem: subsystem)
+      log("Cannot get video file attributes", level: .error)
       return false
     }
 
     // file size
     guard let fileSize = fileAttr[.size] as? FileSize else {
-      Logger.log("Cannot get video file size", level: .error, subsystem: subsystem)
+      log("Cannot get video file size", level: .error)
       return false
     }
 
     // modified date
     guard let fileModifiedDate = fileAttr[.modificationDate] as? Date else {
-      Logger.log("Cannot get video file modification date", level: .error, subsystem: subsystem)
+      log("Cannot get video file modification date", level: .error)
       return false
     }
     let fileTimestamp = FileTimestamp(fileModifiedDate.timeIntervalSince1970)
@@ -49,7 +53,7 @@ class ThumbnailCache {
     // Check metadate in the cache
     if self.fileExists(forName: name) {
       guard let file = try? FileHandle(forReadingFrom: urlFor(name)) else {
-        Logger.log("Cannot open cache file.", level: .error, subsystem: subsystem)
+        log("Cannot open cache file.", level: .error)
         return false
       }
 
@@ -66,7 +70,7 @@ class ThumbnailCache {
   /// Write thumbnail cache to file.
   /// This method is expected to be called when the file doesn't exist.
   static func write(_ thumbnails: [FFThumbnail], forName name: String, forVideo videoPath: URL?) {
-    Logger.log("Writing thumbnail cache...", subsystem: subsystem)
+    log("Writing thumbnail cache...")
 
     let maxCacheSize = Preference.integer(for: .maxThumbnailPreviewCacheSize) * FloatingPointByteCountFormatter.PrefixFactor.mi.rawValue
     if maxCacheSize == 0 {
@@ -77,11 +81,11 @@ class ThumbnailCache {
 
     let pathURL = urlFor(name)
     guard FileManager.default.createFile(atPath: pathURL.path, contents: nil, attributes: nil) else {
-      Logger.log("Cannot create file.", level: .error, subsystem: subsystem)
+      log("Cannot create file.", level: .error)
       return
     }
     guard let file = try? FileHandle(forWritingTo: pathURL) else {
-      Logger.log("Cannot write to file.", level: .error, subsystem: subsystem)
+      log("Cannot write to file.", level: .error)
       return
     }
 
@@ -90,13 +94,13 @@ class ThumbnailCache {
     file.write(versionData)
 
     guard let fileAttr = try? FileManager.default.attributesOfItem(atPath: videoPath!.path) else {
-      Logger.log("Cannot get video file attributes", level: .error, subsystem: subsystem)
+      log("Cannot get video file attributes", level: .error)
       return
     }
 
     // file size
     guard let fileSize = fileAttr[.size] as? FileSize else {
-      Logger.log("Cannot get video file size", level: .error, subsystem: subsystem)
+      log("Cannot get video file size", level: .error)
       return
     }
     let fileSizeData = Data(bytesOf: fileSize)
@@ -104,7 +108,7 @@ class ThumbnailCache {
 
     // modified date
     guard let fileModifiedDate = fileAttr[.modificationDate] as? Date else {
-      Logger.log("Cannot get video file modification date", level: .error, subsystem: subsystem)
+      log("Cannot get video file modification date", level: .error)
       return
     }
     let fileTimestamp = FileTimestamp(fileModifiedDate.timeIntervalSince1970)
@@ -115,11 +119,11 @@ class ThumbnailCache {
     for tb in thumbnails {
       let timestampData = Data(bytesOf: tb.realTime)
       guard let tiffData = tb.image?.tiffRepresentation else {
-        Logger.log("Cannot generate tiff data.", level: .error, subsystem: subsystem)
+        log("Cannot generate tiff data.", level: .error)
         return
       }
       guard let jpegData = NSBitmapImageRep(data: tiffData)?.representation(using: .jpeg, properties: imageProperties) else {
-        Logger.log("Cannot generate jpeg data.", level: .error, subsystem: subsystem)
+        log("Cannot generate jpeg data.", level: .error)
         return
       }
       let blockLength = Int64(timestampData.count + jpegData.count)
@@ -130,20 +134,20 @@ class ThumbnailCache {
     }
 
     CacheManager.shared.needsRefresh = true
-    Logger.log("Finished writing thumbnail cache.", subsystem: subsystem)
+    log("Finished writing thumbnail cache.")
   }
 
   /// Read thumbnail cache to file.
   /// This method is expected to be called when the file exists.
   static func read(forName name: String) -> [FFThumbnail]? {
-    Logger.log("Reading thumbnail cache...", subsystem: subsystem)
+    log("Reading thumbnail cache...")
 
     let pathURL = urlFor(name)
     guard let file = try? FileHandle(forReadingFrom: pathURL) else {
-      Logger.log("Cannot open file.", level: .error, subsystem: subsystem)
+      log("Cannot open file.", level: .error)
       return nil
     }
-    Logger.log("Reading from \(pathURL.path)", subsystem: subsystem)
+    log("Reading from \(pathURL.path)")
 
     var result: [FFThumbnail] = []
 
@@ -159,7 +163,7 @@ class ThumbnailCache {
       // length and timestamp
       guard let blockLength = file.read(type: Int64.self),
             let timestamp = file.read(type: Double.self) else {
-        Logger.log("Cannot read image header. Cache file will be deleted.", level: .warning, subsystem: subsystem)
+        log("Cannot read image header. Cache file will be deleted.", level: .warning)
         file.closeFile()
         deleteCacheFile(at: pathURL)
         return nil
@@ -167,7 +171,7 @@ class ThumbnailCache {
       // jpeg
       let jpegData = file.readData(ofLength: Int(blockLength) - MemoryLayout.size(ofValue: timestamp))
       guard let image = NSImage(data: jpegData) else {
-        Logger.log("Cannot read image. Cache file will be deleted.", level: .warning, subsystem: subsystem)
+        log("Cannot read image. Cache file will be deleted.", level: .warning)
         file.closeFile()
         deleteCacheFile(at: pathURL)
         return nil
@@ -180,7 +184,7 @@ class ThumbnailCache {
     }
 
     file.closeFile()
-    Logger.log("Finished reading thumbnail cache, \(result.count) in total", subsystem: subsystem)
+    log("Finished reading thumbnail cache, \(result.count) in total")
     return result
   }
 
@@ -189,7 +193,7 @@ class ThumbnailCache {
     do {
       try FileManager.default.removeItem(at: pathURL)
     } catch {
-      Logger.log("Cannot delete corrupted cache.", level: .error, subsystem: subsystem)
+      log("Cannot delete corrupted cache.", level: .error)
     }
   }
 

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -444,7 +444,7 @@ extension VideoView {
     guard let mpv = player.mpv else { return false }
 
     guard let primaries = mpv.getString(MPVProperty.videoParamsPrimaries), let gamma = mpv.getString(MPVProperty.videoParamsGamma) else {
-      Logger.log("HDR primaries and gamma not available", level: .warning, subsystem: hdrSubsystem)
+      Logger.log("HDR primaries and gamma not available", subsystem: hdrSubsystem)
       return false
     }
   
@@ -478,7 +478,7 @@ extension VideoView {
     }
 
     guard (window?.screen?.maximumPotentialExtendedDynamicRangeColorComponentValue ?? 1.0) > 1.0 else {
-      Logger.log("HDR video was found but the display does not support EDR mode", level: .warning, subsystem: hdrSubsystem)
+      Logger.log("HDR video was found but the display does not support EDR mode", subsystem: hdrSubsystem)
       return false
     }
 

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -444,12 +444,12 @@ extension VideoView {
     guard let mpv = player.mpv else { return false }
 
     guard let primaries = mpv.getString(MPVProperty.videoParamsPrimaries), let gamma = mpv.getString(MPVProperty.videoParamsGamma) else {
-      Logger.log("HDR primaries and gamma not available", level: .debug, subsystem: hdrSubsystem)
+      Logger.log("HDR primaries and gamma not available", level: .warning, subsystem: hdrSubsystem)
       return false
     }
   
     let peak = mpv.getDouble(MPVProperty.videoParamsSigPeak)
-    Logger.log("HDR gamma=\(gamma), primaries=\(primaries), sig_peak=\(peak)", level: .debug, subsystem: hdrSubsystem)
+    Logger.log("HDR gamma=\(gamma), primaries=\(primaries), sig_peak=\(peak)", subsystem: hdrSubsystem)
 
     var name: CFString? = nil
     switch primaries {
@@ -473,23 +473,23 @@ extension VideoView {
       return false // SDR
 
     default:
-      Logger.log("Unknown HDR color space information gamma=\(gamma) primaries=\(primaries)", level: .debug, subsystem: hdrSubsystem)
+      Logger.log("Unknown HDR color space information gamma=\(gamma) primaries=\(primaries)", level: .warning, subsystem: hdrSubsystem)
       return false
     }
 
     guard (window?.screen?.maximumPotentialExtendedDynamicRangeColorComponentValue ?? 1.0) > 1.0 else {
-      Logger.log("HDR video was found but the display does not support EDR mode", level: .debug, subsystem: hdrSubsystem)
+      Logger.log("HDR video was found but the display does not support EDR mode", level: .warning, subsystem: hdrSubsystem)
       return false
     }
 
     guard player.info.hdrEnabled else { return nil }
 
     if videoLayer.colorspace?.name == name {
-      Logger.log("HDR mode already enabled, skipping", level: .debug, subsystem: hdrSubsystem)
+      Logger.log("HDR mode already enabled, skipping", subsystem: hdrSubsystem)
       return true
     }
 
-    Logger.log("Will activate HDR color space instead of using ICC profile", level: .debug, subsystem: hdrSubsystem)
+    Logger.log("Will activate HDR color space instead of using ICC profile", subsystem: hdrSubsystem)
 
     videoLayer.wantsExtendedDynamicRangeContent = true
     videoLayer.colorspace = CGColorSpace(name: name!)


### PR DESCRIPTION
**Description:**
- Added a log of mpv compile-time configuration
- Refactored `AutoFileMatcher`, `ThumbnailCache`, and `PlayerCore` which added a dedicated `log` function for their subsystems
- Uses more .warning logs
- Changed mpv property/option related logs into .verbose
