### PR TITLE
Honor “open in new window” setting when opening multiple files at once

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -720,7 +720,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 
     // open pending files
     pendingFilesForOpenFile.removeAll()
-    if PlayerCore.activeOrNew.openURLs(urls) == 0 {
+    if PlayerCore.openURLs(urls) == 0 {
       Utility.showAlert("nothing_to_open")
     }
   }
@@ -882,8 +882,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         }
       }
       let isAlternative = (sender as? NSMenuItem)?.tag == AlternativeMenuItemTag
-      let playerCore = PlayerCore.activeOrNewForMenuAction(isAlternative: isAlternative)
-      if playerCore.openURLs(panel.urls) == 0 {
+      if PlayerCore.openURLs(panel.urls, inverseOpenInNewWindowPref: isAlternative) == 0 {
         Utility.showAlert("nothing_to_open")
       }
     }

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -104,6 +104,16 @@ class PlayerCore: NSObject {
     if shouldOpenInSeparateWindows {
       // open each url in its own window. accumulate the return values
       return urls.reduce(nil) { currentReturnValue, url in
+        // skip if url is already open in some player
+        let activePlayerCores = playerCores.filter { $0.info.state != .idle }
+        let relevantActivePlayerCore = activePlayerCores.first { $0.info.currentURL == url }
+
+        if let relevantActivePlayerCore {
+          relevantActivePlayerCore.mainWindow.window?.makeKeyAndOrderFront(nil)
+          return currentReturnValue
+        }
+
+        // open url, combine result into return value
         let openResult = newPlayerCore.openURLs([url])
 
         if let openResult {


### PR DESCRIPTION
- [X] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)

---

## Motivation

Right now, when opening multiple files at once (e.g. dragging them on the app's Dock icon), IINA opens a single window, with the files as playlist items—even when the “Always open media in new window” setting is on.
To me, this isn't the expected behavior; this setting essentially allows user to choose between “I prefer using a single window with a playlist” and “I prefer using one window for each file”, and the batch open behavior fails to honor that preference.

(As a personal data point: for the longest time I thought this was a bug in IINA, that it failed to open multiple files at once; not realizing a playlist was being created. It's only when I started digging into the source to fix the bug that I discovered the actual behavior.)

## Change

With this PR, the app instead opens each file in its own window, if the `alwaysOpenInNewWindow` setting is true. If the setting is false, the current behavior is kept.

## Bonus change

The PR also fixes a related bug (when the “When media is opened > Pause” setting is enabled) where opening multiple files at once sometimes allows them to play for a while before being paused