### PR TITLE
Fix Touch Bar time remaining label in RTL, #4946

### DIFF
--- a/iina/TouchBarSupport.swift
+++ b/iina/TouchBarSupport.swift
@@ -130,6 +130,10 @@ class TouchBarSupport: NSObject, NSTouchBarDelegate {
       label.alignment = .center
       label.font = .monospacedDigitSystemFont(ofSize: 0, weight: .regular)
       label.mode = Preference.bool(for: .touchbarShowRemainingTime) ? .remaining : .duration
+      // The baseWritingDirection must be changed from natural (the default) to leftToRight or the
+      // minus sign will be drawn on the right side of the time string when displaying time
+      // remaining in a right-to-left language.
+      label.baseWritingDirection = .leftToRight
       self.touchBarPosLabels.append(label)
       item.view = label
       item.customizationLabel = NSLocalizedString("touchbar.remainingTimeOrTotalDuration", comment: "Show Remaining Time or Total Duration")


### PR DESCRIPTION
This commit will change the touchBar method in TouchBarSupport to set baseWritingDirection to leftToRight on the DurationDisplayTextField that shows time remaining.

This is a follow-up to PR #4958 which changed the baseWritingDirection in the XIB for the OSC. That fix is correct, but does not fix the DurationDisplayTextField created at runtime by  TouchBarSupport. This commit corrects the TouchBarSupport use case.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4946.

---

**Description:**
