### PR TITLE
Fix RTL causes date in about window to be malformed, #4969

### DIFF
--- a/iina/AboutWindowController.swift
+++ b/iina/AboutWindowController.swift
@@ -71,11 +71,16 @@ class AboutWindowController: NSWindowController {
     mpvVersionLabel.stringValue = PlayerCore.active.mpv.mpvVersion
     ffmpegVersionLabel.stringValue = "FFmpeg \(String(cString: av_version_info()))"
 
+    // Use a localized date for the build date.
+    let toString = DateFormatter()
+    toString.dateStyle = .medium
+    toString.timeStyle = .medium
+
     switch InfoDictionary.shared.buildType {
     case .nightly:
       if let buildDate = InfoDictionary.shared.buildDate,
          let buildSHA = InfoDictionary.shared.shortCommitSHA {
-        buildDateLabel.stringValue = buildDate
+        buildDateLabel.stringValue = toString.string(from: buildDate)
         buildDateLabel.isHidden = false
         buildBranchButton.title = "NIGHTLY " + buildSHA
         buildBranchButton.action = #selector(self.openCommitLink)
@@ -85,7 +90,7 @@ class AboutWindowController: NSWindowController {
       if let buildDate = InfoDictionary.shared.buildDate,
          let buildBranch = InfoDictionary.shared.buildBranch,
          let buildSHA = InfoDictionary.shared.shortCommitSHA {
-        buildDateLabel.stringValue = buildDate
+        buildDateLabel.stringValue = toString.string(from: buildDate)
         buildDateLabel.isHidden = false
         buildBranchButton.title = buildBranch + " " + buildSHA
         buildBranchButton.action = #selector(self.openCommitLink)

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -139,7 +139,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     guard let date = InfoDictionary.shared.buildDate,
           let sdk = InfoDictionary.shared.buildSDK,
           let xcode = InfoDictionary.shared.buildXcode else { return }
-    Logger.log("Built using Xcode \(xcode) and macOS SDK \(sdk) on \(date)")
+    let toString = DateFormatter()
+    toString.dateStyle = .medium
+    toString.timeStyle = .medium
+    // Always use the en_US locale for dates in the log file.
+    toString.locale = Locale(identifier: "en_US")
+    Logger.log("Built using Xcode \(xcode) and macOS SDK \(sdk) on \(toString.string(from: date))")
     guard let branch = InfoDictionary.shared.buildBranch,
           let commit = InfoDictionary.shared.buildCommit else { return }
     Logger.log("From branch \(branch), commit \(commit)")

--- a/iina/Base.lproj/AboutWindowController.xib
+++ b/iina/Base.lproj/AboutWindowController.xib
@@ -107,7 +107,7 @@
                                                 <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" mirrorLayoutDirectionWhenInternationalizing="never" textCompletion="NO" id="O3G-Ax-VRU" userLabel="Date">
                                                     <rect key="frame" x="0.0" y="37" width="180" height="11"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                    <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" selectable="YES" refusesFirstResponder="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" baseWritingDirection="leftToRight" alignment="center" title="Date" usesSingleLineMode="YES" id="hp8-K0-WQf">
+                                                    <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" selectable="YES" refusesFirstResponder="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="Date" usesSingleLineMode="YES" id="hp8-K0-WQf">
                                                         <font key="font" metaFont="miniSystem"/>
                                                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>

--- a/iina/Base.lproj/AboutWindowController.xib
+++ b/iina/Base.lproj/AboutWindowController.xib
@@ -104,10 +104,10 @@
                                         <customView horizontalCompressionResistancePriority="1000" verticalCompressionResistancePriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="10Q-XR-xzb" userLabel="Build View">
                                             <rect key="frame" x="20" y="150" width="180" height="48"/>
                                             <subviews>
-                                                <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" textCompletion="NO" id="O3G-Ax-VRU" userLabel="Date">
+                                                <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" mirrorLayoutDirectionWhenInternationalizing="never" textCompletion="NO" id="O3G-Ax-VRU" userLabel="Date">
                                                     <rect key="frame" x="0.0" y="37" width="180" height="11"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                                                    <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" selectable="YES" refusesFirstResponder="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="Date" usesSingleLineMode="YES" id="hp8-K0-WQf">
+                                                    <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" selectable="YES" refusesFirstResponder="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" baseWritingDirection="leftToRight" alignment="center" title="Date" usesSingleLineMode="YES" id="hp8-K0-WQf">
                                                         <font key="font" metaFont="miniSystem"/>
                                                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                                                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>

--- a/iina/InfoDictionary.swift
+++ b/iina/InfoDictionary.swift
@@ -24,7 +24,7 @@ struct InfoDictionary {
     return String(buildCommit.prefix(7))
   }
 
-  var buildDate: String? {
+  var buildDate: Date? {
     let dateParser: (String) -> Date?
     if #available(macOS 10.12, *) {
       let formatter = ISO8601DateFormatter()
@@ -38,11 +38,7 @@ struct InfoDictionary {
           let dateObj = dateParser(date) else {
       return nil
     }
-    // Use a localized date for the build date.
-    let toString = DateFormatter()
-    toString.dateStyle = .medium
-    toString.timeStyle = .medium
-    return toString.string(from: dateObj)
+    return dateObj
   }
 
   private var buildKeyPrefix: String {


### PR DESCRIPTION
This commit will:
- Change the `Text Direction` to be `Left To Right` for the `Date` text field in `AboutWindowController.xib`
- Change the `Mirror` attribute to be `Never` for the `Date` text field in `AboutWindowController.xib`
- Change the type of the `buildDate` property in `InfoDictionary` to be `Date?` instead of `String?`
- Change `windowDidLoad` in `AboutWindowController` to format `buildDate` as a localized string
- Change `logBuildDetails` in `AppDelegate` to format `buildDate` using the `en_US` locale

These changes correct the localized build date displayed in the about window. They also change the build date displayed in the log file to not use the user's locale.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4969.

---

**Description:**
