### PR TITLE
Fix HistoryController uses deprecated methods, #5004

### DIFF
--- a/iina/PlaybackHistory.swift
+++ b/iina/PlaybackHistory.swift
@@ -15,7 +15,13 @@ fileprivate let KeyPlayed = "IINAPHPlayed"
 fileprivate let KeyAddedDate = "IINAPHDate"
 fileprivate let KeyDuration = "IINAPHDuration"
 
-class PlaybackHistory: NSObject, NSCoding {
+/// An entry in the playback history file.
+/// - Important: This class conforms to [NSSecureCoding](https://developer.apple.com/documentation/foundation/nssecurecoding).
+///     When making changes be certain the requirements for secure coding are not violated by the changes.
+class PlaybackHistory: NSObject, NSCoding, NSSecureCoding {
+
+  /// Indicate this class supports secure coding.
+  static var supportsSecureCoding: Bool { true }
 
   var url: URL
   var name: String
@@ -29,10 +35,10 @@ class PlaybackHistory: NSObject, NSCoding {
 
   required init?(coder aDecoder: NSCoder) {
     guard
-    let url = (aDecoder.decodeObject(forKey: KeyUrl) as? URL),
-    let name = (aDecoder.decodeObject(forKey: KeyName) as? String),
-    let md5 = (aDecoder.decodeObject(forKey: KeyMpvMd5) as? String),
-    let date = (aDecoder.decodeObject(forKey: KeyAddedDate) as? Date)
+      let url = aDecoder.decodeObject(of: NSURL.self, forKey: KeyUrl),
+      let name = aDecoder.decodeObject(of: NSString.self, forKey: KeyName),
+      let md5 = aDecoder.decodeObject(of: NSString.self, forKey: KeyMpvMd5),
+      let date = aDecoder.decodeObject(of: NSDate.self, forKey: KeyAddedDate)
     else {
       return nil
     }
@@ -40,11 +46,11 @@ class PlaybackHistory: NSObject, NSCoding {
     let played = aDecoder.decodeBool(forKey: KeyPlayed)
     let duration = aDecoder.decodeDouble(forKey: KeyDuration)
 
-    self.url = url
-    self.name = name
-    self.mpvMd5 = md5
+    self.url = url as URL
+    self.name = name as String
+    self.mpvMd5 = md5 as String
     self.played = played
-    self.addedDate = date
+    self.addedDate = date as Date
     self.duration = VideoTime(duration)
 
     self.mpvProgress = Utility.playbackProgressFromWatchLater(mpvMd5)

--- a/iina/PlaybackHistory.swift
+++ b/iina/PlaybackHistory.swift
@@ -18,7 +18,7 @@ fileprivate let KeyDuration = "IINAPHDuration"
 /// An entry in the playback history file.
 /// - Important: This class conforms to [NSSecureCoding](https://developer.apple.com/documentation/foundation/nssecurecoding).
 ///     When making changes be certain the requirements for secure coding are not violated by the changes.
-class PlaybackHistory: NSObject, NSCoding, NSSecureCoding {
+class PlaybackHistory: NSObject, NSSecureCoding {
 
   /// Indicate this class supports secure coding.
   static var supportsSecureCoding: Bool { true }


### PR DESCRIPTION
This commit will:
- Change PlaybackHistory to conform to NSSecureCoding
- Change HistoryController to use methods that support secure coding instead of the deprecated methods

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5004.

---

**Description:**
