### PR TITLE
Fix CC_MD5 deprecated warning

### DIFF
--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -7,6 +7,7 @@
 //
 
 import Cocoa
+import CryptoKit
 
 extension NSSlider {
   /** Returns the position of knob center by point */
@@ -331,30 +332,8 @@ extension NSMutableAttributedString {
   }
 }
 
-
-extension NSData {
-  func md5() -> NSString {
-    let digestLength = Int(CC_MD5_DIGEST_LENGTH)
-    let md5Buffer = UnsafeMutablePointer<CUnsignedChar>.allocate(capacity: digestLength)
-
-    CC_MD5(bytes, CC_LONG(length), md5Buffer)
-
-    let output = NSMutableString(capacity: Int(CC_MD5_DIGEST_LENGTH * 2))
-    for i in 0..<digestLength {
-      output.appendFormat("%02x", md5Buffer[i])
-    }
-
-    md5Buffer.deallocate()
-    return NSString(format: output)
-  }
-}
-
 extension Data {
-  var md5: String {
-    get {
-      return (self as NSData).md5() as String
-    }
-  }
+  var md5: String { Insecure.MD5.hash(data: self).map { String(format: "%02x", $0) }.joined() }
 
   var chksum64: UInt64 {
     return withUnsafeBytes {


### PR DESCRIPTION
This commit will:
- Remove the `NSData` extension that was using the deprecated Common Crypto method
- Change the `md5` property in the `Data` extension to generate the MD5 hash using `CryptoKit` instead of calling the `NSData` method

These changes correct a compiler warning that CC_MD5 is deprecated because it is cryptographically broken and should not be used in security contexts. This warning is not generated for the `CryptoKit` method. With `CryptoKit` you must access the method using the `CryptoKit` `Insecure` enum, thus there is no need to warn the programmer that MD5 is insecure.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
