### PR TITLE
Fix colors looks darker in IINA compared to MPV, #5124

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -804,6 +804,13 @@ class MPVController: NSObject {
     return mpv_set_property_string(mpv, name, value)
   }
 
+  func getEnum<T: MPVOptionValue>(_ name: String) -> T {
+    guard let value = getString(name) else {
+      return T.defaultValue
+    }
+    return T.init(rawValue: value) ?? T.defaultValue
+  }
+
   func getInt(_ name: String) -> Int {
     var data = Int64()
     mpv_get_property(mpv, name, MPV_FORMAT_INT64, &data)

--- a/iina/MPVOption.swift
+++ b/iina/MPVOption.swift
@@ -1487,3 +1487,17 @@ struct MPVOption {
   }
 
 }
+
+// MARK: - Enums for Option Values
+
+protocol MPVOptionValue {
+  static var defaultValue: Self { get }
+  init?(rawValue: String)
+}
+
+enum CocoaCbSwRenderer: String, MPVOptionValue {
+  case auto
+  case no
+  case yes
+  static var defaultValue = CocoaCbSwRenderer.auto
+}

--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -10,12 +10,68 @@ import Cocoa
 import OpenGL.GL
 import OpenGL.GL3
 
+let glVersions: [CGLOpenGLProfile] = [
+    kCGLOGLPVersion_3_2_Core,
+    kCGLOGLPVersion_Legacy
+]
+
+let glFormatBase: [CGLPixelFormatAttribute] = [
+    kCGLPFAOpenGLProfile,
+    kCGLPFAAccelerated,
+    kCGLPFADoubleBuffer
+]
+
+let glFormatSoftwareBase: [CGLPixelFormatAttribute] = [
+    kCGLPFAOpenGLProfile,
+    kCGLPFARendererID,
+    CGLPixelFormatAttribute(UInt32(kCGLRendererGenericFloatID)),
+    kCGLPFADoubleBuffer
+]
+
+let glFormatOptional: [[CGLPixelFormatAttribute]] = [
+    [kCGLPFABackingStore],
+    [kCGLPFAAllowOfflineRenderers]
+]
+
+let glFormat10Bit: [CGLPixelFormatAttribute] = [
+    kCGLPFAColorSize,
+    _CGLPixelFormatAttribute(rawValue: 64),
+    kCGLPFAColorFloat
+]
+
+let glFormatAutoGPU: [CGLPixelFormatAttribute] = [
+    kCGLPFASupportsAutomaticGraphicsSwitching
+]
+
+let attributeLookUp: [UInt32: String] = [
+    kCGLOGLPVersion_3_2_Core.rawValue: "kCGLOGLPVersion_3_2_Core",
+    kCGLOGLPVersion_Legacy.rawValue: "kCGLOGLPVersion_Legacy",
+    kCGLPFAOpenGLProfile.rawValue: "kCGLPFAOpenGLProfile",
+    UInt32(kCGLRendererGenericFloatID): "kCGLRendererGenericFloatID",
+    kCGLPFARendererID.rawValue: "kCGLPFARendererID",
+    kCGLPFAAccelerated.rawValue: "kCGLPFAAccelerated",
+    kCGLPFADoubleBuffer.rawValue: "kCGLPFADoubleBuffer",
+    kCGLPFABackingStore.rawValue: "kCGLPFABackingStore",
+    kCGLPFAColorSize.rawValue: "kCGLPFAColorSize",
+    kCGLPFAColorFloat.rawValue: "kCGLPFAColorFloat",
+    kCGLPFAAllowOfflineRenderers.rawValue: "kCGLPFAAllowOfflineRenderers",
+    kCGLPFASupportsAutomaticGraphicsSwitching.rawValue: "kCGLPFASupportsAutomaticGraphicsSwitching"
+]
+
+/// OpenGL layer for `VideoView`.
+///
+/// This class is structured to make it easier to compare it to the reference implementation in the mpv player. Methods and statements
+/// are in the same order as found in the mpv source. However there are differences that cause the implementation to not match up. For
+/// example IINA draws using a background thread whereas mpv uses the main thread. For this reason the locking differs as IINA has to
+/// coordinate access to data that is shared between the main thread and the background thread.
 class ViewLayer: CAOpenGLLayer {
 
-  weak var videoView: VideoView!
+  private weak var videoView: VideoView!
 
   let mpvGLQueue = DispatchQueue(label: "com.colliderli.iina.mpvgl", qos: .userInteractive)
   @Atomic var blocked = false
+
+  private var bufferDepth: GLint = 8
 
   private let cglContext: CGLContextObj
   private let cglPixelFormat: CGLPixelFormatObj
@@ -33,16 +89,20 @@ class ViewLayer: CAOpenGLLayer {
   /// For the display lock a recursive lock is needed because the call to `CATransaction.flush()` in `display` calls
   /// `display_if_needed` which will then call `display` if layout is needed. See the discussion in PR
   /// [#5029](https://github.com/iina/iina/pull/5029).
-  override init() {
-    cglPixelFormat = ViewLayer.createPixelFormat()
+  /// - Parameter videoView: The view this layer will be associated with.
+  init(_ videoView: VideoView) {
+    self.videoView = videoView
+    (cglPixelFormat, bufferDepth) = ViewLayer.createPixelFormat(videoView.player)
     cglContext = ViewLayer.createContext(cglPixelFormat)
     displayLock = NSRecursiveLock()
     super.init()
-
-    isOpaque = true
-    isAsynchronous = false
-
     autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
+    backgroundColor = NSColor.black.cgColor
+    wantsExtendedDynamicRangeContent = true
+    if bufferDepth > 8 {
+      contentsFormat = .RGBA16Float
+    }
+    isAsynchronous = false
   }
 
   /// Returns an initialized shadow copy of the given layer with custom instance variables copied from `layer`.
@@ -54,23 +114,21 @@ class ViewLayer: CAOpenGLLayer {
   /// - Parameter layer: The layer from which custom fields should be copied.
   override init(layer: Any) {
     let previousLayer = layer as! ViewLayer
+    videoView = previousLayer.videoView
     cglPixelFormat = previousLayer.cglPixelFormat
     cglContext = previousLayer.cglContext
     displayLock = previousLayer.displayLock
     super.init(layer: layer)
-    isOpaque = previousLayer.isOpaque
-    isAsynchronous = previousLayer.isAsynchronous
     autoresizingMask = previousLayer.autoresizingMask
-    videoView = previousLayer.videoView
+    backgroundColor = previousLayer.backgroundColor
+    wantsExtendedDynamicRangeContent = previousLayer.wantsExtendedDynamicRangeContent
+    contentsFormat = previousLayer.contentsFormat
+    isAsynchronous = previousLayer.isAsynchronous
   }
 
   required init?(coder aDecoder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
-
-  override func copyCGLPixelFormat(forDisplayMask mask: UInt32) -> CGLPixelFormatObj { cglPixelFormat }
-
-  override func copyCGLContext(forPixelFormat pf: CGLPixelFormatObj) -> CGLContextObj { cglContext }
 
   // MARK: - Draw
 
@@ -109,13 +167,16 @@ class ViewLayer: CAOpenGLLayer {
                                     h: Int32(dims[3]),
                                     internal_format: 0)
           withUnsafeMutablePointer(to: &data) { data in
-            var params: [mpv_render_param] = [
-              mpv_render_param(type: MPV_RENDER_PARAM_OPENGL_FBO, data: .init(data)),
-              mpv_render_param(type: MPV_RENDER_PARAM_FLIP_Y, data: .init(flip)),
-              mpv_render_param()
-            ]
-            mpv_render_context_render(context, &params)
-            ignoreGLError()
+            withUnsafeMutablePointer(to: &bufferDepth) { bufferDepth in
+              var params: [mpv_render_param] = [
+                mpv_render_param(type: MPV_RENDER_PARAM_OPENGL_FBO, data: .init(data)),
+                mpv_render_param(type: MPV_RENDER_PARAM_FLIP_Y, data: .init(flip)),
+                mpv_render_param(type: MPV_RENDER_PARAM_DEPTH, data:.init(bufferDepth)),
+                mpv_render_param()
+              ]
+              mpv_render_context_render(context, &params)
+              ignoreGLError()
+            }
           }
         } else {
           glClearColor(0, 0, 0, 1)
@@ -137,19 +198,9 @@ class ViewLayer: CAOpenGLLayer {
     mpvGLQueue.resume()
   }
 
-  func draw(forced: Bool = false) {
-    videoView.$isUninited.withLock() { isUninited in
-      // The properties forceRender and needsMPVRender are always accessed while holding isUninited's
-      // lock. This avoids the need for separate locks to avoid data races with these flags. No need
-      // to check isUninited at this point.
-      needsMPVRender = true
-      if forced { forceRender = true }
-    }
+  override func copyCGLPixelFormat(forDisplayMask mask: UInt32) -> CGLPixelFormatObj { cglPixelFormat }
 
-    // Must not call display while holding isUninited's lock as that method will attempt to acquire
-    // the lock and our locks do not support recursion.
-    display()
-  }
+  override func copyCGLContext(forPixelFormat pf: CGLPixelFormatObj) -> CGLContextObj { cglContext }
 
   override func display() {
     displayLock.lock()
@@ -191,14 +242,98 @@ class ViewLayer: CAOpenGLLayer {
     }
   }
 
+  func draw(forced: Bool = false) {
+    videoView.$isUninited.withLock() { isUninited in
+      // The properties forceRender and needsMPVRender are always accessed while holding isUninited's
+      // lock. This avoids the need for separate locks to avoid data races with these flags. No need
+      // to check isUninited at this point.
+      needsMPVRender = true
+      if forced { forceRender = true }
+    }
+
+    // Must not call display while holding isUninited's lock as that method will attempt to acquire
+    // the lock and our locks do not support recursion.
+    display()
+  }
+
   // MARK: - Core OpenGL Context and Pixel Format
+
+  private static func createPixelFormat(_ player: PlayerCore) -> (CGLPixelFormatObj, GLint) {
+    var pix: CGLPixelFormatObj?
+    var depth: GLint = 8
+    var err: CGLError = CGLError(rawValue: 0)
+    let swRender: CocoaCbSwRenderer = player.mpv.getEnum(MPVOption.GPURendererOptions.cocoaCbSwRenderer)
+
+    if swRender != .yes {
+      (pix, depth, err) = ViewLayer.findPixelFormat(player)
+    }
+
+    if (err != kCGLNoError || pix == nil) && swRender != .no {
+      (pix, depth, err) = ViewLayer.findPixelFormat(player, software: true)
+    }
+
+    guard let pixelFormat = pix, err == kCGLNoError else {
+      Logger.fatal("Cannot create OpenGL pixel format!")
+    }
+
+    return (pixelFormat, depth)
+  }
+
+  private static func findPixelFormat(_ player: PlayerCore, software: Bool = false) -> (CGLPixelFormatObj?, GLint, CGLError) {
+    let subsystem = Logger.makeSubsystem("layer\(player.playerNumber)")
+    var pix: CGLPixelFormatObj?
+    var err: CGLError = CGLError(rawValue: 0)
+    var npix: GLint = 0
+
+    for ver in glVersions {
+      var glBase = software ? glFormatSoftwareBase : glFormatBase
+      glBase.insert(CGLPixelFormatAttribute(ver.rawValue), at: 1)
+
+      var glFormat = [glBase]
+      if player.mpv.getFlag(MPVOption.GPURendererOptions.cocoaCb10bitContext) {
+        glFormat += [glFormat10Bit]
+      }
+      glFormat += glFormatOptional
+
+      if !Preference.bool(for: .forceDedicatedGPU) {
+        glFormat += [glFormatAutoGPU]
+      }
+
+      for index in stride(from: glFormat.count-1, through: 0, by: -1) {
+        let format = glFormat.flatMap { $0 } + [_CGLPixelFormatAttribute(rawValue: 0)]
+        err = CGLChoosePixelFormat(format, &pix, &npix)
+
+        if err == kCGLBadAttribute || err == kCGLBadPixelFormat || pix == nil {
+          glFormat.remove(at: index)
+        } else {
+          let attArray = format.map({ (value: _CGLPixelFormatAttribute) -> String in
+            return attributeLookUp[value.rawValue] ?? String(value.rawValue)
+          })
+
+          Logger.log("Created CGL pixel format with attributes: " +
+                     "\(attArray.joined(separator: ", "))", subsystem: subsystem)
+          return (pix, glFormat.contains(glFormat10Bit) ? 16 : 8, err)
+        }
+      }
+    }
+
+    let errS = String(cString: CGLErrorString(err))
+    Logger.log("Couldn't create a " + "\(software ? "software" : "hardware accelerated") " +
+               "CGL pixel format: \(errS) (\(err.rawValue))", subsystem: subsystem)
+    let swRenderer: CocoaCbSwRenderer = player.mpv.getEnum(MPVOption.GPURendererOptions.cocoaCbSwRenderer)
+    if software == false && swRenderer == .auto {
+      Logger.log("Falling back to software renderer", subsystem: subsystem)
+    }
+
+    return (pix, 8, err)
+  }
 
   private static func createContext(_ pixelFormat: CGLPixelFormatObj) -> CGLContextObj {
     var ctx: CGLContextObj?
     CGLCreateContext(pixelFormat, nil, &ctx)
 
     guard let ctx = ctx else {
-      Logger.fatal("Cannot create OpenGL context")
+      Logger.fatal("Cannot create OpenGL context!")
     }
 
     // Sync to vertical retrace.
@@ -210,37 +345,6 @@ class ViewLayer: CAOpenGLLayer {
 
     CGLSetCurrentContext(ctx)
     return ctx
-  }
-
-  private static func createPixelFormat() -> CGLPixelFormatObj {
-    var attributeList: [CGLPixelFormatAttribute] = [
-      kCGLPFADoubleBuffer,
-      kCGLPFAAllowOfflineRenderers,
-      kCGLPFAColorFloat,
-      kCGLPFAColorSize, CGLPixelFormatAttribute(64),
-      kCGLPFAOpenGLProfile, CGLPixelFormatAttribute(kCGLOGLPVersion_3_2_Core.rawValue),
-      kCGLPFAAccelerated,
-    ]
-
-    if (!Preference.bool(for: .forceDedicatedGPU)) {
-      attributeList.append(kCGLPFASupportsAutomaticGraphicsSwitching)
-    }
-
-    var pix: CGLPixelFormatObj?
-    var npix: GLint = 0
-
-    for index in (0..<attributeList.count).reversed() {
-      let attributes = Array(
-        attributeList[0...index] + [_CGLPixelFormatAttribute(rawValue: 0)]
-      )
-      CGLChoosePixelFormat(attributes, &pix, &npix)
-      if let pix = pix {
-        Logger.log("Created OpenGL pixel format with \(attributes)", level: .debug)
-        return pix
-      }
-    }
-
-    Logger.fatal("Cannot create OpenGL pixel format!")
   }
 
   // MARK: - Utils

--- a/other/parse_doc.rb
+++ b/other/parse_doc.rb
@@ -134,6 +134,17 @@ File.open(File.join(__dir__, 'MPVOption.swift'), 'w') do |file|
     file.write "  }\n\n"
   end
 
+  file.write "}\n\n"
+  file.write "// MARK: - Enums for Option Values\n\n"
+  file.write "protocol MPVOptionValue {\n"
+  file.write "  static var defaultValue: Self { get }\n"
+  file.write "  init?(rawValue: String)\n"
+  file.write "}\n\n"
+  file.write "enum CocoaCbSwRenderer: String, MPVOptionValue {\n"
+  file.write "  case auto\n"
+  file.write "  case no\n"
+  file.write "  case yes\n"
+  file.write "  static var defaultValue = CocoaCbSwRenderer.auto\n"
   file.write "}\n"
 end
 


### PR DESCRIPTION
This commit will:
- Change `VideoView.setICCProfile` to set the color space of the level to the color space of the screen
- Remove setting of `wantsExtendedDynamicRangeContent` in `VideoView.requestEdrMode`
- Reordered statements and methods in `VideoLayer` to match up with mpv
- Add `bufferDepth` property to `VideoLayer`
- Replaced setting of `isOpaque` with `backgroundColor` in `VideoLayer`
- Add setting of `wantsExtendedDynamicRangeContent` to `true` in `VideoLayer`
- Add setting of `contentsFormat` to `RGBA16Float` if `bufferDepth` is greater than `8`
- Added setting of `MPV_RENDER_PARAM_DEPTH` to draw in `VideoLayer`
- Changed `createPixelFormat` to support [cocoa-cb-sw-renderer](https://mpv.io/manual/stable/#options-cocoa-cb-sw-renderer)  in `VideoLayer`
- Added a `findPixelForma`t method to `VideoLayer` that supports [cocoa-cb-10bit-context](https://mpv.io/manual/stable/#options-cocoa-cb-10bit-context)
- Changed `InspectorWindowController.updateInfo` to handle color spaces without names
- Changed `parse_doc.rb` to add a `MPVOptionValue` protocol and a `CocoaCbSwRenderer` enum type to `MPVOption`
- Regenerated `MPVOption`
- Added a `getEnum` method to `MPVController` that will return an option value as an enum constant

These changes bring `VideoLayer` closer into alignment with the mpv reference implementation. Some differences are required. IINA uses a background thread for drawing which requires different locking compared to mpv which uses the main thread for drawing.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5124.

---

**Description:**
