### PR TITLE
Key bindings for IINA commands: clean up & remove redundant code

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2987,44 +2987,6 @@ class MainWindowController: PlayerWindowController {
 
   // MARK: - Utility
 
-  internal override func handleIINACommand(_ cmd: IINACommand) {
-    super.handleIINACommand(cmd)
-    switch cmd {
-    case .togglePIP:
-      if #available(macOS 10.12, *) {
-        menuTogglePIP(.dummy)
-      }
-    case .videoPanel:
-      menuShowVideoQuickSettings(.dummy)
-    case .audioPanel:
-      menuShowAudioQuickSettings(.dummy)
-    case .subPanel:
-      menuShowSubQuickSettings(.dummy)
-    case .playlistPanel:
-      menuShowPlaylistPanel(.dummy)
-    case .chapterPanel:
-      menuShowChaptersPanel(.dummy)
-    case .toggleMusicMode:
-      menuSwitchToMiniPlayer(.dummy)
-    case .deleteCurrentFileHard:
-      menuActionHandler.menuDeleteCurrentFileHard(.dummy)
-    case .biggerWindow:
-      let item = NSMenuItem()
-      item.tag = 11
-      menuChangeWindowSize(item)
-    case .smallerWindow:
-      let item = NSMenuItem()
-      item.tag = 10
-      menuChangeWindowSize(item)
-    case .fitToScreen:
-      let item = NSMenuItem()
-      item.tag = 3
-      menuChangeWindowSize(item)
-    default:
-      break
-    }
-  }
-
   private func resetCollectionBehavior() {
     guard !fsState.isFullscreen else { return }
     if Preference.bool(for: .useLegacyFullScreen) {

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -828,20 +828,22 @@ class MenuController: NSObject, NSMenuDelegate {
 
   func updateKeyEquivalentsFrom(_ keyBindings: [KeyMapping]) {
     var settings: [(NSMenuItem, Bool, [String], Bool, ClosedRange<Double>?, String?)] = [
-      (showCurrentFileInFinder, true, ["show-current-file-in-finder"], false, nil, nil),
-      (deleteCurrentFile, true, ["delete-current-file"], false, nil, nil),
-      (savePlaylist, true, ["save-playlist"], false, nil, nil),
-      (quickSettingsVideo, true, ["video-panel"], false, nil, nil),
-      (quickSettingsAudio, true, ["audio-panel"], false, nil, nil),
-      (quickSettingsSub, true, ["sub-panel"], false, nil, nil),
-      (playlistPanel, true, ["playlist-panel"], false, nil, nil),
-      (chapterPanel, true, ["chapter-panel"], false, nil, nil),
-      (findOnlineSub, true, ["find-online-subs"], false, nil, nil),
-      (saveDownloadedSub, true, ["save-downloaded-sub"], false, nil, nil),
-      (biggerSize, true, ["bigger-window"], false, nil, nil),
-      (smallerSize, true, ["smaller-window"], false, nil, nil),
-      (fitToScreen, true, ["fit-to-screen"], false, nil, nil),
-      (miniPlayer, true, ["toggle-music-mode"], false, nil, nil),
+      (showCurrentFileInFinder, true, [IINACommand.showCurrentFileInFinder.rawValue], false, nil, nil),
+      (deleteCurrentFile, true, [IINACommand.deleteCurrentFile.rawValue], false, nil, nil),
+      (savePlaylist, true, [IINACommand.saveCurrentPlaylist.rawValue], false, nil, nil),
+      (quickSettingsVideo, true, [IINACommand.videoPanel.rawValue], false, nil, nil),
+      (quickSettingsAudio, true, [IINACommand.audioPanel.rawValue], false, nil, nil),
+      (quickSettingsSub, true, [IINACommand.subPanel.rawValue], false, nil, nil),
+      (playlistPanel, true, [IINACommand.playlistPanel.rawValue], false, nil, nil),
+      (chapterPanel, true, [IINACommand.chapterPanel.rawValue], false, nil, nil),
+      (findOnlineSub, true, [IINACommand.findOnlineSubs.rawValue], false, nil, nil),
+      (saveDownloadedSub, true, [IINACommand.saveDownloadedSub.rawValue], false, nil, nil),
+      (flip, true, [IINACommand.flip.rawValue], false, nil, nil),
+      (mirror, true, [IINACommand.mirror.rawValue], false, nil, nil),
+      (biggerSize, true, [IINACommand.biggerWindow.rawValue], false, nil, nil),
+      (smallerSize, true, [IINACommand.smallerWindow.rawValue], false, nil, nil),
+      (fitToScreen, true, [IINACommand.fitToScreen.rawValue], false, nil, nil),
+      (miniPlayer, true, [IINACommand.toggleMusicMode.rawValue], false, nil, nil),
       (cycleVideoTracks, false, ["cycle", "video"], false, nil, nil),
       (cycleAudioTracks, false, ["cycle", "audio"], false, nil, nil),
       (cycleSubtitles, false, ["cycle", "sub"], false, nil, nil),
@@ -893,7 +895,7 @@ class MenuController: NSObject, NSMenuDelegate {
     ]
 
     if #available(macOS 10.12, *) {
-      settings.append((pictureInPicture, true, ["toggle-pip"], false, nil, nil))
+      settings.append((pictureInPicture, true, [IINACommand.togglePIP.rawValue], false, nil, nil))
     }
 
     var otherActionsMenuItems: [NSMenuItem] = []

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -395,16 +395,6 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     return 72 + (isVideoVisible ? videoWrapperView.frame.height : 0)
   }
 
-  internal override func handleIINACommand(_ cmd: IINACommand) {
-    super.handleIINACommand(cmd)
-    switch cmd {
-    case .toggleMusicMode:
-      menuSwitchToMiniPlayer(.dummy)
-    default:
-      break
-    }
-  }
-
 }
 
 fileprivate extension NSRect {

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -628,20 +628,8 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
       AppDelegate.shared.openFile(self)
     case .openURL:
       AppDelegate.shared.openURL(self)
-    case .flip:
-      menuActionHandler.menuToggleFlip(.dummy)
-    case .mirror:
-      menuActionHandler.menuToggleMirror(.dummy)
-    case .saveCurrentPlaylist:
-      menuActionHandler.menuSavePlaylist(.dummy)
-    case .showCurrentFileInFinder:
-      menuActionHandler.menuShowCurrentFileInFinder(.dummy)
-    case .deleteCurrentFile:
-      menuActionHandler.menuDeleteCurrentFile(.dummy)
-    case .findOnlineSubs:
-      menuActionHandler.menuFindOnlineSub(.dummy)
-    case .saveDownloadedSub:
-      menuActionHandler.saveDownloadedSub(.dummy)
+    case .deleteCurrentFileHard:
+      menuActionHandler.menuDeleteCurrentFileHard(.dummy)
     default:
       break
     }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**

Now that the fix for #4567 has been merged, it's clear that a lot of code for handling key bindings for IINA commands is now redundant because most of them are now being mapped to hidden menu items. This became apparent while examining PR #5005, which is adding a new command.

To be specific, of all the commands enumerated in `IINACommand.swift`, I found that nearly all of them are already being mapped to menu items in `MenuController.updateKeyEquivalentsFrom()`, so the checks for these can be simply deleted from `PlayerWindowController.handleIINACommand()` and its overrides; they will never be used. I handled the remaining 5 commands as follows:

- `flip`, `mirror`: I migrated handling for these to `updateKeyEquivalentsFrom`. It was easy because all the objects were already created and easily referenced there.
- `openFile` and `openURL`: I tried migrating these to `updateKeyEquivalentsFrom`, but for some reason, the `Option` key was being added to their equivalents. Did not dig into why this was happening; just decided to leave them in `handleIINACommand` instead.
- `deleteCurrentFileHard`: this is a less-used command, and it didn't have an `NSMenuItem` object in `MenuController`, so it would have required more code to migrate. I did move it up from `MainWindowController` to `PlayerWindowController` so that it can also be recognized in music mode. I'm assuming that was an oversight when that feature was created.

Note that this should be considered lower-priority and not merged too close to a release.