### PR TITLE
Fix icon(forFileType:) deprecated warning

### DIFF
--- a/iina/HistoryWindowController.swift
+++ b/iina/HistoryWindowController.swift
@@ -215,7 +215,7 @@ class HistoryWindowController: NSWindowController, NSOutlineViewDelegate, NSOutl
         let fileExists = !entry.url.isFileURL || FileManager.default.fileExists(atPath: entry.url.path)
         filenameView.textField?.stringValue = entry.url.isFileURL ? entry.name : entry.url.absoluteString
         filenameView.textField?.textColor = fileExists ? .controlTextColor : .disabledControlTextColor
-        filenameView.docImage.image = NSWorkspace.shared.icon(forFileType: entry.url.pathExtension)
+        filenameView.docImage.image = NSWorkspace.shared.icon(forFile: entry.url.path)
       } else if identifier == .progress {
         // Progress cell
         let progressView = cell as! HistoryProgressCellView


### PR DESCRIPTION
The commit will change the call to the deprecated method icon(forFileType:) in History WindowController.outlineView to call icon(forFile:) instead.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
