### PR TITLE
Add a loading window when loading network resources

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -896,8 +896,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
   @IBAction func openURL(_ sender: AnyObject) {
     Logger.log("Menu - Open URL")
     openURLWindow.isAlternativeAction = sender.tag == AlternativeMenuItemTag
+    openURLWindow.resetWindowState()
     openURLWindow.showWindow(nil)
-    openURLWindow.resetFields()
   }
 
   @IBAction func menuNewWindow(_ sender: Any) {

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -896,8 +896,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
   @IBAction func openURL(_ sender: AnyObject) {
     Logger.log("Menu - Open URL")
     openURLWindow.isAlternativeAction = sender.tag == AlternativeMenuItemTag
-    openURLWindow.resetWindowState()
     openURLWindow.showWindow(nil)
+    openURLWindow.resetWindowState()
   }
 
   @IBAction func menuNewWindow(_ sender: Any) {

--- a/iina/Base.lproj/OpenURLWindowController.xib
+++ b/iina/Base.lproj/OpenURLWindowController.xib
@@ -210,11 +210,11 @@ Gw
                         <rect key="frame" x="0.0" y="0.0" width="576" height="257"/>
                         <subviews>
                             <progressIndicator wantsLayer="YES" maxValue="100" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="Ear-Xt-Ces">
-                                <rect key="frame" x="205" y="121" width="16" height="16"/>
+                                <rect key="frame" x="198" y="121" width="16" height="16"/>
                             </progressIndicator>
                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="D8E-zU-6dD">
-                                <rect key="frame" x="227" y="119" width="123" height="19"/>
-                                <textFieldCell key="cell" lineBreakMode="clipping" title="Loading Media…" id="3T9-gp-4UE">
+                                <rect key="frame" x="220" y="119" width="136" height="19"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" title="Loading Media……" id="3T9-gp-4UE">
                                     <font key="font" metaFont="system" size="16"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>

--- a/iina/Base.lproj/OpenURLWindowController.xib
+++ b/iina/Base.lproj/OpenURLWindowController.xib
@@ -23,7 +23,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" titlebarAppearsTransparent="YES" id="F0z-JX-Cv5">
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" titlebarAppearsTransparent="YES" id="F0z-JX-Cv5">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenNone="YES"/>
             <rect key="contentRect" x="1062" y="556" width="576" height="270"/>

--- a/iina/Base.lproj/OpenURLWindowController.xib
+++ b/iina/Base.lproj/OpenURLWindowController.xib
@@ -23,7 +23,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" titlebarAppearsTransparent="YES" id="F0z-JX-Cv5">
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="IINAOpenURLWindow" animationBehavior="default" titlebarAppearsTransparent="YES" id="F0z-JX-Cv5">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenNone="YES"/>
             <rect key="contentRect" x="1062" y="556" width="576" height="270"/>

--- a/iina/Base.lproj/OpenURLWindowController.xib
+++ b/iina/Base.lproj/OpenURLWindowController.xib
@@ -32,7 +32,7 @@
                 <rect key="frame" x="0.0" y="0.0" width="576" height="257"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
-                    <visualEffectView appearanceType="inheritedVibrantLight" blendingMode="behindWindow" material="underWindowBackground" state="active" translatesAutoresizingMaskIntoConstraints="NO" id="X1z-XY-que">
+                    <visualEffectView blendingMode="behindWindow" material="underWindowBackground" state="active" translatesAutoresizingMaskIntoConstraints="NO" id="X1z-XY-que">
                         <rect key="frame" x="0.0" y="0.0" width="576" height="257"/>
                         <subviews>
                             <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cWl-pb-Ohf">
@@ -206,14 +206,14 @@ Gw
                             <constraint firstAttribute="trailing" secondItem="cWl-pb-Ohf" secondAttribute="trailing" constant="16" id="y1Z-e7-Gjk"/>
                         </constraints>
                     </visualEffectView>
-                    <visualEffectView hidden="YES" blendingMode="behindWindow" material="appearanceBased" state="followsWindowActiveState" translatesAutoresizingMaskIntoConstraints="NO" id="EmQ-3e-yGf">
+                    <visualEffectView hidden="YES" blendingMode="behindWindow" material="underWindowBackground" state="active" translatesAutoresizingMaskIntoConstraints="NO" id="EmQ-3e-yGf">
                         <rect key="frame" x="0.0" y="0.0" width="576" height="257"/>
                         <subviews>
-                            <progressIndicator wantsLayer="YES" maxValue="100" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="Ear-Xt-Ces">
-                                <rect key="frame" x="198" y="121" width="16" height="16"/>
+                            <progressIndicator wantsLayer="YES" maxValue="100" indeterminate="YES" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="Ear-Xt-Ces">
+                                <rect key="frame" x="272" y="113" width="32" height="32"/>
                             </progressIndicator>
                             <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="D8E-zU-6dD">
-                                <rect key="frame" x="220" y="119" width="136" height="19"/>
+                                <rect key="frame" x="220" y="86" width="136" height="19"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="Loading Media……" id="3T9-gp-4UE">
                                     <font key="font" metaFont="system" size="16"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -222,10 +222,10 @@ Gw
                             </textField>
                         </subviews>
                         <constraints>
-                            <constraint firstItem="D8E-zU-6dD" firstAttribute="centerY" secondItem="EmQ-3e-yGf" secondAttribute="centerY" id="Urq-s5-Vhp"/>
-                            <constraint firstItem="Ear-Xt-Ces" firstAttribute="centerY" secondItem="D8E-zU-6dD" secondAttribute="centerY" id="dJ4-X2-Vk2"/>
-                            <constraint firstItem="D8E-zU-6dD" firstAttribute="centerX" secondItem="EmQ-3e-yGf" secondAttribute="centerX" id="m1k-t5-qUq"/>
-                            <constraint firstItem="D8E-zU-6dD" firstAttribute="leading" secondItem="Ear-Xt-Ces" secondAttribute="trailing" constant="8" id="wXM-ri-6zU"/>
+                            <constraint firstItem="D8E-zU-6dD" firstAttribute="top" secondItem="Ear-Xt-Ces" secondAttribute="bottom" constant="8" id="3ja-3M-Yb7"/>
+                            <constraint firstItem="Ear-Xt-Ces" firstAttribute="centerX" secondItem="EmQ-3e-yGf" secondAttribute="centerX" id="SZ1-wj-8ED"/>
+                            <constraint firstItem="D8E-zU-6dD" firstAttribute="centerX" secondItem="EmQ-3e-yGf" secondAttribute="centerX" id="Xg7-RP-buE"/>
+                            <constraint firstItem="Ear-Xt-Ces" firstAttribute="centerY" secondItem="EmQ-3e-yGf" secondAttribute="centerY" id="twW-4I-1Tk"/>
                         </constraints>
                     </visualEffectView>
                 </subviews>

--- a/iina/Base.lproj/OpenURLWindowController.xib
+++ b/iina/Base.lproj/OpenURLWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23090" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14313.18"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23090"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -10,7 +10,9 @@
             <connections>
                 <outlet property="errorMessageLabel" destination="cCl-dx-rAP" id="PsQ-Xc-fWf"/>
                 <outlet property="httpPrefixTextField" destination="eo6-z2-yqh" id="vac-xq-4hq"/>
+                <outlet property="loadingMediaProgressIndicator" destination="Ear-Xt-Ces" id="IoJ-Cq-uvg"/>
                 <outlet property="openButton" destination="bUw-Ua-E9U" id="8la-Az-aOD"/>
+                <outlet property="overlayView" destination="EmQ-3e-yGf" id="k4W-7i-qvZ"/>
                 <outlet property="passwordField" destination="P8y-xt-YCV" id="luf-wj-Kmt"/>
                 <outlet property="rememberPasswordCheckBox" destination="NkO-nb-bTI" id="XRU-d9-JbB"/>
                 <outlet property="urlField" destination="H7k-7S-pad" id="Jz2-kb-EOh"/>
@@ -25,18 +27,18 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
             <windowCollectionBehavior key="collectionBehavior" fullScreenNone="YES"/>
             <rect key="contentRect" x="1062" y="556" width="576" height="270"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
-            <view key="contentView" wantsLayer="YES" misplaced="YES" id="se5-gp-TjO">
-                <rect key="frame" x="0.0" y="0.0" width="576" height="270"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1415"/>
+            <view key="contentView" wantsLayer="YES" id="se5-gp-TjO">
+                <rect key="frame" x="0.0" y="0.0" width="576" height="257"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
                     <visualEffectView appearanceType="inheritedVibrantLight" blendingMode="behindWindow" material="underWindowBackground" state="active" translatesAutoresizingMaskIntoConstraints="NO" id="X1z-XY-que">
-                        <rect key="frame" x="0.0" y="0.0" width="576" height="256"/>
+                        <rect key="frame" x="0.0" y="0.0" width="576" height="257"/>
                         <subviews>
                             <stackView distribution="fill" orientation="horizontal" alignment="top" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cWl-pb-Ohf">
-                                <rect key="frame" x="16" y="216" width="544" height="24"/>
+                                <rect key="frame" x="16" y="217" width="544" height="24"/>
                                 <subviews>
-                                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eo6-z2-yqh">
+                                    <textField wantsLayer="YES" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="eo6-z2-yqh">
                                         <rect key="frame" x="-2" y="0.0" width="56" height="24"/>
                                         <textFieldCell key="cell" lineBreakMode="clipping" title="http://" id="kqT-tD-Wzp">
                                             <font key="font" metaFont="system" size="20"/>
@@ -44,7 +46,7 @@
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="H7k-7S-pad">
+                                    <textField wantsLayer="YES" focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="H7k-7S-pad">
                                         <rect key="frame" x="54" y="0.0" width="492" height="24"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" focusRingType="none" placeholderString="Please enter the URL here……" usesSingleLineMode="YES" id="XV7-VP-Ua2">
                                             <font key="font" metaFont="system" size="20"/>
@@ -69,7 +71,7 @@
                                 </customSpacing>
                             </stackView>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bUw-Ua-E9U">
-                                <rect key="frame" x="493" y="9" width="73" height="32"/>
+                                <rect key="frame" x="500" y="9" width="67" height="32"/>
                                 <buttonCell key="cell" type="push" title="Open" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="8sC-lH-DOd">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -82,7 +84,7 @@ DQ
                                 </connections>
                             </button>
                             <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="B9e-iq-atc">
-                                <rect key="frame" x="415" y="9" width="82" height="32"/>
+                                <rect key="frame" x="430" y="9" width="76" height="32"/>
                                 <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="iNG-ee-EW6">
                                     <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                     <font key="font" metaFont="system"/>
@@ -94,16 +96,16 @@ Gw
                                     <action selector="cancelBtnAction:" target="-2" id="EhB-pE-plk"/>
                                 </connections>
                             </button>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="atI-YI-EWn">
-                                <rect key="frame" x="22" y="175" width="139" height="17"/>
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="atI-YI-EWn">
+                                <rect key="frame" x="22" y="177" width="139" height="16"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" title="HTTP Authentication" id="wxH-ic-Uug">
                                     <font key="font" metaFont="systemBold"/>
                                     <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                     <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField hidden="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cCl-dx-rAP">
-                                <rect key="frame" x="14" y="198" width="78" height="14"/>
+                            <textField hidden="YES" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cCl-dx-rAP">
+                                <rect key="frame" x="14" y="199" width="78" height="14"/>
                                 <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" title="URL is invalid." id="gaI-DT-l2c">
                                     <font key="font" metaFont="smallSystem"/>
                                     <color key="textColor" name="systemRedColor" catalog="System" colorSpace="catalog"/>
@@ -111,37 +113,37 @@ Gw
                                 </textFieldCell>
                             </textField>
                             <box title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="qud-MM-CKm">
-                                <rect key="frame" x="21" y="57" width="534" height="112"/>
+                                <rect key="frame" x="21" y="56" width="534" height="115"/>
                                 <view key="contentView" id="UGp-0p-kT0">
-                                    <rect key="frame" x="3" y="3" width="528" height="106"/>
+                                    <rect key="frame" x="4" y="5" width="526" height="107"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <subviews>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EO0-B1-NEj">
-                                            <rect key="frame" x="14" y="76" width="58" height="14"/>
+                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EO0-B1-NEj">
+                                            <rect key="frame" x="14" y="77" width="58" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" title="Username" id="Q1z-9O-n4X">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="11C-SC-jkc">
-                                            <rect key="frame" x="268" y="76" width="55" height="14"/>
+                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="11C-SC-jkc">
+                                            <rect key="frame" x="267" y="77" width="55" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" lineBreakMode="clipping" title="Password" id="uM6-Bp-Wdk">
                                                 <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="AAr-OR-upR">
-                                            <rect key="frame" x="16" y="46" width="238" height="22"/>
+                                        <textField wantsLayer="YES" focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="AAr-OR-upR">
+                                            <rect key="frame" x="16" y="48" width="237" height="21"/>
                                             <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="i6U-Vn-OMz">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
                                         </textField>
-                                        <secureTextField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="P8y-xt-YCV">
-                                            <rect key="frame" x="270" y="46" width="238" height="22"/>
+                                        <secureTextField wantsLayer="YES" focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="P8y-xt-YCV">
+                                            <rect key="frame" x="269" y="48" width="237" height="21"/>
                                             <secureTextFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" id="ub0-4i-uZc">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
@@ -155,7 +157,7 @@ Gw
                                             </connections>
                                         </secureTextField>
                                         <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="NkO-nb-bTI">
-                                            <rect key="frame" x="14" y="14" width="386" height="18"/>
+                                            <rect key="frame" x="14" y="15" width="390" height="18"/>
                                             <buttonCell key="cell" type="check" title="Remember username and password for this host in keychain" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="m0D-hR-3pr">
                                                 <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                                                 <font key="font" metaFont="system"/>
@@ -185,6 +187,7 @@ Gw
                         </subviews>
                         <constraints>
                             <constraint firstItem="atI-YI-EWn" firstAttribute="leading" secondItem="X1z-XY-que" secondAttribute="leading" constant="24" id="140-si-az8"/>
+                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="atI-YI-EWn" secondAttribute="trailing" id="IIT-1M-VGr"/>
                             <constraint firstItem="cWl-pb-Ohf" firstAttribute="leading" secondItem="X1z-XY-que" secondAttribute="leading" constant="16" id="NDt-VE-GP3"/>
                             <constraint firstItem="atI-YI-EWn" firstAttribute="top" secondItem="cWl-pb-Ohf" secondAttribute="bottom" constant="24" id="NeK-m3-nZS"/>
                             <constraint firstAttribute="trailing" secondItem="qud-MM-CKm" secondAttribute="trailing" constant="24" id="OZq-1f-H6w"/>
@@ -203,20 +206,46 @@ Gw
                             <constraint firstAttribute="trailing" secondItem="cWl-pb-Ohf" secondAttribute="trailing" constant="16" id="y1Z-e7-Gjk"/>
                         </constraints>
                     </visualEffectView>
+                    <visualEffectView hidden="YES" blendingMode="behindWindow" material="appearanceBased" state="followsWindowActiveState" translatesAutoresizingMaskIntoConstraints="NO" id="EmQ-3e-yGf">
+                        <rect key="frame" x="0.0" y="0.0" width="576" height="257"/>
+                        <subviews>
+                            <progressIndicator wantsLayer="YES" maxValue="100" indeterminate="YES" controlSize="small" style="spinning" translatesAutoresizingMaskIntoConstraints="NO" id="Ear-Xt-Ces">
+                                <rect key="frame" x="205" y="121" width="16" height="16"/>
+                            </progressIndicator>
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="D8E-zU-6dD">
+                                <rect key="frame" x="227" y="119" width="123" height="19"/>
+                                <textFieldCell key="cell" lineBreakMode="clipping" title="Loading Media…" id="3T9-gp-4UE">
+                                    <font key="font" metaFont="system" size="16"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="D8E-zU-6dD" firstAttribute="centerY" secondItem="EmQ-3e-yGf" secondAttribute="centerY" id="Urq-s5-Vhp"/>
+                            <constraint firstItem="Ear-Xt-Ces" firstAttribute="centerY" secondItem="D8E-zU-6dD" secondAttribute="centerY" id="dJ4-X2-Vk2"/>
+                            <constraint firstItem="D8E-zU-6dD" firstAttribute="centerX" secondItem="EmQ-3e-yGf" secondAttribute="centerX" id="m1k-t5-qUq"/>
+                            <constraint firstItem="D8E-zU-6dD" firstAttribute="leading" secondItem="Ear-Xt-Ces" secondAttribute="trailing" constant="8" id="wXM-ri-6zU"/>
+                        </constraints>
+                    </visualEffectView>
                 </subviews>
                 <constraints>
                     <constraint firstAttribute="trailing" secondItem="X1z-XY-que" secondAttribute="trailing" id="Eyf-vR-YrS"/>
                     <constraint firstAttribute="bottom" secondItem="X1z-XY-que" secondAttribute="bottom" id="T34-vK-ECf"/>
+                    <constraint firstAttribute="trailing" secondItem="EmQ-3e-yGf" secondAttribute="trailing" id="Vlf-R4-xP6"/>
                     <constraint firstItem="X1z-XY-que" firstAttribute="top" secondItem="se5-gp-TjO" secondAttribute="top" id="Zzo-7D-h9G"/>
+                    <constraint firstAttribute="bottom" secondItem="EmQ-3e-yGf" secondAttribute="bottom" id="a14-dB-rep"/>
+                    <constraint firstItem="EmQ-3e-yGf" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" id="avp-po-ojr"/>
                     <constraint firstItem="X1z-XY-que" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" id="e5q-Il-ITO"/>
+                    <constraint firstItem="EmQ-3e-yGf" firstAttribute="top" secondItem="se5-gp-TjO" secondAttribute="top" id="jrb-xS-7Gm"/>
                 </constraints>
             </view>
             <connections>
                 <outlet property="delegate" destination="-2" id="0bl-1N-AYu"/>
             </connections>
-            <point key="canvasLocation" x="158" y="171"/>
+            <point key="canvasLocation" x="158" y="170.5"/>
         </window>
-        <secureTextField verticalHuggingPriority="750" id="a3w-Hu-aMP">
+        <secureTextField focusRingType="none" verticalHuggingPriority="750" id="a3w-Hu-aMP">
             <rect key="frame" x="0.0" y="0.0" width="96" height="22"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <secureTextFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="o6r-Zv-w8b">
@@ -229,7 +258,7 @@ Gw
             </secureTextFieldCell>
             <point key="canvasLocation" x="194" y="425"/>
         </secureTextField>
-        <secureTextField verticalHuggingPriority="750" id="hjA-b6-vjs">
+        <secureTextField focusRingType="none" verticalHuggingPriority="750" id="hjA-b6-vjs">
             <rect key="frame" x="0.0" y="0.0" width="96" height="22"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <secureTextFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="BAX-zD-Sub">

--- a/iina/OpenURLWindowController.swift
+++ b/iina/OpenURLWindowController.swift
@@ -29,6 +29,7 @@ class OpenURLWindowController: NSWindowController, NSTextFieldDelegate, NSContro
   var isAlternativeAction = false
 
   var playerCore: PlayerCore?
+  var loadingURL: String?
 
   override func windowDidLoad() {
     super.windowDidLoad()
@@ -48,6 +49,7 @@ class OpenURLWindowController: NSWindowController, NSTextFieldDelegate, NSContro
     _ = window
     overlayView.isHidden = false
     self.playerCore = playerCore
+    loadingURL = playerCore.info.currentURL?.absoluteString
     if #available(macOS 14, *) {
       NSApp.activate()
     } else {
@@ -56,9 +58,9 @@ class OpenURLWindowController: NSWindowController, NSTextFieldDelegate, NSContro
     showWindow(self)
   }
 
-  func failedToLoadURL(url: String?) {
+  func failedToLoadURL() {
     guard isWindowLoaded && window?.isVisible == true else { return }
-    urlField.stringValue = url ?? ""
+    urlField.stringValue = loadingURL ?? ""
     errorMessageLabel.isHidden = false
     overlayView.isHidden = true
     urlField.textColor = .systemRed
@@ -73,6 +75,7 @@ class OpenURLWindowController: NSWindowController, NSTextFieldDelegate, NSContro
     window?.makeFirstResponder(urlField)
     overlayView.isHidden = true
     playerCore = nil
+    loadingURL = nil
   }
 
   func windowShouldClose(_ sender: NSWindow) -> Bool {

--- a/iina/OpenURLWindowController.swift
+++ b/iina/OpenURLWindowController.swift
@@ -56,6 +56,14 @@ class OpenURLWindowController: NSWindowController, NSTextFieldDelegate, NSContro
     showWindow(self)
   }
 
+  func failedToLoadURL(url: String?) {
+    guard isWindowLoaded && window?.isVisible == true else { return }
+    urlField.stringValue = url ?? ""
+    errorMessageLabel.isHidden = false
+    overlayView.isHidden = true
+    urlField.textColor = .systemRed
+  }
+
   func resetWindowState() {
     urlField.stringValue = ""
     usernameField.stringValue = ""

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1872,17 +1872,22 @@ class PlayerCore: NSObject {
 
   func idleActiveChanged() {
     if receivedEndFileWhileLoading && info.state == .starting {
-      if AppDelegate.shared.openURLWindow.window?.isVisible == true && info.isNetworkResource {
-        AppDelegate.shared.openURLWindow.failedToLoadURL(url: info.currentURL?.absoluteString)
-      } else {
-        errorOpeningFileAndCloseMainWindow()
+      DispatchQueue.main.async { [unowned self] in
+        currentController.close()
+        if AppDelegate.shared.openURLWindow.window?.isVisible == true && info.isNetworkResource {
+          AppDelegate.shared.openURLWindow.failedToLoadURL(url: info.currentURL?.absoluteString)
+        } else {
+          Utility.showAlert("error_open")
+        }
       }
       info.currentURL = nil
       info.isNetworkResource = false
     }
     receivedEndFileWhileLoading = false
     if info.state.loaded {
-      closeWindow()
+      DispatchQueue.main.async {
+        self.currentController.close()
+      }
     }
     if info.state != .loading {
       log("Playback has stopped")
@@ -2307,19 +2312,6 @@ class PlayerCore: NSObject {
   func hideOSD() {
     DispatchQueue.main.async {
       self.mainWindow.hideOSD()
-    }
-  }
-
-  func errorOpeningFileAndCloseMainWindow() {
-    DispatchQueue.main.async {
-      Utility.showAlert("error_open")
-      self.mainWindow.close()
-    }
-  }
-
-  func closeWindow() {
-    DispatchQueue.main.async {
-      self.currentController.close()
     }
   }
 

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -394,6 +394,9 @@ class PlayerCore: NSObject {
     // clear currentFolder since playlist is cleared, so need to auto-load again in playerCore#fileStarted
     info.currentFolder = nil
     info.isNetworkResource = isNetwork
+    if isNetwork {
+      AppDelegate.shared.openURLWindow.showLoadingScreen(playerCore: self)
+    }
 
     let _ = mainWindow.window
     mainWindow.pendingShow = true

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -286,6 +286,9 @@ class PlayerCore: NSObject {
     }
     log("Open URL: \(url.absoluteString)")
     let isNetwork = !url.isFileURL
+    if isNetwork {
+      currentWindow?.close()
+    }
     if shouldAutoLoad {
       info.shouldAutoLoadFiles = true
     }
@@ -2180,6 +2183,7 @@ class PlayerCore: NSObject {
     if currentController.pendingShow {
       currentController.pendingShow = false
       currentController.showWindow(self)
+      AppDelegate.shared.openURLWindow.close()
     }
   }
 

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1830,7 +1830,7 @@ class PlayerCore: NSObject {
   func fileEnded(dueToStopCommand: Bool) {
     // if receive end-file when loading file, might be error
     // wait for idle
-    if info.state == .loading {
+    if info.state == .starting {
       if !dueToStopCommand {
         receivedEndFileWhileLoading = true
       }
@@ -1871,8 +1871,12 @@ class PlayerCore: NSObject {
   }
 
   func idleActiveChanged() {
-    if receivedEndFileWhileLoading && info.state == .loading {
-      errorOpeningFileAndCloseMainWindow()
+    if receivedEndFileWhileLoading && info.state == .starting {
+      if AppDelegate.shared.openURLWindow.window?.isVisible == true && info.isNetworkResource {
+        AppDelegate.shared.openURLWindow.failedToLoadURL(url: info.currentURL?.absoluteString)
+      } else {
+        errorOpeningFileAndCloseMainWindow()
+      }
       info.currentURL = nil
       info.isNetworkResource = false
     }

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1874,8 +1874,8 @@ class PlayerCore: NSObject {
     if receivedEndFileWhileLoading && info.state == .starting {
       DispatchQueue.main.async { [unowned self] in
         currentController.close()
-        if AppDelegate.shared.openURLWindow.window?.isVisible == true && info.isNetworkResource {
-          AppDelegate.shared.openURLWindow.failedToLoadURL(url: info.currentURL?.absoluteString)
+        if AppDelegate.shared.openURLWindow.window?.isVisible == true {
+          AppDelegate.shared.openURLWindow.failedToLoadURL()
         } else {
           Utility.showAlert("error_open")
         }

--- a/iina/en.lproj/OpenURLWindowController.strings
+++ b/iina/en.lproj/OpenURLWindowController.strings
@@ -21,3 +21,6 @@
 
 /* Class = "NSTextFieldCell"; title = "HTTP Authentication"; ObjectID = "wxH-ic-Uug"; */
 "wxH-ic-Uug.title" = "HTTP Authentication";
+
+/* Class = "NSTextFieldCell"; title = "Loading Media……"; ObjectID = "3T9-gp-4UE"; */
+"3T9-gp-4UE.title" = "Loading Media……";


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)

---

**Description:**
After #5054, the main window will show after the video is loaded by mpv and the video size is available from mpv. Therefore when the user is loading a video from Internet through yt-dlp, nothing will show up until the video is loaded, which will take a considerate amount of time. This PR adds a loading window (which reuses the `OpenURLWindow`) when opening a URL.

Changes in this PR:
- Added an overlay view in the `OpenURLWindow` which works as a loading screen for when loading internet resources
- Added autosave name for `OpenURLWindow`
- When user closes the `OpenURLWindow` when loading a URL, stop the player core
- Fixed an issue where the "Unable to open URL" error dialog doesn't popup
  - By changing `info.state == .loading` to `info.state == .starting` when deciding whether or not mpv couldn't load the URL
  - @low-batt please confirm whether or not this is the correct fix
- Improved error handling: if mpv couldn't load the URL and `OpenURLWindow` is open with the loading screen, `OpenURLWindow` will change back to normal mode with error message, so that the user can input another URL and try again. See the video below:


https://github.com/user-attachments/assets/b2747bc3-c3cd-4d15-a341-ad4cb3ecda3b


https://github.com/user-attachments/assets/40df5b5b-d42f-4aea-b1cc-449a621c6720

