### PR TITLE
Remove the custom Switch and use NSSwitch

### DIFF
--- a/iina/Base.lproj/QuickSettingViewController.xib
+++ b/iina/Base.lproj/QuickSettingViewController.xib
@@ -33,9 +33,12 @@
                 <outlet property="customAudioDelayTextField" destination="Qiz-tS-aWT" id="QQg-ZP-uPz"/>
                 <outlet property="customSpeedTextField" destination="sIs-a1-rGR" id="kRd-3q-zab"/>
                 <outlet property="customSubDelayTextField" destination="eOz-bB-vzM" id="oqr-mw-c55"/>
+                <outlet property="deinterlaceLabel" destination="m39-41-Kwj" id="ggm-Dk-mpK"/>
                 <outlet property="deinterlaceSwitch" destination="UKk-rD-n2A" id="iXS-qY-rHf"/>
                 <outlet property="gammaSlider" destination="fLl-8b-pj0" id="jEi-R0-6G0"/>
+                <outlet property="hardwareDecodingLabel" destination="OvF-ci-44R" id="DlO-Bf-VR3"/>
                 <outlet property="hardwareDecodingSwitch" destination="AbD-ap-nO5" id="prt-hm-rsB"/>
+                <outlet property="hdrLabel" destination="xJo-hi-ale" id="KYh-mb-vQn"/>
                 <outlet property="hdrSwitch" destination="TNg-iM-cVP" id="Cg7-4J-pyL"/>
                 <outlet property="hideSwitch" destination="9f0-0q-rg2" id="tTx-Gl-HNL"/>
                 <outlet property="hueSlider" destination="mKB-Mu-l5Y" id="vy8-lj-ko8"/>

--- a/iina/Base.lproj/QuickSettingViewController.xib
+++ b/iina/Base.lproj/QuickSettingViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23077.2" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22690"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23077.2"/>
         <capability name="Named colors" minToolsVersion="9.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
@@ -33,10 +33,10 @@
                 <outlet property="customAudioDelayTextField" destination="Qiz-tS-aWT" id="QQg-ZP-uPz"/>
                 <outlet property="customSpeedTextField" destination="sIs-a1-rGR" id="kRd-3q-zab"/>
                 <outlet property="customSubDelayTextField" destination="eOz-bB-vzM" id="oqr-mw-c55"/>
-                <outlet property="deinterlaceSwitch" destination="SMb-H5-j6h" id="PZ6-te-OHr"/>
+                <outlet property="deinterlaceSwitch" destination="UKk-rD-n2A" id="iXS-qY-rHf"/>
                 <outlet property="gammaSlider" destination="fLl-8b-pj0" id="jEi-R0-6G0"/>
-                <outlet property="hardwareDecodingSwitch" destination="7z5-cT-Huj" id="lHA-DF-UM7"/>
-                <outlet property="hdrSwitch" destination="U8P-fW-N3q" id="VUC-bd-g4X"/>
+                <outlet property="hardwareDecodingSwitch" destination="AbD-ap-nO5" id="prt-hm-rsB"/>
+                <outlet property="hdrSwitch" destination="TNg-iM-cVP" id="Cg7-4J-pyL"/>
                 <outlet property="hideSwitch" destination="9f0-0q-rg2" id="tTx-Gl-HNL"/>
                 <outlet property="hueSlider" destination="mKB-Mu-l5Y" id="vy8-lj-ko8"/>
                 <outlet property="pluginContentContainerView" destination="GeS-T1-vtB" id="a96-Mh-BMb"/>
@@ -87,13 +87,13 @@
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY" customClass="QuickSettingView" customModule="IINA" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="377" height="912"/>
+            <rect key="frame" x="0.0" y="0.0" width="367" height="912"/>
             <subviews>
                 <stackView distribution="fillEqually" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="200" verticalStackHuggingPriority="250" horizontalHuggingPriority="200" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dNi-Ib-2vd" userLabel="TabButtons Stack View">
-                    <rect key="frame" x="20" y="864" width="337" height="48"/>
+                    <rect key="frame" x="20" y="864" width="327" height="48"/>
                     <subviews>
                         <button imageHugsTitle="YES" horizontalHuggingPriority="252" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ma8-6g-tVw" userLabel="VideoTab Button">
-                            <rect key="frame" x="0.0" y="0.0" width="107" height="48"/>
+                            <rect key="frame" x="0.0" y="0.0" width="104" height="48"/>
                             <buttonCell key="cell" type="square" title="VIDEO" bezelStyle="shadowlessSquare" image="tab_video" imagePosition="leading" alignment="center" imageScaling="proportionallyDown" inset="2" id="lQt-I0-jHO">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="systemBold"/>
@@ -103,7 +103,7 @@
                             </connections>
                         </button>
                         <button tag="1" imageHugsTitle="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3Fk-ey-FhK" userLabel="AudioTab Buttom">
-                            <rect key="frame" x="115" y="0.0" width="107" height="48"/>
+                            <rect key="frame" x="112" y="0.0" width="103" height="48"/>
                             <buttonCell key="cell" type="square" title="AUDIO" bezelStyle="shadowlessSquare" image="tab_audio" imagePosition="leading" alignment="center" imageScaling="proportionallyDown" inset="2" id="cpm-5o-a2c">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="systemBold"/>
@@ -113,7 +113,7 @@
                             </connections>
                         </button>
                         <button tag="2" imageHugsTitle="YES" horizontalHuggingPriority="253" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="rH3-pU-mFc" userLabel="SubtitlesTab Button">
-                            <rect key="frame" x="230" y="0.0" width="107" height="48"/>
+                            <rect key="frame" x="223" y="0.0" width="104" height="48"/>
                             <buttonCell key="cell" type="square" title="SUBTITLES" bezelStyle="shadowlessSquare" image="tab_sub" imagePosition="leading" alignment="center" imageScaling="proportionallyDown" inset="2" id="NxO-to-jcI">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="systemBold"/>
@@ -144,19 +144,19 @@
                     </customSpacing>
                 </stackView>
                 <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="L78-cf-BxB" userLabel="BelowTabButtons Horizontal Line">
-                    <rect key="frame" x="0.0" y="861" width="377" height="5"/>
+                    <rect key="frame" x="0.0" y="861" width="367" height="5"/>
                 </box>
                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="iNg-R1-bXw" userLabel="PluginTabs View">
-                    <rect key="frame" x="0.0" y="827" width="377" height="36"/>
+                    <rect key="frame" x="0.0" y="827" width="367" height="36"/>
                     <subviews>
                         <scrollView borderType="none" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" hasVerticalScroller="NO" usesPredominantAxisScrolling="NO" verticalScrollElasticity="none" translatesAutoresizingMaskIntoConstraints="NO" id="dfw-cq-GHm" userLabel="PluginsTabs Scroll View">
-                            <rect key="frame" x="0.0" y="1" width="377" height="35"/>
+                            <rect key="frame" x="0.0" y="1" width="367" height="35"/>
                             <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="Q9c-dH-CRI" userLabel="PluginsTabs Clip View">
-                                <rect key="frame" x="0.0" y="0.0" width="377" height="35"/>
+                                <rect key="frame" x="0.0" y="0.0" width="367" height="35"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                 <subviews>
                                     <view id="PF8-CN-LtV">
-                                        <rect key="frame" x="0.0" y="0.0" width="362" height="20"/>
+                                        <rect key="frame" x="0.0" y="0.0" width="352" height="20"/>
                                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     </view>
                                 </subviews>
@@ -172,7 +172,7 @@
                             </scroller>
                         </scrollView>
                         <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="Uvg-kn-ZiM" userLabel="BelowPluginsTabs Horizontal Line">
-                            <rect key="frame" x="0.0" y="-2" width="377" height="5"/>
+                            <rect key="frame" x="0.0" y="-2" width="367" height="5"/>
                         </box>
                     </subviews>
                     <constraints>
@@ -187,7 +187,7 @@
                     </constraints>
                 </customView>
                 <tabView drawsBackground="NO" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="udA-m2-eJb" userLabel="AllTabs Tab View">
-                    <rect key="frame" x="0.0" y="0.0" width="377" height="827"/>
+                    <rect key="frame" x="0.0" y="0.0" width="367" height="827"/>
                     <font key="font" metaFont="system"/>
                     <tabViewItems>
                         <tabViewItem label="Video" identifier="1" id="CYP-el-A6A" userLabel="VideoTab Tab View Item">
@@ -202,16 +202,16 @@
                                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                             <subviews>
                                                 <view translatesAutoresizingMaskIntoConstraints="NO" id="ZGz-La-n9c" userLabel="VideoTab Flipped CONTENT VIEW" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="67" width="367" height="760"/>
+                                                    <rect key="frame" x="0.0" y="71" width="367" height="756"/>
                                                     <subviews>
                                                         <customView translatesAutoresizingMaskIntoConstraints="NO" id="seu-WU-cTV" userLabel="HORIZONTAL-INSETS">
-                                                            <rect key="frame" x="20" y="740" width="327" height="0.0"/>
+                                                            <rect key="frame" x="20" y="736" width="327" height="0.0"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="height" id="4UC-le-Tmg"/>
                                                             </constraints>
                                                         </customView>
                                                         <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ng5-FC-tts" userLabel="Video track Label">
-                                                            <rect key="frame" x="18" y="724" width="331" height="16"/>
+                                                            <rect key="frame" x="18" y="720" width="331" height="16"/>
                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Video track:" id="VzC-tM-KT7">
                                                                 <font key="font" metaFont="systemBold"/>
                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -219,7 +219,7 @@
                                                             </textFieldCell>
                                                         </textField>
                                                         <scrollView focusRingType="none" borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ykw-rb-M9D" userLabel="VideoTrackTable Scroll View">
-                                                            <rect key="frame" x="0.0" y="641" width="367" height="75"/>
+                                                            <rect key="frame" x="0.0" y="637" width="367" height="75"/>
                                                             <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="jek-w4-LTf" userLabel="VideoTrackTable Clip View">
                                                                 <rect key="frame" x="0.0" y="0.0" width="367" height="75"/>
                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -375,7 +375,7 @@
                                                             </scroller>
                                                         </scrollView>
                                                         <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CUa-0e-DwY" userLabel="Aspect ratio Label">
-                                                            <rect key="frame" x="18" y="605" width="331" height="16"/>
+                                                            <rect key="frame" x="18" y="601" width="331" height="16"/>
                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Aspect ratio:" id="YgL-iV-bca">
                                                                 <font key="font" metaFont="systemBold"/>
                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -383,7 +383,7 @@
                                                             </textFieldCell>
                                                         </textField>
                                                         <segmentedControl horizontalHuggingPriority="100" verticalHuggingPriority="750" horizontalCompressionResistancePriority="500" translatesAutoresizingMaskIntoConstraints="NO" id="Ljl-w6-gIf" userLabel="AspectRatio Segmented Control">
-                                                            <rect key="frame" x="18" y="574" width="253" height="24"/>
+                                                            <rect key="frame" x="18" y="570" width="253" height="24"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="240" id="43J-t3-UhR"/>
                                                             </constraints>
@@ -403,7 +403,7 @@
                                                             </connections>
                                                         </segmentedControl>
                                                         <textField identifier="customAspectRatio" focusRingType="none" horizontalHuggingPriority="500" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XAI-y0-tcy" userLabel="CustomAspectRatio Text Field">
-                                                            <rect key="frame" x="277" y="576" width="70" height="21"/>
+                                                            <rect key="frame" x="277" y="572" width="70" height="21"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="900" constant="30" id="JnW-kS-XvK"/>
                                                             </constraints>
@@ -417,7 +417,7 @@
                                                             </connections>
                                                         </textField>
                                                         <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oAm-jJ-3kE" userLabel="CropLabel Text Field">
-                                                            <rect key="frame" x="18" y="539" width="331" height="16"/>
+                                                            <rect key="frame" x="18" y="535" width="331" height="16"/>
                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Crop:" id="m9e-IB-IDJ">
                                                                 <font key="font" metaFont="systemBold"/>
                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -425,7 +425,7 @@
                                                             </textFieldCell>
                                                         </textField>
                                                         <segmentedControl horizontalHuggingPriority="100" verticalHuggingPriority="750" horizontalCompressionResistancePriority="500" translatesAutoresizingMaskIntoConstraints="NO" id="sPT-jd-T7a" userLabel="CropChooser Segmented Control">
-                                                            <rect key="frame" x="18" y="508" width="331" height="24"/>
+                                                            <rect key="frame" x="18" y="504" width="331" height="24"/>
                                                             <constraints>
                                                                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="230" id="tTp-B3-gF5"/>
                                                             </constraints>
@@ -446,7 +446,7 @@
                                                             </connections>
                                                         </segmentedControl>
                                                         <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7vv-En-VYY" userLabel="RotationLabel Text Field">
-                                                            <rect key="frame" x="18" y="473" width="331" height="16"/>
+                                                            <rect key="frame" x="18" y="469" width="331" height="16"/>
                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Rotation:" id="to3-rc-Agv">
                                                                 <font key="font" metaFont="systemBold"/>
                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -454,7 +454,7 @@
                                                             </textFieldCell>
                                                         </textField>
                                                         <segmentedControl verticalHuggingPriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="bza-SA-tXE" userLabel="Rotation Segmented Control">
-                                                            <rect key="frame" x="18" y="442" width="171" height="24"/>
+                                                            <rect key="frame" x="18" y="438" width="171" height="24"/>
                                                             <segmentedCell key="cell" refusesFirstResponder="YES" borderStyle="border" alignment="left" segmentDistribution="fillEqually" style="rounded" trackingMode="selectOne" id="z1L-0N-dfK">
                                                                 <font key="font" metaFont="system"/>
                                                                 <segments>
@@ -469,7 +469,7 @@
                                                             </connections>
                                                         </segmentedControl>
                                                         <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="d4r-sL-0Vo" userLabel="SpeedLabel Text Field">
-                                                            <rect key="frame" x="18" y="407" width="331" height="16"/>
+                                                            <rect key="frame" x="18" y="403" width="331" height="16"/>
                                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Speed:" id="1KQ-oZ-A2x">
                                                                 <font key="font" metaFont="systemBold"/>
                                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -477,7 +477,7 @@
                                                             </textFieldCell>
                                                         </textField>
                                                         <customView autoresizesSubviews="NO" horizontalHuggingPriority="200" horizontalCompressionResistancePriority="700" translatesAutoresizingMaskIntoConstraints="NO" id="5v4-Te-950" userLabel="SpeedSlider Container View">
-                                                            <rect key="frame" x="20" y="361" width="327" height="42"/>
+                                                            <rect key="frame" x="20" y="357" width="327" height="42"/>
                                                             <subviews>
                                                                 <slider horizontalHuggingPriority="1" verticalHuggingPriority="700" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="700" translatesAutoresizingMaskIntoConstraints="NO" id="UWh-M9-5Nw" userLabel="SpeedSlider Horizontal Tick Slider">
                                                                     <rect key="frame" x="-2" y="10" width="240" height="20"/>
@@ -581,70 +581,87 @@
                                                             </constraints>
                                                         </customView>
                                                         <box autoresizesSubviews="NO" boxType="custom" cornerRadius="6" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="2ye-g4-fz5" userLabel="Switches Box">
-                                                            <rect key="frame" x="20" y="207" width="327" height="134"/>
+                                                            <rect key="frame" x="20" y="207" width="327" height="130"/>
                                                             <view key="contentView" id="bBc-PP-gHz" userLabel="Switches Box View">
-                                                                <rect key="frame" x="1" y="1" width="325" height="132"/>
+                                                                <rect key="frame" x="1" y="1" width="325" height="128"/>
                                                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                                                 <subviews>
-                                                                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="7z5-cT-Huj" userLabel="HWDecoding Switch" customClass="Switch" customModule="IINA" customModuleProvider="target">
-                                                                        <rect key="frame" x="12" y="92" width="301" height="36"/>
-                                                                        <constraints>
-                                                                            <constraint firstAttribute="height" constant="36" id="g7u-92-6a2"/>
-                                                                        </constraints>
-                                                                        <userDefinedRuntimeAttributes>
-                                                                            <userDefinedRuntimeAttribute type="string" keyPath="title" value="quicksetting.hwdec"/>
-                                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="refusesFirstResponder" value="NO"/>
-                                                                        </userDefinedRuntimeAttributes>
-                                                                    </customView>
                                                                     <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="PyM-xa-vx9" userLabel="Horizontal Line 1">
-                                                                        <rect key="frame" x="12" y="86" width="301" height="5"/>
+                                                                        <rect key="frame" x="12" y="83" width="301" height="5"/>
                                                                     </box>
-                                                                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="SMb-H5-j6h" userLabel="Deinterlace Switch" customClass="Switch" customModule="IINA" customModuleProvider="target">
-                                                                        <rect key="frame" x="12" y="48" width="301" height="36"/>
-                                                                        <constraints>
-                                                                            <constraint firstAttribute="height" constant="36" id="4kX-XS-rz3"/>
-                                                                        </constraints>
-                                                                        <userDefinedRuntimeAttributes>
-                                                                            <userDefinedRuntimeAttribute type="string" keyPath="title" value="quicksetting.deinterlace"/>
-                                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="refusesFirstResponder" value="NO"/>
-                                                                        </userDefinedRuntimeAttributes>
-                                                                    </customView>
                                                                     <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="qYi-uQ-6qo" userLabel="Horizontal Line 2">
-                                                                        <rect key="frame" x="12" y="42" width="301" height="5"/>
+                                                                        <rect key="frame" x="12" y="40" width="301" height="5"/>
                                                                     </box>
-                                                                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="U8P-fW-N3q" userLabel="HDR Switch" customClass="Switch" customModule="IINA" customModuleProvider="target">
-                                                                        <rect key="frame" x="12" y="4" width="301" height="36"/>
-                                                                        <constraints>
-                                                                            <constraint firstAttribute="height" constant="36" id="YSa-1m-THM"/>
-                                                                        </constraints>
-                                                                        <userDefinedRuntimeAttributes>
-                                                                            <userDefinedRuntimeAttribute type="string" keyPath="title" value="quicksetting.hdr"/>
-                                                                            <userDefinedRuntimeAttribute type="boolean" keyPath="refusesFirstResponder" value="NO"/>
-                                                                        </userDefinedRuntimeAttributes>
-                                                                    </customView>
+                                                                    <switch horizontalHuggingPriority="750" verticalHuggingPriority="750" baseWritingDirection="leftToRight" alignment="left" translatesAutoresizingMaskIntoConstraints="NO" id="UKk-rD-n2A">
+                                                                        <rect key="frame" x="265" y="51" width="42" height="25"/>
+                                                                        <connections>
+                                                                            <action selector="deinterlaceAction:" target="-2" id="Wks-al-3dq"/>
+                                                                        </connections>
+                                                                    </switch>
+                                                                    <switch horizontalHuggingPriority="750" verticalHuggingPriority="750" baseWritingDirection="leftToRight" alignment="left" translatesAutoresizingMaskIntoConstraints="NO" id="TNg-iM-cVP">
+                                                                        <rect key="frame" x="265" y="8" width="42" height="25"/>
+                                                                        <connections>
+                                                                            <action selector="hdrAction:" target="-2" id="caQ-5H-pX4"/>
+                                                                        </connections>
+                                                                    </switch>
+                                                                    <switch horizontalHuggingPriority="750" verticalHuggingPriority="750" baseWritingDirection="leftToRight" alignment="left" translatesAutoresizingMaskIntoConstraints="NO" id="AbD-ap-nO5">
+                                                                        <rect key="frame" x="265" y="94" width="42" height="25"/>
+                                                                        <connections>
+                                                                            <action selector="hardwareDecodingAction:" target="-2" id="Fv6-2y-odN"/>
+                                                                        </connections>
+                                                                    </switch>
+                                                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OvF-ci-44R">
+                                                                        <rect key="frame" x="18" y="101" width="124" height="16"/>
+                                                                        <textFieldCell key="cell" lineBreakMode="clipping" title="Hardware Decoding" id="rw1-Qb-0RV">
+                                                                            <font key="font" usesAppearanceFont="YES"/>
+                                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                        </textFieldCell>
+                                                                    </textField>
+                                                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xJo-hi-ale">
+                                                                        <rect key="frame" x="18" y="15" width="32" height="16"/>
+                                                                        <textFieldCell key="cell" lineBreakMode="clipping" title="HDR" id="UW4-by-XRS">
+                                                                            <font key="font" usesAppearanceFont="YES"/>
+                                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                        </textFieldCell>
+                                                                    </textField>
+                                                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="m39-41-Kwj">
+                                                                        <rect key="frame" x="18" y="58" width="73" height="16"/>
+                                                                        <textFieldCell key="cell" lineBreakMode="clipping" title="Deinterlace" id="eqd-nF-8ff">
+                                                                            <font key="font" usesAppearanceFont="YES"/>
+                                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                                        </textFieldCell>
+                                                                    </textField>
                                                                 </subviews>
                                                                 <constraints>
-                                                                    <constraint firstAttribute="bottom" secondItem="U8P-fW-N3q" secondAttribute="bottom" constant="4" id="6lN-OM-fnO"/>
-                                                                    <constraint firstItem="SMb-H5-j6h" firstAttribute="leading" secondItem="7z5-cT-Huj" secondAttribute="leading" id="7Ja-DA-CwF"/>
-                                                                    <constraint firstItem="SMb-H5-j6h" firstAttribute="top" secondItem="7z5-cT-Huj" secondAttribute="bottom" constant="8" id="Fjd-9M-zZt"/>
-                                                                    <constraint firstItem="U8P-fW-N3q" firstAttribute="leading" secondItem="SMb-H5-j6h" secondAttribute="leading" id="GRQ-Bt-V3i"/>
-                                                                    <constraint firstItem="U8P-fW-N3q" firstAttribute="leading" secondItem="PyM-xa-vx9" secondAttribute="leading" id="I97-3I-Tnn"/>
-                                                                    <constraint firstItem="U8P-fW-N3q" firstAttribute="trailing" secondItem="SMb-H5-j6h" secondAttribute="trailing" id="MXl-9i-Z7z"/>
+                                                                    <constraint firstItem="AbD-ap-nO5" firstAttribute="top" secondItem="bBc-PP-gHz" secondAttribute="top" constant="10" id="5cF-CC-AbB"/>
+                                                                    <constraint firstItem="qYi-uQ-6qo" firstAttribute="top" secondItem="UKk-rD-n2A" secondAttribute="bottom" constant="10" id="6VJ-Ah-h6m"/>
+                                                                    <constraint firstItem="TNg-iM-cVP" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="xJo-hi-ale" secondAttribute="trailing" id="AFb-Zd-1Kk"/>
+                                                                    <constraint firstItem="OvF-ci-44R" firstAttribute="firstBaseline" secondItem="AbD-ap-nO5" secondAttribute="firstBaseline" id="C5V-KG-rtA"/>
+                                                                    <constraint firstItem="xJo-hi-ale" firstAttribute="firstBaseline" secondItem="TNg-iM-cVP" secondAttribute="firstBaseline" id="FgR-gq-g9W"/>
+                                                                    <constraint firstItem="OvF-ci-44R" firstAttribute="leading" secondItem="bBc-PP-gHz" secondAttribute="leading" constant="20" symbolic="YES" id="HQZ-2y-rKx"/>
+                                                                    <constraint firstItem="AbD-ap-nO5" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="OvF-ci-44R" secondAttribute="trailing" id="JmL-a7-GPB"/>
+                                                                    <constraint firstAttribute="trailing" secondItem="UKk-rD-n2A" secondAttribute="trailing" constant="20" symbolic="YES" id="SGe-oO-XfD"/>
                                                                     <constraint firstItem="qYi-uQ-6qo" firstAttribute="trailing" secondItem="PyM-xa-vx9" secondAttribute="trailing" id="W6Y-bH-eCi"/>
-                                                                    <constraint firstItem="7z5-cT-Huj" firstAttribute="top" secondItem="bBc-PP-gHz" secondAttribute="top" constant="4" id="X2a-Cb-juO"/>
-                                                                    <constraint firstItem="U8P-fW-N3q" firstAttribute="top" secondItem="qYi-uQ-6qo" secondAttribute="bottom" constant="4" id="ZPR-3B-WSW"/>
+                                                                    <constraint firstAttribute="bottom" secondItem="TNg-iM-cVP" secondAttribute="bottom" constant="10" id="XFf-u8-uTi"/>
                                                                     <constraint firstAttribute="trailing" secondItem="PyM-xa-vx9" secondAttribute="trailing" constant="12" id="Zny-ol-SPy"/>
-                                                                    <constraint firstItem="SMb-H5-j6h" firstAttribute="trailing" secondItem="7z5-cT-Huj" secondAttribute="trailing" id="bTG-eY-qrc"/>
-                                                                    <constraint firstItem="7z5-cT-Huj" firstAttribute="centerX" secondItem="bBc-PP-gHz" secondAttribute="centerX" id="bVd-8a-j88"/>
+                                                                    <constraint firstItem="PyM-xa-vx9" firstAttribute="top" secondItem="AbD-ap-nO5" secondAttribute="bottom" constant="10" id="aZI-9n-idy"/>
                                                                     <constraint firstItem="PyM-xa-vx9" firstAttribute="leading" secondItem="bBc-PP-gHz" secondAttribute="leading" constant="12" id="cAs-bS-FEB"/>
-                                                                    <constraint firstItem="PyM-xa-vx9" firstAttribute="bottom" secondItem="7z5-cT-Huj" secondAttribute="bottom" constant="4" id="mXv-Bz-bFd"/>
-                                                                    <constraint firstItem="U8P-fW-N3q" firstAttribute="top" secondItem="SMb-H5-j6h" secondAttribute="bottom" constant="8" id="t4C-3L-HEY"/>
+                                                                    <constraint firstItem="TNg-iM-cVP" firstAttribute="top" secondItem="qYi-uQ-6qo" secondAttribute="bottom" constant="10" id="eVy-VT-STY"/>
+                                                                    <constraint firstItem="UKk-rD-n2A" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="m39-41-Kwj" secondAttribute="trailing" id="faP-iu-15E"/>
+                                                                    <constraint firstItem="xJo-hi-ale" firstAttribute="leading" secondItem="bBc-PP-gHz" secondAttribute="leading" constant="20" symbolic="YES" id="hah-hi-Vnt"/>
+                                                                    <constraint firstItem="m39-41-Kwj" firstAttribute="leading" secondItem="bBc-PP-gHz" secondAttribute="leading" constant="20" symbolic="YES" id="l2S-aw-jeb"/>
+                                                                    <constraint firstAttribute="trailing" secondItem="AbD-ap-nO5" secondAttribute="trailing" constant="20" symbolic="YES" id="q7m-cn-c9D"/>
+                                                                    <constraint firstItem="m39-41-Kwj" firstAttribute="firstBaseline" secondItem="UKk-rD-n2A" secondAttribute="firstBaseline" id="qP2-ce-a9h"/>
                                                                     <constraint firstItem="qYi-uQ-6qo" firstAttribute="leading" secondItem="PyM-xa-vx9" secondAttribute="leading" id="tkm-Ze-qkw"/>
-                                                                    <constraint firstItem="U8P-fW-N3q" firstAttribute="trailing" secondItem="PyM-xa-vx9" secondAttribute="trailing" id="yTh-eK-yhj"/>
+                                                                    <constraint firstAttribute="trailing" secondItem="TNg-iM-cVP" secondAttribute="trailing" constant="20" symbolic="YES" id="ugo-Rb-i01"/>
+                                                                    <constraint firstItem="UKk-rD-n2A" firstAttribute="top" secondItem="PyM-xa-vx9" secondAttribute="bottom" constant="10" id="w2S-IA-KK8"/>
                                                                 </constraints>
                                                             </view>
                                                             <constraints>
-                                                                <constraint firstAttribute="height" constant="134" id="mMk-SO-lBd"/>
+                                                                <constraint firstAttribute="height" constant="130" id="mMk-SO-lBd"/>
                                                             </constraints>
                                                             <color key="borderColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
                                                             <color key="fillColor" red="0.99999600649999998" green="1" blue="1" alpha="0.10000000000000001" colorSpace="custom" customColorSpace="sRGB"/>
@@ -1596,8 +1613,8 @@
                                     <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3kA-IY-poi" userLabel="SubtitlesTab Scroll View">
                                         <rect key="frame" x="0.0" y="0.0" width="377" height="827"/>
                                         <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="epy-wp-Ja5" userLabel="SubtitlesTab Clip View">
-                                            <rect key="frame" x="0.0" y="0.0" width="362" height="827"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <rect key="frame" x="0.0" y="0.0" width="377" height="827"/>
+                                            <autoresizingMask key="autoresizingMask"/>
                                             <subviews>
                                                 <customView translatesAutoresizingMaskIntoConstraints="NO" id="pm4-x9-WJ5" userLabel="SubtitlesTab Flipped CONTENT VIEW" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
                                                     <rect key="frame" x="0.0" y="-41" width="362" height="868"/>
@@ -1615,7 +1632,7 @@
                                                                     <rect key="frame" x="0.0" y="745" width="362" height="75"/>
                                                                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="dJV-R0-O3M" userLabel="SubTable Clip View">
                                                                         <rect key="frame" x="0.0" y="0.0" width="362" height="75"/>
-                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                        <autoresizingMask key="autoresizingMask"/>
                                                                         <subviews>
                                                                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="2vU-hm-gGB" userLabel="SubTable Table View">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="362" height="75"/>
@@ -1771,7 +1788,7 @@
                                                                     <rect key="frame" x="0.0" y="622" width="362" height="75"/>
                                                                     <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="EKn-MX-Fao" userLabel="SecondarySub Clip View">
                                                                         <rect key="frame" x="0.0" y="0.0" width="362" height="75"/>
-                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                        <autoresizingMask key="autoresizingMask"/>
                                                                         <subviews>
                                                                             <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="Jve-qX-Agy" userLabel="SecondarySub Table View">
                                                                                 <rect key="frame" x="0.0" y="0.0" width="362" height="75"/>

--- a/iina/QuickSettingViewController.swift
+++ b/iina/QuickSettingViewController.swift
@@ -125,9 +125,9 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
   @IBOutlet weak var customSpeedTextField: NSTextField!
   @IBOutlet weak var switchHorizontalLine: NSBox!
   @IBOutlet weak var switchHorizontalLine2: NSBox!
-  @IBOutlet weak var hardwareDecodingSwitch: Switch!
-  @IBOutlet weak var deinterlaceSwitch: Switch!
-  @IBOutlet weak var hdrSwitch: Switch!
+  @IBOutlet weak var hardwareDecodingSwitch: NSSwitch!
+  @IBOutlet weak var deinterlaceSwitch: NSSwitch!
+  @IBOutlet weak var hdrSwitch: NSSwitch!
 
   @IBOutlet weak var brightnessSlider: NSSlider!
   @IBOutlet weak var contrastSlider: NSSlider!
@@ -359,20 +359,10 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
     }
     rotateSegment.selectSegment(withTag: AppData.rotations.firstIndex(of: player.info.rotation) ?? -1)
 
-    deinterlaceSwitch.checked = player.info.deinterlace
-    deinterlaceSwitch.action = {
-      self.player.toggleDeinterlace($0)
-    }
-    hardwareDecodingSwitch.checked = player.info.hwdecEnabled
-    hardwareDecodingSwitch.action = {
-      self.player.toggleHardwareDecoding($0)
-    }
+    deinterlaceSwitch.state = player.info.deinterlace ? .on : .off
+    hardwareDecodingSwitch.state = player.info.hwdecEnabled ? .on : .off
     hdrSwitch.isEnabled = player.info.hdrAvailable
-    hdrSwitch.checked = player.info.hdrAvailable && player.info.hdrEnabled
-    hdrSwitch.action = {
-      self.player.info.hdrEnabled = $0
-      self.player.refreshEdrMode()
-    }
+    hdrSwitch.state = (player.info.hdrAvailable && player.info.hdrEnabled) ? .on : .off
 
     let speed = player.mpv.getDouble(MPVOption.PlaybackControl.speed)
     customSpeedTextField.doubleValue = speed
@@ -549,7 +539,7 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
     player.info.hdrAvailable = available
     if isViewLoaded {
       hdrSwitch.isEnabled = available
-      hdrSwitch.checked = available && player.info.hdrEnabled
+      hdrSwitch.state = (available && player.info.hdrEnabled) ? .on : .off
     }
   }
 
@@ -681,6 +671,19 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
       player.setVideoAspect(value)
       player.sendOSD(.aspect(value))
     }
+  }
+
+  @IBAction func hardwareDecodingAction(_ sender: NSSwitch) {
+    player.toggleHardwareDecoding(sender.state == .on)
+  }
+  
+  @IBAction func deinterlaceAction(_ sender: NSSwitch) {
+    player.toggleDeinterlace(sender.state == .on)
+  }
+  
+  @IBAction func hdrAction(_ sender: NSSwitch) {
+    self.player.info.hdrEnabled = sender.state == .on
+    self.player.refreshEdrMode()
   }
 
   private func redraw(indicator: NSTextField, constraint: NSLayoutConstraint, slider: NSSlider, value: String) {

--- a/iina/QuickSettingViewController.swift
+++ b/iina/QuickSettingViewController.swift
@@ -128,6 +128,9 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
   @IBOutlet weak var hardwareDecodingSwitch: NSSwitch!
   @IBOutlet weak var deinterlaceSwitch: NSSwitch!
   @IBOutlet weak var hdrSwitch: NSSwitch!
+  @IBOutlet weak var hardwareDecodingLabel: NSTextField!
+  @IBOutlet weak var deinterlaceLabel: NSTextField!
+  @IBOutlet weak var hdrLabel: NSTextField!
 
   @IBOutlet weak var brightnessSlider: NSSlider!
   @IBOutlet weak var contrastSlider: NSSlider!
@@ -359,10 +362,15 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
     }
     rotateSegment.selectSegment(withTag: AppData.rotations.firstIndex(of: player.info.rotation) ?? -1)
 
-    deinterlaceSwitch.state = player.info.deinterlace ? .on : .off
     hardwareDecodingSwitch.state = player.info.hwdecEnabled ? .on : .off
+    deinterlaceSwitch.state = player.info.deinterlace ? .on : .off
     hdrSwitch.isEnabled = player.info.hdrAvailable
     hdrSwitch.state = (player.info.hdrAvailable && player.info.hdrEnabled) ? .on : .off
+    
+    // These strings are also contained in the strings file of this view. Remove these lines if the localization of these strings are complete enough.
+    hardwareDecodingLabel.stringValue = NSLocalizedString("quicksetting.hwdec", comment: "Hardware Decoding")
+    deinterlaceLabel.stringValue = NSLocalizedString("quicksetting.deinterlace", comment: "Deinterlace")
+    hdrLabel.stringValue = NSLocalizedString("quicksetting.hdr", comment: "HDR")
 
     let speed = player.mpv.getDouble(MPVOption.PlaybackControl.speed)
     customSpeedTextField.doubleValue = speed

--- a/iina/en.lproj/QuickSettingViewController.strings
+++ b/iina/en.lproj/QuickSettingViewController.strings
@@ -207,3 +207,12 @@
 
 /* Class = "NSTextFieldCell"; title = "Equalizer"; ObjectID = "zcD-Tg-7Oi"; */
 "zcD-Tg-7Oi.title" = "Equalizer:";
+
+/* Class = "NSTextFieldCell"; title = "Hardware Decoding"; ObjectID = "rw1-Qb-0RV"; */
+"rw1-Qb-0RV.title" = "Hardware Decoding";
+
+/* Class = "NSTextFieldCell"; title = "Deinterlace"; ObjectID = "eqd-nF-8ff"; */
+"eqd-nF-8ff.title" = "Deinterlace";
+
+/* Class = "NSTextFieldCell"; title = "HDR"; ObjectID = "UW4-by-XRS"; */
+"UW4-by-XRS.title" = "HDR";


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)

---

**Description:**
This PR removes the `Switch.swift` file and replaced the 3 Switches used in the video tab of QuickSettingView with NSSwitch. One potential problem is that the translations are missing for the text fields, before they were set programmatically. We can either leave it as is and let the Crowdin community to translate them, or I can set them programmatically too. Thoughts?