### PR TITLE
Fix app can quit while playback history is being saved, #5107

### DIFF
--- a/iina/AppData.swift
+++ b/iina/AppData.swift
@@ -148,4 +148,5 @@ extension Notification.Name {
   static let iinaLogoutCompleted = Notification.Name("iinaLoggedOutOfSubtitleProvider")
   static let iinaSecondSubVisibilityChanged = Notification.Name("iinaSecondSubVisibilityChanged")
   static let iinaSubVisibilityChanged = Notification.Name("iinaSubVisibilityChanged")
+  static let iinaHistoryTaskFinished = Notification.Name("iinaHistoryTaskFinished")
 }

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -457,9 +457,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 
     // Check if there are any players that are not shutdown. If all players are already shutdown
     // then application termination can proceed immediately. This will happen if there is only one
-    // player and shutdown was initiated by typing "q" in the player window. That sends a quit
-    // command directly to mpv causing mpv and the player to shutdown before application
-    // termination is initiated.
+    // player and shutdown was initiated by sending a quit command directly to mpv through it's IPC
+    // interface causing mpv and the player to shutdown before application termination is initiated.
     allPlayersHaveShutdown = true
     for player in PlayerCore.playerCores {
       if player.info.state != .shutDown {
@@ -482,6 +481,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     if OnlineSubtitle.loggedIn {
       canTerminateNow = false
       Logger.log("Waiting for log out of online subtitles provider to complete")
+    }
+
+    if HistoryController.shared.tasksOutstanding != 0 {
+      canTerminateNow = false
+      Logger.log("Waiting for saving of playback history to complete")
     }
 
     // If the user pressed Q and mpv initiated the termination then players will already be
@@ -573,13 +577,16 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         // All players have shutdown.
         Logger.log("All players have shutdown")
       }
-      guard !OnlineSubtitle.loggedIn else { return }
-      // All players have shutdown. No longer logged into an online subtitles provider.
+      // If still logged in to subtitle providers or still saving playback history then continue
+      // waiting.
+      guard !OnlineSubtitle.loggedIn, HistoryController.shared.tasksOutstanding == 0 else { return }
+      // All players have shutdown. No longer logged into an online subtitles provider and saving of
+      // playback history has finished.
       Logger.log("Proceeding with application termination")
       // No longer need the timer that forces termination to proceed.
       timer.invalidate()
       // No longer need the observers for players stopping and shutting down, along with the
-      // observer for logout requests completing.
+      // observer for logout requests completing and saving of playback history finishing.
       ObjcUtils.silenced {
         observers.forEach {
           NotificationCenter.default.removeObserver($0)
@@ -622,6 +629,23 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
           level: .warning)
         return
       }
+      proceedWithTermination()
+    }
+    observers.append(observer)
+
+    // Establish an observer for saving of playback history finishing.
+    observer = center.addObserver(forName: .iinaHistoryTaskFinished, object: nil, queue: .main) { _ in
+      guard !self.timedOut else {
+        // Saving of playback history finished after IINA already timed out, gave up waiting, and
+        // told Cocoa to proceed with termination. This is a problem as it indicates playback
+        // history might be being lost.
+        Logger.log("Saving of playback history finished after application termination timed out",
+          level: .warning)
+        return
+      }
+      // If there are still tasks outstanding then must continue waiting.
+      guard HistoryController.shared.tasksOutstanding == 0 else { return }
+      Logger.log("Saving of playback history finished")
       proceedWithTermination()
     }
     observers.append(observer)

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -577,9 +577,10 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         // All players have shutdown.
         Logger.log("All players have shutdown")
       }
-      // If still logged in to subtitle providers or still saving playback history then continue
-      // waiting.
-      guard !OnlineSubtitle.loggedIn, HistoryController.shared.tasksOutstanding == 0 else { return }
+      // If still logged in to subtitle providers then continue waiting.
+      guard !OnlineSubtitle.loggedIn else { return }
+      // If still still saving playback history then continue waiting.
+      guard HistoryController.shared.tasksOutstanding == 0 else { return }
       // All players have shutdown. No longer logged into an online subtitles provider and saving of
       // playback history has finished.
       Logger.log("Proceeding with application termination")

--- a/iina/HistoryController.swift
+++ b/iina/HistoryController.swift
@@ -12,13 +12,19 @@ class HistoryController: NSObject {
 
   static let shared = HistoryController(plistFileURL: Utility.playbackHistoryURL)
 
-  var plistURL: URL
-  var history: [PlaybackHistory]
-  var queue = DispatchQueue(label: "IINAHistoryController", qos: .background)
+  /// Cached copy of the playback history stored in the history file.
+  ///
+  /// This is accessed by both the main thread and a background thread and must be referenced under a lock.
+  @Atomic var history: [PlaybackHistory] = []
+
+  /// Number of tasks currently in the queue.
+  @Atomic var tasksOutstanding = 0
+
+  private let plistURL: URL
+  private let queue = DispatchQueue(label: "IINAHistoryController", qos: .background)
 
   init(plistFileURL: URL) {
     self.plistURL = plistFileURL
-    self.history = []
     super.init()
     read()
   }
@@ -30,39 +36,77 @@ class HistoryController: NSObject {
       let data = try Data(contentsOf: plistURL)
       let object = try NSKeyedUnarchiver.unarchivedObject(ofClasses: [NSArray.self, PlaybackHistory.self],
                                                           from: data)
-      history = object as? [PlaybackHistory] ?? []
+      guard let history = object as? [PlaybackHistory] else {
+        // Secure coding should ensure that this never occurs.
+        log("Unable to convert object read from playback history file to [PlaybackHistory]", level: .error)
+        return
+      }
+      self.history = history
+      log("Read \(history.count) playback history entries")
     } catch {
-      Logger.log("Failed to read playback history file \(plistURL.path): \(error)", level: .error)
+      log("Failed to read playback history file \(plistURL.path): \(error)", level: .error)
     }
   }
 
-  func save() {
+  private func save() {
     do {
-      let data = try NSKeyedArchiver.archivedData(withRootObject: history, requiringSecureCoding: true)
-      try data.write(to: plistURL)
+      try $history.withLock { history in
+        log("Saving \(history.count) playback history entries")
+        let data = try NSKeyedArchiver.archivedData(withRootObject: history, requiringSecureCoding: true)
+        try data.write(to: plistURL, options: [.atomic])
+        log("Saved \(history.count) playback history entries")
+      }
       NotificationCenter.default.post(Notification(name: .iinaHistoryUpdated))
     } catch {
-      Logger.log("Failed to save playback history to file \(plistURL.path): \(error)", level: .error)
+      log("Failed to save playback history to file \(plistURL.path): \(error)", level: .error)
     }
   }
 
+  /// Add an entry to playback history.
+  /// - Note: The entry is added asynchronously by a background thread.
+  /// - Parameters:
+  ///   - url: URL of the media being played.
+  ///   - duration: Total duration of the media.
   func add(_ url: URL, duration: Double) {
     guard Preference.bool(for: .recordPlaybackHistory) else { return }
-    if let existingItem = history.first(where: { $0.mpvMd5 == url.path.md5 }), let index = history.firstIndex(of: existingItem) {
-      history.remove(at: index)
+    $tasksOutstanding.withLock { $0 += 1 }
+    queue.async { [self] in
+      $history.withLock { history in
+        if let existingItem = history.first(where: { $0.mpvMd5 == url.path.md5 }),
+           let index = history.firstIndex(of: existingItem) {
+          history.remove(at: index)
+        }
+        history.insert(PlaybackHistory(url: url, duration: duration), at: 0)
+      }
+      save()
+      $tasksOutstanding.withLock { tasksOutstanding in
+        tasksOutstanding -= 1
+        if tasksOutstanding != 0 {
+          // The history controller must be able to finish saving playback history before IINA
+          // terminates or history will be lost. If termination times out before saving of playback
+          // history has finished then history will be lost. If that happens then the qos of the
+          // history batch queue will need to be raised to allow the history controller to keep up
+          // with requests to save history.
+          log("History tasks outstanding: \(tasksOutstanding)")
+        }
+      }
+      NotificationCenter.default.post(Notification(name: .iinaHistoryTaskFinished))
     }
-    history.insert(PlaybackHistory(url: url, duration: duration), at: 0)
-    save()
   }
 
   func remove(_ entries: [PlaybackHistory]) {
-    history = history.filter { !entries.contains($0) }
+    $history.withLock { history in
+      log("Removing \(entries.count) playback history entries")
+      history = history.filter { !entries.contains($0) }
+    }
     save()
   }
 
-  func removeAll() {
-    history.removeAll()
-    save()
+  private func log(_ message: String, level: Logger.Level = .debug) {
+    Logger.log(message, level: level, subsystem: Logger.Sub.history)
   }
+}
 
+extension Logger.Sub {
+  static let history = Logger.makeSubsystem("history")
 }

--- a/iina/HistoryWindowController.swift
+++ b/iina/HistoryWindowController.swift
@@ -253,10 +253,12 @@ class HistoryWindowController: NSWindowController, NSOutlineViewDelegate, NSOutl
       reloadData()
       return
     }
-    let newObjects = HistoryController.shared.history.filter { entry in
-      let string = searchOption == .filename ? entry.name : entry.url.path
-      // Do a locale-aware, case and diacritic insensitive search:
-      return string.localizedStandardContains(searchString)
+    let newObjects = HistoryController.shared.$history.withLock {
+      $0.filter { entry in
+        let string = searchOption == .filename ? entry.name : entry.url.path
+        // Do a locale-aware, case and diacritic insensitive search:
+        return string.localizedStandardContains(searchString)
+      }
     }
     prepareData(fromHistory: newObjects)
     outlineView.reloadData()

--- a/iina/JavascriptAPICore.swift
+++ b/iina/JavascriptAPICore.swift
@@ -105,14 +105,16 @@ class JavascriptAPICore: JavascriptAPI, JavascriptAPICoreExportable {
   }
 
   func getHistory() -> Any {
-    return HistoryController.shared.history.map {
-      [
-        "name": $0.name,
-        "url": $0.url.absoluteString,
-        "date": $0.addedDate,
-        "progress": $0.mpvProgress?.second ?? NSNull(),
-        "duration": $0.duration.second
-      ] as [String: Any]
+    HistoryController.shared.$history.withLock {
+      $0.map {
+        [
+          "name": $0.name,
+          "url": $0.url.absoluteString,
+          "date": $0.addedDate,
+          "progress": $0.mpvProgress?.second ?? NSNull(),
+          "duration": $0.duration.second
+        ] as [String: Any]
+      }
     }
   }
 

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1791,9 +1791,7 @@ class PlayerCore: NSObject {
     // add to history
     if let url = info.currentURL {
       let duration = info.videoDuration ?? .zero
-      HistoryController.shared.queue.async {
-        HistoryController.shared.add(url, duration: duration.second)
-      }
+      HistoryController.shared.add(url, duration: duration.second)
       if Preference.bool(for: .recordRecentFiles) && Preference.bool(for: .trackAllFilesInRecentOpenMenu) {
         AppDelegate.shared.noteNewRecentDocumentURL(url)
       }


### PR DESCRIPTION
This commit will:
- Change the call to `write` in the `HistoryController.save` method to use the `atomic` option
- Add a` tasksOutstanding` property to `HistoryController` to keep track of how many tasks are in the background queue
- Change the `HistoryController.history` property to be atomic
- Change the methods in `HistoryController`, `HistoryWindowController` and `JavascriptAPICore` to lock the `history` property when accessing it
- Add a `iinaHistoryTaskFinished` notification to `AppData`
- Change `HistoryController.add` to post this notification when a background task finishes
- Change `AppDelegate.applicationShouldTerminate` to establish an observer for the `iinaHistoryTaskFinished` notification and wait until all outstanding `HistoryController` tasks have finished before proceeding with termination
- Add logging to the `HistoryController`
- Remove unused `removeAll` method from `HistoryController`

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5107.

---

**Description:**
