### PR TITLE
Add ability to disable title bar & OSC via enableTitleBarAndOSC pref key

### DIFF
--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -104,7 +104,7 @@ struct Preference {
     // UI
 
     /// If `false`, never show OSC. If `true`, see `enableControlBarAutoHide`. (bool)
-    static let enableOSC = Key("enableOSC")
+    static let enableTitleBarAndOSC = Key("enableTitleBarAndOSC")
 
     /// Whether auto hiding OSC is enabled. (bool)
     static let enableControlBarAutoHide = Key("enableControlBarAutoHide")
@@ -772,7 +772,7 @@ struct Preference {
     .recordPlaybackHistory: true,
     .recordRecentFiles: true,
     .trackAllFilesInRecentOpenMenu: true,
-    .enableOSC: true,
+    .enableTitleBarAndOSC: true,
     .enableControlBarAutoHide: true,
     .controlBarAutoHideTimeout: Float(2.5),
     .oscPosition: OSCPosition.floating.rawValue,

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -103,20 +103,26 @@ struct Preference {
 
     // UI
 
-    /** Horizontal position of control bar. (float, 0 - 1) */
-    static let controlBarPositionHorizontal = Key("controlBarPositionHorizontal")
+    /// If `false`, never show OSC. If `true`, see `enableControlBarAutoHide`. (bool)
+    static let enableOSC = Key("enableOSC")
 
-    /** Horizontal position of control bar. In percentage from bottom. (float, 0 - 1) */
-    static let controlBarPositionVertical = Key("controlBarPositionVertical")
+    /// Whether auto hiding OSC is enabled. (bool)
+    static let enableControlBarAutoHide = Key("enableControlBarAutoHide")
 
-    /** Whether control bar stick to center when dragging. (bool) */
-    static let controlBarStickToCenter = Key("controlBarStickToCenter")
-
-    /** Timeout for auto hiding control bar (float) */
+    /// Timeout for auto hiding OSC, if `enableControlBarAutoHide` is true. (float)
     static let controlBarAutoHideTimeout = Key("controlBarAutoHideTimeout")
 
-    /** Whether auto hiding control bar is enabled. (bool)*/
-    static let enableControlBarAutoHide = Key("enableControlBarAutoHide")
+    /// Where to display OSC. (enum, `.top`, `.bottom`, or `.floating`)
+    static let oscPosition = Key("oscPosition")
+
+    /// Horizontal position of "floating" OSC. (float, 0 - 1)
+    static let controlBarPositionHorizontal = Key("controlBarPositionHorizontal")
+
+    /// Horizontal position of "floating" OSC. In percentage from bottom. (float, 0 - 1)
+    static let controlBarPositionVertical = Key("controlBarPositionVertical")
+
+    /// Whether "floating" OSC sticks to center when dragging. (bool)
+    static let controlBarStickToCenter = Key("controlBarStickToCenter")
 
     static let controlBarToolbarButtons = Key("controlBarToolbarButtons")
 
@@ -134,8 +140,6 @@ struct Preference {
     static let initialWindowSizePosition = Key("initialWindowSizePosition")
     static let resizeWindowTiming = Key("resizeWindowTiming")
     static let resizeWindowOption = Key("resizeWindowOption")
-
-    static let oscPosition = Key("oscPosition")
 
     static let playlistWidth = Key("playlistWidth")
     static let prefetchPlaylistVideoDuration = Key("prefetchPlaylistVideoDuration")
@@ -768,13 +772,14 @@ struct Preference {
     .recordPlaybackHistory: true,
     .recordRecentFiles: true,
     .trackAllFilesInRecentOpenMenu: true,
+    .enableOSC: true,
+    .enableControlBarAutoHide: true,
+    .controlBarAutoHideTimeout: Float(2.5),
+    .oscPosition: OSCPosition.floating.rawValue,
     .controlBarPositionHorizontal: Float(0.5),
     .controlBarPositionVertical: Float(0.1),
     .controlBarStickToCenter: true,
-    .controlBarAutoHideTimeout: Float(2.5),
-    .enableControlBarAutoHide: true,
     .controlBarToolbarButtons: [ToolBarButton.pip.rawValue, ToolBarButton.playlist.rawValue, ToolBarButton.settings.rawValue],
-    .oscPosition: OSCPosition.floating.rawValue,
     .playlistWidth: 270,
     .prefetchPlaylistVideoDuration: true,
     .themeMaterial: Theme.dark.rawValue,


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4553.

---

**Description:**
* Adds new Preference.Key: `.enableTitleBarAndOSC`, default `true`
* Minor reordering of OSC-related pref keys to make more sense, and update some of their comments which fell out of date (sorry, couldn't help myself), as well as making it clearer how some of them work together
* Modify `setupOnScreenController` and logic while entering & exiting full screen to support the new pref
* Add observer for the new key to `MainWindowController` so that `setupOnScreenController` is called as soon as it is changed

This PR only adds the feature itself and its pref entry. I'll submit another PR which adds controls for it to the Settings UI. For those who want to test this for the time being, they can enter the following in the Terminal:
```
# Disable OSC
defaults write com.colliderli.iina enableTitleBarAndOSC 0
```

```
# Enable OSC
defaults write com.colliderli.iina enableTitleBarAndOSC 1
```