### PR TITLE
Allow closing sub download OSD using escape

### DIFF
--- a/iina/Base.lproj/SubChooseViewController.xib
+++ b/iina/Base.lproj/SubChooseViewController.xib
@@ -134,6 +134,9 @@
                     <buttonCell key="cell" type="square" title="CANCEL" bezelStyle="shadowlessSquare" alignment="center" inset="2" id="pPz-om-Xit">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="systemBold"/>
+                        <string key="keyEquivalent" base64-UTF8="YES">
+Gw
+</string>
                     </buttonCell>
                     <connections>
                         <action selector="cancelBtnAction:" target="-2" id="trN-ei-1wo"/>

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -833,19 +833,22 @@ class MainWindowController: PlayerWindowController {
 
   // MARK: - Mouse / Trackpad events
 
-  @discardableResult
-  override func handleKeyBinding(_ keyBinding: KeyMapping) -> Bool {
-    if
-      keyBinding.normalizedMpvKey == "ESC",
-      isShowingPersistentOSD,
-      hideOSDTimer?.isValid != true,
-      let currentEvent = NSApp.currentEvent
-    {
-      if osdStackView.performKeyEquivalent(with: currentEvent) {
-        return true
+  override func keyDown(with event: NSEvent) {
+    if isShowingPersistentOSD {
+      let keyCode = KeyCodeHelper.mpvKeyCode(from: event)
+      let normalizedKeyCode = KeyCodeHelper.normalizeMpv(keyCode)
+
+      if normalizedKeyCode == "ESC", osdStackView.performKeyEquivalent(with: event) {
+        Logger.log("ESC key was handled by OSD", level: .verbose)
+        return
       }
     }
     
+    super.keyDown(with: event)
+  }
+
+  @discardableResult
+  override func handleKeyBinding(_ keyBinding: KeyMapping) -> Bool {
     let success = super.handleKeyBinding(keyBinding)
     if success && keyBinding.action.first! == MPVCommand.screenshot.rawValue {
       player.sendOSD(.screenshot)

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -835,6 +835,17 @@ class MainWindowController: PlayerWindowController {
 
   @discardableResult
   override func handleKeyBinding(_ keyBinding: KeyMapping) -> Bool {
+    if
+      keyBinding.normalizedMpvKey == "ESC",
+      isShowingPersistentOSD,
+      hideOSDTimer?.isValid != true,
+      let currentEvent = NSApp.currentEvent
+    {
+      if osdStackView.performKeyEquivalent(with: currentEvent) {
+        return true
+      }
+    }
+    
     let success = super.handleKeyBinding(keyBinding)
     if success && keyBinding.action.first! == MPVCommand.screenshot.rawValue {
       player.sendOSD(.screenshot)


### PR DESCRIPTION
- [X] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)

---

Currently, it's impossible to dismiss the “online subtitle download” OSD using the keyboard. This PR allows using escape to do just that.

- Now, when escape is pressed, if a persistent OSD is being shown (non-interruptible, and without a scheduled hide), `MainWindowController` gives the OSD view the opportunity to handle the event.
- The `keyBinding.normalizedMpvKey == "ESC"` condition might be safely removed, allowing OSD VCs to opt into handling any event; but I'm not confident enough that it won't disrupt anything.  
Specifically, the forwarding is made necessary by [the `MainWindow.keyDown()` override](https://github.com/iina/iina/blob/7e4ed44666496133299c2c24b8a4b01fba926028/iina/MainWindow.swift#L18), which I don't fully understand.
- It's necessary to check `hideOSDTimer` in addition to `isShowingPersistentOSD`, as this boolean is sometimes true even for auto-dismissed OSDs (i.e. the “screenshot taken” OSD)