### PR TITLE
Fix jittering when live resizing the main window

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1115,6 +1115,7 @@ class MainWindowController: PlayerWindowController {
       if recognizer.state == .began {
         // began
         lastMagnification = recognizer.magnification
+        videoView.videoLayer.isAsynchronous = true
       } else if recognizer.state == .changed {
         // changed
         let offset = recognizer.magnification - lastMagnification + 1.0;
@@ -1130,6 +1131,7 @@ class MainWindowController: PlayerWindowController {
         lastMagnification = recognizer.magnification
       } else if recognizer.state == .ended {
         updateWindowParametersForMPV()
+        videoView.videoLayer.isAsynchronous = false
       }
     }
   }

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1669,12 +1669,17 @@ class MainWindowController: PlayerWindowController {
     player.events.emit(.windowResized, data: window.frame)
   }
 
+  func windowWillStartLiveResize(_ notification: Notification) {
+    videoView.videoLayer.isAsynchronous = true
+  }
+
   // resize framebuffer in videoView after resizing.
   func windowDidEndLiveResize(_ notification: Notification) {
     // Must not access mpv while it is asynchronously processing stop and quit commands.
     // See comments in windowWillExitFullScreen for details.
     guard !isClosing else { return }
     videoView.videoSize = window!.convertToBacking(videoView.bounds).size
+    videoView.videoLayer.isAsynchronous = false
     updateWindowParametersForMPV()
   }
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)

---

**Description:**
Fix #4667

When resizing the player window if the video is playing on a modern macOS, the rendering is unstable and jittering. Note this issue cannot be reproduced on a x86 macOS 10.15.

Set `CAOpenGLLayer.isAsynchronous` to true when live resizing.

Reference implementation: https://github.com/mpv-player/mpv/blob/4ec060f9465ad1b2151fdf36671681cd9900fc63/video/out/mac/gl_layer.swift

Before:

https://github.com/iina/iina/assets/20237141/20982197-f282-4a08-bf01-869593cbc50f

After:

https://github.com/iina/iina/assets/20237141/57b2e210-2db9-4c25-9a92-0c9626f27a64


