### PR TITLE
Fix UI elements not synced when changing modes, #4985

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -1272,7 +1272,7 @@ not applying FFmpeg 9599 workaround
         break
       }
       DispatchQueue.main.async { [self] in
-        player.syncUI(.muteButton)
+        player.syncUI(.volume)
         player.info.isMuted = data
         player.sendOSD(data ? OSDMessage.mute : OSDMessage.unMute)
       }

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1365,6 +1365,7 @@ class MainWindowController: PlayerWindowController {
       exitPIP()
     }
     
+    updateAdditionalInfo()
     player.events.emit(.windowFullscreenChanged, data: true)
   }
 

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -528,6 +528,10 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
   }
 
   // MARK: - UI
+  
+  func setupUI() {
+    player.syncUI([.time, .playButton, .volume])
+  }
 
   @objc
   func updateTitle() {


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4985.
---

**Description:**
This commit fixes 2 bugs when changing modes at paused state:
- When changing to/from music mode while paused, the slider, time, volume icon, and play button is not correctly updated
- When entering full screen while paused, the additional info view is not updated

This commit also added `currentController` which auto select the current window controller (mainWindow/miniPlayer). When syncing UI, only the controls in the current window is updated.
