### PR TITLE
Add scale to the ASS subtitles override level slider

### DIFF
--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -130,6 +130,7 @@
 "preference.enable_adv_settings" = "Enable advanced settings";
 
 "preference.sub_override_level.force" = "force";
+"preference.sub_override_level.scale" = "scale";
 "preference.sub_override_level.strip" = "strip";
 "preference.sub_override_level.yes" = "yes";
 

--- a/iina/Base.lproj/PrefSubViewController.xib
+++ b/iina/Base.lproj/PrefSubViewController.xib
@@ -960,13 +960,17 @@
                     </textFieldCell>
                 </textField>
                 <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="7UX-IL-hdk">
-                    <rect key="frame" x="202" y="5" width="96" height="20"/>
+                    <rect key="frame" x="202" y="5" width="128" height="20"/>
                     <constraints>
-                        <constraint firstAttribute="width" constant="92" id="EJa-Kl-S4K"/>
+                        <constraint firstAttribute="width" constant="124" id="EJa-Kl-S4K"/>
                     </constraints>
-                    <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" maxValue="2" doubleValue="2" tickMarkPosition="below" numberOfTickMarks="3" allowsTickMarkValuesOnly="YES" sliderType="linear" id="63l-gO-fEV"/>
+                    <sliderCell key="cell" controlSize="small" continuous="YES" state="on" alignment="left" maxValue="3" doubleValue="3" tickMarkPosition="below" numberOfTickMarks="4" allowsTickMarkValuesOnly="YES" sliderType="linear" id="63l-gO-fEV"/>
                     <connections>
-                        <binding destination="5Up-Ab-aAm" name="value" keyPath="values.subOverrideLevel" id="ofs-dB-Q12"/>
+                        <binding destination="5Up-Ab-aAm" name="value" keyPath="values.subOverrideLevel" id="jz2-FJ-liL">
+                            <dictionary key="options">
+                                <string key="NSValueTransformerName">ASSOverrideLevelValueTransformer</string>
+                            </dictionary>
+                        </binding>
                     </connections>
                 </slider>
                 <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="FR3-Ar-5Dw">

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -480,10 +480,15 @@ struct Preference {
     }
   }
 
+  /// Enum values for the IINA setting that corresponds to the `mpv`
+  /// [sub-ass-override](https://mpv.io/manual/stable/#options-sub-ass-override) option.
+  ///- Important: In order to preserve backward compatibility with enum values stored in user's settings `scale` was added to
+  ///    the end of the enumeration. This is why the constants are not ordered from least impactful to most impactful.
   enum SubOverrideLevel: Int, InitializingFromKey {
     case yes = 0
     case force
     case strip
+    case scale
 
     static var defaultValue = SubOverrideLevel.yes
 
@@ -497,6 +502,7 @@ struct Preference {
         case .yes: return "yes"
         case .force : return "force"
         case .strip: return "strip"
+        case .scale: return "scale"
         }
       }
     }

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -130,6 +130,7 @@
 "preference.enable_adv_settings" = "Enable advanced settings";
 
 "preference.sub_override_level.force" = "force";
+"preference.sub_override_level.scale" = "scale";
 "preference.sub_override_level.strip" = "strip";
 "preference.sub_override_level.yes" = "yes";
 


### PR DESCRIPTION
This commit will:
- Add a new scale enum constant to `SubOverrideLevel` in `Preferences`
- Add translations for scale in base and English `Localizable.strings`
- Lengthen the override level slider and add an additional tick mark for scale
- Add a `ASSOverrideLevelValueTransformer` class to `PrefSubViewController`
- Change the override level slider to use the transformer when accessing the `subOverrideLevel` setting

This adds the missing `scale` value from IINA's `Override level` setting found in the `ASS Subtitles` section on the `Subtitle tab` of IINA's settings. To preserve backward compatibility with enum values stored in user's settings `scale` was added to the end of the enumeration. This means the enum raw values do not reflect the correct order needed for the slider. The transformer adjusts the values to provide a proper ordering for the slider.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
