### PR TITLE
Fix crash while quitting in mpv_render_context_update, #5023

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1178,8 +1178,6 @@ class MainWindowController: PlayerWindowController {
       window!.setFrame(AppData.sizeWhenNoVideo.centeredRect(in: screen.visibleFrame), display: true,
                        animate: !Preference.bool(for: PK.disableAnimations))
     }
-
-    videoView.videoLayer.draw(forced: true)
   }
 
   /** A method being called when window open. Pretend to be a window delegate. */

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1179,6 +1179,8 @@ class MainWindowController: PlayerWindowController {
                        animate: !Preference.bool(for: PK.disableAnimations))
     }
 
+    // Draw black screen before playing a video. This is needed due to window reuse. Displaying a
+    // frame from a previously played video would violate good privacy practices.
     videoView.videoLayer.draw(forced: true)
   }
 

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1178,6 +1178,8 @@ class MainWindowController: PlayerWindowController {
       window!.setFrame(AppData.sizeWhenNoVideo.centeredRect(in: screen.visibleFrame), display: true,
                        animate: !Preference.bool(for: PK.disableAnimations))
     }
+
+    videoView.videoLayer.draw(forced: true)
   }
 
   /** A method being called when window open. Pretend to be a window delegate. */

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -504,8 +504,6 @@ class PlayerCore: NSObject {
 
   func initVideo() {
     // init mpv render context.
-    // The video layer must be displayed once to get the OpenGL context initialized.
-    mainWindow.videoView.videoLayer.display()
     mpv.mpvInitRendering()
     mainWindow.videoView.startDisplayLink()
   }

--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -64,7 +64,7 @@ class ViewLayer: CAOpenGLLayer {
                         forLayerTime t: CFTimeInterval, displayTime ts: UnsafePointer<CVTimeStamp>?) -> Bool {
     videoView.$isUninited.withLock() { isUninited in
       guard !isUninited else { return false }
-      guard !forceRender else { return true }
+      if forceRender { return true }
       return videoView.player.mpv.shouldRenderUpdateFrame()
     }
   }


### PR DESCRIPTION
This commit will:
- Change where `isUninited` is locked in `VideoLayer`
- Add a `displayLock` property to `VideoLayer`
- Use `displayLock` to single thread the display method
- Move the skip render code from the draw method to the display method

This ensures the render context has not been freed when `shouldRenderUpdateFrame` is called. This also changes the location of the skip render code to match how mpv handles skipping.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5023.

---

**Description:**
