### PR TITLE
Improve Xcode archive

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -4521,6 +4521,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 51537C7229FA26DD00F9A472 /* Nightly.xcconfig */;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = Nightly;
 		};
@@ -4537,6 +4538,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/deps/lib",
 				);
+				SKIP_INSTALL = NO;
 			};
 			name = Nightly;
 		};
@@ -4558,6 +4560,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 51A0F0F629FA2C8E000130CF /* Beta.xcconfig */;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = Beta;
 		};
@@ -4574,6 +4577,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/deps/lib",
 				);
+				SKIP_INSTALL = NO;
 			};
 			name = Beta;
 		};
@@ -4595,6 +4599,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4964988C2919E47900CD61A5 /* Debug.xcconfig */;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = Debug;
 		};
@@ -4602,6 +4607,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 4964988D2919E47900CD61A5 /* Release.xcconfig */;
 			buildSettings = {
+				SKIP_INSTALL = YES;
 			};
 			name = Release;
 		};
@@ -4621,6 +4627,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/deps/lib",
 				);
+				SKIP_INSTALL = NO;
 			};
 			name = Debug;
 		};
@@ -4637,6 +4644,7 @@
 					"$(inherited)",
 					"$(PROJECT_DIR)/deps/lib",
 				);
+				SKIP_INSTALL = NO;
 			};
 			name = Release;
 		};


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**

Being encouraged by the recent movement of the project, I'd like to submit this improvement to the workspace build settings.

After creating an archive via `Product` > `Archive`, examine the "Organizer" window which opens. In the current `develop` branch, the build product will be detected as an "Other Item". This PR will allow it to be detected as an actual "app". This opens up a larger number of export options for the binaries (although the extra options can be tricky to navigate for those who want to create an unsigned local binary - those who wish to do so must use the `Copy App` option - see pics below). Also this PR cleans up the exported zip / folder so that it includes `IINA.app` only and does not export redundant files for `iina-cli` and `iina-plugin` binaries - see pics below.

See [this link](https://developer.apple.com/documentation/technotes/tn3110-resolving-generic-xcode-archive-issue) for more info.

### Steps to create an unsigned binary - current

<img width="857" alt="SCR-20240618-tzii" src="https://github.com/iina/iina/assets/2213815/cb0c7e80-0fea-42b5-be4c-07776484e173">

<img width="857" alt="SCR-20240618-tzki" src="https://github.com/iina/iina/assets/2213815/51825d5f-0fd9-4240-b93f-9f15c66ece45">

<img width="410" alt="SCR-20240618-tzzm" src="https://github.com/iina/iina/assets/2213815/cd189939-dbe6-401c-9c1c-3ad481980fb4">

### Steps to create an unsigned binary - after this PR

<img width="857" alt="SCR-20240618-udba" src="https://github.com/iina/iina/assets/2213815/8ed56ce1-d61a-419d-9882-335254062aea">

<img width="857" alt="SCR-20240618-uddc" src="https://github.com/iina/iina/assets/2213815/5e60b399-748a-4455-ad10-6f3d46a3d602">

<img width="427" alt="SCR-20240618-udgw" src="https://github.com/iina/iina/assets/2213815/3f8ccfb1-5afd-49a8-be1a-b14ade4cfb21">
