### PR TITLE
Fix the window is shifted when pinching to resize

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -148,6 +148,7 @@ class MainWindowController: PlayerWindowController {
   var isPausedPriorToInteractiveMode: Bool = false
 
   var lastMagnification: CGFloat = 0.0
+  var frameWhenStartedPinching = NSRect()
 
   /** Views that will show/hide when cursor moving in/out the window. */
   var fadeableViews: [NSView] = []
@@ -1116,6 +1117,7 @@ class MainWindowController: PlayerWindowController {
         // began
         lastMagnification = recognizer.magnification
         videoView.videoLayer.isAsynchronous = true
+        frameWhenStartedPinching = window.frame
       } else if recognizer.state == .changed {
         // changed
         let offset = recognizer.magnification - lastMagnification + 1.0;
@@ -1125,7 +1127,7 @@ class MainWindowController: PlayerWindowController {
         //Check against max & min threshold
         if newHeight < screenFrame.height && newHeight > minSize.height && newWidth > minSize.width {
           let newSize = NSSize(width: newWidth, height: newHeight);
-          window.setFrame(window.frame.centeredResize(to: newSize), display: true)
+          window.setFrame(frameWhenStartedPinching.centeredResize(to: newSize), display: true)
         }
 
         lastMagnification = recognizer.magnification


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4681.

---

**Description:**
This commit:
- Caches the window frame when started pinching to resize
- Used the cached window frame instead of the current window frame to avoid accumulated rounding errors

Before:
https://github.com/iina/iina/assets/20237141/3bfc10d4-5fbc-419d-80e1-9d41ca6ea623

After:
https://github.com/iina/iina/assets/20237141/eff9cb20-38a0-43d3-a70b-63cdd1d10c6f