### PR TITLE
Fix if a NAS share cannot be reached, iina fails to start, #4973

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -1000,6 +1000,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
   /// be restored when `sharedfilelistd` clears its list.
   ///
   /// If the following is true:
+  /// - Workaround has been enabled by setting `enableRecentDocumentsWorkaround`
   /// - Running under macOS Sonoma and above
   /// - Recording of recent files is enabled
   /// - The list in  [NSDocumentController.shared.recentDocumentURLs](https://developer.apple.com/documentation/appkit/nsdocumentcontroller/1514976-recentdocumenturls) is empty
@@ -1007,18 +1008,44 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
   ///
   /// Then this method assumes that the macOS daemon `sharedfilelistd` cleared the list and it populates the list of recent
   /// document URLs with the list stored in IINA's settings.
+  /// - Note: This workaround can cause significant slowdown at startup if the list of recent documents contains files on a mounted
+  ///         volume that is unreachable. For this reason the workaround is disabled by default and must be enabled by running the
+  ///         following command in [Terminal](https://support.apple.com/guide/terminal/welcome/mac):
+  ///         `defaults write com.colliderli.iina enableRecentDocumentsWorkaround true`
   private func restoreRecentDocuments() {
-    guard #available(macOS 14, *), Preference.bool(for: .recordRecentFiles),
+    guard Preference.bool(for: .enableRecentDocumentsWorkaround),
+          #available(macOS 14, *), Preference.bool(for: .recordRecentFiles),
           NSDocumentController.shared.recentDocumentURLs.isEmpty,
           let recentDocuments = Preference.array(for: .recentDocuments),
           !recentDocuments.isEmpty else { return }
     var foundStale = false
     for document in recentDocuments {
       var isStale = false
-      guard let asData = document as? Data,
-            let bookmark = try? URL(resolvingBookmarkData: asData, bookmarkDataIsStale: &isStale) else {
-        guard let asString = document as? String, let url = URL(string: asString) else { continue }
+      // Recent documents are normally stored as bookmark data.
+      guard let asData = document as? Data else {
+        guard let asString = document as? String, let url = URL(string: asString) else {
+          // Should never occur. This is an internal error.
+          Logger.log("Saved recent document is of unrecognized type: \(type(of: document))",
+                     level: .error)
+          continue
+        }
         // Saving as a bookmark must have failed and instead the URL was saved as a string.
+        NSDocumentController.shared.noteNewRecentDocumentURL(url)
+        continue
+      }
+      // Must not cause macOS to prompt the user to mount a volume when the list contains files that
+      // are on volumes that are not currently mounted.
+      guard let bookmark = try? URL(resolvingBookmarkData: asData,
+                                    options: [.withoutMounting, .withoutUI],
+                                    bookmarkDataIsStale: &isStale) else {
+        // Creating a URL from a bookmark fails if the original file can not be located or is on a
+        // volume that is not mounted. Form a URL from the path contained in the bookmark.
+        guard let resource = URL.resourceValues(forKeys: [.pathKey], fromBookmarkData: asData),
+              let path = resource.path, let url = URL(string: path) else {
+          Logger.log("Unable to obtain obtain the path from a bookmark", level: .error)
+          continue
+        }
+        Logger.log("Unable to create a bookmark, creating URL from path for: \(path)", level: .verbose)
         NSDocumentController.shared.noteNewRecentDocumentURL(url)
         continue
       }
@@ -1041,12 +1068,14 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
   /// `restoreRecentDocuments` and the issue [#4688](https://github.com/iina/iina/issues/4688) for more
   /// information..
   func saveRecentDocuments() {
-    guard #available(macOS 14, *) else { return }
+    guard Preference.bool(for: .enableRecentDocumentsWorkaround), #available(macOS 14, *) else { return }
     var recentDocuments: [Any] = []
     for document in NSDocumentController.shared.recentDocumentURLs {
       guard let bookmark = try? document.bookmarkData() else {
         // Fall back to storing a string when unable to create a bookmark.
-        recentDocuments.append(document.absoluteString)
+        let path = document.absoluteString
+        Logger.log("Unable to create a bookmark, saving recent document as a string: \(path)")
+        recentDocuments.append(path)
         continue
       }
       recentDocuments.append(bookmark)

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -299,7 +299,12 @@ struct Preference {
 
     static let iinaEnablePluginSystem = Key("iinaEnablePluginSystem")
 
-    /** Workaround for issue [#4688](https://github.com/iina/iina/issues/4688) */
+    /// Workaround for issue [#4688](https://github.com/iina/iina/issues/4688)
+    /// - Note: This workaround can cause significant slowdown at startup if the list of recent documents contains files on a mounted
+    ///         volume that is unreachable. For this reason the workaround is disabled by default and must be enabled by running the
+    ///         following command in [Terminal](https://support.apple.com/guide/terminal/welcome/mac):
+    ///         `defaults write com.colliderli.iina enableRecentDocumentsWorkaround true`
+    static let enableRecentDocumentsWorkaround = Key("enableRecentDocumentsWorkaround")
     static let recentDocuments = Key("recentDocuments")
   }
 
@@ -884,6 +889,7 @@ struct Preference {
 
     .suppressCannotPreventDisplaySleep: false,
 
+    .enableRecentDocumentsWorkaround: false,
     .recentDocuments: [Any]()
   ]
 


### PR DESCRIPTION
This commit will:
- Add a new preference `enableRecentDocumentsWorkaround`
- Change the `AppDelegate` methods `restoreRecentDocuments` and `saveRecentDocuments` to not do anything if `enableRecentDocumentsWorkaround` has not been set to `true`
- Change `restoreRecentDocuments` to use the options `withoutMounting` and `withoutUI` when creating a URL from bookmark data
- Add code to `restoreRecentDocuments` to create a URL from a string if creating using bookmark data fails

This has to do with the workaround added for issue #4688 where starting with Sonoma macOS erases the list of recent documents when an unsigned IINA executable is run. This affects developers as well as normal users that test nightly builds. These changes correct the problem with IINA causing macOS to prompt the user to mount volumes when the list of recent documents contains files on volumes that are not mounted.

However it is not possible to correct the long delays when the volume is mounted, but unreachable, such as a NAS that macOS does not know yet has been shutdown. For this reason this commit adds a preference that must be set using terminal and the defaults command to enable the workaround.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4973.

---

**Description:**
