### PR TITLE
Show OSD for loop status change when related option changes

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -1305,7 +1305,18 @@ class MPVController: NSObject {
       }
 
     case MPVOption.PlaybackControl.loopPlaylist, MPVOption.PlaybackControl.loopFile:
-      DispatchQueue.main.async { self.player.syncUI(.loop) }
+      DispatchQueue.main.async { [self] in
+        let loopMode = player.getLoopMode()
+        switch loopMode {
+        case .file:
+          player.sendOSD(.fileLoop)
+        case .playlist:
+          player.sendOSD(.playlistLoop)
+        default:
+          player.sendOSD(.noLoop)
+        }
+        player.syncUI(.loop)
+      }
 
     case MPVOption.Video.deinterlace:
       guard let data = UnsafePointer<Bool>(OpaquePointer(property.data))?.pointee else {

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1008,14 +1008,11 @@ class PlayerCore: NSObject {
     case .playlist:
       mpv.setString(MPVOption.PlaybackControl.loopPlaylist, "inf")
       mpv.setString(MPVOption.PlaybackControl.loopFile, "no")
-      sendOSD(.playlistLoop)
     case .file:
       mpv.setString(MPVOption.PlaybackControl.loopFile, "inf")
-      sendOSD(.fileLoop)
     case .off:
       mpv.setString(MPVOption.PlaybackControl.loopPlaylist, "no")
       mpv.setString(MPVOption.PlaybackControl.loopFile, "no")
-      sendOSD(.noLoop)
     }
   }
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4841.

---

**Description:**
Listen to `MPVOption.PlaybackControl.loopFile` and `MPVOption.PlaybackControl.loopPlaylist` to display OSDs for loop status changes.