### PR TITLE
Only access player.info when loaded on video reconfig, fix #5090

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1982,7 +1982,7 @@ class PlayerCore: NSObject {
 
   func onVideoReconfig() {
     // If loading file, video reconfig can return 0 width and height
-    guard info.state != .loading, info.state.active else { return }
+    guard info.state.loaded else { return }
     var dwidth = mpv.getInt(MPVProperty.dwidth)
     var dheight = mpv.getInt(MPVProperty.dheight)
     if info.rotation == 90 || info.rotation == 270 {


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5090.

---

**Description:**
The crash described in #5090 happens when `player.info.state` is `starting`, so it passes the guard check and proceeded with the fields of `info.displayWidth` and `info.displayHeight` undefined. Before the commit c5be6e0, the logic here was to check if the file is loading and return. Change the guard check to `loaded` to match the previous behavior.