### PR TITLE
Add “Show Current File in Finder” menu item (#5001)

### DIFF
--- a/iina/Base.lproj/KeyBinding.strings
+++ b/iina/Base.lproj/KeyBinding.strings
@@ -52,6 +52,7 @@
 "iina.toggle-flip" = "Toggle flip";
 "iina.toggle-mirror" = "Toggle mirror";
 "iina.save-playlist" = "Save current playlist";
+"iina.show-current-file-in-finder" = "Show current file in Finder";
 "iina.delete-current-file" = "Delete current file";
 "iina.delete-current-file-hard" = "Delete current file directly without moving to trash";
 "iina.find-online-subs" = "Find online subtitles";

--- a/iina/Base.lproj/MainMenu.xib
+++ b/iina/Base.lproj/MainMenu.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="22505" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22690"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22505"/>
     </dependencies>
     <objects>
         <customObject id="-2" userLabel="File's Owner" customClass="NSApplication">
@@ -130,6 +130,9 @@
                                 </connections>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="N0Z-h7-JSg"/>
+                            <menuItem title="Show Current File in Finder" id="che-dy-QUU">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                            </menuItem>
                             <menuItem title="Delete Current File" id="npH-8B-XA4">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                             </menuItem>
@@ -781,6 +784,7 @@ CA
                 <outlet property="resetAudioDelay" destination="H3d-jR-YCr" id="Qx9-n3-F90"/>
                 <outlet property="resetSubDelay" destination="SLr-6g-Mgh" id="8oW-hm-TNq"/>
                 <outlet property="resetTextSize" destination="P1a-ot-P31" id="fJk-GP-GBM"/>
+                <outlet property="showCurrentFileInFinder" destination="che-dy-QUU" id="p1H-Xj-dbg"/>
                 <outlet property="rotationMenu" destination="5xN-ZB-VLI" id="YGx-Ae-oMp"/>
                 <outlet property="saveDownloadedSub" destination="9zk-co-roT" id="lGr-mb-oHw"/>
                 <outlet property="savePlaylist" destination="Mjr-lL-oEt" id="ftc-bn-4Qi"/>

--- a/iina/IINACommand.swift
+++ b/iina/IINACommand.swift
@@ -30,6 +30,7 @@ enum IINACommand: String {
   case fitToScreen = "fit-to-screen"
 
   case saveCurrentPlaylist = "save-playlist"
+  case showCurrentFileInFinder = "show-current-file-in-finder"
   case deleteCurrentFile = "delete-current-file"
   case deleteCurrentFileHard = "delete-current-file-hard"
 

--- a/iina/KeyBindingDataLoader.swift
+++ b/iina/KeyBindingDataLoader.swift
@@ -57,6 +57,7 @@ class KeyBindingDataLoader {
     KBI("open-file", type: .iinaCmd),
     KBI("open-url", type: .iinaCmd),
     KBI("save-playlist", type: .iinaCmd),
+    KBI("show-current-file-in-finder", type: .iinaCmd),
     KBI("delete-current-file", type: .iinaCmd),
     KBI("delete-current-file-hard", type: .iinaCmd),
     KBI.separator(),

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -45,6 +45,12 @@ class MainMenuActionHandler: NSResponder {
     }
   }
 
+  @objc func menuShowCurrentFileInFinder(_ sender: NSMenuItem) {
+    guard let url = player.info.currentURL else { return }
+    guard !player.info.isNetworkResource else { return }
+    NSWorkspace.shared.activateFileViewerSelecting([url])
+  }
+
   @objc func menuDeleteCurrentFile(_ sender: NSMenuItem) {
     guard let url = player.info.currentURL else { return }
     do {

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -9,7 +9,7 @@
 import Cocoa
 
 
-class MainMenuActionHandler: NSResponder {
+class MainMenuActionHandler: NSResponder, NSMenuItemValidation {
 
   unowned var player: PlayerCore
 
@@ -466,6 +466,16 @@ extension MainMenuActionHandler {
     }
   }
 
+  func validateMenuItem(_ menuItem: NSMenuItem) -> Bool {
+    switch menuItem.action {
+    case #selector(menuShowCurrentFileInFinder(_:)):
+      return player.info.currentURL != nil && !player.info.isNetworkResource
+    default:
+      break
+    }
+    return menuItem.isEnabled
+  }
+  
   // MARK: - Plugin
 
   @objc func reloadAllPlugins(_ sender: NSMenuItem) {

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -46,8 +46,7 @@ class MainMenuActionHandler: NSResponder, NSMenuItemValidation {
   }
 
   @objc func menuShowCurrentFileInFinder(_ sender: NSMenuItem) {
-    guard let url = player.info.currentURL else { return }
-    guard !player.info.isNetworkResource else { return }
+    guard let url = player.info.currentURL, !player.info.isNetworkResource else { return }
     NSWorkspace.shared.activateFileViewerSelecting([url])
   }
 

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -86,6 +86,7 @@ class MenuController: NSObject, NSMenuDelegate {
   @IBOutlet weak var openURL: NSMenuItem!
   @IBOutlet weak var openURLAlternative: NSMenuItem!
   @IBOutlet weak var savePlaylist: NSMenuItem!
+  @IBOutlet weak var showCurrentFileInFinder: NSMenuItem!
   @IBOutlet weak var deleteCurrentFile: NSMenuItem!
   @IBOutlet weak var newWindow: NSMenuItem!
   @IBOutlet weak var newWindowSeparator: NSMenuItem!
@@ -221,6 +222,7 @@ class MenuController: NSObject, NSMenuDelegate {
     stringForOpenURLAlternative = openURLAlternative.title
 
     savePlaylist.action = #selector(MainMenuActionHandler.menuSavePlaylist(_:))
+    showCurrentFileInFinder.action = #selector(MainMenuActionHandler.menuShowCurrentFileInFinder(_:))
     deleteCurrentFile.action = #selector(MainMenuActionHandler.menuDeleteCurrentFile(_:))
 
     if Preference.bool(for: .enableCmdN) {
@@ -826,6 +828,7 @@ class MenuController: NSObject, NSMenuDelegate {
 
   func updateKeyEquivalentsFrom(_ keyBindings: [KeyMapping]) {
     var settings: [(NSMenuItem, Bool, [String], Bool, ClosedRange<Double>?, String?)] = [
+      (showCurrentFileInFinder, true, ["show-current-file-in-finder"], false, nil, nil),
       (deleteCurrentFile, true, ["delete-current-file"], false, nil, nil),
       (savePlaylist, true, ["save-playlist"], false, nil, nil),
       (quickSettingsVideo, true, ["video-panel"], false, nil, nil),

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -634,6 +634,8 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
       menuActionHandler.menuToggleMirror(.dummy)
     case .saveCurrentPlaylist:
       menuActionHandler.menuSavePlaylist(.dummy)
+    case .showCurrentFileInFinder:
+      menuActionHandler.menuShowCurrentFileInFinder(.dummy)
     case .deleteCurrentFile:
       menuActionHandler.menuDeleteCurrentFile(.dummy)
     case .findOnlineSubs:

--- a/iina/config/iina-default-input.conf
+++ b/iina/config/iina-default-input.conf
@@ -48,6 +48,7 @@ Meta+2 set window-scale 2
 #@iina Meta+= bigger-window
 
 #@iina Ctrl+Meta+p toggle-pip
+#@iina Shift+Meta+R show-current-file-in-finder
 Ctrl+Meta+f cycle fullscreen
 Ctrl+Meta+t cycle ontop
 

--- a/iina/config/input.conf
+++ b/iina/config/input.conf
@@ -31,6 +31,7 @@
 #@iina Shift+Meta+p playlist-panel
 #@iina Shift+Meta+c chapter-panel
 #@iina Ctrl+Meta+p toggle-pip
+#@iina Shift+Meta+R show-current-file-in-finder
 
 MBTN_LEFT     ignore              # don't do anything
 MBTN_LEFT_DBL cycle fullscreen    # toggle fullscreen

--- a/iina/config/movist-default-input.conf
+++ b/iina/config/movist-default-input.conf
@@ -7,6 +7,7 @@
 #@iina Alt+Meta+c chapter-panel
 #@iina Alt+Meta+m toggle-music-mode
 #@iina Ctrl+Meta+p toggle-pip
+#@iina Alt+Meta+r show-current-file-in-finder
 
 #@iina Meta+- smaller-window
 #@iina Meta++ bigger-window

--- a/iina/config/vlc-default-input.conf
+++ b/iina/config/vlc-default-input.conf
@@ -8,6 +8,7 @@
 #@iina Alt+Meta+c chapter-panel
 #@iina Alt+Meta+m toggle-music-mode
 #@iina Ctrl+Meta+p toggle-pip
+#@iina Alt+Meta+r show-current-file-in-finder
 
 Meta+f cycle fullscreen
 ESC set fullscreen no

--- a/iina/en.lproj/KeyBinding.strings
+++ b/iina/en.lproj/KeyBinding.strings
@@ -52,6 +52,7 @@
 "iina.toggle-flip" = "Toggle flip";
 "iina.toggle-mirror" = "Toggle mirror";
 "iina.save-playlist" = "Save current playlist";
+"iina.show-current-file-in-finder" = "Show current file in Finder";
 "iina.delete-current-file" = "Delete current file";
 "iina.delete-current-file-hard" = "Delete current file directly without moving to trash";
 "iina.find-online-subs" = "Find online subtitles";

--- a/iina/en.lproj/MainMenu.strings
+++ b/iina/en.lproj/MainMenu.strings
@@ -331,6 +331,9 @@
 /* Class = "NSMenuItem"; title = "Volume + 1%"; ObjectID = "c6Y-0e-vgf"; */
 "c6Y-0e-vgf.title" = "Volume + 1%";
 
+/* Class = "NSMenuItem"; title = "Show Current File in Finder"; ObjectID = "che-dy-QUU"; */
+"che-dy-QUU.title" = "Show Current File in Finder";
+
 /* Class = "NSMenuItem"; title = "Aspect Ratio"; ObjectID = "d15-8v-dXA"; */
 "d15-8v-dXA.title" = "Aspect Ratio";
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5001.

---

**Description:**
Adds a menu bar item (under `File`) to reveal the current file in Finder.
~~For some reason I was unable to set a Cmd+R shortcut, even though I set it through the interface builder, the shortcut doesn't work, so the PR does not currently include a shortcut.~~
Built and tested with XCode 15.1, on MacOS 14.5.