### PR TITLE
Close enable screensaver while playing audio files, #4954

### DIFF
--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -184,7 +184,6 @@
 
 "alert.fatal_error" = "Fatal error: %@ \nThe application will exit now.";
 "alert.mpv_error" = "Internal error %@ (%@) when setting option %@.";
-"alert.sleep" = "Cannot prevent display sleep! (0x%0X8)";
 
 "alert.unsupported_audio" = "Unsupported external audio file.";
 "alert.unsupported_sub" = "Unsupported external subtitle.";

--- a/iina/Base.lproj/PrefGeneralViewController.xib
+++ b/iina/Base.lproj/PrefGeneralViewController.xib
@@ -24,19 +24,19 @@
             <point key="canvasLocation" x="-1607" y="64"/>
         </customView>
         <customView id="6zR-96-iKB" userLabel="Prefs &gt; General &gt; Behavior">
-            <rect key="frame" x="0.0" y="0.0" width="480" height="501"/>
+            <rect key="frame" x="0.0" y="0.0" width="480" height="557"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
-                <textField identifier="SectionTitleBehavior" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="38y-2I-MGs">
-                    <rect key="frame" x="-2" y="477" width="66" height="16"/>
+                <textField identifier="SectionTitleBehavior" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="38y-2I-MGs">
+                    <rect key="frame" x="-2" y="533" width="66" height="16"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Behavior:" id="uQR-Fx-oEm">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OXi-vL-mzp">
-                    <rect key="frame" x="118" y="477" width="65" height="16"/>
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OXi-vL-mzp">
+                    <rect key="frame" x="118" y="533" width="65" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="At launch:" id="gqT-CB-Puw">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -44,7 +44,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bV8-LP-cwH">
-                    <rect key="frame" x="186" y="470" width="179" height="25"/>
+                    <rect key="frame" x="186" y="526" width="179" height="25"/>
                     <popUpButtonCell key="cell" type="push" title="Show welcome window" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="z9T-8h-1T0" id="6y1-KS-0tJ">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="menu"/>
@@ -61,20 +61,20 @@
                     </connections>
                 </popUpButton>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="DUm-O0-pdI">
-                    <rect key="frame" x="118" y="224" width="235" height="18"/>
-                    <constraints>
-                        <constraint firstAttribute="height" constant="16" id="b1L-o2-7jn"/>
-                    </constraints>
+                    <rect key="frame" x="118" y="280" width="235" height="18"/>
                     <buttonCell key="cell" type="check" title="Always open media in new window" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="M0z-bI-88d">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
+                    <constraints>
+                        <constraint firstAttribute="height" constant="16" id="b1L-o2-7jn"/>
+                    </constraints>
                     <connections>
                         <binding destination="IBP-Mz-Maa" name="value" keyPath="values.alwaysOpenInNewWindow" id="pIG-7D-0J8"/>
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="5G0-Ih-CIb">
-                    <rect key="frame" x="118" y="200" width="223" height="18"/>
+                    <rect key="frame" x="118" y="256" width="223" height="18"/>
                     <buttonCell key="cell" type="check" title="Quit after all windows are closed" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="YLo-6E-tT7">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -84,7 +84,7 @@
                     </buttonCell>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="Xi9-i5-9V4">
-                    <rect key="frame" x="118" y="176" width="281" height="18"/>
+                    <rect key="frame" x="118" y="232" width="281" height="18"/>
                     <buttonCell key="cell" type="check" title="Keep window open after playback finishes" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="2iM-j7-AzQ">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -94,7 +94,7 @@
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="F6o-D4-gDa">
-                    <rect key="frame" x="118" y="152" width="210" height="18"/>
+                    <rect key="frame" x="118" y="208" width="210" height="18"/>
                     <buttonCell key="cell" type="check" title="Resume last playback position" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="jOB-D3-WT3">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -114,7 +114,7 @@
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="6Hg-O4-cBP">
-                    <rect key="frame" x="118" y="120" width="160" height="18"/>
+                    <rect key="frame" x="118" y="176" width="160" height="18"/>
                     <buttonCell key="cell" type="check" title="Use legacy full screen" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="TvB-UM-FrS">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -124,7 +124,7 @@
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="QvG-Ma-br0">
-                    <rect key="frame" x="118" y="96" width="291" height="18"/>
+                    <rect key="frame" x="118" y="152" width="291" height="18"/>
                     <buttonCell key="cell" type="check" title="Black out other monitors while in full screen" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="KYi-0W-zOr">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -171,7 +171,7 @@
                     </connections>
                 </popUpButton>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="b7I-2V-MYa">
-                    <rect key="frame" x="118" y="64" width="416" height="18"/>
+                    <rect key="frame" x="118" y="120" width="416" height="18"/>
                     <buttonCell key="cell" type="check" title="Switch to &quot;music mode&quot; automatically when playing an audio file" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="KfL-r7-Uav">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -180,8 +180,28 @@
                         <binding destination="IBP-Mz-Maa" name="value" keyPath="values.autoSwitchToMusicMode" id="yWA-OL-vl0"/>
                     </connections>
                 </button>
+                <button translatesAutoresizingMaskIntoConstraints="NO" id="MWj-we-UuR" userLabel="Require display to stay on while actively playing video">
+                    <rect key="frame" x="118" y="88" width="350" height="18"/>
+                    <buttonCell key="cell" type="check" title="Require display to stay on while actively playing video" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="r2u-P9-J5p">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="IBP-Mz-Maa" name="value" keyPath="values.preventDisplaySleepForVideo" id="NFH-rv-hxv"/>
+                    </connections>
+                </button>
+                <button translatesAutoresizingMaskIntoConstraints="NO" id="fms-nd-RFo" userLabel="Require display to stay on while actively playing audio">
+                    <rect key="frame" x="118" y="64" width="351" height="18"/>
+                    <buttonCell key="cell" type="check" title="Require display to stay on while actively playing audio" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="yla-DT-YTx">
+                        <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <binding destination="IBP-Mz-Maa" name="value" keyPath="values.preventDisplaySleepForAudio" id="j1Q-RZ-NGC"/>
+                    </connections>
+                </button>
                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aKH-Me-5XB" customClass="CollapseView" customModule="IINA" customModuleProvider="target">
-                    <rect key="frame" x="120" y="412" width="360" height="57"/>
+                    <rect key="frame" x="120" y="468" width="360" height="57"/>
                     <subviews>
                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Pga-vd-zGA">
                             <rect key="frame" x="0.0" y="40" width="360" height="17"/>
@@ -274,7 +294,7 @@
                     </customSpacing>
                 </stackView>
                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8iE-FU-0g0" customClass="CollapseView" customModule="IINA" customModuleProvider="target">
-                    <rect key="frame" x="120" y="257" width="360" height="147"/>
+                    <rect key="frame" x="120" y="313" width="360" height="147"/>
                     <subviews>
                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="W54-Em-Hx4">
                             <rect key="frame" x="0.0" y="130" width="360" height="17"/>
@@ -419,16 +439,20 @@
                 <constraint firstItem="bV8-LP-cwH" firstAttribute="leading" secondItem="OXi-vL-mzp" secondAttribute="trailing" constant="8" id="8Kb-Fe-QIo"/>
                 <constraint firstItem="b7I-2V-MYa" firstAttribute="top" secondItem="QvG-Ma-br0" secondAttribute="bottom" constant="16" id="9H8-4r-eDa"/>
                 <constraint firstItem="bV8-LP-cwH" firstAttribute="baseline" secondItem="OXi-vL-mzp" secondAttribute="baseline" id="9fY-Y6-onK"/>
+                <constraint firstItem="MWj-we-UuR" firstAttribute="leading" secondItem="b7I-2V-MYa" secondAttribute="leading" id="CNM-Ri-Ubf"/>
                 <constraint firstItem="tUl-6f-ClP" firstAttribute="top" secondItem="ibu-Tq-kBr" secondAttribute="bottom" constant="8" id="DQg-F2-jP7"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="fms-nd-RFo" secondAttribute="trailing" id="DYp-M6-7kk"/>
                 <constraint firstItem="38y-2I-MGs" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="6zR-96-iKB" secondAttribute="leading" constant="120" id="Dd3-CV-21F"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="6Hg-O4-cBP" secondAttribute="trailing" priority="100" id="EU4-oh-Sn4"/>
                 <constraint firstItem="Xi9-i5-9V4" firstAttribute="height" secondItem="DUm-O0-pdI" secondAttribute="height" id="Eee-r5-9jP"/>
                 <constraint firstItem="38y-2I-MGs" firstAttribute="top" secondItem="6zR-96-iKB" secondAttribute="top" constant="8" id="EkZ-1t-Li0"/>
                 <constraint firstItem="6Hg-O4-cBP" firstAttribute="height" secondItem="DUm-O0-pdI" secondAttribute="height" id="FS1-AW-faa"/>
+                <constraint firstItem="MWj-we-UuR" firstAttribute="top" secondItem="b7I-2V-MYa" secondAttribute="bottom" constant="16" id="GLc-3e-sDg"/>
                 <constraint firstItem="ONF-nX-zDm" firstAttribute="baseline" secondItem="ibu-Tq-kBr" secondAttribute="baseline" id="GtH-hr-0BD"/>
                 <constraint firstItem="ibu-Tq-kBr" firstAttribute="leading" secondItem="b7I-2V-MYa" secondAttribute="leading" id="Iut-G6-4zl"/>
                 <constraint firstItem="aKH-Me-5XB" firstAttribute="leading" secondItem="OXi-vL-mzp" secondAttribute="leading" id="NEg-jy-N85"/>
                 <constraint firstItem="F6o-D4-gDa" firstAttribute="leading" secondItem="Xi9-i5-9V4" secondAttribute="leading" id="ONu-Gw-6jM"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="MWj-we-UuR" secondAttribute="trailing" id="Ov9-bk-NKH"/>
                 <constraint firstItem="F6o-D4-gDa" firstAttribute="height" secondItem="DUm-O0-pdI" secondAttribute="height" id="Owa-Fs-41I"/>
                 <constraint firstItem="tUl-6f-ClP" firstAttribute="height" secondItem="DUm-O0-pdI" secondAttribute="height" id="PId-am-AqK"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="bV8-LP-cwH" secondAttribute="trailing" id="Plb-z2-kxR"/>
@@ -439,14 +463,15 @@
                 <constraint firstItem="b7I-2V-MYa" firstAttribute="height" secondItem="DUm-O0-pdI" secondAttribute="height" id="Y3C-r1-4Ae"/>
                 <constraint firstItem="Xi9-i5-9V4" firstAttribute="top" secondItem="5G0-Ih-CIb" secondAttribute="bottom" constant="8" id="YOU-SQ-93U"/>
                 <constraint firstItem="6Hg-O4-cBP" firstAttribute="top" secondItem="F6o-D4-gDa" secondAttribute="bottom" constant="16" id="a76-ej-aJs"/>
-                <constraint firstItem="ONF-nX-zDm" firstAttribute="top" secondItem="b7I-2V-MYa" secondAttribute="bottom" constant="16" id="awt-JH-Sx1"/>
+                <constraint firstItem="ONF-nX-zDm" firstAttribute="top" secondItem="fms-nd-RFo" secondAttribute="bottom" constant="16" id="awt-JH-Sx1"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="DUm-O0-pdI" secondAttribute="trailing" priority="100" id="c2z-9x-EKo"/>
                 <constraint firstItem="tUl-6f-ClP" firstAttribute="leading" secondItem="ibu-Tq-kBr" secondAttribute="leading" id="d7A-WU-gG9"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ONF-nX-zDm" secondAttribute="trailing" id="esl-VM-bcw"/>
                 <constraint firstItem="DUm-O0-pdI" firstAttribute="leading" secondItem="8iE-FU-0g0" secondAttribute="leading" id="ez5-7v-y5R"/>
                 <constraint firstItem="aKH-Me-5XB" firstAttribute="top" secondItem="OXi-vL-mzp" secondAttribute="bottom" constant="8" id="gTe-Cv-cgu"/>
                 <constraint firstItem="6Hg-O4-cBP" firstAttribute="leading" secondItem="F6o-D4-gDa" secondAttribute="leading" id="hbH-qB-dC3"/>
-                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="b7I-2V-MYa" secondAttribute="trailing" priority="100" id="kla-t0-rVJ"/>
+                <constraint firstItem="fms-nd-RFo" firstAttribute="leading" secondItem="MWj-we-UuR" secondAttribute="leading" id="kB0-Na-qV6"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="b7I-2V-MYa" secondAttribute="trailing" priority="100" constant="-54" id="kla-t0-rVJ"/>
                 <constraint firstItem="ONF-nX-zDm" firstAttribute="leading" secondItem="ibu-Tq-kBr" secondAttribute="trailing" constant="8" id="myc-5t-FrF"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="5G0-Ih-CIb" secondAttribute="trailing" priority="100" id="n4Z-6X-Oou"/>
                 <constraint firstItem="b7I-2V-MYa" firstAttribute="leading" secondItem="QvG-Ma-br0" secondAttribute="leading" id="o0g-jc-tgK"/>
@@ -459,6 +484,7 @@
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="F6o-D4-gDa" secondAttribute="trailing" priority="100" id="tRu-Sz-D5y"/>
                 <constraint firstItem="5G0-Ih-CIb" firstAttribute="leading" secondItem="DUm-O0-pdI" secondAttribute="leading" id="uxk-Ul-hVP"/>
                 <constraint firstItem="Xi9-i5-9V4" firstAttribute="leading" secondItem="5G0-Ih-CIb" secondAttribute="leading" id="vs3-xk-YxI"/>
+                <constraint firstItem="fms-nd-RFo" firstAttribute="top" secondItem="MWj-we-UuR" secondAttribute="bottom" constant="8" id="x7i-56-ISU"/>
                 <constraint firstItem="38y-2I-MGs" firstAttribute="leading" secondItem="6zR-96-iKB" secondAttribute="leading" id="ykt-2x-cLQ"/>
             </constraints>
             <point key="canvasLocation" x="-2189" y="118.5"/>

--- a/iina/Base.lproj/PrefGeneralViewController.xib
+++ b/iina/Base.lproj/PrefGeneralViewController.xib
@@ -24,11 +24,11 @@
             <point key="canvasLocation" x="-1607" y="64"/>
         </customView>
         <customView id="6zR-96-iKB" userLabel="Prefs &gt; General &gt; Behavior">
-            <rect key="frame" x="0.0" y="0.0" width="480" height="557"/>
+            <rect key="frame" x="0.0" y="0.0" width="480" height="574"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField identifier="SectionTitleBehavior" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="38y-2I-MGs">
-                    <rect key="frame" x="-2" y="533" width="66" height="16"/>
+                    <rect key="frame" x="-2" y="550" width="66" height="16"/>
                     <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Behavior:" id="uQR-Fx-oEm">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -36,7 +36,7 @@
                     </textFieldCell>
                 </textField>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OXi-vL-mzp">
-                    <rect key="frame" x="118" y="533" width="65" height="16"/>
+                    <rect key="frame" x="118" y="550" width="65" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="At launch:" id="gqT-CB-Puw">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -44,7 +44,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bV8-LP-cwH">
-                    <rect key="frame" x="186" y="526" width="179" height="25"/>
+                    <rect key="frame" x="186" y="543" width="179" height="25"/>
                     <popUpButtonCell key="cell" type="push" title="Show welcome window" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="z9T-8h-1T0" id="6y1-KS-0tJ">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="menu"/>
@@ -61,7 +61,7 @@
                     </connections>
                 </popUpButton>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="DUm-O0-pdI">
-                    <rect key="frame" x="118" y="280" width="235" height="18"/>
+                    <rect key="frame" x="118" y="297" width="235" height="18"/>
                     <buttonCell key="cell" type="check" title="Always open media in new window" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="M0z-bI-88d">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -74,7 +74,7 @@
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="5G0-Ih-CIb">
-                    <rect key="frame" x="118" y="256" width="223" height="18"/>
+                    <rect key="frame" x="118" y="273" width="223" height="18"/>
                     <buttonCell key="cell" type="check" title="Quit after all windows are closed" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="YLo-6E-tT7">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -84,7 +84,7 @@
                     </buttonCell>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="Xi9-i5-9V4">
-                    <rect key="frame" x="118" y="232" width="281" height="18"/>
+                    <rect key="frame" x="118" y="249" width="281" height="18"/>
                     <buttonCell key="cell" type="check" title="Keep window open after playback finishes" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="2iM-j7-AzQ">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -94,7 +94,7 @@
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="F6o-D4-gDa">
-                    <rect key="frame" x="118" y="208" width="210" height="18"/>
+                    <rect key="frame" x="118" y="225" width="210" height="18"/>
                     <buttonCell key="cell" type="check" title="Resume last playback position" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="jOB-D3-WT3">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -114,7 +114,7 @@
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="6Hg-O4-cBP">
-                    <rect key="frame" x="118" y="176" width="160" height="18"/>
+                    <rect key="frame" x="118" y="193" width="160" height="18"/>
                     <buttonCell key="cell" type="check" title="Use legacy full screen" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="TvB-UM-FrS">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -124,7 +124,7 @@
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="QvG-Ma-br0">
-                    <rect key="frame" x="118" y="152" width="291" height="18"/>
+                    <rect key="frame" x="118" y="169" width="291" height="18"/>
                     <buttonCell key="cell" type="check" title="Black out other monitors while in full screen" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="KYi-0W-zOr">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -171,7 +171,7 @@
                     </connections>
                 </popUpButton>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="b7I-2V-MYa">
-                    <rect key="frame" x="118" y="120" width="416" height="18"/>
+                    <rect key="frame" x="118" y="137" width="416" height="18"/>
                     <buttonCell key="cell" type="check" title="Switch to &quot;music mode&quot; automatically when playing an audio file" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="KfL-r7-Uav">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -180,28 +180,37 @@
                         <binding destination="IBP-Mz-Maa" name="value" keyPath="values.autoSwitchToMusicMode" id="yWA-OL-vl0"/>
                     </connections>
                 </button>
-                <button translatesAutoresizingMaskIntoConstraints="NO" id="MWj-we-UuR" userLabel="Require display to stay on while actively playing video">
-                    <rect key="frame" x="118" y="88" width="350" height="18"/>
-                    <buttonCell key="cell" type="check" title="Require display to stay on while actively playing video" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="r2u-P9-J5p">
+                <button translatesAutoresizingMaskIntoConstraints="NO" id="MWj-we-UuR">
+                    <rect key="frame" x="118" y="105" width="317" height="18"/>
+                    <buttonCell key="cell" type="check" title="Prevent screen saver from starting while playing" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="r2u-P9-J5p">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                     <connections>
-                        <binding destination="IBP-Mz-Maa" name="value" keyPath="values.preventDisplaySleepForVideo" id="NFH-rv-hxv"/>
+                        <binding destination="IBP-Mz-Maa" name="value" keyPath="values.preventScreenSaver" id="EeM-5F-WOt"/>
                     </connections>
                 </button>
-                <button translatesAutoresizingMaskIntoConstraints="NO" id="fms-nd-RFo" userLabel="Require display to stay on while actively playing audio">
-                    <rect key="frame" x="118" y="64" width="351" height="18"/>
-                    <buttonCell key="cell" type="check" title="Require display to stay on while actively playing audio" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="yla-DT-YTx">
+                <button translatesAutoresizingMaskIntoConstraints="NO" id="fms-nd-RFo">
+                    <rect key="frame" x="138" y="81" width="303" height="18"/>
+                    <buttonCell key="cell" type="check" title="Not while in Music Mode or only playing audio" bezelStyle="regularSquare" imagePosition="left" inset="2" id="yla-DT-YTx">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
                     <connections>
-                        <binding destination="IBP-Mz-Maa" name="value" keyPath="values.preventDisplaySleepForAudio" id="j1Q-RZ-NGC"/>
+                        <binding destination="IBP-Mz-Maa" name="enabled" keyPath="values.preventScreenSaver" id="118-qC-OuP"/>
+                        <binding destination="IBP-Mz-Maa" name="value" keyPath="values.allowScreenSaverForAudio" id="vnC-IC-vz6"/>
                     </connections>
                 </button>
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="vNn-a9-lMx" userLabel="Still prevents system from sleeping">
+                    <rect key="frame" x="156" y="64" width="191" height="14"/>
+                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Still prevents system from sleeping." id="Kdk-iC-e1C">
+                        <font key="font" metaFont="message" size="11"/>
+                        <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aKH-Me-5XB" customClass="CollapseView" customModule="IINA" customModuleProvider="target">
-                    <rect key="frame" x="120" y="468" width="360" height="57"/>
+                    <rect key="frame" x="120" y="485" width="360" height="57"/>
                     <subviews>
                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Pga-vd-zGA">
                             <rect key="frame" x="0.0" y="40" width="360" height="17"/>
@@ -294,7 +303,7 @@
                     </customSpacing>
                 </stackView>
                 <stackView distribution="fill" orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="8iE-FU-0g0" customClass="CollapseView" customModule="IINA" customModuleProvider="target">
-                    <rect key="frame" x="120" y="313" width="360" height="147"/>
+                    <rect key="frame" x="120" y="330" width="360" height="147"/>
                     <subviews>
                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="W54-Em-Hx4">
                             <rect key="frame" x="0.0" y="130" width="360" height="17"/>
@@ -463,15 +472,16 @@
                 <constraint firstItem="b7I-2V-MYa" firstAttribute="height" secondItem="DUm-O0-pdI" secondAttribute="height" id="Y3C-r1-4Ae"/>
                 <constraint firstItem="Xi9-i5-9V4" firstAttribute="top" secondItem="5G0-Ih-CIb" secondAttribute="bottom" constant="8" id="YOU-SQ-93U"/>
                 <constraint firstItem="6Hg-O4-cBP" firstAttribute="top" secondItem="F6o-D4-gDa" secondAttribute="bottom" constant="16" id="a76-ej-aJs"/>
-                <constraint firstItem="ONF-nX-zDm" firstAttribute="top" secondItem="fms-nd-RFo" secondAttribute="bottom" constant="16" id="awt-JH-Sx1"/>
+                <constraint firstItem="ONF-nX-zDm" firstAttribute="top" secondItem="vNn-a9-lMx" secondAttribute="bottom" constant="15" id="awt-JH-Sx1"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="DUm-O0-pdI" secondAttribute="trailing" priority="100" id="c2z-9x-EKo"/>
                 <constraint firstItem="tUl-6f-ClP" firstAttribute="leading" secondItem="ibu-Tq-kBr" secondAttribute="leading" id="d7A-WU-gG9"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ONF-nX-zDm" secondAttribute="trailing" id="esl-VM-bcw"/>
                 <constraint firstItem="DUm-O0-pdI" firstAttribute="leading" secondItem="8iE-FU-0g0" secondAttribute="leading" id="ez5-7v-y5R"/>
                 <constraint firstItem="aKH-Me-5XB" firstAttribute="top" secondItem="OXi-vL-mzp" secondAttribute="bottom" constant="8" id="gTe-Cv-cgu"/>
                 <constraint firstItem="6Hg-O4-cBP" firstAttribute="leading" secondItem="F6o-D4-gDa" secondAttribute="leading" id="hbH-qB-dC3"/>
-                <constraint firstItem="fms-nd-RFo" firstAttribute="leading" secondItem="MWj-we-UuR" secondAttribute="leading" id="kB0-Na-qV6"/>
+                <constraint firstItem="fms-nd-RFo" firstAttribute="leading" secondItem="MWj-we-UuR" secondAttribute="leading" constant="20" id="kB0-Na-qV6"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="b7I-2V-MYa" secondAttribute="trailing" priority="100" constant="-54" id="kla-t0-rVJ"/>
+                <constraint firstItem="vNn-a9-lMx" firstAttribute="leading" secondItem="fms-nd-RFo" secondAttribute="leading" constant="18" id="lG1-jq-YPl"/>
                 <constraint firstItem="ONF-nX-zDm" firstAttribute="leading" secondItem="ibu-Tq-kBr" secondAttribute="trailing" constant="8" id="myc-5t-FrF"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="5G0-Ih-CIb" secondAttribute="trailing" priority="100" id="n4Z-6X-Oou"/>
                 <constraint firstItem="b7I-2V-MYa" firstAttribute="leading" secondItem="QvG-Ma-br0" secondAttribute="leading" id="o0g-jc-tgK"/>
@@ -484,10 +494,12 @@
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="F6o-D4-gDa" secondAttribute="trailing" priority="100" id="tRu-Sz-D5y"/>
                 <constraint firstItem="5G0-Ih-CIb" firstAttribute="leading" secondItem="DUm-O0-pdI" secondAttribute="leading" id="uxk-Ul-hVP"/>
                 <constraint firstItem="Xi9-i5-9V4" firstAttribute="leading" secondItem="5G0-Ih-CIb" secondAttribute="leading" id="vs3-xk-YxI"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="vNn-a9-lMx" secondAttribute="trailing" id="wvP-eI-idM"/>
                 <constraint firstItem="fms-nd-RFo" firstAttribute="top" secondItem="MWj-we-UuR" secondAttribute="bottom" constant="8" id="x7i-56-ISU"/>
+                <constraint firstItem="vNn-a9-lMx" firstAttribute="top" secondItem="fms-nd-RFo" secondAttribute="bottom" constant="4" id="yOD-3c-NX7"/>
                 <constraint firstItem="38y-2I-MGs" firstAttribute="leading" secondItem="6zR-96-iKB" secondAttribute="leading" id="ykt-2x-cLQ"/>
             </constraints>
-            <point key="canvasLocation" x="-2189" y="118.5"/>
+            <point key="canvasLocation" x="-2189" y="57"/>
         </customView>
         <userDefaultsController representsSharedInstance="YES" id="IBP-Mz-Maa"/>
         <customView id="y7O-rd-dnT" userLabel="Prefs &gt; General &gt; Playlist">

--- a/iina/Base.lproj/QuickSettingViewController.xib
+++ b/iina/Base.lproj/QuickSettingViewController.xib
@@ -1982,9 +1982,9 @@
                                                                     </view>
                                                                 </box>
                                                                 <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dXz-x4-sm5" userLabel="SubDelay Horizontal Tick Bottom Slider">
-                                                                    <rect key="frame" x="30" y="440" width="244" height="20"/>
+                                                                    <rect key="frame" x="30" y="440" width="233" height="20"/>
                                                                     <constraints>
-                                                                        <constraint firstAttribute="width" constant="240" id="Qpm-gC-Y2e"/>
+                                                                        <constraint firstAttribute="width" constant="229" id="Qpm-gC-Y2e"/>
                                                                     </constraints>
                                                                     <sliderCell key="cell" controlSize="small" continuous="YES" refusesFirstResponder="YES" state="on" alignment="left" minValue="-5" maxValue="5" tickMarkPosition="below" numberOfTickMarks="21" sliderType="linear" id="h1D-gP-Dst"/>
                                                                     <connections>
@@ -2019,7 +2019,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="r77-VA-Z1b">
-                                                                    <rect key="frame" x="253" y="430" width="21" height="11"/>
+                                                                    <rect key="frame" x="242" y="430" width="21" height="11"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="+5s" id="xfX-wr-DTJ">
                                                                         <font key="font" metaFont="label" size="9"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -2027,7 +2027,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField focusRingType="none" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eOz-bB-vzM" userLabel="CustomDelayEdit Text Field">
-                                                                    <rect key="frame" x="280" y="440" width="50" height="21"/>
+                                                                    <rect key="frame" x="269" y="440" width="50" height="21"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="ptd-kK-aWm"/>
                                                                     </constraints>
@@ -2042,7 +2042,7 @@
                                                                     </connections>
                                                                 </textField>
                                                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4U2-kT-76O">
-                                                                    <rect key="frame" x="328" y="443" width="4" height="16"/>
+                                                                    <rect key="frame" x="317" y="443" width="15" height="16"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="s" id="bsT-FB-GhF">
                                                                         <font key="font" metaFont="system"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -2050,7 +2050,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kzp-GR-Sy4">
-                                                                    <rect key="frame" x="145" y="430" width="15" height="11"/>
+                                                                    <rect key="frame" x="139" y="430" width="15" height="11"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="0s" id="LEZ-fv-buL">
                                                                         <font key="font" metaFont="label" size="9"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>

--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -22,6 +22,12 @@ class PlaybackInfo {
     case bSet
   }
 
+  enum MediaIsAudioStatus {
+    case unknown
+    case isAudio
+    case notAudio
+  }
+
   unowned let player: PlayerCore
 
   init(_ pc: PlayerCore) {
@@ -65,6 +71,17 @@ class PlaybackInfo {
     guard let duration = videoDuration, let position = videoPosition else { return }
     if position.second < 0 { position.second = 0 }
     if position.second > duration.second { position.second = duration.second }
+  }
+
+  var isAudio: MediaIsAudioStatus {
+    guard !isNetworkResource else { return .notAudio }
+    let noVideoTrack = videoTracks.isEmpty
+    let noAudioTrack = audioTracks.isEmpty
+    if noVideoTrack && noAudioTrack {
+      return .unknown
+    }
+    let allVideoTracksAreAlbumCover = !videoTracks.contains { !$0.isAlbumart }
+    return (noVideoTrack || allVideoTracksAreAlbumCover) ? .isAudio : .notAudio
   }
 
   var isSeeking: Bool = false

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -2541,10 +2541,17 @@ class PlayerCore: NSObject {
 
   static func checkStatusForSleep() {
     for player in playing {
-      if player.info.isPlaying {
+      guard player.info.isPlaying else { continue }
+      let isAudio = player.info.isAudio
+      guard isAudio != .unknown else { continue }
+      if player.info.isAudio == .isAudio {
+        guard Preference.bool(for: .preventDisplaySleepForAudio) else { continue }
         SleepPreventer.preventSleep()
         return
       }
+      guard Preference.bool(for: .preventDisplaySleepForVideo) else { continue }
+      SleepPreventer.preventSleep()
+      return
     }
     SleepPreventer.allowSleep()
   }

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -2540,19 +2540,27 @@ class PlayerCore: NSObject {
   }
 
   static func checkStatusForSleep() {
+    guard Preference.bool(for: .preventScreenSaver) else {
+      SleepPreventer.allowSleep()
+      return
+    }
+    // Look for players actively playing that are not in music mode and are not just playing audio.
     for player in playing {
-      guard player.info.isPlaying else { continue }
-      let isAudio = player.info.isAudio
-      guard isAudio != .unknown else { continue }
-      if player.info.isAudio == .isAudio {
-        guard Preference.bool(for: .preventDisplaySleepForAudio) else { continue }
-        SleepPreventer.preventSleep()
-        return
-      }
-      guard Preference.bool(for: .preventDisplaySleepForVideo) else { continue }
+      guard player.info.isPlaying,
+            player.info.isAudio != .isAudio && !player.isInMiniPlayer else { continue }
       SleepPreventer.preventSleep()
       return
     }
+    // Now look for players in music mode or playing audio.
+    for player in playing {
+      guard player.info.isPlaying,
+            player.info.isAudio == .isAudio || player.isInMiniPlayer else { continue }
+      // Either prevent the screen saver from activating or prevent system from sleeping depending
+      // upon user setting.
+      SleepPreventer.preventSleep(allowScreenSaver: Preference.bool(for: .allowScreenSaverForAudio))
+      return
+    }
+    // No players are actively playing.
     SleepPreventer.allowSleep()
   }
 }

--- a/iina/PrefUtilsViewController.swift
+++ b/iina/PrefUtilsViewController.swift
@@ -111,7 +111,9 @@ class PrefUtilsViewController: PreferenceViewController, PreferenceWindowEmbedda
   @IBAction func resetSuppressedAlertsBtnAction(_ sender: Any) {
     Utility.quickAskPanel("restore_alerts", sheetWindow: view.window) { respond in
       guard respond == .alertFirstButtonReturn else { return }
-      Preference.set(false, for: .suppressCannotPreventDisplaySleep)
+      // This operation used to restore an alert about preventing display sleeping failing. That
+      // alert has been removed so at this time we do not have any alerts that can be suppressed.
+      // That might change in the future, so for now we are retaining this operation.
       self.restoreAlertsRestoredLabel.isHidden = false
     }
   }

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -73,6 +73,9 @@ struct Preference {
     /** Resume from last position */
     static let resumeLastPosition = Key("resumeLastPosition")
 
+    static let preventDisplaySleepForAudio = Key("preventDisplaySleepForAudio")
+    static let preventDisplaySleepForVideo = Key("preventDisplaySleepForVideo")
+
     static let alwaysFloatOnTop = Key("alwaysFloatOnTop")
     static let alwaysShowOnTopIcon = Key("alwaysShowOnTopIcon")
 
@@ -769,6 +772,8 @@ struct Preference {
     .legacyFullScreenAnimation: false,
     .showChapterPos: false,
     .resumeLastPosition: true,
+    .preventDisplaySleepForAudio: true,
+    .preventDisplaySleepForVideo: true,
     .useMediaKeys: true,
     .useAppleRemote: false,
     .alwaysFloatOnTop: false,

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -73,8 +73,8 @@ struct Preference {
     /** Resume from last position */
     static let resumeLastPosition = Key("resumeLastPosition")
 
-    static let preventDisplaySleepForAudio = Key("preventDisplaySleepForAudio")
-    static let preventDisplaySleepForVideo = Key("preventDisplaySleepForVideo")
+    static let preventScreenSaver = Key("preventScreenSaver")
+    static let allowScreenSaverForAudio = Key("allowScreenSaverForAudio")
 
     static let alwaysFloatOnTop = Key("alwaysFloatOnTop")
     static let alwaysShowOnTopIcon = Key("alwaysShowOnTopIcon")
@@ -298,9 +298,6 @@ struct Preference {
 
     static let iinaLastPlayedFilePath = Key("iinaLastPlayedFilePath")
     static let iinaLastPlayedFilePosition = Key("iinaLastPlayedFilePosition")
-
-    /** Alerts */
-    static let suppressCannotPreventDisplaySleep = Key("suppressCannotPreventDisplaySleep")
 
     /** Internal */
     static let iinaEnablePluginSystem = Key("iinaEnablePluginSystem")
@@ -772,8 +769,8 @@ struct Preference {
     .legacyFullScreenAnimation: false,
     .showChapterPos: false,
     .resumeLastPosition: true,
-    .preventDisplaySleepForAudio: true,
-    .preventDisplaySleepForVideo: true,
+    .preventScreenSaver: true,
+    .allowScreenSaverForAudio: false,
     .useMediaKeys: true,
     .useAppleRemote: false,
     .alwaysFloatOnTop: false,
@@ -917,8 +914,6 @@ struct Preference {
     .watchProperties: [String](),
     .savedVideoFilters: [SavedFilter](),
     .savedAudioFilters: [SavedFilter](),
-
-    .suppressCannotPreventDisplaySleep: false,
 
     .enableRecentDocumentsWorkaround: false,
     .recentDocuments: [Any](),

--- a/iina/SleepPreventer.swift
+++ b/iina/SleepPreventer.swift
@@ -6,76 +6,67 @@
 //  Copyright © 2017 lhc. All rights reserved.
 //
 
-import IOKit.pwr_mgt
-
-
+/// Manage process information agent
+/// [activities](https://developer.apple.com/documentation/foundation/processinfo#1651116) for preventing
+/// sleep.
+/// - Attention: This portion of macOS has proven to be **unreliable**. Previously the macOS function
+///     [IOPMAssertionCreateWithName](https://developer.apple.com/documentation/iokit/1557134-iopmassertioncreatewithname)
+///     was used to create a
+///     [kIOPMAssertionTypeNoDisplaySleep](https://developer.apple.com/documentation/iokit/kiopmassertiontypenodisplaysleep)
+///     assertion with the macOS power management system. That method returns a status code so IINA was able to detect when
+///     macOS power management was malfunctioning. This class now uses the
+///     [beginActivity](https://developer.apple.com/documentation/foundation/processinfo/1415995-beginactivity)
+///     method that does not provide a status code so it will not be obvious when macOS is broken. Should a user report problems
+///     with sleep prevention review issues [#3842](https://github.com/iina/iina/issues/3842) and
+///     [#3478](https://github.com/iina/iina/issues/3478) to see if they explain the failure.
 class SleepPreventer: NSObject {
 
-  static private let reason = "IINA is playing video" as CFString
+  /// Token returned by [beginActivity](https://developer.apple.com/documentation/foundation/processinfo/1415995-beginactivity).
+  static private var activityToken: NSObjectProtocol?
 
-  static private var assertionID = IOPMAssertionID()
+  /// If `true` then the current activity only prevents the system from sleeping.
+  static private var allowScreenSaver = false
 
-  static private var haveShownAlert = false
-
-  static private var preventedSleep = false
-
-  /// Ask macOS to not dim or sleep the display.
+  /// Ask macOS to prevent the screen saver from starting or just prevent the system from sleeping.
   ///
-  /// This method uses the macOS function [IOPMAssertionCreateWithName](https://developer.apple.com/documentation/iokit/1557134-iopmassertioncreatewithname)
-  /// to create a [kIOPMAssertionTypeNoDisplaySleep](https://developer.apple.com/documentation/iokit/kiopmassertiontypenodisplaysleep)
-  /// assertion with the macOS power management system.
-  /// - Attention: This portion of macOS has proven to be **unreliable**.
+  /// This method uses the macOS function
+  /// [beginActivity](https://developer.apple.com/documentation/foundation/processinfo/1415995-beginactivity)
+  /// to create an
+  /// [idleDisplaySleepDisabled](https://developer.apple.com/documentation/foundation/processinfo/activityoptions/1416839-idledisplaysleepdisabled)
+  /// activity that prevents the screen saver from starting or an
+  /// [idleSystemSleepDisabled](https://developer.apple.com/documentation/foundation/processinfo/activityoptions/1409849-idlesystemsleepdisabled)
+  /// activity that prevents the system from sleeping.
   ///
-  /// It is important to inform the user that macOS power management is malfunctioning as this can explain
-  /// why there is trouble with audio/video playback. For this reason IINA posts an alert if  `IOPMAssertionCreateWithName` fails.
-  ///
-  /// As this alert can be irritating to users the alert is only displayed once per IINA invocation. In addition
-  /// the alert supports a [suppression button](https://developer.apple.com/documentation/appkit/nsalert/1535196-showssuppressionbutton)
-  /// to allow the user to permanently suppress this alert. 
-  ///
-  /// See issues [#3842](https://github.com/iina/iina/issues/3842) and [#3478](https://github.com/iina/iina/issues/3478) for details on the macOS failure.
-  static func preventSleep() {
-    if preventedSleep {
+  /// To see the power management assertion created by the activity run the command `pmset -g assertions` in  terminal.
+  /// - Parameter allowScreenSaver: If `true` the screen saver will be allowed to start but the system will be prevented from
+  ///     sleeping.
+  static func preventSleep(allowScreenSaver: Bool = false) {
+    if activityToken != nil {
+      guard self.allowScreenSaver != allowScreenSaver else { return }
+      // The outstanding activity does not match what is requested. End the current activity and
+      // create a new one.
+      allowSleep()
+    }
+    SleepPreventer.allowScreenSaver = allowScreenSaver
+    let options: ProcessInfo.ActivityOptions = allowScreenSaver ?
+      .idleSystemSleepDisabled : .idleDisplaySleepDisabled
+    activityToken = ProcessInfo.processInfo.beginActivity(options: options,
+                                                          reason: "IINA playback is in progress")
+    guard allowScreenSaver else {
+      Logger.log("Preventing screen saver from starting", level: .verbose)
       return
     }
-
-    let success = IOPMAssertionCreateWithName(kIOPMAssertionTypeNoDisplaySleep as NSString,
-                                              IOPMAssertionLevel(kIOPMAssertionLevelOn),
-                                              reason,
-                                              &assertionID)
-    guard success != kIOReturnSuccess else {
-      Logger.log("Requiring screen to stay powered on", level: .verbose)
-      preventedSleep = true
-      return
-    }
-    // Something has gone wrong with power management on this Mac.
-    Logger.log(String(format: "IOPMAssertionCreateWithName returned 0x%0X8, \(String(cString: mach_error_string(success)))",
-                      success), level: .error)
-    Logger.log(
-      "Cannot prevent display sleep because macOS power management is broken on this machine",
-      level: .error)
-    // To avoid irritating users only display this alert once per IINA invocation and support a
-    // button to allow the alert to be permanently suppressed.
-    guard !haveShownAlert else { return }
-    haveShownAlert = true
-    DispatchQueue.main.async {
-      Utility.showAlert("sleep", arguments: [success],
-                        suppressionKey: .suppressCannotPreventDisplaySleep)
-    }
+    Logger.log("Preventing system from sleeping", level: .verbose)
   }
 
   static func allowSleep() {
-    if !preventedSleep {
+    guard let activityToken = activityToken else { return }
+    ProcessInfo.processInfo.endActivity(activityToken)
+    SleepPreventer.activityToken = nil
+    guard allowScreenSaver else {
+      Logger.log("Allowing screen saver to start when inactive", level: .verbose)
       return
-    } else {
-      let success = IOPMAssertionRelease(assertionID)
-      if success == kIOReturnSuccess {
-        Logger.log("Allowing screen to power off", level: .verbose)
-        preventedSleep = false
-      } else {
-        Logger.log("Cannot allow display sleep", level: .warning)
-      }
     }
+    Logger.log("Allowing system to sleep when inactive", level: .verbose)
   }
-
 }

--- a/iina/SleepPreventer.swift
+++ b/iina/SleepPreventer.swift
@@ -44,6 +44,7 @@ class SleepPreventer: NSObject {
                                               reason,
                                               &assertionID)
     guard success != kIOReturnSuccess else {
+      Logger.log("Requiring screen to stay powered on", level: .verbose)
       preventedSleep = true
       return
     }
@@ -69,6 +70,7 @@ class SleepPreventer: NSObject {
     } else {
       let success = IOPMAssertionRelease(assertionID)
       if success == kIOReturnSuccess {
+        Logger.log("Allowing screen to power off", level: .verbose)
         preventedSleep = false
       } else {
         Logger.log("Cannot allow display sleep", level: .warning)

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -184,7 +184,6 @@
 
 "alert.fatal_error" = "Fatal error: %@ \nThe application will exit now.";
 "alert.mpv_error" = "Internal error %@ (%@) when setting option %@.";
-"alert.sleep" = "Cannot prevent display sleep! (0x%0X8)";
 
 "alert.unsupported_audio" = "Unsupported external audio file.";
 "alert.unsupported_sub" = "Unsupported external subtitle.";

--- a/iina/en.lproj/PrefGeneralViewController.strings
+++ b/iina/en.lproj/PrefGeneralViewController.strings
@@ -56,6 +56,9 @@
 /* Class = "NSButtonCell"; title = "Black out other monitors while in full screen"; ObjectID = "KYi-0W-zOr"; */
 "KYi-0W-zOr.title" = "Black out other monitors while in full screen";
 
+/* Class = "NSTextFieldCell"; title = "Still prevents system from sleeping."; ObjectID = "Kdk-iC-e1C"; */
+"Kdk-iC-e1C.title" = "Still prevents system from sleeping.";
+
 /* Class = "NSButtonCell"; title = "Switch to \"music mode\" automatically when playing an audio file"; ObjectID = "KfL-r7-Uav"; */
 "KfL-r7-Uav.title" = "Switch to \"music mode\" automatically when playing an audio file";
 
@@ -131,8 +134,8 @@
 /* Class = "NSTextFieldCell"; title = "Screenshots:"; ObjectID = "pdx-zt-kf2"; */
 "pdx-zt-kf2.title" = "Screenshots:";
 
-/* Class = "NSButtonCell"; title = "Require display to stay on while actively playing video"; ObjectID = "r2u-P9-J5p"; */
-"r2u-P9-J5p.title" = "Require display to stay on while actively playing video";
+/* Class = "NSButtonCell"; title = "Prevent screen saver from starting while playing"; ObjectID = "r2u-P9-J5p"; */
+"r2u-P9-J5p.title" = "Prevent screen saver from starting while playing";
 
 /* Class = "NSMenuItem"; title = "Hourly"; ObjectID = "slG-Jb-54B"; */
 "slG-Jb-54B.title" = "Hourly";
@@ -149,8 +152,8 @@
 /* Class = "NSTextFieldCell"; title = "Pause/resume when:"; ObjectID = "xr2-rB-O0x"; */
 "xr2-rB-O0x.title" = "Pause/resume when:";
 
-/* Class = "NSButtonCell"; title = "Require display to stay on while actively playing audio"; ObjectID = "yla-DT-YTx"; */
-"yla-DT-YTx.title" = "Require display to stay on while actively playing audio";
+/* Class = "NSButtonCell"; title = "Not while in Music Mode or only playing audio"; ObjectID = "yla-DT-YTx"; */
+"yla-DT-YTx.title" = "Not while in Music Mode or only playing audio";
 
 /* Class = "NSMenuItem"; title = "Show welcome window"; ObjectID = "z9T-8h-1T0"; */
 "z9T-8h-1T0.title" = "Show welcome window";

--- a/iina/en.lproj/PrefGeneralViewController.strings
+++ b/iina/en.lproj/PrefGeneralViewController.strings
@@ -131,6 +131,9 @@
 /* Class = "NSTextFieldCell"; title = "Screenshots:"; ObjectID = "pdx-zt-kf2"; */
 "pdx-zt-kf2.title" = "Screenshots:";
 
+/* Class = "NSButtonCell"; title = "Require display to stay on while actively playing video"; ObjectID = "r2u-P9-J5p"; */
+"r2u-P9-J5p.title" = "Require display to stay on while actively playing video";
+
 /* Class = "NSMenuItem"; title = "Hourly"; ObjectID = "slG-Jb-54B"; */
 "slG-Jb-54B.title" = "Hourly";
 
@@ -145,6 +148,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Pause/resume when:"; ObjectID = "xr2-rB-O0x"; */
 "xr2-rB-O0x.title" = "Pause/resume when:";
+
+/* Class = "NSButtonCell"; title = "Require display to stay on while actively playing audio"; ObjectID = "yla-DT-YTx"; */
+"yla-DT-YTx.title" = "Require display to stay on while actively playing audio";
 
 /* Class = "NSMenuItem"; title = "Show welcome window"; ObjectID = "z9T-8h-1T0"; */
 "z9T-8h-1T0.title" = "Show welcome window";


### PR DESCRIPTION
This commit will:
- Add new settings `preventDisplaySleepForAudio` and `preventDisplaySleepForVideo`
- Change the `PlayerCore` `checkCurrentMediaIsAudio` method into an `isAudio` `PlaybackInfo` property
- Add a `Require display to stay on while actively playing video` checkbox to the settings window `General` tab
- Add a similar checkbox for playing audio
- Change the `PlayerCore.checkStatusForSleep` method to support the new settings
- Add logging to `SleepPreventer`

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4954.

---

**Description:**
