### PR TITLE
Fix crash in MPVController.hooks.modify disabling plugin, #5127

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -1013,8 +1013,8 @@ class MPVController: NSObject {
   }
 
   func removeHooks(withIdentifier id: String) {
-    $hooks.withLock {
-      $0.filter { (k, v) in v.isJavascript && v.id == id }.keys.forEach { hooks.removeValue(forKey: $0) }
+    $hooks.withLock { hooks in
+      hooks.filter { (k, v) in v.isJavascript && v.id == id }.keys.forEach { hooks.removeValue(forKey: $0) }
     }
   }
 


### PR DESCRIPTION
This commit will correct MPVController.removeHooks, removing the double locking that is triggering the crash.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5127.

---

**Description:**
