### PR TITLE
Allow drop of playlist files into Welcome window

### DIFF
--- a/iina/DraggingDetect.swift
+++ b/iina/DraggingDetect.swift
@@ -140,6 +140,7 @@ extension PlayerCore {
     if types.contains(.nsFilenames) {
       guard var paths = pb.propertyList(forType: .nsFilenames) as? [String] else { return [] }
       paths = Utility.resolvePaths(paths)
+      
       // check 3d lut files
       if paths.count == 1 && Utility.lut3dExt.contains(paths[0].lowercasedPathExtension) {
         return .copy
@@ -147,11 +148,20 @@ extension PlayerCore {
 
       if isPlaylist {
         return hasPlayableFiles(in: paths) ? .copy : []
-      } else {
-        let theOnlyPathIsBDFolder = paths.count == 1 && isBDFolder(URL(fileURLWithPath: paths[0]))
-        return theOnlyPathIsBDFolder ||
-          hasPlayableFiles(in: paths) ||
-          hasSubtitleFile(in: paths) ? .copy : []
+      }
+
+      if paths.count == 1 {
+        let url = URL(fileURLWithPath: paths[0])
+
+        if isBDFolder(url)
+            || Utility.playlistFileExt.contains(url.absoluteString.lowercasedPathExtension) {
+          return .copy
+        }
+      }
+
+      if hasPlayableFiles(in: paths)
+          || hasSubtitleFile(in: paths) {
+        return .copy
       }
     } else if types.contains(.nsURL) {
       return .copy


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**

Allows playlist files such as `*.m3u` to be opened by dropping them onto the Welcome window, so it matches the drag & drop functionality of the IINA dock icon.

This cleans up a little bit of the affected code in `DraggingDetect.acceptFromPasteboard` so it more closely resembles the code in `PlayerCore.openURLs`, but the key part is the added check for `Utility.playlistFileExt.contains(url.absoluteString.lowercasedPathExtension)`.