### PR TITLE
Don't resize on opening media and switching modes

### DIFF
--- a/iina/Base.lproj/MiniPlayerWindowController.xib
+++ b/iina/Base.lproj/MiniPlayerWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="32700.99.1234" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23089" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="22690"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23089"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -43,12 +43,12 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" frameAutosaveName="IINAMiniPlayerWindow" animationBehavior="default" tabbingMode="disallowed" id="F0z-JX-Cv5" userLabel="MiniPlayer Window" customClass="MiniPlayerWindow" customModule="IINA" customModuleProvider="target">
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="IINAMiniPlayerWindow" animationBehavior="default" tabbingMode="disallowed" id="F0z-JX-Cv5" userLabel="MiniPlayer Window" customClass="MiniPlayerWindow" customModule="IINA" customModuleProvider="target">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenNone="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="300" height="72"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="3440" height="1415"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1415"/>
             <value key="minSize" type="size" width="300" height="72"/>
             <view key="contentView" id="se5-gp-TjO">
                 <rect key="frame" x="0.0" y="0.0" width="300" height="72"/>
@@ -74,7 +74,7 @@
                     <visualEffectView wantsLayer="YES" blendingMode="behindWindow" material="underWindowBackground" state="active" translatesAutoresizingMaskIntoConstraints="NO" id="HdA-I9-dRJ">
                         <rect key="frame" x="0.0" y="0.0" width="300" height="72"/>
                         <subviews>
-                            <textField wantsLayer="YES" horizontalHuggingPriority="249" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xAK-xc-Njn" customClass="DurationDisplayTextField" customModule="IINA" customModuleProvider="target">
+                            <textField wantsLayer="YES" focusRingType="none" horizontalHuggingPriority="249" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xAK-xc-Njn" customClass="DurationDisplayTextField" customModule="IINA" customModuleProvider="target">
                                 <rect key="frame" x="260" y="7" width="36" height="11"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="32" id="Dnz-rF-ikZ"/>
@@ -88,7 +88,7 @@
                                     <binding destination="-2" name="font" keyPath="monospacedFont" id="TM3-Ri-L7h"/>
                                 </connections>
                             </textField>
-                            <textField wantsLayer="YES" horizontalHuggingPriority="249" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9EY-2T-Ebf" customClass="DurationDisplayTextField" customModule="IINA" customModuleProvider="target">
+                            <textField wantsLayer="YES" focusRingType="none" horizontalHuggingPriority="249" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9EY-2T-Ebf" customClass="DurationDisplayTextField" customModule="IINA" customModuleProvider="target">
                                 <rect key="frame" x="4" y="7" width="36" height="11"/>
                                 <constraints>
                                     <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="32" id="1iE-QR-s8H"/>
@@ -112,7 +112,7 @@
                             <customView translatesAutoresizingMaskIntoConstraints="NO" id="Zv7-H8-iOq">
                                 <rect key="frame" x="0.0" y="24" width="300" height="48"/>
                                 <subviews>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="h25-bp-EvL" customClass="ScrollingTextField" customModule="IINA" customModuleProvider="target">
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="h25-bp-EvL" customClass="ScrollingTextField" customModule="IINA" customModuleProvider="target">
                                         <rect key="frame" x="133" y="26" width="35" height="16"/>
                                         <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" alignment="center" title="Title" id="Rs9-6l-6vp">
                                             <font key="font" metaFont="system"/>
@@ -120,7 +120,7 @@
                                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <textField wantsLayer="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kcj-EY-i9R" customClass="ScrollingTextField" customModule="IINA" customModuleProvider="target">
+                                    <textField wantsLayer="YES" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kcj-EY-i9R" customClass="ScrollingTextField" customModule="IINA" customModuleProvider="target">
                                         <rect key="frame" x="109" y="8" width="82" height="14"/>
                                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Artist - Album" id="Nle-gv-CWY">
                                             <font key="font" metaFont="message" size="11"/>
@@ -420,7 +420,7 @@
                         <action selector="volumeSliderChanges:" target="-2" id="24x-7W-lsa"/>
                     </connections>
                 </slider>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="MP6-sS-T7f">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="MP6-sS-T7f">
                     <rect key="frame" x="143" y="9" width="34" height="14"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="30" id="UDC-wZ-xua"/>

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -180,6 +180,9 @@ class MainWindowController: PlayerWindowController {
   var isShowingPersistentOSD = false
   var osdContext: Any?
 
+  /** This variable is true when the window should show but waiting for size from mpv */
+  var pendingShow = false
+
   // MARK: - Enums
 
   // Window state
@@ -650,7 +653,6 @@ class MainWindowController: PlayerWindowController {
 
     player.events.emit(.windowLoaded)
 
-    isClosing = false
     // Must workaround an AppKit defect in some versions of macOS. This defect is known to exist in
     // Catalina and Big Sur. The problem was not reproducible in early versions of Monterey. It
     // reappeared in Ventura. The status of other versions of macOS is unknown, however the
@@ -2567,7 +2569,8 @@ class MainWindowController: PlayerWindowController {
       if let screenFrame = window.screen?.frame {
         rect = rect.constrain(in: screenFrame)
       }
-      if !player.mainWindow.window!.isVisible && !player.isInMiniPlayer {
+      if pendingShow && !player.isInMiniPlayer {
+        pendingShow = false
         window.setFrame(rect, display: false, animate: false)
         showWindow(nil)
       } else if player.disableWindowAnimation || Preference.bool(for: .disableAnimations) {

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -553,7 +553,6 @@ class MainWindowController: PlayerWindowController {
     guard let cv = window.contentView else { return }
     cv.autoresizesSubviews = false
     addVideoViewToWindow()
-    window.setIsVisible(true)
 
     // gesture recognizer
     cv.addGestureRecognizer(magnificationGestureRecognizer)
@@ -650,6 +649,41 @@ class MainWindowController: PlayerWindowController {
     }
 
     player.events.emit(.windowLoaded)
+
+    isClosing = false
+    // Must workaround an AppKit defect in some versions of macOS. This defect is known to exist in
+    // Catalina and Big Sur. The problem was not reproducible in early versions of Monterey. It
+    // reappeared in Ventura. The status of other versions of macOS is unknown, however the
+    // workaround should be safe to apply in any version of macOS. The problem was reported in
+    // issues #4229, #3159, #3097 and #3253. The titles of open windows shown in the "Window" menu
+    // are automatically managed by the AppKit framework. To improve performance PlayerCore caches
+    // and reuses player instances along with their windows. This technique is valid and recommended
+    // by Apple. But in some versions of macOS, if a window is reused the framework will display the
+    // title first used for the window in the "Window" menu even after IINA has updated the title of
+    // the window. This problem can also be seen when right-clicking or control-clicking the IINA
+    // icon in the dock. As a workaround reset the window's title to "Window" before it is reused.
+    // This is the default title AppKit assigns to a window when it is first created. Surprising and
+    // rather disturbing this works as a workaround, but it does.
+    window.title = "Window"
+
+    // As there have been issues in this area, log details about the screen selection process.
+    NSScreen.log("window!.screen", window.screen)
+    NSScreen.log("NSScreen.main", NSScreen.main)
+    NSScreen.screens.enumerated().forEach { screen in
+      NSScreen.log("NSScreen.screens[\(screen.offset)]" , screen.element)
+    }
+
+    var screen = window.selectDefaultScreen()
+
+    if let rectString = UserDefaults.standard.value(forKey: "MainWindowLastPosition") as? String {
+      let rect = NSRectFromString(rectString)
+      if let lastScreen = NSScreen.screens.first(where: { NSPointInRect(rect.origin, $0.visibleFrame) }) {
+        screen = lastScreen
+        NSScreen.log("MainWindowLastPosition \(rect.origin) matched", screen)
+      }
+    }
+
+    videoView.videoLayer.draw(forced: true)
   }
 
   /// Returns the position in seconds for the given percent of the total duration of the video the percentage represents.
@@ -1132,57 +1166,10 @@ class MainWindowController: PlayerWindowController {
 
   // MARK: - Window delegate: Open / Close
 
-  func windowWillOpen() {
-    // Must workaround an AppKit defect in some versions of macOS. This defect is known to exist in
-    // Catalina and Big Sur. The problem was not reproducible in early versions of Monterey. It
-    // reappeared in Ventura. The status of other versions of macOS is unknown, however the
-    // workaround should be safe to apply in any version of macOS. The problem was reported in
-    // issues #4229, #3159, #3097 and #3253. The titles of open windows shown in the "Window" menu
-    // are automatically managed by the AppKit framework. To improve performance PlayerCore caches
-    // and reuses player instances along with their windows. This technique is valid and recommended
-    // by Apple. But in some versions of macOS, if a window is reused the framework will display the
-    // title first used for the window in the "Window" menu even after IINA has updated the title of
-    // the window. This problem can also be seen when right-clicking or control-clicking the IINA
-    // icon in the dock. As a workaround reset the window's title to "Window" before it is reused.
-    // This is the default title AppKit assigns to a window when it is first created. Surprising and
-    // rather disturbing this works as a workaround, but it does.
-    window!.title = "Window"
-
-    // As there have been issues in this area, log details about the screen selection process.
-    NSScreen.log("window!.screen", window!.screen, subsystem: subsystem)
-    NSScreen.log("NSScreen.main", NSScreen.main, subsystem: subsystem)
-    NSScreen.screens.enumerated().forEach { screen in
-      NSScreen.log("NSScreen.screens[\(screen.offset)]" , screen.element, subsystem: subsystem)
-    }
-
-    var screen = window!.selectDefaultScreen()
-
-    if let rectString = UserDefaults.standard.value(forKey: "MainWindowLastPosition") as? String {
-      let rect = NSRectFromString(rectString)
-      if let lastScreen = NSScreen.screens.first(where: { NSPointInRect(rect.origin, $0.visibleFrame) }) {
-        screen = lastScreen
-        NSScreen.log("MainWindowLastPosition \(rect.origin) matched", screen, subsystem: subsystem)
-      }
-    }
-
-    if shouldApplyInitialWindowSize, let wfg = windowFrameFromGeometry(newSize: AppData.sizeWhenNoVideo, screen: screen) {
-      window!.setFrame(wfg, display: true, animate: !Preference.bool(for: PK.disableAnimations))
-    } else {
-      window!.setFrame(AppData.sizeWhenNoVideo.centeredRect(in: screen.visibleFrame), display: true,
-                       animate: !Preference.bool(for: PK.disableAnimations))
-    }
-
-    // Draw black screen before playing a video. This is needed due to window reuse. Displaying a
-    // frame from a previously played video would violate good privacy practices.
-    videoView.videoLayer.draw(forced: true)
-  }
-
   /** A method being called when window open. Pretend to be a window delegate. */
-  override func windowDidOpen() {
-    super.windowDidOpen()
+  override func showWindow(_ sender: Any?) {
+    super.showWindow(sender)
 
-    window!.makeMain()
-    window!.makeKeyAndOrderFront(nil)
     resetCollectionBehavior()
     // update buffer indicator view
     updateBufferIndicatorView()
@@ -2580,7 +2567,10 @@ class MainWindowController: PlayerWindowController {
       if let screenFrame = window.screen?.frame {
         rect = rect.constrain(in: screenFrame)
       }
-      if player.disableWindowAnimation || Preference.bool(for: .disableAnimations) {
+      if !player.mainWindow.window!.isVisible && !player.isInMiniPlayer {
+        window.setFrame(rect, display: false, animate: false)
+        showWindow(nil)
+      } else if player.disableWindowAnimation || Preference.bool(for: .disableAnimations) {
         window.setFrame(rect, display: true, animate: false)
       } else {
         // animated `setFrame` can be inaccurate!

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2569,11 +2569,8 @@ class MainWindowController: PlayerWindowController {
       if let screenFrame = window.screen?.frame {
         rect = rect.constrain(in: screenFrame)
       }
-      if pendingShow && !player.isInMiniPlayer {
-        pendingShow = false
-        window.setFrame(rect, display: false, animate: false)
-        showWindow(nil)
-      } else if player.disableWindowAnimation || Preference.bool(for: .disableAnimations) {
+
+      if player.disableWindowAnimation || Preference.bool(for: .disableAnimations) || !window.isVisible {
         window.setFrame(rect, display: true, animate: false)
       } else {
         // animated `setFrame` can be inaccurate!

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -180,9 +180,6 @@ class MainWindowController: PlayerWindowController {
   var isShowingPersistentOSD = false
   var osdContext: Any?
 
-  /** This variable is true when the window should show but waiting for size from mpv */
-  var pendingShow = false
-
   // MARK: - Enums
 
   // Window state
@@ -2479,7 +2476,7 @@ class MainWindowController: PlayerWindowController {
   }
 
   /** Set window size when info available, or video size changed. */
-  func adjustFrameByVideoSize() {
+  override func handleVideoSizeChange() {
     guard let window = window else { return }
 
     let (width, height) = player.videoSizeForDisplay

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -271,7 +271,8 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
 
   func updateVideoSize() {
     guard let window = window else { return }
-    let (width, height) = defaultAlbumArt.isHidden ? player.videoSizeForDisplay : (1, 1)
+    let w = player.info.displayWidth, h = player.info.displayHeight
+    let (width, height) = (w == 0 && h == 0) ? (1, 1) :  player.videoSizeForDisplay
     let aspect = CGFloat(width) / CGFloat(height)
     let currentHeight = videoView.frame.height
     let newHeight = videoView.frame.width / aspect

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -269,7 +269,7 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     volumeButton.image = image
   }
 
-  func updateVideoSize() {
+  override func handleVideoSizeChange() {
     guard let window = window else { return }
     let w = player.info.displayWidth, h = player.info.displayHeight
     let (width, height) = (w == 0 && h == 0) ? (1, 1) :  player.videoSizeForDisplay
@@ -282,10 +282,6 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     var frame = window.frame
     frame.size.height += newHeight - currentHeight - 0.5
     window.setFrame(frame, display: true, animate: false)
-
-    if !window.isVisible {
-      showWindow(self)
-    }
   }
 
   func updateVideoViewAspectConstraint(withAspect aspect: CGFloat) {

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -281,6 +281,10 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     var frame = window.frame
     frame.size.height += newHeight - currentHeight - 0.5
     window.setFrame(frame, display: true, animate: false)
+
+    if !window.isVisible {
+      showWindow(self)
+    }
   }
 
   func updateVideoViewAspectConstraint(withAspect aspect: CGFloat) {

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -551,6 +551,17 @@ class PlayerCore: NSObject {
     }
   }
 
+  /// Swtich the current player to mini player from the main window.
+  ///
+  /// - Parameters:
+  ///     - showMiniPlayer: set to false when this function is called when tracklist is changed.
+  ///     In this case, wait for `MPV_EVENT_VIDEO_RECONFIG` to show the mini player.
+  ///
+  /// This function is called:
+  /// 1) On `trackListChanged`, it will check the current media and settings to determine whether
+  /// or not to switch to mini player automatically
+  /// 2) On user initiated button actions
+  ///
   func switchToMiniPlayer(automatically: Bool = false, showMiniPlayer: Bool = true) {
     log("Switch to mini player, automatically=\(automatically)")
     if !automatically {
@@ -628,6 +639,19 @@ class PlayerCore: NSObject {
     events.emit(.musicModeChanged, data: true)
   }
 
+  /// Swtich the current player to main player from the mini player.
+  ///
+  /// - Parameters:
+  ///     - showMainWindow: set to false when this function is called when tracklist is changed.
+  ///     In this case, wait for `MPV_EVENT_VIDEO_RECONFIG` to show the main window. Also set to false
+  ///     when the mini player is closed.
+  ///
+  /// This function is called:
+  /// 1) On `trackListChanged`, it will check the current media and settings to determine whether
+  /// or not to switch to main window automatically
+  /// 2) On user initiated button actions
+  /// 3) When closing the mini player
+  ///
   func switchBackFromMiniPlayer(automatically: Bool = false, showMainWindow: Bool = true) {
     log("Switch to normal window from mini player, automatically=\(automatically)")
     if !automatically {
@@ -657,9 +681,9 @@ class PlayerCore: NSObject {
     if showMainWindow {
       currentController.setupUI()
       mainWindow.updateTitle()
-      mainWindow.videoView.videoLayer.draw(forced: true)
       notifyWindowVideoSizeChanged()
     }
+    mainWindow.videoView.videoLayer.draw(forced: true)
     events.emit(.musicModeChanged, data: false)
   }
 
@@ -2149,6 +2173,10 @@ class PlayerCore: NSObject {
       miniPlayer.updateVideoSize()
     } else {
       mainWindow.adjustFrameByVideoSize()
+      if mainWindow.pendingShow {
+        mainWindow.pendingShow = false
+        mainWindow.showWindow(self)
+      }
     }
   }
 

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -395,9 +395,9 @@ class PlayerCore: NSObject {
     info.currentFolder = nil
     info.isNetworkResource = isNetwork
 
-    let isFirstLoad = !mainWindow.loaded
     let _ = mainWindow.window
     mainWindow.pendingShow = true
+    miniPlayer.pendingShow = true
     initialWindow.close()
 
     // Send load file command
@@ -632,6 +632,7 @@ class PlayerCore: NSObject {
     }
 
     currentController.setupUI()
+    miniPlayer.pendingShow = true
     if showMiniPlayer {
       notifyWindowVideoSizeChanged()
     }
@@ -2169,14 +2170,10 @@ class PlayerCore: NSObject {
   }
 
   func notifyWindowVideoSizeChanged() {
-    if isInMiniPlayer {
-      miniPlayer.updateVideoSize()
-    } else {
-      mainWindow.adjustFrameByVideoSize()
-      if mainWindow.pendingShow {
-        mainWindow.pendingShow = false
-        mainWindow.showWindow(self)
-      }
+    currentController.handleVideoSizeChange()
+    if currentController.pendingShow {
+      currentController.pendingShow = false
+      currentController.showWindow(self)
     }
   }
 

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -606,8 +606,6 @@ class PlayerCore: NSObject {
 
     isInMiniPlayer = true
 
-    videoView.videoLayer.draw(forced: true)
-
     // restore layout
     if needRestoreLayout {
       if !Preference.bool(for: .musicModeShowAlbumArt) {
@@ -622,6 +620,8 @@ class PlayerCore: NSObject {
     }
 
     currentController.setupUI()
+    notifyMainWindowVideoSizeChanged()
+    videoView.videoLayer.draw(forced: true)
     events.emit(.musicModeChanged, data: true)
   }
 
@@ -650,11 +650,11 @@ class PlayerCore: NSObject {
     miniPlayer.window?.orderOut(nil)
     isInMiniPlayer = false
 
-    mainWindow.videoView.videoLayer.draw(forced: true)
-
     mainWindow.updateTitle()
 
     currentController.setupUI()
+    notifyMainWindowVideoSizeChanged()
+    mainWindow.videoView.videoLayer.draw(forced: true)
     events.emit(.musicModeChanged, data: false)
   }
 

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -653,10 +653,10 @@ class PlayerCore: NSObject {
     miniPlayer.window?.orderOut(nil)
     isInMiniPlayer = false
 
+    mainWindow.pendingShow = true
     if showMainWindow {
       currentController.setupUI()
       mainWindow.updateTitle()
-      mainWindow.pendingShow = true
       mainWindow.videoView.videoLayer.draw(forced: true)
       notifyWindowVideoSizeChanged()
     }

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -398,18 +398,6 @@ class PlayerCore: NSObject {
     let isFirstLoad = !mainWindow.loaded
     let _ = mainWindow.window
     initialWindow.close()
-    if isInMiniPlayer {
-      miniPlayer.showWindow(nil)
-    } else {
-      // we only want to call windowWillOpen when the window is currently closed.
-      // if the window is opened for the first time, it will become visible in windowDidLoad, so we need to check isFirstLoad.
-      // window.isVisible will work from the second time.
-      if isFirstLoad || !mainWindow.window!.isVisible {
-        mainWindow.windowWillOpen()
-      }
-      mainWindow.showWindow(nil)
-      mainWindow.windowDidOpen()
-    }
 
     // Send load file command
     info.justOpenedFile = true

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -559,8 +559,11 @@ class PlayerCore: NSObject {
                  level: .verbose, subsystem: subsystem)
     }
 
+    // hide main window
+    mainWindow.window?.orderOut(self)
+
     let needRestoreLayout = !miniPlayer.loaded
-    miniPlayer.showWindow(self)
+    let _ = miniPlayer.window
 
     miniPlayer.updateTitle()
     refreshSyncUITimer()
@@ -601,8 +604,6 @@ class PlayerCore: NSObject {
       miniPlayer.setToInitialWindowSize(display: true, animate: false)
     }
 
-    // hide main window
-    mainWindow.window?.orderOut(self)
     isInMiniPlayer = true
 
     videoView.videoLayer.draw(forced: true)
@@ -644,15 +645,7 @@ class PlayerCore: NSObject {
                                                                  toItem: mainWindowContentView, attribute: attr, multiplier: 1, constant: 0)
       mainWindow.videoViewConstraints[attr]!.isActive = true
     }
-    // show main window
-    if showMainWindow {
-      mainWindow.window?.makeKeyAndOrderFront(self)
-    }
-    // if aspect ratio is not set
-    let (width, height) = originalVideoSize
-    if width == 0 && height == 0 {
-      mainWindow.window?.aspectRatio = AppData.sizeWhenNoVideo
-    }
+
     // hide mini player
     miniPlayer.window?.orderOut(nil)
     isInMiniPlayer = false

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -513,15 +513,6 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
     performMouseAction(action)
   }
   
-  // MARK: - Window delegate: Open / Close
-  
-  func windowDidOpen() {
-    if Preference.bool(for: .alwaysFloatOnTop) {
-      setWindowFloatingOnTop(true)
-    }
-    videoView.startDisplayLink()
-  }
-  
   // MARK: - Window delegate: Activeness status
 
   func windowDidBecomeMain(_ notification: Notification) {

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -155,6 +155,12 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
 
   internal var mouseActionDisabledViews: [NSView?] {[]}
 
+  /** This variable is true when the window ready to show but waiting for size from mpv.
+   In the `notifyWindowVideoSizeChanged()` call, this variable will be checked and the
+   window will be shown if this variable is true.
+   */
+  internal var pendingShow = false
+
   // MARK: - Initiaization
 
   override func windowDidLoad() {
@@ -534,7 +540,7 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
   }
 
   // MARK: - UI
-  
+
   func setupUI() {
     player.syncUI([.time, .playButton, .volume])
   }
@@ -606,6 +612,10 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
     if (updateOnTopStatus) {
       self.isOntop = onTop
     }
+  }
+
+  func handleVideoSizeChange() {
+    fatalError("Must implement in the subclass")
   }
 
   // MARK: - IBActions


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
---
**Description:**
Thanks to https://github.com/iina/iina/pull/5029, now initiating rendering doesn't require a forced draw to the main window. Previously, IINA first draw the video in a small window, then resize to the desired window size. This PR change the behavior to show the main window after the geometry is calculated, therefore no resizing animation is required, the window will show directly to the final size.

Specifically, this PR:
- Removed `windowWillOpen()` and moved contents to newly added `override showWindow(_:)`
- Removed `windowDidOpen()` and moved contents to the end of `windowDidLoad()`
  - `PlayerWindowController.windowDidOpen()` also got removed.
- Removed code which explicitly shows the main window when opening media and creating the main window
- Calls `showWindow(_:)` after the final window geometry is calculated and set as the window frame
- Show mini player after videoreconfig

`windowWillOpen()` and `windowDidOpen()` are not standard NSWindow functions, and they are easy to be confused with other NSWindow lifecycle functions, so I moved them and move the code into override functions.

The current implementation is far from clean, but in order to not refactor too much code, I only made changes to necessary parts. Also I feel the animation for changing modes (music -> normal and reverse) bit clunky and not consistent, but that's not in the scope of this PR.

**Demo:**
Before:
https://github.com/iina/iina/assets/20237141/241eca90-66b5-47e9-92c1-551316fc1e36

After:
https://github.com/iina/iina/assets/20237141/3ea7629e-38b2-47ba-ba5c-9c36c9707990

