### PR TITLE
Fix order of locking OpenGL context

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -683,8 +683,6 @@ class MPVController: NSObject {
 
   func mpvUninitRendering() {
     guard let mpvRenderContext = mpvRenderContext else { return }
-    lockAndSetOpenGLContext()
-    defer { unlockOpenGLContext() }
     mpv_render_context_set_update_callback(mpvRenderContext, nil, nil)
     mpv_render_context_free(mpvRenderContext)
   }

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -90,6 +90,8 @@ class VideoView: NSView {
   /// - Important: Once mpv has been instructed to quit accessing the mpv core can result in a crash, therefore locks must be
   ///     used to coordinate uninitializing the view so that other threads do not attempt to use the mpv core while it is shutting down.
   func uninit() {
+    player.mpv.lockAndSetOpenGLContext()
+    defer { player.mpv.unlockOpenGLContext() }
     $isUninited.withLock() { isUninited in
       guard !isUninited else { return }
       isUninited = true

--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -151,12 +151,14 @@ class ViewLayer: CAOpenGLLayer {
         return
       }
       guard needsMPVRender else { return }
-
-      // Neither canDraw nor draw(inCGLContext:) were called by AppKit, needs a skip render.
-      // This can happen when IINA is playing in another space, as might occur when just playing
-      // audio. See issue #5025.
-      videoView.player.mpv.lockAndSetOpenGLContext()
-      defer { videoView.player.mpv.unlockOpenGLContext() }
+    }
+    // Neither canDraw nor draw(inCGLContext:) were called by AppKit, needs a skip render.
+    // This can happen when IINA is playing in another space, as might occur when just playing
+    // audio. See issue #5025.
+    videoView.player.mpv.lockAndSetOpenGLContext()
+    defer { videoView.player.mpv.unlockOpenGLContext() }
+    videoView.$isUninited.withLock() { isUninited in
+      guard !isUninited else { return }
       if let renderContext = videoView.player.mpv.mpvRenderContext,
          videoView.player.mpv.shouldRenderUpdateFrame() {
         var skip: CInt = 1


### PR DESCRIPTION
This commit will change `ViewLayer.display` and `MPVController.mpvUninitRendering` to lock the OpenGL context before locking `VideoView.isUninited`. This order is required to be compatible with the locking performed by `CAOpenGLLayer`.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
