### PR TITLE
Fix inconsistent grammar of "music mode", #5076

### DIFF
--- a/iina/Base.lproj/PrefGeneralViewController.xib
+++ b/iina/Base.lproj/PrefGeneralViewController.xib
@@ -192,7 +192,7 @@
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="fms-nd-RFo">
                     <rect key="frame" x="138" y="81" width="303" height="18"/>
-                    <buttonCell key="cell" type="check" title="Not while in Music Mode or only playing audio" bezelStyle="regularSquare" imagePosition="left" inset="2" id="yla-DT-YTx">
+                    <buttonCell key="cell" type="check" title="Not while in &quot;music mode&quot; or only playing audio" bezelStyle="regularSquare" imagePosition="left" inset="2" id="yla-DT-YTx">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>

--- a/iina/en.lproj/PrefGeneralViewController.strings
+++ b/iina/en.lproj/PrefGeneralViewController.strings
@@ -152,8 +152,8 @@
 /* Class = "NSTextFieldCell"; title = "Pause/resume when:"; ObjectID = "xr2-rB-O0x"; */
 "xr2-rB-O0x.title" = "Pause/resume when:";
 
-/* Class = "NSButtonCell"; title = "Not while in Music Mode or only playing audio"; ObjectID = "yla-DT-YTx"; */
-"yla-DT-YTx.title" = "Not while in Music Mode or only playing audio";
+/* Class = "NSButtonCell"; title = "Not while in \"music mode\" or only playing audio"; ObjectID = "yla-DT-YTx"; */
+"yla-DT-YTx.title" = "Not while in \"music mode\" or only playing audio";
 
 /* Class = "NSMenuItem"; title = "Show welcome window"; ObjectID = "z9T-8h-1T0"; */
 "z9T-8h-1T0.title" = "Show welcome window";


### PR DESCRIPTION
This commit will change the reference to music mode in the new setting in the behavior section on the general tab to be in lowercase and enclosed in double quotes to match the style of other references.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5076.

---

**Description:**
