### PR TITLE
Fix IINA displays malformed quick settings panel, #4980

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2045,8 +2045,10 @@ class MainWindowController: PlayerWindowController {
     let width = type.width()
     sideBarWidthConstraint.constant = width
     // The macOS setting could change at any point in time. Remember which type of animation is
-    // being used.
-    let useFade = AccessibilityPreferences.motionReductionEnabled
+    // being used. Avoid using fading when disabling animations as that animation will initially
+    // malfunction if used with a short duration.
+    let useFade = AccessibilityPreferences.motionReductionEnabled &&
+                  !Preference.bool(for: PK.disableAnimations)
     if useFade {
       sideBarRightConstraint.constant = 0
     } else {
@@ -2080,8 +2082,10 @@ class MainWindowController: PlayerWindowController {
     sidebarAnimationState = .willHide
     let currWidth = sideBarWidthConstraint.constant
     // The macOS setting could change at any point in time. Remember which type of animation is
-    // being used.
-    let useFade = AccessibilityPreferences.motionReductionEnabled
+    // being used. Avoid using fading when disabling animations as that animation will initially
+    // malfunction if used with a short duration.
+    let useFade = AccessibilityPreferences.motionReductionEnabled &&
+                  !Preference.bool(for: PK.disableAnimations)
     NSAnimationContext.runAnimationGroup({ (context) in
       context.duration = animate ? AccessibilityPreferences.adjustedDuration(SideBarAnimationDuration) : 0
       context.timingFunction = CAMediaTimingFunction(name: .easeIn)


### PR DESCRIPTION
This commit will change the MainWindowController methods showSideBar and hideSideBar to not use a fade transition if disabling animations by using a short duration. Short durations work fine with sliding transitions, but with fading AppKit will sometimes fail to draw portions of the quick setting panel.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4980.

---

**Description:**
