### PR TITLE
Always display Find Online Subtitle OSD messages

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1896,7 +1896,7 @@ class MainWindowController: PlayerWindowController {
   ///     timeline indicators should not flip in a right-to-left language. Thus OSD messages referencing a position within the video
   ///     must always use a left to right layout.
   func displayOSD(_ message: OSDMessage, autoHide: Bool = true, forcedTimeout: Float? = nil, accessoryView: NSView? = nil, context: Any? = nil) {
-    guard player.displayOSD && !isShowingPersistentOSD else { return }
+    guard player.displayOSD || message.isAlwaysShown, !isShowingPersistentOSD else { return }
 
     if hideOSDTimer != nil {
       hideOSDTimer!.invalidate()

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1896,7 +1896,7 @@ class MainWindowController: PlayerWindowController {
   ///     timeline indicators should not flip in a right-to-left language. Thus OSD messages referencing a position within the video
   ///     must always use a left to right layout.
   func displayOSD(_ message: OSDMessage, autoHide: Bool = true, forcedTimeout: Float? = nil, accessoryView: NSView? = nil, context: Any? = nil) {
-    guard player.displayOSD || message.isAlwaysShown, !isShowingPersistentOSD else { return }
+    guard player.displayOSD || message.alwaysEnabled, !isShowingPersistentOSD else { return }
 
     if hideOSDTimer != nil {
       hideOSDTimer!.invalidate()

--- a/iina/OSDMessage.swift
+++ b/iina/OSDMessage.swift
@@ -94,8 +94,8 @@ enum OSDMessage {
   /// A user may disable the OSD by unchecking the `Enable OSD` setting found on the `UI` tab in the `On Screen Display`
   /// section of IINA's settings. Or they may check the `Use mpv's OSD` setting found on the `Advanced` tab which implicitly
   /// disables IINA's OSD. _However_ not all OSD messages are optional notifications. The `Find Online Subtitles` feature
-  /// uses the OSD for its user interface. These messages must always been shown.
-  var isAlwaysShown: Bool {
+  /// uses the OSD for its user interface. These messages must still be displayed when the OSD is disabled.
+  var alwaysEnabled: Bool {
     switch self {
     case .canceled: fallthrough
     case .cannotConnect: fallthrough

--- a/iina/OSDMessage.swift
+++ b/iina/OSDMessage.swift
@@ -89,6 +89,29 @@ enum OSDMessage {
   case custom(String)
   case customWithDetail(String, String)
 
+  /// `True` if this message must always be shown, otherwise `false`.
+  ///
+  /// A user may disable the OSD by unchecking the `Enable OSD` setting found on the `UI` tab in the `On Screen Display`
+  /// section of IINA's settings. Or they may check the `Use mpv's OSD` setting found on the `Advanced` tab which implicitly
+  /// disables IINA's OSD. _However_ not all OSD messages are optional notifications. The `Find Online Subtitles` feature
+  /// uses the OSD for its user interface. These messages must always been shown.
+  var isAlwaysShown: Bool {
+    switch self {
+    case .canceled: fallthrough
+    case .cannotConnect: fallthrough
+    case .cannotLogin: fallthrough
+    case .downloadedSub: fallthrough
+    case .fileError: fallthrough
+    case .foundSub: fallthrough
+    case .networkError: fallthrough
+    case .savedSub: fallthrough
+    case .startFindingSub: fallthrough
+    case .timedOut:
+      return true
+    default: return false
+    }
+  }
+
   func message() -> (String, OSDType) {
     switch self {
     case .fileStart(let filename):

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -2158,7 +2158,7 @@ class PlayerCore: NSObject {
 
   func sendOSD(_ osd: OSDMessage, autoHide: Bool = true, forcedTimeout: Float? = nil, accessoryView: NSView? = nil, context: Any? = nil, external: Bool = false) {
     // querying `mainWindow.isWindowLoaded` will initialize mainWindow unexpectly
-    guard mainWindow.loaded, Preference.bool(for: .enableOSD) || osd.isAlwaysShown else { return }
+    guard mainWindow.loaded, Preference.bool(for: .enableOSD) || osd.alwaysEnabled else { return }
     if info.disableOSDForFileLoading && !external {
       guard case .fileStart = osd else {
         return

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -2158,7 +2158,7 @@ class PlayerCore: NSObject {
 
   func sendOSD(_ osd: OSDMessage, autoHide: Bool = true, forcedTimeout: Float? = nil, accessoryView: NSView? = nil, context: Any? = nil, external: Bool = false) {
     // querying `mainWindow.isWindowLoaded` will initialize mainWindow unexpectly
-    guard mainWindow.loaded && Preference.bool(for: .enableOSD) else { return }
+    guard mainWindow.loaded, Preference.bool(for: .enableOSD) || osd.isAlwaysShown else { return }
     if info.disableOSDForFileLoading && !external {
       guard case .fileStart = osd else {
         return


### PR DESCRIPTION
This commit will:
- Add an isAlwaysShown property to OSDMessage that is true for OSD messages emitted by the Find Online Subtitles feature
- Change PlayerCore.sendOSD to send messages whose isAlwaysShown property is true even when the enableOSD setting is false
- Change MainWindowController.displayOSD to display messages whose isAlwaysShown property is true even when the IINA OSD is disabled due to the user enabling mpv's OSD

These changes correct a problem where IINA's Find Online Subtitles feature appears to do nothing when the OSD is disabled. This feature uses the OSD to interact with the user. Failing to display the messages breaks the feature.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
