### PR TITLE
Update Settings' tab icons & toolbar icons using SF symbols

### DIFF
--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -535,6 +535,23 @@ extension NSImage {
     newImage.unlockFocus()
     return newImage
   }
+
+  /// Try to find a SF Symbol. If the symbol is found, then return the symbol with the configuration applied; otherwise,
+  /// return the fallback image.
+  ///
+  /// - Parameters:
+  ///   - name: The name of the SF Symbol
+  ///   - configuration: The symbol configuration for the SF symbol
+  ///   - fallbackName: If the current macOS doesn't contains the wanted SF symbol, then the fallback image will be returned
+  @available(macOS 11.0, *)
+  static func findSFSymbol(_ name: String, withConfiguration configuration: NSImage.SymbolConfiguration?, fallbackName: NSImage.Name) -> NSImage {
+    guard let symbol = NSImage(systemSymbolName: name, accessibilityDescription: nil) else { return NSImage(named: fallbackName)! }
+    if let configuration, let configed = symbol.withSymbolConfiguration(configuration) {
+      return configed
+    }
+    return symbol
+  }
+
 }
 
 

--- a/iina/PrefAdvancedViewController.swift
+++ b/iina/PrefAdvancedViewController.swift
@@ -23,7 +23,11 @@ class PrefAdvancedViewController: PreferenceViewController, PreferenceWindowEmbe
   }
 
   var preferenceTabImage: NSImage {
-    return NSImage(named: NSImage.Name("pref_advanced"))!
+    if #available(macOS 14.0, *) {
+      return makeSymbol("flask")
+    } else {
+      return NSImage(named: NSImage.Name("pref_advanced"))!
+    }
   }
 
   var preferenceContentIsScrollable: Bool {

--- a/iina/PrefAdvancedViewController.swift
+++ b/iina/PrefAdvancedViewController.swift
@@ -23,11 +23,7 @@ class PrefAdvancedViewController: PreferenceViewController, PreferenceWindowEmbe
   }
 
   var preferenceTabImage: NSImage {
-    if #available(macOS 14.0, *) {
-      return makeSymbol("flask")
-    } else {
-      return NSImage(named: NSImage.Name("pref_advanced"))!
-    }
+    return makeSymbol("flask", fallbackName: "pref_advanced")
   }
 
   var preferenceContentIsScrollable: Bool {

--- a/iina/PrefCodecViewController.swift
+++ b/iina/PrefCodecViewController.swift
@@ -20,11 +20,7 @@ class PrefCodecViewController: PreferenceViewController, PreferenceWindowEmbedda
   }
 
   var preferenceTabImage: NSImage {
-    if #available(macOS 12.0, *) {
-      return makeSymbol("play.rectangle.on.rectangle")
-    } else {
-      return NSImage(named: NSImage.Name("pref_av"))!
-    }
+    return makeSymbol("play.rectangle.on.rectangle", fallbackName: "pref_av")
   }
 
   override var sectionViews: [NSView] {

--- a/iina/PrefCodecViewController.swift
+++ b/iina/PrefCodecViewController.swift
@@ -20,7 +20,11 @@ class PrefCodecViewController: PreferenceViewController, PreferenceWindowEmbedda
   }
 
   var preferenceTabImage: NSImage {
-    return NSImage(named: NSImage.Name("pref_av"))!
+    if #available(macOS 12.0, *) {
+      return makeSymbol("play.rectangle.on.rectangle")
+    } else {
+      return NSImage(named: NSImage.Name("pref_av"))!
+    }
   }
 
   override var sectionViews: [NSView] {

--- a/iina/PrefControlViewController.swift
+++ b/iina/PrefControlViewController.swift
@@ -20,7 +20,11 @@ class PrefControlViewController: PreferenceViewController, PreferenceWindowEmbed
   }
 
   var preferenceTabImage: NSImage {
-    return NSImage(named: NSImage.Name("pref_control"))!
+    if #available(macOS 12.0, *) {
+      return makeSymbol("rectangle.and.hand.point.up.left")
+    } else {
+      return NSImage(named: NSImage.Name("pref_control"))!
+    }
   }
 
   override var sectionViews: [NSView] {

--- a/iina/PrefControlViewController.swift
+++ b/iina/PrefControlViewController.swift
@@ -20,11 +20,7 @@ class PrefControlViewController: PreferenceViewController, PreferenceWindowEmbed
   }
 
   var preferenceTabImage: NSImage {
-    if #available(macOS 12.0, *) {
-      return makeSymbol("rectangle.and.hand.point.up.left")
-    } else {
-      return NSImage(named: NSImage.Name("pref_control"))!
-    }
+    return makeSymbol("rectangle.and.hand.point.up.left", fallbackName: "pref_control")
   }
 
   override var sectionViews: [NSView] {

--- a/iina/PrefGeneralViewController.swift
+++ b/iina/PrefGeneralViewController.swift
@@ -21,11 +21,7 @@ class PrefGeneralViewController: PreferenceViewController, PreferenceWindowEmbed
   }
 
   var preferenceTabImage: NSImage {
-    if #available(macOS 11.0, *) {
-      return makeSymbol("gear")
-    } else {
-      return NSImage(named: NSImage.Name("pref_general"))!
-    }
+    return makeSymbol("gear", fallbackName: "pref_general")
   }
 
   override var sectionViews: [NSView] {

--- a/iina/PrefGeneralViewController.swift
+++ b/iina/PrefGeneralViewController.swift
@@ -21,7 +21,11 @@ class PrefGeneralViewController: PreferenceViewController, PreferenceWindowEmbed
   }
 
   var preferenceTabImage: NSImage {
-    return NSImage(named: NSImage.Name("pref_general"))!
+    if #available(macOS 11.0, *) {
+      return makeSymbol("gear")
+    } else {
+      return NSImage(named: NSImage.Name("pref_general"))!
+    }
   }
 
   override var sectionViews: [NSView] {

--- a/iina/PrefKeyBindingViewController.swift
+++ b/iina/PrefKeyBindingViewController.swift
@@ -23,11 +23,7 @@ class PrefKeyBindingViewController: PreferenceViewController, PreferenceWindowEm
   }
 
   var preferenceTabImage: NSImage {
-    if #available(macOS 11.0, *) {
-      return makeSymbol("keyboard.badge.ellipsis")
-    } else {
-      return NSImage(named: NSImage.Name("pref_kb"))!
-    }
+    return makeSymbol("keyboard.badge.ellipsis", fallbackName: "pref_kb")
   }
 
   var preferenceContentIsScrollable: Bool {

--- a/iina/PrefKeyBindingViewController.swift
+++ b/iina/PrefKeyBindingViewController.swift
@@ -12,7 +12,7 @@ fileprivate let fm = FileManager.default
 fileprivate typealias KC = PrefKeyBindingViewController
 
 @objcMembers
-class PrefKeyBindingViewController: NSViewController, PreferenceWindowEmbeddable {
+class PrefKeyBindingViewController: PreferenceViewController, PreferenceWindowEmbeddable {
 
   override var nibName: NSNib.Name {
     return NSNib.Name("PrefKeyBindingViewController")
@@ -23,7 +23,11 @@ class PrefKeyBindingViewController: NSViewController, PreferenceWindowEmbeddable
   }
 
   var preferenceTabImage: NSImage {
-    return NSImage(named: NSImage.Name("pref_kb"))!
+    if #available(macOS 11.0, *) {
+      return makeSymbol("keyboard.badge.ellipsis")
+    } else {
+      return NSImage(named: NSImage.Name("pref_kb"))!
+    }
   }
 
   var preferenceContentIsScrollable: Bool {

--- a/iina/PrefNetworkViewController.swift
+++ b/iina/PrefNetworkViewController.swift
@@ -18,11 +18,7 @@ class PrefNetworkViewController: PreferenceViewController, PreferenceWindowEmbed
   var viewIdentifier: String = "PrefNetworkViewController"
 
   var preferenceTabImage: NSImage {
-    if #available(macOS 11.0, *) {
-      return makeSymbol("network")
-    } else {
-      return NSImage(named: NSImage.Name("pref_network"))!
-    }
+    return makeSymbol("network", fallbackName: "pref_network")
   }
 
   var preferenceTabTitle: String {

--- a/iina/PrefNetworkViewController.swift
+++ b/iina/PrefNetworkViewController.swift
@@ -18,7 +18,11 @@ class PrefNetworkViewController: PreferenceViewController, PreferenceWindowEmbed
   var viewIdentifier: String = "PrefNetworkViewController"
 
   var preferenceTabImage: NSImage {
-    return NSImage(named: NSImage.Name("pref_network"))!
+    if #available(macOS 11.0, *) {
+      return makeSymbol("network")
+    } else {
+      return NSImage(named: NSImage.Name("pref_network"))!
+    }
   }
 
   var preferenceTabTitle: String {

--- a/iina/PrefPluginViewController.swift
+++ b/iina/PrefPluginViewController.swift
@@ -25,7 +25,7 @@ fileprivate extension NSPasteboard.PasteboardType {
   static let iinaPluginID = NSPasteboard.PasteboardType(rawValue: "com.colliderli.iina.pluginID")
 }
 
-class PrefPluginViewController: NSViewController, PreferenceWindowEmbeddable {
+class PrefPluginViewController: PreferenceViewController, PreferenceWindowEmbeddable {
   override var nibName: NSNib.Name {
     return NSNib.Name("PrefPluginViewController")
   }
@@ -35,7 +35,11 @@ class PrefPluginViewController: NSViewController, PreferenceWindowEmbeddable {
   }
 
   var preferenceTabImage: NSImage {
-    return NSImage(named: NSImage.Name("pref_general"))!
+    if #available(macOS 11.0, *) {
+      return makeSymbol("puzzlepiece.extension")
+    } else {
+      return NSImage(named: NSImage.Name("pref_general"))!
+    }
   }
 
   var preferenceContentIsScrollable: Bool {

--- a/iina/PrefPluginViewController.swift
+++ b/iina/PrefPluginViewController.swift
@@ -35,11 +35,7 @@ class PrefPluginViewController: PreferenceViewController, PreferenceWindowEmbedd
   }
 
   var preferenceTabImage: NSImage {
-    if #available(macOS 11.0, *) {
-      return makeSymbol("puzzlepiece.extension")
-    } else {
-      return NSImage(named: NSImage.Name("pref_general"))!
-    }
+    return makeSymbol("puzzlepiece.extension", fallbackName: "pref_general")
   }
 
   var preferenceContentIsScrollable: Bool {

--- a/iina/PrefSubViewController.swift
+++ b/iina/PrefSubViewController.swift
@@ -21,11 +21,7 @@ class PrefSubViewController: PreferenceViewController, PreferenceWindowEmbeddabl
   }
 
   var preferenceTabImage: NSImage {
-    if #available(macOS 11.0, *) {
-      return makeSymbol("captions.bubble")
-    } else {
-      return NSImage(named: NSImage.Name("pref_sub"))!
-    }
+    return makeSymbol("captions.bubble", fallbackName: "pref_sub")
   }
 
   override var sectionViews: [NSView] {

--- a/iina/PrefSubViewController.swift
+++ b/iina/PrefSubViewController.swift
@@ -21,7 +21,11 @@ class PrefSubViewController: PreferenceViewController, PreferenceWindowEmbeddabl
   }
 
   var preferenceTabImage: NSImage {
-    return NSImage(named: NSImage.Name("pref_sub"))!
+    if #available(macOS 11.0, *) {
+      return makeSymbol("captions.bubble")
+    } else {
+      return NSImage(named: NSImage.Name("pref_sub"))!
+    }
   }
 
   override var sectionViews: [NSView] {

--- a/iina/PrefUIViewController.swift
+++ b/iina/PrefUIViewController.swift
@@ -29,11 +29,7 @@ class PrefUIViewController: PreferenceViewController, PreferenceWindowEmbeddable
   }
 
   var preferenceTabImage: NSImage {
-    if #available(macOS 11.0, *) {
-      return makeSymbol("macwindow")
-    } else {
-      return NSImage(named: NSImage.Name("pref_ui"))!
-    }
+    return makeSymbol("macwindow", fallbackName: "pref_ui")
   }
 
   static var oscToolbarButtons: [Preference.ToolBarButton] {

--- a/iina/PrefUIViewController.swift
+++ b/iina/PrefUIViewController.swift
@@ -29,7 +29,11 @@ class PrefUIViewController: PreferenceViewController, PreferenceWindowEmbeddable
   }
 
   var preferenceTabImage: NSImage {
-    return NSImage(named: NSImage.Name("pref_ui"))!
+    if #available(macOS 11.0, *) {
+      return makeSymbol("macwindow")
+    } else {
+      return NSImage(named: NSImage.Name("pref_ui"))!
+    }
   }
 
   static var oscToolbarButtons: [Preference.ToolBarButton] {

--- a/iina/PrefUtilsViewController.swift
+++ b/iina/PrefUtilsViewController.swift
@@ -19,11 +19,7 @@ class PrefUtilsViewController: PreferenceViewController, PreferenceWindowEmbedda
   }
 
   var preferenceTabImage: NSImage {
-    if #available(macOS 11.0, *) {
-      return makeSymbol("wrench.and.screwdriver")
-    } else {
-      return NSImage(named: NSImage.Name("pref_utils"))!
-    }
+    return makeSymbol("wrench.and.screwdriver", fallbackName: "pref_utils")
   }
 
   override var sectionViews: [NSView] {

--- a/iina/PrefUtilsViewController.swift
+++ b/iina/PrefUtilsViewController.swift
@@ -19,7 +19,11 @@ class PrefUtilsViewController: PreferenceViewController, PreferenceWindowEmbedda
   }
 
   var preferenceTabImage: NSImage {
-    return NSImage(named: NSImage.Name("pref_utils"))!
+    if #available(macOS 11.0, *) {
+      return makeSymbol("wrench.and.screwdriver")
+    } else {
+      return NSImage(named: NSImage.Name("pref_utils"))!
+    }
   }
 
   override var sectionViews: [NSView] {

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -8,6 +8,8 @@
 
 import Cocoa
 
+fileprivate let toolBarSymbolStyle = NSImage.SymbolConfiguration(pointSize: 14, weight: .medium)
+
 protocol InitializingFromKey {
 
   static var defaultValue: Self { get }
@@ -699,13 +701,13 @@ struct Preference {
 
     func image() -> NSImage {
       switch self {
-      case .settings: return NSImage(named: NSImage.actionTemplateName)!
-      case .playlist: return #imageLiteral(resourceName: "playlist")
-      case .pip: return #imageLiteral(resourceName: "pip")
-      case .fullScreen: return #imageLiteral(resourceName: "fullscreen")
-      case .musicMode: return #imageLiteral(resourceName: "toggle-album-art")
-      case .subTrack: return #imageLiteral(resourceName: "sub-track")
-      case .screenshot: return #imageLiteral(resourceName: "screenshot")
+      case .settings: return Utility.findSFSymbol("gearshape", withConfiguration: toolBarSymbolStyle, fallbackName: NSImage.actionTemplateName)
+      case .playlist: return Utility.findSFSymbol("list.bullet", withConfiguration: toolBarSymbolStyle, fallbackName: "playlist")
+      case .pip: return Utility.findSFSymbol("pip.swap", withConfiguration: toolBarSymbolStyle, fallbackName: "pip")
+      case .fullScreen: return Utility.findSFSymbol("arrow.up.left.and.arrow.down.right", withConfiguration: toolBarSymbolStyle, fallbackName: "fullscreen")
+      case .musicMode: return Utility.findSFSymbol("music.note.list", withConfiguration: toolBarSymbolStyle, fallbackName: "toggle-album-art")
+      case .subTrack: return Utility.findSFSymbol("captions.bubble.fill", withConfiguration: toolBarSymbolStyle, fallbackName: "sub-track")
+      case .screenshot: return Utility.findSFSymbol("camera.shutter.button", withConfiguration: toolBarSymbolStyle, fallbackName: "screenshot")
       }
     }
 

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -8,8 +8,6 @@
 
 import Cocoa
 
-fileprivate let toolBarSymbolStyle = NSImage.SymbolConfiguration(pointSize: 14, weight: .medium)
-
 protocol InitializingFromKey {
 
   static var defaultValue: Self { get }
@@ -700,14 +698,19 @@ struct Preference {
     case screenshot
 
     func image() -> NSImage {
+      func makeSymbol(_ name: String, _ fallbackName: NSImage.Name) -> NSImage {
+        guard #available(macOS 11.0, *) else { return NSImage(named: fallbackName)! }
+        let configuration = NSImage.SymbolConfiguration(pointSize: 14, weight: .medium)
+        return NSImage.findSFSymbol(name, withConfiguration: configuration, fallbackName: fallbackName)
+      }
       switch self {
-      case .settings: return Utility.findSFSymbol("gearshape", withConfiguration: toolBarSymbolStyle, fallbackName: NSImage.actionTemplateName)
-      case .playlist: return Utility.findSFSymbol("list.bullet", withConfiguration: toolBarSymbolStyle, fallbackName: "playlist")
-      case .pip: return Utility.findSFSymbol("pip.swap", withConfiguration: toolBarSymbolStyle, fallbackName: "pip")
-      case .fullScreen: return Utility.findSFSymbol("arrow.up.left.and.arrow.down.right", withConfiguration: toolBarSymbolStyle, fallbackName: "fullscreen")
-      case .musicMode: return Utility.findSFSymbol("music.note.list", withConfiguration: toolBarSymbolStyle, fallbackName: "toggle-album-art")
-      case .subTrack: return Utility.findSFSymbol("captions.bubble.fill", withConfiguration: toolBarSymbolStyle, fallbackName: "sub-track")
-      case .screenshot: return Utility.findSFSymbol("camera.shutter.button", withConfiguration: toolBarSymbolStyle, fallbackName: "screenshot")
+      case .settings: return makeSymbol("gearshape", NSImage.actionTemplateName)
+      case .playlist: return makeSymbol("list.bullet", "playlist")
+      case .pip: return makeSymbol("pip.swap", "pip")
+      case .fullScreen: return makeSymbol("arrow.up.left.and.arrow.down.right", "fullscreen")
+      case .musicMode: return makeSymbol("music.note.list", "toggle-album-art")
+      case .subTrack: return makeSymbol("captions.bubble.fill", "sub-track")
+      case .screenshot: return makeSymbol("camera.shutter.button", "screenshot")
       }
     }
 

--- a/iina/PreferenceViewController.swift
+++ b/iina/PreferenceViewController.swift
@@ -16,7 +16,6 @@ class PreferenceViewController: NSViewController {
     return []
   }
 
-  @available(macOS 11.0, *)
   func makeSymbol(_ name: String, fallbackName: NSImage.Name) -> NSImage {
     let configuration = NSImage.SymbolConfiguration(pointSize: 18, weight: .bold)
     return Utility.findSFSymbol(name, withConfiguration: configuration, fallbackName: fallbackName)

--- a/iina/PreferenceViewController.swift
+++ b/iina/PreferenceViewController.swift
@@ -17,8 +17,9 @@ class PreferenceViewController: NSViewController {
   }
 
   @available(macOS 11.0, *)
-  func makeSymbol(_ name: String) -> NSImage {
-    return NSImage(systemSymbolName: name, accessibilityDescription: nil)!.withSymbolConfiguration(.init(pointSize: 18, weight: .bold))!
+  func makeSymbol(_ name: String, fallbackName: NSImage.Name) -> NSImage {
+    let configuration = NSImage.SymbolConfiguration(pointSize: 18, weight: .bold)
+    return Utility.findSFSymbol(name, withConfiguration: configuration, fallbackName: fallbackName)
   }
 
   override func viewDidLoad() {

--- a/iina/PreferenceViewController.swift
+++ b/iina/PreferenceViewController.swift
@@ -16,6 +16,7 @@ class PreferenceViewController: NSViewController {
     return []
   }
 
+  @available(macOS 11.0, *)
   func makeSymbol(_ name: String) -> NSImage {
     return NSImage(systemSymbolName: name, accessibilityDescription: nil)!.withSymbolConfiguration(.init(pointSize: 18, weight: .bold))!
   }

--- a/iina/PreferenceViewController.swift
+++ b/iina/PreferenceViewController.swift
@@ -16,6 +16,10 @@ class PreferenceViewController: NSViewController {
     return []
   }
 
+  func makeSymbol(_ name: String) -> NSImage {
+    return NSImage(systemSymbolName: name, accessibilityDescription: nil)!.withSymbolConfiguration(.init(pointSize: 18, weight: .bold))!
+  }
+
   override func viewDidLoad() {
     super.viewDidLoad()
 

--- a/iina/PreferenceViewController.swift
+++ b/iina/PreferenceViewController.swift
@@ -17,8 +17,9 @@ class PreferenceViewController: NSViewController {
   }
 
   func makeSymbol(_ name: String, fallbackName: NSImage.Name) -> NSImage {
+    guard #available(macOS 11, *) else { return NSImage(named: fallbackName)! }
     let configuration = NSImage.SymbolConfiguration(pointSize: 18, weight: .bold)
-    return Utility.findSFSymbol(name, withConfiguration: configuration, fallbackName: fallbackName)
+    return NSImage.findSFSymbol(name, withConfiguration: configuration, fallbackName: fallbackName)
   }
 
   override func viewDidLoad() {

--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -555,6 +555,22 @@ class Utility {
     }
   }
 
+  /// Try to find a SF Symbol. If the symbol is found, then return the symbol with the configuration applied; otherwise,
+  /// return the fallback image.
+  ///
+  /// - Parameters:
+  ///   - name: The name of the SF Symbol
+  ///   - configuration: The symbol configuration for the SF symbol
+  ///   - fallbackName: If the current macOS doesn't contains the wanted SF symbol, then the fallback image will be returned
+  static func findSFSymbol(_ name: String, withConfiguration configuration: NSImage.SymbolConfiguration?, fallbackName: NSImage.Name) -> NSImage {
+    let symbol = NSImage.init(systemSymbolName: name, accessibilityDescription: nil)
+    guard let symbol else { return NSImage(named: fallbackName)! }
+    if let configuration {
+      return symbol.withSymbolConfiguration(configuration) ?? symbol
+    }
+    return symbol
+  }
+
   // MARK: - Util classes
 
   class FontAttributes {

--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -563,8 +563,7 @@ class Utility {
   ///   - configuration: The symbol configuration for the SF symbol
   ///   - fallbackName: If the current macOS doesn't contains the wanted SF symbol, then the fallback image will be returned
   static func findSFSymbol(_ name: String, withConfiguration configuration: NSImage.SymbolConfiguration?, fallbackName: NSImage.Name) -> NSImage {
-    let symbol = NSImage.init(systemSymbolName: name, accessibilityDescription: nil)
-    guard let symbol else { return NSImage(named: fallbackName)! }
+    guard #available(macOS 11.0, *), let symbol = NSImage(systemSymbolName: name, accessibilityDescription: nil) else { return NSImage(named: fallbackName)! }
     if let configuration {
       return symbol.withSymbolConfiguration(configuration) ?? symbol
     }

--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -555,21 +555,6 @@ class Utility {
     }
   }
 
-  /// Try to find a SF Symbol. If the symbol is found, then return the symbol with the configuration applied; otherwise,
-  /// return the fallback image.
-  ///
-  /// - Parameters:
-  ///   - name: The name of the SF Symbol
-  ///   - configuration: The symbol configuration for the SF symbol
-  ///   - fallbackName: If the current macOS doesn't contains the wanted SF symbol, then the fallback image will be returned
-  static func findSFSymbol(_ name: String, withConfiguration configuration: NSImage.SymbolConfiguration?, fallbackName: NSImage.Name) -> NSImage {
-    guard #available(macOS 11.0, *), let symbol = NSImage(systemSymbolName: name, accessibilityDescription: nil) else { return NSImage(named: fallbackName)! }
-    if let configuration {
-      return symbol.withSymbolConfiguration(configuration) ?? symbol
-    }
-    return symbol
-  }
-
   // MARK: - Util classes
 
   class FontAttributes {


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)

---

**Description:**
Now that the plugin system has been enabled by default (f78497434211254b220389bc3de9526ff2ada060), we need a new icon for that. To take advantage of this opportunity, I chose some icons from SF symbols to replace the current ones, which are really old btw. Icons are not available at runtime are simply fallback to the old ones.

before -> after
![image](https://github.com/user-attachments/assets/589bb1f7-34cf-4b2d-8d6c-552d79251876) ![image](https://github.com/user-attachments/assets/85f0209f-444c-4123-b322-4368d850c2db)

I also updated the icons for toolbar items:
![image](https://github.com/user-attachments/assets/40a41ee5-317d-4797-9313-3e382ff3d8af)

The paddings in this one needs to be adjusted later.

Feel free to propose better ones