### PR TITLE
Change the text color in inspector from `textColor` to `labelColor`

### DIFF
--- a/iina/Base.lproj/InspectorWindowController.xib
+++ b/iina/Base.lproj/InspectorWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23077.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22690"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23077.2"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -1084,7 +1084,7 @@
                                                     <rect key="frame" x="0.0" y="0.0" width="420" height="201"/>
                                                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" translatesAutoresizingMaskIntoConstraints="NO" id="MlR-S8-3gW" userLabel="WatchTable Clip View">
                                                         <rect key="frame" x="0.0" y="0.0" width="420" height="201"/>
-                                                        <autoresizingMask key="autoresizingMask"/>
+                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                         <subviews>
                                                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" typeSelect="NO" autosaveName="InspectorWatchTable" rowSizeStyle="automatic" headerView="pnK-fx-7et" viewBased="YES" floatsGroupRows="NO" id="oUp-DO-OKl" userLabel="WatchTable Table View">
                                                                 <rect key="frame" x="0.0" y="0.0" width="420" height="173"/>
@@ -1113,7 +1113,7 @@
                                                                                         <rect key="frame" x="2" y="1" width="182" height="16"/>
                                                                                         <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="left" title="KeyColumn Table View Cell" usesSingleLineMode="YES" id="HA9-NO-iHC">
                                                                                             <font key="font" usesAppearanceFont="YES"/>
-                                                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                                                             <color key="backgroundColor" red="0.11764705882352941" green="0.11764705882352941" blue="0.11764705882352941" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                                                         </textFieldCell>
                                                                                     </textField>
@@ -1195,7 +1195,7 @@
                                             </constraints>
                                         </customView>
                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="PST-dF-CNB">
-                                            <rect key="frame" x="12" y="10.5" width="16.5" height="20"/>
+                                            <rect key="frame" x="12" y="10" width="16" height="20"/>
                                             <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSAddTemplate" imagePosition="overlaps" alignment="center" lineBreakMode="truncatingTail" state="on" imageScaling="proportionallyDown" inset="2" id="C0z-MP-Vib">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -1209,7 +1209,7 @@
                                             </connections>
                                         </button>
                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Tel-U0-EC3">
-                                            <rect key="frame" x="28" y="15" width="16.5" height="11"/>
+                                            <rect key="frame" x="28" y="15" width="16" height="11"/>
                                             <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRemoveTemplate" imagePosition="overlaps" alignment="center" lineBreakMode="truncatingTail" state="on" imageScaling="proportionallyDown" inset="2" id="kY7-c8-qmB">
                                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                                 <font key="font" metaFont="system"/>

--- a/iina/InspectorWindowController.swift
+++ b/iina/InspectorWindowController.swift
@@ -350,7 +350,7 @@ class InspectorWindowController: NSWindowController, NSWindowDelegate, NSTableVi
         if !player.isStopping, !player.isStopped, !player.isShuttingDown, !player.isShutdown,
             let value = PlayerCore.lastActive.mpv.getString(property) {
           textField.stringValue = value
-          textField.textColor = .controlTextColor
+          textField.textColor = .labelColor
         } else {
           let errorString = NSLocalizedString("inspector.error", comment: "Error")
 
@@ -467,7 +467,7 @@ class InspectorWindowController: NSWindowController, NSWindowDelegate, NSTableVi
   // MARK: Utils
 
   private func setLabelColor(_ label: NSTextField, by state: Bool) {
-    label.textColor = state ? NSColor.textColor : NSColor.disabledControlTextColor
+    label.textColor = state ? NSColor.labelColor : NSColor.disabledControlTextColor
   }
 
   private func saveWatchList() {


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)

---

**Description:**
This commit increases the sharpness of the text fields. This is especially obvious when the background is a light color.

Before:
![image](https://github.com/iina/iina/assets/20237141/dc1afb4b-fee1-47e0-b78c-8dbc6fead9bd)

After:
![image](https://github.com/iina/iina/assets/20237141/7109d1ef-856d-4a4b-8868-31c332421b6f)

