### PR TITLE
Respect disable animation PK in `adjustFrameByVideoSize()`

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2573,7 +2573,7 @@ class MainWindowController: PlayerWindowController {
       if let screenFrame = window.screen?.frame {
         rect = rect.constrain(in: screenFrame)
       }
-      if player.disableWindowAnimation {
+      if player.disableWindowAnimation || Preference.bool(for: .disableAnimations) {
         window.setFrame(rect, display: true, animate: false)
       } else {
         // animated `setFrame` can be inaccurate!


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)

---

**Description:**
Currently `.disableAnimation` is not respected in `adjustFrameByVideoSize()`, e.g. when opening a new media. This commit disable the animation if the `disableAnimation` is set to true.