### PR TITLE
Fix crash in PlaybackInfo.calculateTotalDuration, #5095

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -800,7 +800,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
       }
 
       // enqueue
-      if let enqueueValue = queryDict["enqueue"], enqueueValue == "1", !PlayerCore.lastActive.info.playlist.isEmpty {
+      let playlistEmpty = PlayerCore.lastActive.info.$playlist.withLock { $0.isEmpty }
+      if let enqueueValue = queryDict["enqueue"], enqueueValue == "1", !playlistEmpty {
         PlayerCore.lastActive.addToPlaylist(urlValue)
         PlayerCore.lastActive.postNotification(.iinaPlaylistChanged)
         PlayerCore.lastActive.sendOSD(.addToPlaylist(1))

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -31,10 +31,11 @@ class MainMenuActionHandler: NSResponder, NSMenuItemValidation {
     Utility.quickSavePanel(title: "Save to playlist", types: ["m3u8"], sheetWindow: player.currentWindow) { (url) in
       if url.isFileURL {
         var playlist = ""
-        for item in self.player.info.playlist {
-          playlist.append((item.filename + "\n"))
+        self.player.info.$playlist.withLock {
+          for item in $0 {
+            playlist.append((item.filename + "\n"))
+          }
         }
-
         do {
           try playlist.write(to: url, atomically: true, encoding: String.Encoding.utf8)
         } catch let error as NSError {

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -431,9 +431,11 @@ class MenuController: NSObject, NSMenuDelegate {
 
   private func updatePlaylist() {
     playlistMenu.removeAllItems()
-    for (index, item) in PlayerCore.active.info.playlist.enumerated() {
-      playlistMenu.addItem(withTitle: item.filenameForDisplay, action: #selector(MainMenuActionHandler.menuPlaylistItem(_:)),
-                           tag: index, obj: nil, stateOn: item.isCurrent)
+    PlayerCore.active.info.$playlist.withLock { playlist in
+      for (index, item) in playlist.enumerated() {
+        playlistMenu.addItem(withTitle: item.filenameForDisplay, action: #selector(MainMenuActionHandler.menuPlaylistItem(_:)),
+                             tag: index, obj: nil, stateOn: item.isCurrent)
+      }
     }
   }
 

--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -231,7 +231,15 @@ class PlaybackInfo {
     }
   }
 
-  var playlist: [MPVPlaylistItem] = []
+  /// Copy of the mpv playlist.
+  /// - Important: Obtaining video duration, playback progress, and metadata for files in the playlist can be a slow operation, so a
+  ///     background task is used and the results are cached. Thus the playlist must be protected with a lock as well as the cache.
+  ///     To avoid the need to lock multiple locks the cache properties are always accessed while holding the playlist lock. The cache
+  ///     properties are private to force all access to be through class methods that properly coordinate thread access.
+  @Atomic var playlist: [MPVPlaylistItem] = []
+  private var cachedVideoDurationAndProgress: [String: (duration: Double?, progress: Double?)] = [:]
+  private var cachedMetadata: [String: (title: String?, album: String?, artist: String?)] = [:]
+
   var chapters: [MPVChapter] = []
   var chapter = 0
 
@@ -242,18 +250,8 @@ class PlaybackInfo {
   var currentSubsInfo: [FileInfo] = []
   var currentVideosInfo: [FileInfo] = []
 
-  // The cache is read by the main thread and updated by a background thread therefore all use
-  // must be through the class methods that properly coordinate thread access.
-  private var cachedVideoDurationAndProgress: [String: (duration: Double?, progress: Double?)] = [:]
-  private var cachedMetadata: [String: (title: String?, album: String?, artist: String?)] = [:]
-
-  // Queue dedicated to providing serialized access to class data shared between threads.
-  // Data is accessed by the main thread, therefore the QOS for the queue must not be too low
-  // to avoid blocking the main thread for an extended period of time.
-  private let lockQueue = DispatchQueue(label: "IINAPlaybackInfoLock", qos: .userInitiated)
-
   func calculateTotalDuration() -> Double? {
-    lockQueue.sync {
+    $playlist.withLock { playlist in
       var totalDuration: Double? = 0
       for p in playlist {
         if let duration = cachedVideoDurationAndProgress[p.filename]?.duration {
@@ -268,7 +266,7 @@ class PlaybackInfo {
   }
 
   func calculateTotalDuration(_ indexes: IndexSet) -> Double {
-    lockQueue.sync {
+    $playlist.withLock { playlist in
       indexes
         .compactMap { cachedVideoDurationAndProgress[playlist[$0].filename]?.duration }
         .compactMap { $0 > 0 ? $0 : 0 }
@@ -276,32 +274,55 @@ class PlaybackInfo {
     }
   }
 
+  /// Return the cached duration and progress for the given file if present in the cache.
+  /// - Parameter file: File to return the duration and progress for.
+  /// - Returns: A tuple containing the duration and progress if found in the cache, otherwise `nil`.
+  /// - Important: To avoid the need to lock multiple locks the cache properties are always accessed while holding the playlist lock.
   func getCachedVideoDurationAndProgress(_ file: String) -> (duration: Double?, progress: Double?)? {
-    lockQueue.sync {
+    $playlist.withLock { _ in
       cachedVideoDurationAndProgress[file]
     }
   }
 
+  /// Store the given duration for the given file in the cache.
+  /// - Parameters:
+  ///   - file: File to store the duration for.
+  ///   - duration: The duration of the file.
+  /// - Important: To avoid the need to lock multiple locks the cache properties are always accessed while holding the playlist lock.
   func setCachedVideoDuration(_ file: String, _ duration: Double) {
-    lockQueue.sync {
+    $playlist.withLock { _ in
       cachedVideoDurationAndProgress[file]?.duration = duration
     }
   }
 
+  /// Store the given duration and progress for the given file in the cache.
+  /// - Parameters:
+  ///   - file: File to store the duration and progress for.
+  ///   - value: A tuple containing the duration and progress for the file.
+  /// - Important: To avoid the need to lock multiple locks the cache properties are always accessed while holding the playlist lock.
   func setCachedVideoDurationAndProgress(_ file: String, _ value: (duration: Double?, progress: Double?)) {
-    lockQueue.sync {
+    $playlist.withLock { _ in
       cachedVideoDurationAndProgress[file] = value
     }
   }
 
+  /// Return the cached metadata for the given file if present in the cache.
+  /// - Parameter file: File to return the metadata for.
+  /// - Returns: A tuple containing the title, album and artist if found in the cache, otherwise `nil`.
+  /// - Important: To avoid the need to lock multiple locks the cache properties are always accessed while holding the playlist lock.
   func getCachedMetadata(_ file: String) -> (title: String?, album: String?, artist: String?)? {
-    lockQueue.sync {
+    $playlist.withLock { _ in
       cachedMetadata[file]
     }
   }
 
+  /// Store the given metadata for the given file in the cache.
+  /// - Parameters:
+  ///   - file: File to store the title, album and artist for.
+  ///   - value: A tuple containing the duration and progress for the file.
+  /// - Important: To avoid the need to lock multiple locks the cache properties are always accessed while holding the playlist lock.
   func setCachedMetadata(_ file: String, _ value: (title: String?, album: String?, artist: String?)) {
-    lockQueue.sync {
+    $playlist.withLock { _ in
       cachedMetadata[file] = value
     }
   }

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1243,8 +1243,8 @@ class PlayerCore: NSObject {
     for path in paths {
       _addToPlaylist(path)
     }
-    if index <= info.playlist.count && index >= 0 {
-      let previousCount = info.playlist.count
+    let previousCount = info.$playlist.withLock { $0.count }
+    if index <= previousCount && index >= 0 {
       for i in 0..<paths.count {
         playlistMove(previousCount + i, to: index + i)
       }
@@ -2405,14 +2405,16 @@ class PlayerCore: NSObject {
   }
 
   func getPlaylist() {
-    info.playlist.removeAll()
-    let playlistCount = mpv.getInt(MPVProperty.playlistCount)
-    for index in 0..<playlistCount {
-      let playlistItem = MPVPlaylistItem(filename: mpv.getString(MPVProperty.playlistNFilename(index))!,
-                                         isCurrent: mpv.getFlag(MPVProperty.playlistNCurrent(index)),
-                                         isPlaying: mpv.getFlag(MPVProperty.playlistNPlaying(index)),
-                                         title: mpv.getString(MPVProperty.playlistNTitle(index)))
-      info.playlist.append(playlistItem)
+    info.$playlist.withLock { playlist in
+      playlist.removeAll()
+      let playlistCount = mpv.getInt(MPVProperty.playlistCount)
+      for index in 0..<playlistCount {
+        let playlistItem = MPVPlaylistItem(filename: mpv.getString(MPVProperty.playlistNFilename(index))!,
+                                           isCurrent: mpv.getFlag(MPVProperty.playlistNCurrent(index)),
+                                           isPlaying: mpv.getFlag(MPVProperty.playlistNPlaying(index)),
+                                           title: mpv.getString(MPVProperty.playlistNTitle(index)))
+        playlist.append(playlistItem)
+      }
     }
   }
 

--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -650,7 +650,6 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
   }
 
   @IBAction func contextMenuPlayInNewWindow(_ sender: NSMenuItem) {
-
     let files = {
       self.player.info.$playlist.withLock { playlist in
         self.selectedRows!.enumerated().map { (_, i) in

--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -256,7 +256,7 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
 
   func numberOfRows(in tableView: NSTableView) -> Int {
     if tableView == playlistTableView {
-      return player.info.playlist.count
+      return player.info.$playlist.withLock { $0.count }
     } else if tableView == chapterTableView {
       return player.info.chapters.count
     } else {
@@ -269,7 +269,9 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
   func copyToPasteboard(_ tableView: NSTableView, writeRowsWith rowIndexes: IndexSet, to pboard: NSPasteboard) {
     do {
       let indexesData = try NSKeyedArchiver.archivedData(withRootObject: rowIndexes, requiringSecureCoding: true)
-      let filePaths = rowIndexes.map { player.info.playlist[$0].filename }
+      let filePaths = player.info.$playlist.withLock { playlist in
+        rowIndexes.map { playlist[$0].filename }
+      }
       pboard.declareTypes([.iinaPlaylistItem, .nsFilenames], owner: tableView)
       pboard.setData(indexesData, forType: .iinaPlaylistItem)
       pboard.setPropertyList(filePaths, forType: .nsFilenames)
@@ -397,7 +399,8 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
     Utility.quickMultipleOpenPanel(title: "Add to playlist", canChooseDir: true) { urls in
       let playableFiles = self.player.getPlayableFiles(in: urls)
       if playableFiles.count != 0 {
-        self.player.addToPlaylist(paths: playableFiles.map { $0.path }, at: self.player.info.playlist.count)
+        self.player.addToPlaylist(paths: playableFiles.map { $0.path },
+                                  at: self.player.info.$playlist.withLock { $0.count })
         self.player.mainWindow.playlistView.reloadData(playlist: true, chapters: false)
         self.player.sendOSD(.addToPlaylist(playableFiles.count))
       }
@@ -459,7 +462,7 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
   @IBAction func subBtnAction(_ sender: NSButton) {
     let row = playlistTableView.row(for: sender)
     guard let vc = subPopover.contentViewController as? SubPopoverViewController else { return }
-    vc.filePath = player.info.playlist[row].filename
+    vc.filePath = player.info.$playlist.withLock { $0[row].filename }
     vc.tableView.reloadData()
     vc.heightConstraint.constant = (vc.tableView.rowHeight + vc.tableView.intercellSpacing.height) * CGFloat(vc.tableView.numberOfRows)
     subPopover.show(relativeTo: sender.bounds, of: sender, preferredEdge: .maxY)
@@ -482,8 +485,11 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
 
     // playlist
     if tableView == playlistTableView {
-      guard row < info.playlist.count else { return nil }
-      let item = info.playlist[row]
+      let item: MPVPlaylistItem? = info.$playlist.withLock { playlist in
+        guard row < playlist.count else { return nil }
+        return playlist[row]
+      }
+      guard let item else { return nil }
 
       if identifier == .isChosen {
         let pointer = view.userInterfaceLayoutDirection == .rightToLeft ?
@@ -644,9 +650,13 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
   }
 
   @IBAction func contextMenuPlayInNewWindow(_ sender: NSMenuItem) {
-    let files = selectedRows!.enumerated().map { (_, i) in
-      URL(fileURLWithPath: player.info.playlist[i].filename)
-    }
+
+    let files = {
+      self.player.info.$playlist.withLock { playlist in
+        self.selectedRows!.enumerated().map { (_, i) in
+          URL(fileURLWithPath: playlist[i].filename)
+        }}
+    }()
     PlayerCore.newPlayerCore.openURLs(files, shouldAutoLoad: false)
   }
 
@@ -661,8 +671,9 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
 
     var successes = IndexSet()
     for index in selectedRows {
-      guard !player.info.playlist[index].isNetworkResource else { continue }
-      let url = URL(fileURLWithPath: player.info.playlist[index].filename)
+      let playlistItem = player.info.$playlist.withLock { $0[index] }
+      guard !playlistItem.isNetworkResource else { continue }
+      let url = URL(fileURLWithPath: playlistItem.filename)
       do {
         Logger.log("Trashing row \(index): \(url.standardizedFileURL)", subsystem: player.subsystem)
         try FileManager.default.trashItem(at: url, resultingItemURL: nil)
@@ -683,9 +694,11 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
   @IBAction func contextMenuShowInFinder(_ sender: NSMenuItem) {
     guard let selectedRows = selectedRows else { return }
     var urls: [URL] = []
-    for index in selectedRows {
-      if !player.info.playlist[index].isNetworkResource {
-        urls.append(URL(fileURLWithPath: player.info.playlist[index].filename))
+    player.info.$playlist.withLock { playlist in
+      for index in selectedRows {
+        if !playlist[index].isNetworkResource {
+          urls.append(URL(fileURLWithPath: playlist[index].filename))
+        }
       }
     }
     playlistTableView.deselectAll(nil)
@@ -694,7 +707,7 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
 
   @IBAction func contextMenuAddSubtitle(_ sender: NSMenuItem) {
     guard let selectedRows = selectedRows, let index = selectedRows.first else { return }
-    let filename = player.info.playlist[index].filename
+    let filename = player.info.$playlist.withLock { $0[index].filename }
     let fileURL = URL(fileURLWithPath: filename).deletingLastPathComponent()
     Utility.quickMultipleOpenPanel(title: NSLocalizedString("alert.choose_media_file.title", comment: "Choose Media File"), dir: fileURL, canChooseDir: true) { subURLs in
       for subURL in subURLs {
@@ -708,7 +721,7 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
   @IBAction func contextMenuWrongSubtitle(_ sender: NSMenuItem) {
     guard let selectedRows = selectedRows else { return }
     for index in selectedRows {
-      let filename = player.info.playlist[index].filename
+      let filename = player.info.$playlist.withLock { $0[index].filename }
       player.info.$matchedSubs.withLock { $0[filename]?.removeAll() }
       playlistTableView.reloadData(forRowIndexes: selectedRows, columnIndexes: IndexSet(integersIn: 0...1))
     }
@@ -739,7 +752,7 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
     let isSingleItem = rows.count == 1
 
     if !rows.isEmpty {
-      let firstURL = player.info.playlist[rows.first!]
+      let firstURL = player.info.$playlist.withLock { $0[rows.first!] }
       let matchedSubCount = player.info.getMatchedSubs(firstURL.filename)?.count ?? 0
       let title: String = isSingleItem ?
         firstURL.filenameForDisplay :
@@ -764,8 +777,8 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
 
       result.addItem(NSMenuItem.separator())
       // network resources related operations
-      let networkCount = rows.filter {
-        player.info.playlist[$0].isNetworkResource
+      let networkCount = player.info.$playlist.withLock { playlist in
+        rows.filter { playlist[$0].isNetworkResource }
       }.count
       if networkCount != 0 {
         result.addItem(withTitle: NSLocalizedString("pl_menu.browser", comment: "Open in Browser"), action: #selector(self.contextOpenInBrowser(_:)))
@@ -972,7 +985,7 @@ class SubPopoverViewController: NSViewController, NSTableViewDelegate, NSTableVi
   @IBAction func wrongSubBtnAction(_ sender: AnyObject) {
     player.info.$matchedSubs.withLock { $0[filePath]?.removeAll() }
     tableView.reloadData()
-    if let row = player.info.playlist.firstIndex(where: { $0.filename == filePath }) {
+    if let row = player.info.$playlist.withLock({ $0.firstIndex(where: { $0.filename == filePath }) }) {
       playlistTableView.reloadData(forRowIndexes: IndexSet(integer: row), columnIndexes: IndexSet(integersIn: 0...1))
     }
   }


### PR DESCRIPTION
This commit will:
- Add the `Atomic` property wrapper to `PlaybackInfo.playlist`
- Remove `PlaybackInfo.lockQueue` and instead use the playlist lock to single thread access to the playlist itself as well as the playlist cache
- Change all code that was directly accessing the playlist to use the lock

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5095.

---

**Description:**
