### PR TITLE
Fix crash while quitting in AutoFileMatcher, #5056

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -711,10 +711,14 @@ class MPVController: NSObject {
 
   /// Shutdown this mpv controller.
   func mpvQuit() {
-    // Observers must be removed to avoid accessing the mpv core after it has shutdown.
-    removeObservers()
-    // Start mpv quitting. Even though this command is being sent using the synchronous command API
-    // the quit command is special and will be executed by mpv asynchronously.
+    // Remove observers for IINA preference. Must not attempt to change a mpv setting
+    // in response to an IINA preference change while mpv is shutting down.
+    removeOptionObservers()
+    // Remove observers for mpv properties. Because 0 was passed for reply_userdata when
+    // registering mpv property observers all observers can be removed in one call.
+    mpv_unobserve_property(mpv, 0)
+    // Start mpv quitting. Even though this command is being sent using the synchronous
+    // command API the quit command is special and will be executed by mpv asynchronously.
     command(.quit, level: .verbose)
   }
 
@@ -999,18 +1003,23 @@ class MPVController: NSObject {
   private func readEvents() {
     queue.async {
       while ((self.mpv) != nil) {
-        let event = mpv_wait_event(self.mpv, 0)
+        let event = mpv_wait_event(self.mpv, 0)!
+        let eventId = event.pointee.event_id
         // Do not deal with mpv-event-none
-        if event?.pointee.event_id == MPV_EVENT_NONE {
+        if eventId == MPV_EVENT_NONE {
           break
         }
         self.handleEvent(event)
+        // Must stop reading events once the mpv core is shutdown.
+        if eventId == MPV_EVENT_SHUTDOWN {
+          break
+        }
       }
     }
   }
 
   // Handle the event
-  private func handleEvent(_ event: UnsafePointer<mpv_event>!) {
+  private func handleEvent(_ event: UnsafePointer<mpv_event>) {
     let eventId = event.pointee.event_id
 
     switch eventId {
@@ -1096,7 +1105,7 @@ class MPVController: NSObject {
       }
 
     case MPV_EVENT_END_FILE:
-      let reason = event!.pointee.data.load(as: mpv_end_file_reason.self)
+      let reason = event.pointee.data.load(as: mpv_end_file_reason.self)
       DispatchQueue.main.async {
         self.player.fileEnded(dueToStopCommand: reason == MPV_END_FILE_REASON_STOP)
       }

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -89,8 +89,8 @@ extension MainMenuActionHandler {
 
   @objc func menuStop(_ sender: NSMenuItem) {
     // FIXME: handle stop
-    player.stop()
     player.sendOSD(.stop)
+    player.stop()
   }
 
   @objc func menuStep(_ sender: NSMenuItem) {


### PR DESCRIPTION
This commit will:
- Correct the `active` computed property in `PlayerState` to not consider the stopping state as active
- Change the `PlaybackInfo.state` computed property to prevent additional inappropriate state transitions
- Change `PlayerCore.sendOSD` to not show messages unless the player is active to prevent an unreported crash
- Change `MPVController.readEvents` to stop once a `MPV_EVENT_SHUTDOWN` has been processed
- Change the `fileLoaded` and `fileStarted` `PlayerCore` methods to do nothing if the player state is not active
- Change the logger subsystem for `AutoFileMatcher` to include the player identifier
- Change the names of the `PlayerCore` dispatch queues to include the player identifier
- Move `TicketExpiredError` from `AutoFileMatcher` to `PlayerCore`
- Add a `checkTicket` method to `PlayerCore`
- Change more` AutoFileMatcher` methods to check the ticket and throw errors
- Change `AutoFileMatcher.startMatching` to rethrow errors
- Change `PlayerCore.fileStarted` to check the background queue ticket and catch errors
- Change `PlayerCore.fileStarted` to have the background task queue a main thread task that will continue the process of stopping the player if it was waiting for the background task to finish
- Change `PlayerCore.findIdlePlayerCore` to not choose an idle core if it's background task is still running

These changes cause the player to not send a stop command to mpv until the background task has stopped. A mpv core will stop on its own when the end of a video is reached. For that reason these changes also cause the player to not send a quit command to mpv until the background task has stopped. These changes correct crashes that happens when the background task is still running when the mpv core is quitting. This can occur for example, when a user starts playing the wrong video and immediately quits IINA before the background task has a chance to finish.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5056.

---

**Description:**
