### PR TITLE
Add secondary subtitle OSD messages

### DIFF
--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -67,8 +67,12 @@
 "osd.subtitle_pos" = "Subtitle Position: %.1f";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
-"osd.sub_second_hidden" = "Second Subtitles Hidden";
-"osd.sub_second_visible" = "Second Subtitles Visible";
+"osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_hidden" = "Secondary Subtitles Hidden";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
 "osd.screenshot" = "Screenshot Captured";
@@ -134,8 +138,8 @@
 "menu.sub_delay" = "Subtitle Delay: %.2fs";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
-"menu.sub_second_hide" = "Hide Second Subtitles";
-"menu.sub_second_show" = "Show Second Subtitles";
+"menu.sub_second_hide" = "Hide Secondary Subtitles";
+"menu.sub_second_show" = "Show Secondary Subtitles";
 "menu.fullscreen" = "Enter Full Screen";
 "menu.exit_fullscreen" = "Exit Full Screen";
 "menu.pip" = "Enter Picture-in-Picture";
@@ -170,7 +174,10 @@
 "menu.crop_custom" = "Custom...";
 "menu.find_online_sub" = "Find Online Subtitles from %@";
 
+"track.audio" = "Audio";
 "track.none" = "<None>";
+"track.sub" = "Subtitle";
+"track.video" = "Video";
 
 "subtrack.no_loaded" = "No Subtitles Loaded";
 "subtrack.no_external" = "No External Subtitles Found";

--- a/iina/Base.lproj/MainMenu.xib
+++ b/iina/Base.lproj/MainMenu.xib
@@ -534,9 +534,9 @@ CA
                             <menuItem title="Hide Subtitles" id="smo-rw-rg7" userLabel="Hide Subtitles">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                             </menuItem>
-                            <menuItem title="Second Subtitle" id="mGw-jm-5x2">
+                            <menuItem title="Secondary Subtitle" id="mGw-jm-5x2">
                                 <modifierMask key="keyEquivalentModifierMask"/>
-                                <menu key="submenu" title="Second Subtitle" systemMenu="font" id="UwY-P2-Xdb">
+                                <menu key="submenu" title="Secondary Subtitle" systemMenu="font" id="UwY-P2-Xdb">
                                     <items>
                                         <menuItem title="&lt;None&gt;" id="9pa-9C-ueQ">
                                             <modifierMask key="keyEquivalentModifierMask"/>
@@ -547,7 +547,7 @@ CA
                                     </items>
                                 </menu>
                             </menuItem>
-                            <menuItem title="Hide Second Subtitles" id="BOm-ia-wOV">
+                            <menuItem title="Hide Secondary Subtitles" id="BOm-ia-wOV">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                             </menuItem>
                             <menuItem title="Load External Subtitle…" id="k6x-hf-ATi">

--- a/iina/Base.lproj/QuickSettingViewController.xib
+++ b/iina/Base.lproj/QuickSettingViewController.xib
@@ -1982,9 +1982,9 @@
                                                                     </view>
                                                                 </box>
                                                                 <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dXz-x4-sm5" userLabel="SubDelay Horizontal Tick Bottom Slider">
-                                                                    <rect key="frame" x="30" y="440" width="244" height="20"/>
+                                                                    <rect key="frame" x="30" y="440" width="233" height="20"/>
                                                                     <constraints>
-                                                                        <constraint firstAttribute="width" constant="240" id="Qpm-gC-Y2e"/>
+                                                                        <constraint firstAttribute="width" constant="229" id="Qpm-gC-Y2e"/>
                                                                     </constraints>
                                                                     <sliderCell key="cell" controlSize="small" continuous="YES" refusesFirstResponder="YES" state="on" alignment="left" minValue="-5" maxValue="5" tickMarkPosition="below" numberOfTickMarks="21" sliderType="linear" id="h1D-gP-Dst"/>
                                                                     <connections>
@@ -2019,7 +2019,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="r77-VA-Z1b">
-                                                                    <rect key="frame" x="253" y="430" width="21" height="11"/>
+                                                                    <rect key="frame" x="242" y="430" width="21" height="11"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="+5s" id="xfX-wr-DTJ">
                                                                         <font key="font" metaFont="label" size="9"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -2027,7 +2027,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField focusRingType="none" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eOz-bB-vzM" userLabel="CustomDelayEdit Text Field">
-                                                                    <rect key="frame" x="280" y="440" width="50" height="21"/>
+                                                                    <rect key="frame" x="269" y="440" width="50" height="21"/>
                                                                     <constraints>
                                                                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="50" id="ptd-kK-aWm"/>
                                                                     </constraints>
@@ -2042,7 +2042,7 @@
                                                                     </connections>
                                                                 </textField>
                                                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4U2-kT-76O">
-                                                                    <rect key="frame" x="328" y="443" width="4" height="16"/>
+                                                                    <rect key="frame" x="317" y="443" width="15" height="16"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="s" id="bsT-FB-GhF">
                                                                         <font key="font" metaFont="system"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -2050,7 +2050,7 @@
                                                                     </textFieldCell>
                                                                 </textField>
                                                                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kzp-GR-Sy4">
-                                                                    <rect key="frame" x="145" y="430" width="15" height="11"/>
+                                                                    <rect key="frame" x="139" y="430" width="15" height="11"/>
                                                                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="0s" id="LEZ-fv-buL">
                                                                         <font key="font" metaFont="label" size="9"/>
                                                                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -142,11 +142,13 @@ class MPVController: NSObject {
     MPVOption.Audio.volume: MPV_FORMAT_DOUBLE,
     MPVOption.Audio.audioDelay: MPV_FORMAT_DOUBLE,
     MPVOption.PlaybackControl.speed: MPV_FORMAT_DOUBLE,
-    MPVOption.Subtitles.subVisibility: MPV_FORMAT_FLAG,
+    MPVOption.Subtitles.secondarySubDelay: MPV_FORMAT_DOUBLE,
+    MPVOption.Subtitles.secondarySubPos: MPV_FORMAT_DOUBLE,
     MPVOption.Subtitles.secondarySubVisibility: MPV_FORMAT_FLAG,
     MPVOption.Subtitles.subDelay: MPV_FORMAT_DOUBLE,
-    MPVOption.Subtitles.subScale: MPV_FORMAT_DOUBLE,
     MPVOption.Subtitles.subPos: MPV_FORMAT_DOUBLE,
+    MPVOption.Subtitles.subScale: MPV_FORMAT_DOUBLE,
+    MPVOption.Subtitles.subVisibility: MPV_FORMAT_FLAG,
     MPVOption.Equalizer.contrast: MPV_FORMAT_INT64,
     MPVOption.Equalizer.brightness: MPV_FORMAT_INT64,
     MPVOption.Equalizer.gamma: MPV_FORMAT_INT64,
@@ -1294,16 +1296,18 @@ not applying FFmpeg 9599 workaround
         }
       }
 
+    case MPVOption.Subtitles.secondarySubDelay:
+      fallthrough
     case MPVOption.Subtitles.subDelay:
       guard let data = UnsafePointer<Double>(OpaquePointer(property.data))?.pointee else {
-        logPropertyValueError(MPVOption.Subtitles.subDelay, property.format)
+        logPropertyValueError(name, property.format)
         break
       }
-      DispatchQueue.main.async { [self] in
-        player.info.subDelay = data
-        player.sendOSD(.subDelay(data))
-        player.needReloadQuickSettingsView()
+      guard name == MPVOption.Subtitles.subDelay else {
+        DispatchQueue.main.async { self.player.secondarySubDelayChanged(data) }
+        break
       }
+      DispatchQueue.main.async { self.player.subDelayChanged(data) }
 
     case MPVOption.Subtitles.subScale:
       guard let data = UnsafePointer<Double>(OpaquePointer(property.data))?.pointee else {
@@ -1317,15 +1321,18 @@ not applying FFmpeg 9599 workaround
         player.needReloadQuickSettingsView()
       }
 
+    case MPVOption.Subtitles.secondarySubPos:
+      fallthrough
     case MPVOption.Subtitles.subPos:
       guard let data = UnsafePointer<Double>(OpaquePointer(property.data))?.pointee else {
-        logPropertyValueError(MPVOption.Subtitles.subPos, property.format)
+        logPropertyValueError(name, property.format)
         break
       }
-      DispatchQueue.main.async { [self] in
-        player.sendOSD(.subPos(data))
-        player.needReloadQuickSettingsView()
+      guard name == MPVOption.Subtitles.subPos else {
+        DispatchQueue.main.async { self.player.secondarySubPosChanged(data) }
+        break
       }
+      DispatchQueue.main.async { self.player.subPosChanged(data) }
 
     case MPVOption.Equalizer.contrast:
       guard let data = UnsafePointer<Int64>(OpaquePointer(property.data))?.pointee else {

--- a/iina/OSDMessage.swift
+++ b/iina/OSDMessage.swift
@@ -48,7 +48,9 @@ enum OSDMessage {
   case subScale(Double)
   case subHidden
   case subVisible
+  case secondSubDelay(Double)
   case secondSubHidden
+  case secondSubPos(Double)
   case secondSubVisible
   case subPos(Double)
   case mute
@@ -187,6 +189,23 @@ enum OSDMessage {
         return (str, .withProgress(toPercent(value, 10)))
       }
 
+    case .secondSubDelay(let value):
+      if value == 0 {
+        return (
+          NSLocalizedString("osd.sub_second_delay.nodelay", comment: "Secondary Subtitle Delay: No Delay"),
+          .withProgress(0.5)
+        )
+      } else {
+        let str = value > 0 ? String(format: NSLocalizedString("osd.sub_second_delay.later", comment: "Secondary Subtitle Delay: %fs Later"),abs(value)) : String(format: NSLocalizedString("osd.sub_second_delay.earlier", comment: "Secondary Subtitle Delay: %fs Earlier"), abs(value))
+        return (str, .withProgress(toPercent(value, 10)))
+      }
+
+    case .secondSubPos(let value):
+      return (
+        String(format: NSLocalizedString("osd.sub_second_pos", comment: "Secondary Subtitle Position: %f"), value),
+        .withProgress(value / 100)
+      )
+
     case .subDelay(let value):
       if value == 0 {
         return (
@@ -261,13 +280,19 @@ enum OSDMessage {
       )
 
     case .track(let track):
-      let trackTypeStr: String
+      let keySuffix: String
       switch track.type {
-      case .video: trackTypeStr = "Video"
-      case .audio: trackTypeStr = "Audio"
-      case .sub: trackTypeStr = "Subtitle"
-      case .secondSub: trackTypeStr = "Second Subtitle"
+      case .video: keySuffix = "video"
+      case .audio: keySuffix = "audio"
+      case .sub: keySuffix = "sub"
+      case .secondSub:
+        // This enum constant is only used for setting the secondary subtitle. No track should use
+        // this type. This is an internal error.
+        Logger.log("Invalid subtitle track type: secondSub", level: .error)
+        keySuffix = "sub"
       }
+      let trackTypeStr = String(format: NSLocalizedString("track." + keySuffix,
+        comment: "Kind of track (Audio, Video, Subtitle)"))
       return (trackTypeStr + ": " + track.readableTitle, .normal)
 
     case .subScale(let value):

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1865,10 +1865,21 @@ class PlayerCore: NSObject {
     mainWindow.videoView.refreshEdrMode()
   }
 
+  func secondarySubDelayChanged(_ delay: Double) {
+    sendOSD(.secondSubDelay(delay))
+    needReloadQuickSettingsView()
+  }
+
+  func secondarySubPosChanged(_ position: Double) {
+    sendOSD(.secondSubPos(position))
+    needReloadQuickSettingsView()
+  }
+
   func secondarySidChanged() {
     guard !isShuttingDown, !isShutdown else { return }
     info.secondSid = Int(mpv.getInt(MPVOption.Subtitles.secondarySid))
     postNotification(.iinaSIDChanged)
+    sendOSD(.track(info.currentTrack(.secondSub) ?? .noneSubTrack))
   }
 
   func secondSubVisibilityChanged(_ visible: Bool) {
@@ -1883,6 +1894,17 @@ class PlayerCore: NSObject {
     info.sid = Int(mpv.getInt(MPVOption.TrackSelection.sid))
     postNotification(.iinaSIDChanged)
     sendOSD(.track(info.currentTrack(.sub) ?? .noneSubTrack))
+  }
+
+  func subDelayChanged(_ delay: Double) {
+    info.subDelay = delay
+    sendOSD(.subDelay(delay))
+    needReloadQuickSettingsView()
+  }
+
+  func subPosChanged(_ position: Double) {
+    sendOSD(.subPos(position))
+    needReloadQuickSettingsView()
   }
 
   func subVisibilityChanged(_ visible: Bool) {

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -67,8 +67,12 @@
 "osd.subtitle_pos" = "Subtitle Position: %.1f";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
-"osd.sub_second_hidden" = "Second Subtitles Hidden";
-"osd.sub_second_visible" = "Second Subtitles Visible";"osd.mute" = "Mute";
+"osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_hidden" = "Secondary Subtitles Hidden";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
 "osd.screenshot" = "Screenshot Captured";
@@ -134,8 +138,8 @@
 "menu.sub_delay" = "Subtitle Delay: %.2fs";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
-"menu.sub_second_hide" = "Hide Second Subtitles";
-"menu.sub_second_show" = "Show Second Subtitles";
+"menu.sub_second_hide" = "Hide Secondary Subtitles";
+"menu.sub_second_show" = "Show Secondary Subtitles";
 "menu.fullscreen" = "Enter Full Screen";
 "menu.exit_fullscreen" = "Exit Full Screen";
 "menu.pip" = "Enter Picture-in-Picture";
@@ -170,7 +174,10 @@
 "menu.crop_custom" = "Custom...";
 "menu.find_online_sub" = "Find Online Subtitles from %@";
 
+"track.audio" = "Audio";
 "track.none" = "<None>";
+"track.sub" = "Subtitle";
+"track.video" = "Video";
 
 "subtrack.no_loaded" = "No Subtitles Loaded";
 "subtrack.no_external" = "No External Subtitles Found";

--- a/iina/en.lproj/MainMenu.strings
+++ b/iina/en.lproj/MainMenu.strings
@@ -268,8 +268,8 @@
 /* Class = "NSMenuItem"; title = "Pause"; ObjectID = "UOE-MJ-8ku"; */
 "UOE-MJ-8ku.title" = "Pause";
 
-/* Class = "NSMenu"; title = "Second Subtitle"; ObjectID = "UwY-P2-Xdb"; */
-"UwY-P2-Xdb.title" = "Second Subtitle";
+/* Class = "NSMenu"; title = "Secondary Subtitle"; ObjectID = "UwY-P2-Xdb"; */
+"UwY-P2-Xdb.title" = "Secondary Subtitle";
 
 /* Class = "NSMenuItem"; title = "Redo"; ObjectID = "VDZ-ro-z5z"; */
 "VDZ-ro-z5z.title" = "Redo";
@@ -394,8 +394,8 @@
 /* Class = "NSMenuItem"; title = "Make Upper Case"; ObjectID = "m7w-hc-Y2F"; */
 "m7w-hc-Y2F.title" = "Make Upper Case";
 
-/* Class = "NSMenuItem"; title = "Second Subtitle"; ObjectID = "mGw-jm-5x2"; */
-"mGw-jm-5x2.title" = "Second Subtitle";
+/* Class = "NSMenuItem"; title = "Secondary Subtitle"; ObjectID = "mGw-jm-5x2"; */
+"mGw-jm-5x2.title" = "Secondary Subtitle";
 
 /* Class = "NSMenuItem"; title = "Enter Picture in Picture"; ObjectID = "mND-N8-z6o"; */
 "mND-N8-z6o.title" = "Enter Picture in Picture";


### PR DESCRIPTION
This commit will:
- Add OSD messages for secondary subtitle delay and position changing
- Add an OSD message for the selected secondary subtitle changing
- Add localization for the name of the track type in track change OSD messages
- Change the Second Subtitles Hidden/Visible OSD messages to use Secondary instead of Second
- Change Show/Hide Second Subtitles menu item to use Secondary instead of Second

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
