### PR TITLE
Fix duplicate identifier error

### DIFF
--- a/iina/Base.lproj/PrefUIViewController.xib
+++ b/iina/Base.lproj/PrefUIViewController.xib
@@ -1249,7 +1249,7 @@ Picture:</string>
             <rect key="frame" x="0.0" y="0.0" width="550" height="90"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField identifier="SectionTitleThumb" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="M1d-6z-urt" userLabel="Accessibility">
+                <textField identifier="SectionTitleAccessibility" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="M1d-6z-urt" userLabel="Accessibility">
                     <rect key="frame" x="-2" y="70" width="91" height="16"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Accessibility:" id="AYW-Xu-ySw">
                         <font key="font" metaFont="systemBold"/>


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**

Fixes the following "warning" introduced by PR #4871:
```
Multiple objects using identifier "SectionTitleThumb" (Identifiers must be unique)
```

Besides the warning triggering some people's OCD, this might have broken the type-to-search feature for the new section.