### PR TITLE
Fix crash while quitting in mpv_render_context_free, #5031

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -688,6 +688,9 @@ class MPVController: NSObject {
     defer { unlockOpenGLContext() }
     mpv_render_context_set_update_callback(mpvRenderContext, nil, nil)
     mpv_render_context_free(mpvRenderContext)
+    self.mpvRenderContext = nil
+    mpv_destroy(mpv)
+    mpv = nil
   }
 
   func mpvReportSwap() {
@@ -721,7 +724,7 @@ class MPVController: NSObject {
     mpv_unobserve_property(mpv, 0)
     // Start mpv quitting. Even though this command is being sent using the synchronous
     // command API the quit command is special and will be executed by mpv asynchronously.
-    command(.quit)
+    command(.quit, level: .verbose)
   }
 
   // MARK: - Command & property
@@ -1030,17 +1033,6 @@ class MPVController: NSObject {
     }
   }
 
-  /// Tell Cocoa to terminate the application.
-  ///
-  /// - Note: This code must be in a method that can be a target of a selector in order to support macOS 10.11.
-  ///     The `perform` method in `RunLoop` that accepts a closure was introduced in macOS 10.12. If IINA drops
-  ///     support for 10.11 then the code in this method can be moved to the closure in `handleEvent and this
-  ///     method can then be removed.`
-  @objc
-  internal func terminateApplication() {
-    NSApp.terminate(nil)
-  }
-
   // Handle the event
   private func handleEvent(_ event: UnsafePointer<mpv_event>!) {
     let eventId = event.pointee.event_id
@@ -1049,34 +1041,14 @@ class MPVController: NSObject {
     case MPV_EVENT_SHUTDOWN:
       let quitByMPV = !player.isShuttingDown
       if quitByMPV {
-        // This happens when the user presses "q" in a player window and the quit command is sent
-        // directly to mpv. The user could also use mpv's IPC interface to send the quit command to
+        // This happens when the user uses mpv's IPC interface to send the quit command directly to
         // mpv. Must not attempt to change a mpv setting in response to an IINA preference change
         // now that mpv has shut down. This is not needed when IINA sends the quit command to mpv
         // as in that case the observers are removed before the quit command is sent.
         removeOptionObservers()
-        // Submit the following task synchronously to ensure it is done before application
-        // termination is started.
-        DispatchQueue.main.sync {
-          self.player.mpvHasShutdown(isMPVInitiated: true)
-        }
-        // Initiate application termination. AppKit requires this be done from the main thread,
-        // however the main dispatch queue must not be used to avoid blocking the queue as per
-        // instructions from Apple.
-        if #available(macOS 10.12, *) {
-          RunLoop.main.perform(inModes: [.common]) {
-            self.terminateApplication()
-          }
-        } else {
-          RunLoop.main.perform(#selector(self.terminateApplication), target: self,
-                               argument: nil, order: Int.min, modes: [.common])
-        }
-      } else {
-        mpv_destroy(mpv)
-        mpv = nil
-        DispatchQueue.main.async {
-          self.player.mpvHasShutdown()
-        }
+      }
+      DispatchQueue.main.async {
+        self.player.mpvHasShutdown(isMPVInitiated: quitByMPV)
       }
 
     case MPV_EVENT_LOG_MESSAGE:

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -244,6 +244,18 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
         abLoop()
         returnValue = 0
 
+      case MPVCommand.quit.rawValue:
+        // Initiate application termination. AppKit requires this be done from the main thread,
+        // however the main dispatch queue must not be used to avoid blocking the queue as per
+        // instructions from Apple. IINA must support quitting being initiated by mpv as the user
+        // could use mpv's IPC interface to send the quit command directly to mpv. However the
+        // shutdown sequence is cleaner when initiated by IINA, so we do not send the quit command
+        // to mpv and instead trigger the normal app termination sequence.
+        RunLoop.main.perform(inModes: [.common]) {
+          NSApp.terminate(nil)
+        }
+        returnValue = 0
+
       case MPVCommand.screenshot.rawValue:
         return player.screenshot(fromKeyBinding: keyBinding)
         

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -92,7 +92,7 @@ class VideoView: NSView {
       guard !isUninited else { return }
       isUninited = true
 
-      videoLayer.suspend()
+      stopDisplayLink()
       player.mpv.mpvUninitRendering()
     }
   }


### PR DESCRIPTION
This commit will:
- Move the call to `mpv_destroy` in `MPVController` from `handleEvent` to `mpvUninitRendering`
- Move the call to `NSApp.terminate` in `MPVController` from `handleEvent` to `PlayerCore.mpvHasShutdown`
- Add call to `NSApp.terminate` in `PlayerWindowController.handleKeyBinding` for when a key is bound to the mpv `quit` command
- Remove call to `VideoLayer.suspend` from `VideoView.uninit`
- Move call to `stopDisplayLink` from `PlayerCore.uninitVideo` to `VideoView.uninit`
- Change code in `MainWindowController` that checks `isClosing` to instead check the player status
- Remove i`sClosing` property from `MainWindowController`

These changes cause uninitializing the video, which involves calling `mpv_render_context_free`, to be done after the `quit` command finishes instead of before. This also changes the call to `mpv_destroy` to be performed right after the call to `mpv_render_context_free` with the OpenGL context locked. This matches how mpv uses `mpv_destroy`.

This also changes the behavior of keys bound to the mpv `quit` command. Previously the `quit` command would be passed to mpv. With this commit the key press starts the normal app termination sequence.

Testing proved the `isClosing` flag did not cover all cases and the state of the player needed to be checked.

The crash in `mpv_render_context_free` could not be reproduced, so it is not known for certain that these changes fixed issue #5031.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5031.

---

**Description:**
