### PR TITLE
Double click in the input config table to rename a config (+ bug fixes)

### DIFF
--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -193,11 +193,13 @@
 "alert.config.duplicate.title" = "Duplicate Configuration";
 "alert.config.duplicate.message" = "Please enter name for the duplicated configuration file.";
 "alert.config.empty_name" = "The name cannot be empty.";
-"alert.config.name_existing" = "The name already exists.";
+"alert.config.name_existing" = "A config with the same name already exists.";
 "alert.config.file_existing.title" = "File Already Exists";
 "alert.config.file_existing.message" = "A config file with the same filename already exists. Choose OK to show the file in Finder.";
 "alert.config.cannot_create" = "Cannot create config file!\n%@";
 "alert.config.cannot_write" = "Cannot write to config file!";
+"alert.config.rename.title" = "Rename Input Configuration";
+"alert.config.rename.message" = "Please enter the new name for the configuration.";
 
 "alert.filter.incorrect" = "Error occurred when setting filters. Please check your parameter format.";
 "alert.add_filter.title" = "New Filter";

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -195,7 +195,7 @@
 "alert.config.empty_name" = "The name cannot be empty.";
 "alert.config.name_existing" = "The name already exists.";
 "alert.config.file_existing.title" = "File Already Exists";
-"alert.config.file_existing.message" = "This should not happen. Choose OK to overwrite, Cancel to show the file in Finder.";
+"alert.config.file_existing.message" = "A config file with the same filename already exists. Choose OK to show the file in Finder.";
 "alert.config.cannot_create" = "Cannot create config file!\n%@";
 "alert.config.cannot_write" = "Cannot write to config file!";
 

--- a/iina/Base.lproj/PrefKeyBindingViewController.xib
+++ b/iina/Base.lproj/PrefKeyBindingViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21701" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21701"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22690"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -29,14 +29,14 @@
             <rect key="frame" x="0.0" y="0.0" width="480" height="311"/>
             <subviews>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="LU9-QU-BFL">
-                    <rect key="frame" x="-1" y="286" width="121" height="16"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="14" id="lOm-I3-MpB"/>
-                    </constraints>
+                    <rect key="frame" x="-1" y="286" width="183" height="16"/>
                     <buttonCell key="cell" type="check" title="Use system media control" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="2WY-CR-baD">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="14" id="lOm-I3-MpB"/>
+                    </constraints>
                     <connections>
                         <binding destination="XM5-Sj-lhw" name="value" keyPath="values.useMediaKeys" id="C7t-pc-JuC"/>
                     </connections>
@@ -111,7 +111,7 @@
                         <autoresizingMask key="autoresizingMask"/>
                     </tableHeaderView>
                 </scrollView>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZWR-gT-S2p">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZWR-gT-S2p">
                     <rect key="frame" x="0.0" y="238" width="91" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Configuration:" id="au5-6f-s55">
                         <font key="font" metaFont="system"/>
@@ -136,33 +136,33 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="f5l-5w-zmm">
-                                <rect key="frame" x="0.0" y="-1.5" width="20.5" height="24"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" secondItem="f5l-5w-zmm" secondAttribute="height" multiplier="1:1" id="nxu-Es-dAW"/>
-                                </constraints>
+                                <rect key="frame" x="0.0" y="-2" width="20" height="24"/>
                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" inset="2" id="De2-o3-Acv">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="f5l-5w-zmm" secondAttribute="height" multiplier="1:1" id="nxu-Es-dAW"/>
+                                </constraints>
                                 <connections>
                                     <action selector="addKeyMappingBtnAction:" target="-2" id="oNc-c8-i9c"/>
                                 </connections>
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="uFG-OF-DJ5">
-                                <rect key="frame" x="20" y="3" width="20.5" height="15"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" secondItem="uFG-OF-DJ5" secondAttribute="height" multiplier="1:1" id="ka8-vi-ux9"/>
-                                </constraints>
+                                <rect key="frame" x="20" y="3" width="20" height="15"/>
                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" inset="2" id="nAC-n9-1YJ">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="uFG-OF-DJ5" secondAttribute="height" multiplier="1:1" id="ka8-vi-ux9"/>
+                                </constraints>
                                 <connections>
                                     <action selector="removeKeyMappingBtnAction:" target="-2" id="aeN-fq-0zS"/>
                                 </connections>
                             </button>
                             <button toolTip="Show the raw mpv key code and command." translatesAutoresizingMaskIntoConstraints="NO" id="l2M-TH-eCt">
-                                <rect key="frame" x="184" y="3" width="100" height="12"/>
+                                <rect key="frame" x="184" y="4" width="100" height="11"/>
                                 <buttonCell key="cell" type="check" title="Display raw values" bezelStyle="regularSquare" imagePosition="left" controlSize="mini" inset="2" id="3RK-1k-otl">
                                     <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                     <font key="font" metaFont="label" size="9"/>
@@ -236,7 +236,7 @@
                                                 <rect key="frame" x="1" y="1" width="176" height="17"/>
                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                 <subviews>
-                                                    <textField verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="k3i-eY-hmO">
+                                                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="k3i-eY-hmO">
                                                         <rect key="frame" x="0.0" y="1" width="96" height="16"/>
                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="rVW-78-nDm">
                                                             <font key="font" metaFont="system"/>
@@ -248,7 +248,7 @@
                                                         </connections>
                                                     </textField>
                                                     <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="3VI-bM-Xn1">
-                                                        <rect key="frame" x="164" y="-1.5" width="12.5" height="22"/>
+                                                        <rect key="frame" x="164" y="-1" width="12" height="21"/>
                                                         <constraints>
                                                             <constraint firstAttribute="width" constant="12" id="Du5-ms-7jx"/>
                                                             <constraint firstAttribute="height" constant="12" id="p6c-c0-YEO"/>
@@ -274,6 +274,9 @@
                                         </prototypeCellViews>
                                     </tableColumn>
                                 </tableColumns>
+                                <connections>
+                                    <action trigger="doubleAction" selector="configFileListDoubleAction:" target="-2" id="cFL-H1-Eks"/>
+                                </connections>
                             </tableView>
                         </subviews>
                     </clipView>
@@ -296,27 +299,27 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="iCp-ho-SlQ" userLabel="Square + Button">
-                                <rect key="frame" x="0.0" y="-1.5" width="20.5" height="24"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" secondItem="iCp-ho-SlQ" secondAttribute="height" multiplier="1:1" id="W5T-Sa-grr"/>
-                                </constraints>
+                                <rect key="frame" x="0.0" y="-2" width="20" height="24"/>
                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="only" alignment="center" inset="2" id="sxT-LD-iKe">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="iCp-ho-SlQ" secondAttribute="height" multiplier="1:1" id="W5T-Sa-grr"/>
+                                </constraints>
                                 <connections>
                                     <action selector="newConfFileAction:" target="-2" id="zyI-2f-FHa"/>
                                 </connections>
                             </button>
                             <button translatesAutoresizingMaskIntoConstraints="NO" id="EpF-t6-PtC" userLabel="Square - Button">
-                                <rect key="frame" x="20" y="3" width="20.5" height="15"/>
-                                <constraints>
-                                    <constraint firstAttribute="width" secondItem="EpF-t6-PtC" secondAttribute="height" multiplier="1:1" id="NBy-aM-7Gt"/>
-                                </constraints>
+                                <rect key="frame" x="20" y="3" width="20" height="15"/>
                                 <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="only" alignment="center" inset="2" id="mZx-Q0-d48">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
                                 </buttonCell>
+                                <constraints>
+                                    <constraint firstAttribute="width" secondItem="EpF-t6-PtC" secondAttribute="height" multiplier="1:1" id="NBy-aM-7Gt"/>
+                                </constraints>
                                 <connections>
                                     <action selector="deleteConfFileAction:" target="-2" id="v3N-VV-gc0"/>
                                 </connections>
@@ -357,7 +360,7 @@
                     <color key="borderColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                     <color key="fillColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                 </box>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="tP6-Ua-acA">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="tP6-Ua-acA">
                     <rect key="frame" x="0.0" y="220" width="480" height="14"/>
                     <textFieldCell key="cell" controlSize="small" title="Label" id="M4N-eg-JA8">
                         <font key="font" metaFont="message" size="11"/>
@@ -375,7 +378,7 @@
                         <action selector="importConfigBtnAction:" target="-2" id="m3a-yn-NIE"/>
                     </connections>
                 </button>
-                <searchField wantsLayer="YES" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="x6N-6q-HiV">
+                <searchField wantsLayer="YES" focusRingType="none" verticalHuggingPriority="750" textCompletion="NO" translatesAutoresizingMaskIntoConstraints="NO" id="x6N-6q-HiV">
                     <rect key="frame" x="188" y="190" width="292" height="22"/>
                     <constraints>
                         <constraint firstAttribute="height" constant="22" id="aql-K3-x6M"/>
@@ -393,7 +396,7 @@
                         </binding>
                     </connections>
                 </searchField>
-                <textField identifier="SectionTitleSettings" hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JxQ-iv-eAN">
+                <textField identifier="SectionTitleSettings" hidden="YES" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JxQ-iv-eAN">
                     <rect key="frame" x="427" y="255" width="55" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Settings" id="8yJ-Rj-GWo">
                         <font key="font" metaFont="system"/>
@@ -450,8 +453,8 @@
         </arrayController>
     </objects>
     <resources>
-        <image name="NSAddTemplate" width="18" height="17"/>
-        <image name="NSLockLockedTemplate" width="19" height="19"/>
-        <image name="NSRemoveTemplate" width="18" height="5"/>
+        <image name="NSAddTemplate" width="18" height="16"/>
+        <image name="NSLockLockedTemplate" width="18" height="18"/>
+        <image name="NSRemoveTemplate" width="18" height="4"/>
     </resources>
 </document>

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -442,7 +442,7 @@ not applying FFmpeg 9599 workaround
     // Load external scripts
 
     // Load keybindings. This is still required for mpv to handle media keys or apple remote.
-    let userConfigs = Preference.dictionary(for: .inputConfigs)
+    let userConfigs = PrefKeyBindingViewController.userConfigs
     var inputConfPath =  PrefKeyBindingViewController.defaultConfigs["IINA Default"]
     if let confFromUd = Preference.string(for: .currentInputConfigName) {
       if let currentConfigFilePath = Utility.getFilePath(Configs: userConfigs, forConfig: confFromUd, showAlert: false) {

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -424,7 +424,7 @@ class PlayerCore: NSObject {
 
   static func loadKeyBindings() {
     Logger.log("Loading key bindings")
-    let userConfigs = Preference.dictionary(for: .inputConfigs)
+    let userConfigs = PrefKeyBindingViewController.userConfigs
     let iinaDefaultConfPath = PrefKeyBindingViewController.defaultConfigs["IINA Default"]!
     var inputConfPath = iinaDefaultConfPath
     if let confFromUd = Preference.string(for: .currentInputConfigName) {

--- a/iina/PrefKeyBindingViewController.swift
+++ b/iina/PrefKeyBindingViewController.swift
@@ -267,6 +267,7 @@ class PrefKeyBindingViewController: NSViewController, PreferenceWindowEmbeddable
   /// If the target config file cannot be found, or the file cannot be parsed correctly, it will fallback to the default config.
   /// - Parameter configName: the target config name
   private func loadConfigFile(_ configName: String?) {
+    guard configName != Preference.string(for: .currentInputConfigName) else { return }
     isLoading = true
     
     func fallback() {

--- a/iina/PrefKeyBindingViewController.swift
+++ b/iina/PrefKeyBindingViewController.swift
@@ -66,7 +66,8 @@ class PrefKeyBindingViewController: NSViewController, PreferenceWindowEmbeddable
   var currentConfName: String!
   var currentConfFilePath: String!
   
-  var isLoading = false
+  // This variable is to prevent `NSTableView.reloadData()` in the `loadConfigFile` to trigger `loadConfigFile` again thus forming an infinite loop
+  var isLoadingConfig = false
 
   var shouldEnableEdit: Bool = true
 
@@ -268,10 +269,10 @@ class PrefKeyBindingViewController: NSViewController, PreferenceWindowEmbeddable
   /// - Parameter configName: the target config name
   private func loadConfigFile(_ configName: String?) {
     guard configName != Preference.string(for: .currentInputConfigName) else { return }
-    isLoading = true
+    isLoadingConfig = true
     
     func fallback() {
-      isLoading = false
+      isLoadingConfig = false
       Utility.showAlert("keybinding_config.error", arguments: [currentConfName], sheetWindow: view.window)
       loadConfigFile(fallbackDefault)
     }
@@ -296,7 +297,7 @@ class PrefKeyBindingViewController: NSViewController, PreferenceWindowEmbeddable
     setKeybindingsForPlayerCore()
     changeButtonEnabledStatus()
     
-    isLoading = false
+    isLoadingConfig = false
   }
 
   /// Check whether or not a new config file with provided filename should be created.
@@ -393,7 +394,7 @@ extension PrefKeyBindingViewController: NSTableViewDelegate, NSTableViewDataSour
   }
 
   func tableViewSelectionDidChange(_ notification: Notification) {
-    guard !isLoading else { return }
+    guard !isLoadingConfig else { return }
     if let tableView = notification.object as? NSTableView, tableView == confTableView {
       guard let title = cachedConfigNames[at: confTableView.selectedRow], title != currentConfName else { return }
       loadConfigFile(title)

--- a/iina/PrefKeyBindingViewController.swift
+++ b/iina/PrefKeyBindingViewController.swift
@@ -216,12 +216,31 @@ class PrefKeyBindingViewController: NSViewController, PreferenceWindowEmbeddable
     Utility.quickPromptPanel("config.duplicate", sheetWindow: view.window) { newName in
       guard let newFilePath = self.checkNewConfigFile(with: newName) else { return }
 
-      let currFilePath = self.currentConfFilePath!
       do {
-        try self.fm.copyItem(atPath: currFilePath, toPath: newFilePath)
+        try self.fm.copyItem(atPath: self.currentConfFilePath!, toPath: newFilePath)
       } catch let error {
         Utility.showAlert("config.cannot_create", arguments: [error.localizedDescription], sheetWindow: self.view.window)
         return
+      }
+      self.enableNewConfigFile(newName, newFilePath)
+    }
+    
+  }
+  
+  @IBAction func configFileListDoubleAction(_ sender: NSTableView) {
+    guard shouldEnableEdit else { return }
+    Utility.quickPromptPanel("config.rename", sheetWindow: view.window) { newName in
+      guard let newFilePath = self.checkNewConfigFile(with: newName) else { return }
+      let oldName = self.currentConfName!
+      do {
+        try self.fm.moveItem(atPath: self.currentConfFilePath!, toPath: newFilePath)
+      } catch let error {
+        Utility.showAlert("config.cannot_create", arguments: [error.localizedDescription], sheetWindow: self.view.window)
+        return
+      }
+      self.userConfigs.removeValue(forKey: oldName)
+      if let index = self.userConfigNames.firstIndex(of: oldName) {
+        self.userConfigNames.remove(at: index)
       }
       self.enableNewConfigFile(newName, newFilePath)
     }

--- a/iina/PrefKeyBindingViewController.swift
+++ b/iina/PrefKeyBindingViewController.swift
@@ -103,8 +103,8 @@ class PrefKeyBindingViewController: NSViewController, PreferenceWindowEmbeddable
     }
 
     // Load the config file saved in user default
-    loadConfigFile(Preference.string(for: .currentInputConfigName))
-    
+    loadConfigFile(Preference.string(for: .currentInputConfigName), true)
+
     NotificationCenter.default.addObserver(forName: .iinaKeyBindingChanged, object: nil, queue: .main, using: saveToConfFile)
   }
 
@@ -267,8 +267,8 @@ class PrefKeyBindingViewController: NSViewController, PreferenceWindowEmbeddable
   /// This function firstly reloads the table data, select the config file row, then load the config file.
   /// If the target config file cannot be found, or the file cannot be parsed correctly, it will fallback to the default config.
   /// - Parameter configName: the target config name
-  private func loadConfigFile(_ configName: String?) {
-    guard configName != Preference.string(for: .currentInputConfigName) else { return }
+  private func loadConfigFile(_ configName: String?, _ initialSetup: Bool = false) {
+    guard configName != Preference.string(for: .currentInputConfigName) || initialSetup else { return }
     isLoadingConfig = true
     
     func fallback() {
@@ -293,10 +293,13 @@ class PrefKeyBindingViewController: NSViewController, PreferenceWindowEmbeddable
     mappingController.add(contentsOf: mapping)
     mappingController.setSelectionIndexes(IndexSet())
 
-    Preference.set(currentConfName, for: .currentInputConfigName)
-    setKeybindingsForPlayerCore()
     changeButtonEnabledStatus()
-    
+
+    if !initialSetup {
+      Preference.set(currentConfName, for: .currentInputConfigName)
+      setKeybindingsForPlayerCore()
+    }
+
     isLoadingConfig = false
   }
 

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -253,9 +253,6 @@ struct Preference {
     static let useMediaKeys = Key("useMediaKeys")
     static let useAppleRemote = Key("useAppleRemote")
 
-    /** User created input config list (dic) */
-    static let inputConfigs = Key("inputConfigs")
-
     /** Current input config name */
     static let currentInputConfigName = Key("currentInputConfigName")
 
@@ -837,7 +834,6 @@ struct Preference {
     .ytdlRawOptions: "",
     .httpProxy: "",
 
-    .inputConfigs: [String: Any](),
     .currentInputConfigName: "IINA Default",
 
     .enableAdvancedSettings: false,

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -193,11 +193,13 @@
 "alert.config.duplicate.title" = "Duplicate Configuration";
 "alert.config.duplicate.message" = "Please enter name for the duplicated configuration file.";
 "alert.config.empty_name" = "The name cannot be empty.";
-"alert.config.name_existing" = "The name already exists.";
+"alert.config.name_existing" = "A config with the same name already exists.";
 "alert.config.file_existing.title" = "File Already Exists";
 "alert.config.file_existing.message" = "A config file with the same filename already exists. Choose OK to show the file in Finder.";
 "alert.config.cannot_create" = "Cannot create config file!\n%@";
 "alert.config.cannot_write" = "Cannot write to config file!";
+"alert.config.rename.title" = "Rename Input Configuration";
+"alert.config.rename.message" = "Please enter the new name for the configuration.";
 
 "alert.filter.incorrect" = "Error occurred when setting filters. Please check your parameter format.";
 "alert.add_filter.title" = "New Filter";

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -195,7 +195,7 @@
 "alert.config.empty_name" = "The name cannot be empty.";
 "alert.config.name_existing" = "The name already exists.";
 "alert.config.file_existing.title" = "File Already Exists";
-"alert.config.file_existing.message" = "This should not happen. Choose OK to overwrite, Cancel to show the file in Finder.";
+"alert.config.file_existing.message" = "A config file with the same filename already exists. Choose OK to show the file in Finder.";
 "alert.config.cannot_create" = "Cannot create config file!\n%@";
 "alert.config.cannot_write" = "Cannot write to config file!";
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)

---

**Description:**
This PR:
- Enable the user to change the config name by double clicking in the input config table
- Refactors the configuration creation/duplication to eliminate duplicated code
- Change some of the wordings to make things clearer
- Stabilize the default input config files by using `KeyValuePairs`

Besides, this PR also fixes the usage of the `Utility.quickAskPanel`:

https://github.com/iina/iina/blob/94176bb558334e6abf1299fb02f3f921a649a860/iina/PrefKeyBindingViewController.swift#L177-L188

Previously it used the return value of the `quickAskPanel`, however, if the `quickAskPanel` is provided with the sheet window, it will always return `false` immediately without waiting for user input in the `NSAlert` panel. So 1) the "delete file" part of code could never be called, and 2) it always shows the existing file in Finder after the `NSAlert` is initiated (instead of after the user clicking the cancel button).

This PR changes the logic to show the existing file when clicking on OK, and do nothing when clicking on cancel. And also change the wording from "This should not happen..." to "A config file with the same filename already exists..." 

I also remove the file deletion code because maybe its too dangerous to remove user files with "OK" or an enter hit in a seemingly unrelated alert window (the user want to create a config, but end up with deleting their file), let alone that part of code was never been executed before due to the erroneous usage.