### PR TITLE
Combine separate flags into a player state property

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -166,6 +166,7 @@
 		519CCABD2BFFAEF10079DCAF /* HardwareDecodeCapabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519CCABC2BFFAEF10079DCAF /* HardwareDecodeCapabilities.swift */; };
 		51AC1CAB2A9FBF3700DF7079 /* OpenSubClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC1CAA2A9FBF3700DF7079 /* OpenSubClient.swift */; };
 		51C1BA3A291CA76700C1208A /* InfoDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C1BA39291CA76700C1208A /* InfoDictionary.swift */; };
+		51C889D52C42FF7F007B2584 /* PlayerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C889D42C42FF7F007B2584 /* PlayerState.swift */; };
 		51CACB9529D500290034CEE5 /* VideoPIPViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51CACB9429D500290034CEE5 /* VideoPIPViewController.swift */; };
 		51DE55C92A6646710050AD06 /* Sysctl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DE55C82A6646710050AD06 /* Sysctl.swift */; };
 		51E63DFB29CFB031008AFC20 /* PlaySlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E63DFA29CFB031008AFC20 /* PlaySlider.swift */; };
@@ -313,9 +314,9 @@
 		B4E446F725CB54EF0069F06E /* Mustache in Frameworks */ = {isa = PBXBuildFile; productRef = B4E446F625CB54EF0069F06E /* Mustache */; };
 		B4E4470125CE3F930069F06E /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = B4E4470025CE3F930069F06E /* Sparkle */; };
 		C789872F1E34EF170005769F /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = C78987311E34EF170005769F /* InfoPlist.strings */; };
+		D17504A82918F13E005C3DD0 /* OSCToolbarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17504A72918F13E005C3DD0 /* OSCToolbarButton.swift */; };
 		D1A4D98A2B1495270009AB4E /* LegacyMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A4D9892B1495270009AB4E /* LegacyMigration.swift */; };
 		D1B4E24E2A3AFC9100E36F1D /* MiniPlayerWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1B4E24D2A3AFC9100E36F1D /* MiniPlayerWindow.swift */; };
-		D17504A82918F13E005C3DD0 /* OSCToolbarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17504A72918F13E005C3DD0 /* OSCToolbarButton.swift */; };
 		E301EFDA21312AB300BC8588 /* KeychainAccess.swift in Sources */ = {isa = PBXBuildFile; fileRef = E301EFD921312AB300BC8588 /* KeychainAccess.swift */; };
 		E30D2EBD21F5FD2600E1FF0D /* PluginOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E30D2EBC21F5FD2600E1FF0D /* PluginOverlayView.swift */; };
 		E322A4F820A8442E00C67D32 /* PlaylistPlaybackProgressView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E322A4F720A8442E00C67D32 /* PlaylistPlaybackProgressView.swift */; };
@@ -1163,6 +1164,7 @@
 		51AC1CAA2A9FBF3700DF7079 /* OpenSubClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSubClient.swift; sourceTree = "<group>"; };
 		51C1BA39291CA76700C1208A /* InfoDictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InfoDictionary.swift; sourceTree = "<group>"; };
 		51C3ED782C234BFA004546F9 /* imgutils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = imgutils.h; sourceTree = "<group>"; };
+		51C889D42C42FF7F007B2584 /* PlayerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerState.swift; sourceTree = "<group>"; };
 		51CACB9429D500290034CEE5 /* VideoPIPViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPIPViewController.swift; sourceTree = "<group>"; };
 		51DE55C82A6646710050AD06 /* Sysctl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sysctl.swift; sourceTree = "<group>"; };
 		51E63DFA29CFB031008AFC20 /* PlaySlider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaySlider.swift; sourceTree = "<group>"; };
@@ -1738,9 +1740,9 @@
 		C7DBA5EB1F07C5FD00C2B416 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/InitialWindowController.strings; sourceTree = "<group>"; };
 		C7DC79CE1EC63821002DE23B /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/HistoryWindowController.strings; sourceTree = "<group>"; };
 		C7E90B522087EC5700A58B6B /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/SubChooseViewController.strings; sourceTree = "<group>"; };
+		D17504A72918F13E005C3DD0 /* OSCToolbarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSCToolbarButton.swift; sourceTree = "<group>"; };
 		D1A4D9892B1495270009AB4E /* LegacyMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyMigration.swift; sourceTree = "<group>"; };
 		D1B4E24D2A3AFC9100E36F1D /* MiniPlayerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerWindow.swift; sourceTree = "<group>"; };
-		D17504A72918F13E005C3DD0 /* OSCToolbarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSCToolbarButton.swift; sourceTree = "<group>"; };
 		D27556FC1EC6E1C300CAB2A4 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/HistoryWindowController.strings"; sourceTree = "<group>"; };
 		D27E35CE1E379B6D0064BE57 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/MainMenu.strings"; sourceTree = "<group>"; };
 		D27E35CF1E379B6D0064BE57 /* zh-Hant */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hant"; path = "zh-Hant.lproj/MainWindowController.strings"; sourceTree = "<group>"; };
@@ -2569,6 +2571,7 @@
 				E3958564253133E80096811F /* SidebarTabView.xib */,
 				512B8FDC2BC2376E00AF41BF /* OutlineView.swift */,
 				D17504A72918F13E005C3DD0 /* OSCToolbarButton.swift */,
+				51C889D42C42FF7F007B2584 /* PlayerState.swift */,
 			);
 			name = Accessories;
 			sourceTree = "<group>";
@@ -3122,6 +3125,7 @@
 				84C6D3621EAF8D63009BF721 /* HistoryController.swift in Sources */,
 				E38B3213214FB9EA000F6D27 /* PrefPluginPermissionView.swift in Sources */,
 				51E63DFD29CFB04C008AFC20 /* PlaySliderLoopKnob.swift in Sources */,
+				51C889D52C42FF7F007B2584 /* PlayerState.swift in Sources */,
 				847644081D48B413004F6DF5 /* MPVOption.swift in Sources */,
 				84817C961DBDCA5F00CC2279 /* SettingsListCellView.swift in Sources */,
 				84A886F31E26CA24008755BB /* Regex.swift in Sources */,

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -429,9 +429,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
       // For debugging list players that have not terminated.
       for player in PlayerCore.playerCores {
         let label = player.label ?? "unlabeled"
-        if !player.isStopped {
+        if player.info.state == .stopping {
           Logger.log("Player \(label) failed to stop", level: .warning)
-        } else if !player.isShutdown {
+        } else if player.info.state == .shuttingDown {
           Logger.log("Player \(label) failed to shutdown", level: .warning)
         }
       }
@@ -501,7 +501,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     // termination is initiated.
     allPlayersHaveShutdown = true
     for player in PlayerCore.playerCores {
-      if !player.isShutdown {
+      if player.info.state != .shutDown {
         allPlayersHaveShutdown = false
         break
       }
@@ -585,7 +585,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
       if !allPlayersHaveShutdown {
         // If any player has not shutdown then continue waiting.
         for player in PlayerCore.playerCores {
-          guard player.isShutdown else { return }
+          guard player.info.state == .shutDown else { return }
         }
         allPlayersHaveShutdown = true
         // All players have shutdown.
@@ -646,7 +646,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 
     // Instruct any players that are already stopped to start shutting down.
     for player in PlayerCore.playerCores {
-      if player.isStopped && !player.isShutdown {
+      if player.info.state == .stopped || player.info.state == .idle {
         player.shutdown()
       }
     }

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -646,7 +646,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 
     // Instruct any players that are already stopped to start shutting down.
     for player in PlayerCore.playerCores {
-      if player.info.state == .stopped || player.info.state == .idle {
+      if player.info.state == .idle {
         player.shutdown()
       }
     }

--- a/iina/FilterWindowController.swift
+++ b/iina/FilterWindowController.swift
@@ -103,7 +103,7 @@ class FilterWindowController: NSWindowController, NSWindowDelegate {
     // notification to be posted and that results in the observer established above calling this
     // method. Thus this method may be called after IINA has commanded mpv to shutdown. Once mpv has
     // been told to shutdown mpv APIs must not be called as it can trigger a crash in mpv.
-    guard !pc.isShuttingDown, !pc.isShutdown else { return }
+    guard pc.info.isActive else { return }
     filters = pc.mpv.getFilters(filterType)
     filterIsSaved = [Bool](repeatElement(false, count: filters.count))
     savedFilters.forEach { savedFilter in

--- a/iina/FilterWindowController.swift
+++ b/iina/FilterWindowController.swift
@@ -103,7 +103,7 @@ class FilterWindowController: NSWindowController, NSWindowDelegate {
     // notification to be posted and that results in the observer established above calling this
     // method. Thus this method may be called after IINA has commanded mpv to shutdown. Once mpv has
     // been told to shutdown mpv APIs must not be called as it can trigger a crash in mpv.
-    guard pc.info.isActive else { return }
+    guard pc.info.state.active else { return }
     filters = pc.mpv.getFilters(filterType)
     filterIsSaved = [Bool](repeatElement(false, count: filters.count))
     savedFilters.forEach { savedFilter in

--- a/iina/InspectorWindowController.swift
+++ b/iina/InspectorWindowController.swift
@@ -157,7 +157,7 @@ class InspectorWindowController: NSWindowController, NSWindowDelegate, NSTableVi
 
   func updateInfo(dynamic: Bool = false) {
     let player = PlayerCore.lastActive
-    guard player.info.isActive else { return }
+    guard player.info.state.active else { return }
     let controller = player.mpv!
     let info = player.info
 
@@ -261,8 +261,9 @@ class InspectorWindowController: NSWindowController, NSWindowDelegate, NSTableVi
         : "N/A";
       self.setLabelColor(self.vprimariesField, by: sigPeak > 0)
 
-      if PlayerCore.lastActive.mainWindow.loaded && controller.fileLoaded {
-        if let colorspace = PlayerCore.lastActive.mainWindow.videoView.videoLayer.colorspace {
+      let player = PlayerCore.lastActive
+      if player.mainWindow.loaded && player.info.state.loaded {
+        if let colorspace = player.mainWindow.videoView.videoLayer.colorspace {
           let isHdr = colorspace != VideoView.SRGB
           self.vcolorspaceField.stringValue = "\(colorspace.name!) (\(isHdr ? "H" : "S")DR)"
         } else {
@@ -271,9 +272,9 @@ class InspectorWindowController: NSWindowController, NSWindowDelegate, NSTableVi
       } else {
         self.vcolorspaceField.stringValue = "N/A"
       }
-      self.setLabelColor(self.vcolorspaceField, by: controller.fileLoaded)
+      self.setLabelColor(self.vcolorspaceField, by: player.info.state.loaded)
 
-      if PlayerCore.lastActive.mainWindow.loaded && controller.fileLoaded {
+      if player.mainWindow.loaded && player.info.state.loaded {
         if let hwPf = controller.getString(MPVProperty.videoParamsHwPixelformat) {
           self.vPixelFormat.stringValue = "\(hwPf) (HW)"
         } else if let swPf = controller.getString(MPVProperty.videoParamsPixelformat) {
@@ -282,7 +283,7 @@ class InspectorWindowController: NSWindowController, NSWindowDelegate, NSTableVi
           self.vPixelFormat.stringValue = "N/A"
         }
       }
-      self.setLabelColor(self.vPixelFormat, by: controller.fileLoaded)
+      self.setLabelColor(self.vPixelFormat, by: player.info.state.loaded)
     }
   }
 
@@ -347,7 +348,7 @@ class InspectorWindowController: NSWindowController, NSWindowDelegate, NSTableVi
       let player = PlayerCore.lastActive
 
       if let textField = cell.textField {
-        if player.info.isActive, let value = player.mpv.getString(property) {
+        if player.info.state.active, let value = player.mpv.getString(property) {
           textField.stringValue = value
           textField.textColor = .labelColor
         } else {

--- a/iina/InspectorWindowController.swift
+++ b/iina/InspectorWindowController.swift
@@ -157,7 +157,7 @@ class InspectorWindowController: NSWindowController, NSWindowDelegate, NSTableVi
 
   func updateInfo(dynamic: Bool = false) {
     let player = PlayerCore.lastActive
-    guard !player.isStopping, !player.isStopped, !player.isShuttingDown, !player.isShutdown else { return }
+    guard player.info.isActive else { return }
     let controller = player.mpv!
     let info = player.info
 
@@ -347,8 +347,7 @@ class InspectorWindowController: NSWindowController, NSWindowDelegate, NSTableVi
       let player = PlayerCore.lastActive
 
       if let textField = cell.textField {
-        if !player.isStopping, !player.isStopped, !player.isShuttingDown, !player.isShutdown,
-            let value = PlayerCore.lastActive.mpv.getString(property) {
+        if player.info.isActive, let value = player.mpv.getString(property) {
           textField.stringValue = value
           textField.textColor = .labelColor
         } else {

--- a/iina/JavascriptAPICore.swift
+++ b/iina/JavascriptAPICore.swift
@@ -307,9 +307,9 @@ fileprivate class StatusAPI: JavascriptAPI, CoreSubAPIExportable {
   func __proxyGet(_ prop: String) -> Any? {
     switch prop {
     case "paused":
-      return !player!.info.isPlaying
+      return player!.info.state == .paused
     case "idle":
-      return player!.info.isIdle
+      return player!.info.state == .idle
     case "position":
       return player!.info.videoPosition?.second ?? NSNull()
     case "duration":

--- a/iina/JavascriptAPIPlaylist.swift
+++ b/iina/JavascriptAPIPlaylist.swift
@@ -25,7 +25,7 @@ class JavascriptAPIPlaylist: JavascriptAPI, JavascriptAPIPlaylistExportable {
   var menuItemBuilder: JSManagedValue?
 
   private func isPlaying() -> Bool {
-    if player!.info.isIdle {
+    if player!.info.state == .idle {
       log("Playlist API is only available when playing files.", level: .error)
       return false
     }

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -1122,7 +1122,7 @@ class MPVController: NSObject {
     case MPV_EVENT_END_FILE:
       let reason = event!.pointee.data.load(as: mpv_end_file_reason.self)
       DispatchQueue.main.async {
-        self.player.fileEnded(doToStopCommand: reason == MPV_END_FILE_REASON_STOP)
+        self.player.fileEnded(dueToStopCommand: reason == MPV_END_FILE_REASON_STOP)
       }
 
     case MPV_EVENT_COMMAND_REPLY:

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -1088,7 +1088,7 @@ class MPVController: NSObject {
 
     case MPV_EVENT_SEEK:
       DispatchQueue.main.async { [self] in
-        player.info.state = .seeking
+        player.info.isSeeking = true
         // When playback is paused the display link may be shutdown in order to not waste energy.
         // It must be running when seeking to avoid slowdowns caused by mpv waiting for IINA to call
         // mpv_render_report_swap.
@@ -1105,6 +1105,7 @@ class MPVController: NSObject {
 
     case MPV_EVENT_PLAYBACK_RESTART:
       DispatchQueue.main.async { [self] in
+        player.info.isSeeking = false
         // When playback is paused the display link may be shutdown in order to not waste energy.
         // The display link will be restarted while seeking. If playback is paused shut it down
         // again.

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -107,7 +107,7 @@ extension MainMenuActionHandler {
   }
 
   @objc func menuStepFrame(_ sender: NSMenuItem) {
-    if player.info.isPlaying {
+    if player.info.state == .playing {
       player.pause()
     }
     if sender.tag == 0 { // -> 1f

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2714,7 +2714,7 @@ class MainWindowController: PlayerWindowController {
   }
 
   func updateNetworkState() {
-    let needShowIndicator = player.info.pausedForCache || player.info.state == .seeking
+    let needShowIndicator = player.info.pausedForCache || player.info.isSeeking
 
     if needShowIndicator {
       let usedStr = FloatingPointByteCountFormatter.string(fromByteCount: player.info.cacheUsed, prefixedBy: .ki)

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -242,7 +242,7 @@ class MainWindowController: PlayerWindowController {
   var fsState: FullScreenState = .windowed {
     didSet {
       // Must not access mpv while it is asynchronously processing stop and quit commands.
-      guard !player.isStopping, !player.isStopped, !player.isShuttingDown, !player.isShutdown else { return }
+      guard player.info.isActive else { return }
       switch fsState {
       case .fullscreen: player.mpv.setFlag(MPVOption.Window.fullscreen, true)
       case .animating:  break
@@ -1395,7 +1395,7 @@ class MainWindowController: PlayerWindowController {
     // operation is processed asynchronously by mpv. If the window is being closed due to IINA
     // quitting then mpv could be in the process of shutting down. Must not access mpv while it is
     // asynchronously processing stop and quit commands.
-    guard !player.isStopping, !player.isStopped, !player.isShuttingDown, !player.isShutdown else { return }
+    guard player.info.isActive else { return }
     videoView.videoLayer.suspend()
     player.mpv.setFlag(MPVOption.Window.keepaspect, false)
   }
@@ -1432,7 +1432,7 @@ class MainWindowController: PlayerWindowController {
 
     // Must not access mpv while it is asynchronously processing stop and quit commands.
     // See comments in windowWillExitFullScreen for details.
-    guard !player.isStopping, !player.isStopped, !player.isShuttingDown, !player.isShutdown else { return }
+    guard player.info.isActive else { return }
     showUI()
     updateTimer()
 
@@ -1674,7 +1674,7 @@ class MainWindowController: PlayerWindowController {
   func windowDidEndLiveResize(_ notification: Notification) {
     // Must not access mpv while it is asynchronously processing stop and quit commands.
     // See comments in windowWillExitFullScreen for details.
-    guard !player.isStopping, !player.isStopped, !player.isShuttingDown, !player.isShutdown else { return }
+    guard player.info.isActive else { return }
     videoView.videoSize = window!.convertToBacking(videoView.bounds).size
     videoView.videoLayer.isAsynchronous = false
     updateWindowParametersForMPV()
@@ -2938,7 +2938,7 @@ class MainWindowController: PlayerWindowController {
   /** When slider changes */
   @IBAction override func playSliderChanges(_ sender: NSSlider) {
     // guard let event = NSApp.currentEvent else { return }
-    guard !player.info.fileLoading else { return }
+    guard player.info.isActive, player.info.state != .loading else { return }
     super.playSliderChanges(sender)
 
     // seek and update time

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -242,7 +242,7 @@ class MainWindowController: PlayerWindowController {
   var fsState: FullScreenState = .windowed {
     didSet {
       // Must not access mpv while it is asynchronously processing stop and quit commands.
-      guard player.info.isActive else { return }
+      guard player.info.state.active else { return }
       switch fsState {
       case .fullscreen: player.mpv.setFlag(MPVOption.Window.fullscreen, true)
       case .animating:  break
@@ -1336,7 +1336,7 @@ class MainWindowController: PlayerWindowController {
       fadeableViews.append(additionalInfoView)
     }
 
-    if player.info.isPaused {
+    if player.info.state == .paused {
       if Preference.bool(for: .playWhenEnteringFullScreen) {
         player.resume()
       } else {
@@ -1395,7 +1395,7 @@ class MainWindowController: PlayerWindowController {
     // operation is processed asynchronously by mpv. If the window is being closed due to IINA
     // quitting then mpv could be in the process of shutting down. Must not access mpv while it is
     // asynchronously processing stop and quit commands.
-    guard player.info.isActive else { return }
+    guard player.info.state.active else { return }
     videoView.videoLayer.suspend()
     player.mpv.setFlag(MPVOption.Window.keepaspect, false)
   }
@@ -1417,7 +1417,7 @@ class MainWindowController: PlayerWindowController {
       removeBlackWindow()
     }
 
-    if player.info.isPaused {
+    if player.info.state == .paused {
       // When playback is paused the display link is stopped in order to avoid wasting energy on
       // needless processing. It must be running while transitioning from full screen mode. Now that
       // the transition has completed it can be stopped.
@@ -1432,7 +1432,7 @@ class MainWindowController: PlayerWindowController {
 
     // Must not access mpv while it is asynchronously processing stop and quit commands.
     // See comments in windowWillExitFullScreen for details.
-    guard player.info.isActive else { return }
+    guard player.info.state.active else { return }
     showUI()
     updateTimer()
 
@@ -1441,12 +1441,12 @@ class MainWindowController: PlayerWindowController {
     videoView.layoutSubtreeIfNeeded()
     videoView.videoLayer.resume()
 
-    if Preference.bool(for: .pauseWhenLeavingFullScreen) && player.info.isPlaying {
+    if Preference.bool(for: .pauseWhenLeavingFullScreen) && player.info.state == .playing {
       player.pause()
     }
 
     // restore ontop status
-    if player.info.isPlaying {
+    if player.info.state == .playing {
       setWindowFloatingOnTop(isOntop, updateOnTopStatus: false)
     }
 
@@ -1674,7 +1674,7 @@ class MainWindowController: PlayerWindowController {
   func windowDidEndLiveResize(_ notification: Notification) {
     // Must not access mpv while it is asynchronously processing stop and quit commands.
     // See comments in windowWillExitFullScreen for details.
-    guard player.info.isActive else { return }
+    guard player.info.state.active else { return }
     videoView.videoSize = window!.convertToBacking(videoView.bounds).size
     videoView.videoLayer.isAsynchronous = false
     updateWindowParametersForMPV()
@@ -1713,7 +1713,7 @@ class MainWindowController: PlayerWindowController {
     if NSApp.keyWindow == nil ||
       (NSApp.keyWindow?.windowController is MainWindowController ||
         (NSApp.keyWindow?.windowController is MiniPlayerWindowController && NSApp.keyWindow?.windowController != player.miniPlayer)) {
-      if Preference.bool(for: .pauseWhenInactive), player.info.isPlaying {
+      if Preference.bool(for: .pauseWhenInactive), player.info.state == .playing {
         player.pause()
         isPausedDueToInactive = true
       }
@@ -1738,7 +1738,7 @@ class MainWindowController: PlayerWindowController {
   }
 
   func windowWillMiniaturize(_ notification: Notification) {
-    if Preference.bool(for: .pauseWhenMinimized), player.info.isPlaying {
+    if Preference.bool(for: .pauseWhenMinimized), player.info.state == .playing {
       isPausedDueToMiniaturization = true
       player.pause()
     }
@@ -2203,7 +2203,7 @@ class MainWindowController: PlayerWindowController {
       return
     }
 
-    isPausedPriorToInteractiveMode = player.info.isPaused
+    isPausedPriorToInteractiveMode = player.info.state == .paused
     player.pause()
     isInInteractiveMode = true
     hideUI()
@@ -2714,7 +2714,7 @@ class MainWindowController: PlayerWindowController {
   }
 
   func updateNetworkState() {
-    let needShowIndicator = player.info.pausedForCache || player.info.isSeeking
+    let needShowIndicator = player.info.pausedForCache || player.info.state == .seeking
 
     if needShowIndicator {
       let usedStr = FloatingPointByteCountFormatter.string(fromByteCount: player.info.cacheUsed, prefixedBy: .ki)
@@ -2749,7 +2749,7 @@ class MainWindowController: PlayerWindowController {
 
   @IBAction override func playButtonAction(_ sender: NSButton) {
     super.playButtonAction(sender)
-    if (player.info.isPaused) {
+    if player.info.state == .paused {
       // speed is already reset by playerCore
       speedValueIndex = AppData.availableSpeedValues.count / 2
       leftArrowLabel.isHidden = true
@@ -2938,7 +2938,7 @@ class MainWindowController: PlayerWindowController {
   /** When slider changes */
   @IBAction override func playSliderChanges(_ sender: NSSlider) {
     // guard let event = NSApp.currentEvent else { return }
-    guard player.info.isActive, player.info.state != .loading else { return }
+    guard player.info.state.active, player.info.state != .loading else { return }
     super.playSliderChanges(sender)
 
     // seek and update time
@@ -3001,7 +3001,7 @@ extension MainWindowController: PIPViewControllerDelegate {
 
     pipVideo = NSViewController()
     pipVideo.view = videoView
-    pip.playing = player.info.isPlaying
+    pip.playing = player.info.state == .playing
     pip.title = window?.title
 
     pip.presentAsPicture(inPicture: pipVideo)
@@ -3056,7 +3056,7 @@ extension MainWindowController: PIPViewControllerDelegate {
     // it's not necessary while the video is playing and significantly more
     // noticeable, we only redraw if we are paused.
     let currentTrackIsAlbumArt = player.info.currentTrack(.video)?.isAlbumart ?? false
-    if player.info.isPaused || currentTrackIsAlbumArt {
+    if player.info.state == .paused || currentTrackIsAlbumArt {
       videoView.videoLayer.draw(forced: true)
     }
 

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -490,7 +490,7 @@ class MenuController: NSObject, NSMenuDelegate {
     let isDisplayingChapters = player.mainWindow.sideBarStatus == .playlist &&
           player.mainWindow.playlistView.currentTab == .chapters
     chapterPanel?.title = isDisplayingChapters ? Constants.String.hideChaptersPanel : Constants.String.chaptersPanel
-    pause.title = player.info.isPaused ? Constants.String.resume : Constants.String.pause
+    pause.title = player.info.state == .paused ? Constants.String.resume : Constants.String.pause
     abLoop.state = player.isABLoopActive ? .on : .off
     let loopMode = player.getLoopMode()
     fileLoop.state = loopMode == .file ? .on : .off

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -168,7 +168,7 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
   // MARK: - Window delegate: Open / Close
 
   func windowWillClose(_ notification: Notification) {
-    if player.info.state != .shuttingDown {
+    if player.info.state != .shuttingDown && player.info.state != .shutDown {
       // not needed if called when terminating the whole app
       player.overrideAutoSwitchToMusicMode = false
       player.switchBackFromMiniPlayer(automatically: true, showMainWindow: false)

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -168,7 +168,7 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
   // MARK: - Window delegate: Open / Close
 
   func windowWillClose(_ notification: Notification) {
-    if !player.isShuttingDown {
+    if player.info.state != .shuttingDown {
       // not needed if called when terminating the whole app
       player.overrideAutoSwitchToMusicMode = false
       player.switchBackFromMiniPlayer(automatically: true, showMainWindow: false)

--- a/iina/PlaySliderCell.swift
+++ b/iina/PlaySliderCell.swift
@@ -168,7 +168,7 @@ class PlaySliderCell: NSSliderCell {
   // MARK:- Tracking the Mouse
 
   override func startTracking(at startPoint: NSPoint, in controlView: NSView) -> Bool {
-    isPausedBeforeSeeking = playerCore.info.isPaused
+    isPausedBeforeSeeking = playerCore.info.state == .paused
     let result = super.startTracking(at: startPoint, in: controlView)
     if result {
       playerCore.pause()

--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -34,41 +34,26 @@ class PlaybackInfo {
     player = pc
   }
 
-  /// `True` if the player is in an active state, `false` otherwise.
-  /// - Important: When the player is not in an active state the operations on the player **must be** restricted. In particular
-  ///         player methods that access the mpv core **must not** be called when the player is in the `shuttingDown` or
-  ///         `shutDown` states. Accessing the mpv core when the player is in these states can trigger a crash.
-  var isActive: Bool { PlayerState.activeStates.contains(state) }
-
-  var isIdle: Bool { state == .idle }
-  var isPaused: Bool { state == .paused }
-  var isPlaying: Bool { state == .playing }
-  var isSeeking: Bool { state == .seeking}
+  // TODO: - Change log level of state changed message to be .verbose once state is confirmed working.
 
   /// The state the `PlayerCore` is in.
   /// - Note: A computed property is used to prevent inappropriate state changes. When IINA terminates players that are actively
   ///     playing will first be stopped and then shutdown. Once a player has stopped the mpv core will go idle. This happens
   ///     asynchronously and could occur after the quit command has been sent to mpv. Thus we must be sure the state does not
   ///     transition from `.shuttingDown` to `.idle`.
-  var state: PlayerState {
-    get { _state }
-    set {
-      guard _state != newValue else { return }
+  var state: PlayerState = .idle {
+    didSet {
+      guard state != oldValue else { return }
       // Once the player is in the shuttingDown state it can only move to the shutDown state. Once
       // in the shutDown state the state can't change.
-      guard _state != .loading || newValue != .idle,
-            _state != .shuttingDown || newValue == .shutDown, _state != .shutDown else {
-        player.log("Ignoring attempt to change state from \(_state) to \(newValue)")
+      guard oldValue != .loading || state != .idle,
+            oldValue != .shuttingDown || state == .shutDown, oldValue != .shutDown else {
+        player.log("Blocked attempt to change state from \(oldValue) to \(state)")
+        state = oldValue
         return
       }
-      _state = newValue
-    }
-  }
-  // TODO: - Change log level to be .verbose once state is confirmed working.
-  private var _state: PlayerState = .idle {
-    didSet {
-      player.log("State changed from \(oldValue) to \(_state)")
-      switch _state {
+      player.log("State changed from \(oldValue) to \(state)")
+      switch state {
       case .idle:
         PlayerCore.checkStatusForSleep()
       case .playing:

--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -81,6 +81,8 @@ class PlaybackInfo {
     }
   }
 
+  var isSeeking: Bool = false
+
   var currentURL: URL? {
     didSet {
       if let url = currentURL {

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1809,11 +1809,11 @@ class PlayerCore: NSObject {
     syncUI(.playlist)
   }
 
-  func fileEnded(doToStopCommand: Bool) {
+  func fileEnded(dueToStopCommand: Bool) {
     // if receive end-file when loading file, might be error
     // wait for idle
     if info.state == .loading {
-      if !doToStopCommand {
+      if !dueToStopCommand {
         receivedEndFileWhileLoading = true
       }
     } else {

--- a/iina/PlayerState.swift
+++ b/iina/PlayerState.swift
@@ -35,12 +35,6 @@ enum PlayerState: Int {
   /// for the `pause` property was received with a value of `true`.
   case paused
 
-  /// Player is seeking.
-  ///
-  /// A [MPV_EVENT_SEEK](https://mpv.io/manual/stable/#command-interface-mpv-event-seek) was recieived
-  /// indicating seeking is in progress.
-  case seeking
-
   /// The asynchronous `stop` command has been sent to mpv.
   case stopping
 

--- a/iina/PlayerState.swift
+++ b/iina/PlayerState.swift
@@ -1,0 +1,105 @@
+//
+//  PlayerState.swift
+//  iina
+//
+//  Created by low-batt on 7/13/24.
+//  Copyright © 2024 lhc. All rights reserved.
+//
+
+import Foundation
+
+/// The mutually exclusive states a `PlayerCore` can be in.
+struct PlayerState: OptionSet, CustomStringConvertible {
+  let rawValue: Int
+
+  var description: String {
+    switch self {
+    case .idle: return "idle"
+    case .loading: return "loading"
+    case .starting: return "starting"
+    case .playing: return "playing"
+    case .paused: return "paused"
+    case .seeking: return "seeking"
+    case .stopping: return "stopping"
+    case .stopped: return "stopped"
+    case .shuttingDown: return "shuttingDown"
+    case .shutDown: return "shutDown"
+    default:
+      var result = ""
+      for state in PlayerState.allStates {
+        guard self.contains(state) else { continue }
+        if !result.isEmpty {
+          result += ","
+        }
+        result += state.description
+      }
+      return "[\(result)]"
+    }
+  }
+
+  // MARK: - States
+
+  /// No file is loaded.
+  ///
+  /// This is the initial state of a player. The player returns to this state when a
+  /// [MPV_EVENT_PROPERTY_CHANGE](https://mpv.io/manual/stable/#command-interface-mpv-event-property-change)
+  /// for the `idle-active` property is received with a value of `true`.
+  static let idle = PlayerState(rawValue: 1 << 0)
+
+  /// The asynchronous `loadfile` command has been sent to mpv.
+  static let loading = PlayerState(rawValue: 1 << 1)
+
+  /// Player is loading the file.
+  ///
+  /// A [MPV_EVENT_START_FILE](https://mpv.io/manual/stable/#command-interface-mpv-event-start-file)
+  /// was received.
+  static let starting = PlayerState(rawValue: 1 << 2)
+
+  /// Player is playing the file.
+  ///
+  /// Initially entered when [MPV_EVENT_FILE_LOADED](https://mpv.io/manual/stable/#command-interface-mpv-event-file-loaded)
+  /// is received indicating file is loaded and playing.
+  static let playing = PlayerState(rawValue: 1 << 3)
+
+  /// Playback has paused.
+  ///
+  /// A [MPV_EVENT_PROPERTY_CHANGE](https://mpv.io/manual/stable/#command-interface-mpv-event-property-change)
+  /// for the `pause` property was received with a value of `true`.
+  static let paused = PlayerState(rawValue: 1 << 4)
+
+  /// Player is seeking.
+  ///
+  /// A [MPV_EVENT_SEEK](https://mpv.io/manual/stable/#command-interface-mpv-event-seek) was recieived
+  /// indicating seeking is in progress.
+  static let seeking = PlayerState(rawValue: 1 << 5)
+
+  /// The asynchronous `stop` command has been sent to mpv.
+  static let stopping = PlayerState(rawValue: 1 << 6)
+
+  /// Playback has stopped and the media has been unloaded.
+  ///
+  /// A [MPV_EVENT_END_FILE](https://mpv.io/manual/stable/#command-interface-mpv-event-end-file)
+  /// was received with a reason of [MPV_END_FILE_REASON_STOP](https://mpv.io/manual/stable/#command-interface-stop)
+  /// indicating the `stop` command completed.
+  static let stopped = PlayerState(rawValue: 1 << 7)
+
+  /// The asynchronous `quit` command has been sent to mpv initiating shutdown.
+  static let shuttingDown = PlayerState(rawValue: 1 << 8)
+
+  /// Shutdown of the player has completed (mpv has shutdown).
+  ///
+  /// A [MPV_EVENT_SHUTDOWN](https://mpv.io/manual/stable/#command-interface-mpv-event-shutdown)
+  /// was received indicating the `quit` command completed.
+  static let shutDown = PlayerState(rawValue: 1 << 9)
+
+  // MARK: - Sets
+
+  /// States in which the player is considered active.
+  ///
+  /// These are the states in which the player normally interacts with the mpv core. The mpv core **must not** be accessed when the
+  /// player is in the `shuttingDown` or `shutDown` states. Accessing the core in these states can trigger a crash.
+  static let activeStates: PlayerState = [.loading, .starting, .playing, .paused, .seeking]
+
+  static let allStates: [PlayerState] = [.idle, .loading, .starting, .playing, .paused, .seeking,
+                                        .stopping, .stopped, .shuttingDown, .shutDown]
+}

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -636,7 +636,7 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
   }
 
   @IBAction func playSliderChanges(_ sender: NSSlider) {
-    guard !player.info.fileLoading else { return }
+    guard player.info.isActive else { return }
     let percentage = 100 * sender.doubleValue / sender.maxValue
     player.seek(percent: percentage, forceExact: !followGlobalSeekTypeWhenAdjustSlider)
   }

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -78,7 +78,7 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
       }
     case PK.alwaysFloatOnTop.rawValue:
       if let newValue = change[.newKey] as? Bool {
-        if player.info.isPlaying {
+        if player.info.state == .playing {
           setWindowFloatingOnTop(newValue)
         }
       }
@@ -451,7 +451,7 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
 
     if scrollAction == .seek && isTrackpadBegan {
       // record pause status
-      if player.info.isPlaying {
+      if player.info.state == .playing {
         player.pause()
         wasPlayingBeforeSeeking = true
       }
@@ -579,7 +579,7 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
     // IINA listens for changes to mpv properties such as chapter that can occur during file loading
     // resulting in this function being called before mpv has set its position and duration
     // properties. Confirm the window and file have been loaded.
-    guard loaded, player.mpv.fileLoaded else { return }
+    guard loaded, player.info.state.loaded else { return }
     // The mpv documentation for the duration property indicates mpv is not always able to determine
     // the video duration in which case the property is not available.
     guard let duration = player.info.videoDuration else {
@@ -628,7 +628,7 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
   }
 
   @IBAction func playButtonAction(_ sender: NSButton) {
-    player.info.isPaused ? player.resume() : player.pause()
+    player.info.state == .paused ? player.resume() : player.pause()
   }
 
   @IBAction func muteButtonAction(_ sender: NSButton) {
@@ -636,7 +636,7 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
   }
 
   @IBAction func playSliderChanges(_ sender: NSSlider) {
-    guard player.info.isActive else { return }
+    guard player.info.state.active else { return }
     let percentage = 100 * sender.doubleValue / sender.maxValue
     player.seek(percent: percentage, forceExact: !followGlobalSeekTypeWhenAdjustSlider)
   }

--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -158,6 +158,7 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
   }
 
   func reloadData(playlist: Bool, chapters: Bool) {
+    guard player.info.isActive else { return }
     if playlist {
       player.getPlaylist()
       playlistTableView.reloadData()

--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -158,7 +158,7 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
   }
 
   func reloadData(playlist: Bool, chapters: Bool) {
-    guard player.info.isActive else { return }
+    guard player.info.state.active else { return }
     if playlist {
       player.getPlaylist()
       playlistTableView.reloadData()

--- a/iina/TouchBarSupport.swift
+++ b/iina/TouchBarSupport.swift
@@ -169,7 +169,7 @@ class TouchBarSupport: NSObject, NSTouchBarDelegate {
   }
 
   func updateTouchBarPlayBtn() {
-    if player.info.isPaused {
+    if player.info.state == .paused {
       touchBarPlayPauseBtn?.image = NSImage(named: NSImage.touchBarPlayTemplateName)
     } else {
       touchBarPlayPauseBtn?.image = NSImage(named: NSImage.touchBarPauseTemplateName)
@@ -276,7 +276,7 @@ class TouchBarPlaySlider: NSSlider {
 
   override func touchesBegan(with event: NSEvent) {
     isTouching = true
-    wasPlayingBeforeTouching = playerCore.info.isPlaying
+    wasPlayingBeforeTouching = playerCore.info.state == .playing
     playerCore.pause()
     super.touchesBegan(with: event)
   }
@@ -369,7 +369,7 @@ class TouchBarPlaySliderCell: NSSliderCell {
 
   override func drawKnob(_ knobRect: NSRect) {
     let info = playerCore.info
-    guard !info.isIdle else { return }
+    guard info.state.active else { return }
     if isTouching, let dur = info.videoDuration?.second, let tb = info.getThumbnail(forSecond: (doubleValue / 100) * dur), let image = tb.image {
       NSGraphicsContext.saveGraphicsState()
       NSBezierPath(roundedRect: knobRect, xRadius: 3, yRadius: 3).setClip()
@@ -397,7 +397,7 @@ class TouchBarPlaySliderCell: NSSliderCell {
 
   override func drawBar(inside rect: NSRect, flipped: Bool) {
     let info = playerCore.info
-    guard !info.isIdle else { return }
+    guard info.state.active else { return }
     let barRect = self.barRect(flipped: flipped)
     if let image = backgroundImage, info.thumbnailsProgress == cachedThumbnailProgress {
       // draw cached background image

--- a/iina/VideoPIPViewController.swift
+++ b/iina/VideoPIPViewController.swift
@@ -15,7 +15,7 @@ class VideoPIPViewController: PIPViewController {
   /// If the image is changing there is no need to force a draw. However if playback is paused, or if playback is in progress but the video
   /// track is an album art still image then drawing is required.
   private func forceDraw() {
-    guard let controller = delegate as? MainWindowController, controller.player.info.isPaused
+    guard let controller = delegate as? MainWindowController, controller.player.info.state == .paused
             || controller.player.info.currentTrack(.video)?.isAlbumart ?? false else { return }
     controller.videoView.videoLayer.draw(forced: true)
   }

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -425,9 +425,7 @@ class VideoView: NSView {
 
 extension VideoView {
   func refreshEdrMode() {
-    guard player.mainWindow.loaded else { return }
-    guard player.mpv.fileLoaded else { return }
-    guard let displayId = currentDisplay else { return }
+    guard player.mainWindow.loaded, player.info.state.loaded, let displayId = currentDisplay else { return }
     if let screen = self.window?.screen {
       NSScreen.log("Refreshing HDR for \(player.subsystem.rawValue) @ display\(displayId)", screen,
                    subsystem: hdrSubsystem)


### PR DESCRIPTION
This commit will:
- Add a `PlayerState` struct that defines the mutually exclusive states a `PlayerCore` can be in
- Add a property to `PlaybackInfo` to hold a player's state
- Remove the `fileLoading`, `isStopping`, `isStopped`, `isShuttingDown` and `isShutdown` properties from `PlayerCore`
- Change the `isIdle`, i`sPaused`, `isPlaying` and `isSeeking` `PlaybackInfo` properties to be computed properties that check the state of the player
- Add an i`sActive` computed property to `PlaybackInfo` that checks if the player is in an active state
- Move remaining `MPV_EVENT_SHUTDOWN` processing from `MPVController` to `PlayerCore` and the main thread to avoid the need for locks
- Change handling of `MPV_EVENT_END_FILE` to check the player state instead of `MPV_END_FILE_REASON_STOP`
- Add an `isActive` guard to `PlaylistViewController.reloadData`

This makes the state the player is in explicit in one property. This also corrects some errors in the app termination sequence.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
