### PR TITLE
Disable HDR workaround by default

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -562,7 +562,7 @@ class MainWindowController: PlayerWindowController {
     // workaround another bug in Ventura where an external monitor goes black could not be
     // reproduced (issue #4015). The workaround adds a tiny subview with such a low alpha level it
     // is invisible to the human eye. This workaround may not be effective in all cases.
-    if #available(macOS 13, *) {
+    if #available(macOS 13, *), Preference.bool(for: .enableHdrWorkaround) {
       let view = NSView(frame: NSRect(origin: .zero, size: NSSize(width: 0.1, height: 0.1)))
       view.wantsLayer = true
       view.layer?.backgroundColor = NSColor.black.cgColor

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -311,6 +311,11 @@ struct Preference {
     static let recentDocuments = Key("recentDocuments")
 
     static let enableFFmpegImageDecoder = Key("enableFFmpegImageDecoder")
+
+    /// The belief is that the workaround for issue #3844 that adds a tiny subview to the player window is no longer needed.
+    /// To confirm this the workaround is being disabled by default using this preference. Should all go well this workaround will be
+    /// removed in the future.
+    static let enableHdrWorkaround = Key("enableHdrWorkaround")
   }
 
   // MARK: - Enums
@@ -918,7 +923,8 @@ struct Preference {
     .enableRecentDocumentsWorkaround: false,
     .recentDocuments: [Any](),
 
-    .enableFFmpegImageDecoder: true
+    .enableFFmpegImageDecoder: true,
+    .enableHdrWorkaround: false
   ]
 
 


### PR DESCRIPTION
This commit will:
- Add a new preference `enableHdrWorkaround` with a default value of `false`
- Change `MainWindowController.windowDidLoad` to check the setting when deciding to apply the workaround

This disables by default the HDR workaround for issue #3844 that added a tiny subview to the player window. The belief is that due to changes in IINA the workaround is no longer needed. To confirm this the workaround is being disabled behind a setting so that it can still be enabled should a problem be reported. If no problems are reported then the workaround can be removed from the code.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
