### PR TITLE
Fix Touch Bar updated when not visible, #4869

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -157,6 +157,7 @@
 		49542982216C34950058F680 /* ToolbarItemIcon.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 49542981216C34950058F680 /* ToolbarItemIcon.pdf */; };
 		49542986216C34950058F680 /* OpenInIINA.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 49542973216C34950058F680 /* OpenInIINA.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		496B19921E2968530035AF10 /* PIP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 496B19911E2968530035AF10 /* PIP.framework */; };
+		5111B18B2C8BCEAC00DEC0AC /* TouchBarSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5111B18A2C8BCEAC00DEC0AC /* TouchBarSettings.swift */; };
 		512B8FDD2BC2376E00AF41BF /* OutlineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512B8FDC2BC2376E00AF41BF /* OutlineView.swift */; };
 		513A4FFA29B53F8100A8EA7D /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513A4FF929B53F8100A8EA7D /* Atomic.swift */; };
 		515B5E5A2A579903001FCD49 /* iina-plugin in Copy Executables */ = {isa = PBXBuildFile; fileRef = E38558872A484A2D0083772D /* iina-plugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
@@ -1178,6 +1179,7 @@
 		4964988E2919E47900CD61A5 /* OpenInIINA.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = OpenInIINA.xcconfig; sourceTree = "<group>"; };
 		496B19911E2968530035AF10 /* PIP.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PIP.framework; path = /System/Library/PrivateFrameworks/PIP.framework; sourceTree = "<group>"; };
 		49F7E3BF2920D65C002DA28E /* Availability.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Availability.xcconfig; sourceTree = "<group>"; };
+		5111B18A2C8BCEAC00DEC0AC /* TouchBarSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchBarSettings.swift; sourceTree = "<group>"; };
 		512B8FDC2BC2376E00AF41BF /* OutlineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutlineView.swift; sourceTree = "<group>"; };
 		513A4FF929B53F8100A8EA7D /* Atomic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
 		51537C7229FA26DD00F9A472 /* Nightly.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Nightly.xcconfig; sourceTree = "<group>"; };
@@ -2211,6 +2213,7 @@
 				E374160B20F138A900B4F7F9 /* CollapseView.swift */,
 				519872FE26879B9B00F84BCC /* AccessibilityPreferences.swift */,
 				D1A4D9892B1495270009AB4E /* LegacyMigration.swift */,
+				5111B18A2C8BCEAC00DEC0AC /* TouchBarSettings.swift */,
 			);
 			name = Preference;
 			sourceTree = "<group>";
@@ -3117,6 +3120,7 @@
 				E38B3216214FF700000F6D27 /* EventController.swift in Sources */,
 				E3CB75BD1FDACB82004DB10A /* SavedFilter.swift in Sources */,
 				E337D5E4241C12BE00B5729A /* PrefPluginPermissionListView.swift in Sources */,
+				5111B18B2C8BCEAC00DEC0AC /* TouchBarSettings.swift in Sources */,
 				E3785B072A83039600787CB7 /* JavascriptAPIWebSocket.swift in Sources */,
 				E342832F20B7149800139865 /* Logger.swift in Sources */,
 				84F725561D4783EE000DEF1B /* VolumeSliderCell.swift in Sources */,

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -108,10 +108,23 @@ class PlayerCore: NSObject {
   }
   private var _touchBarSupport: Any?
 
-  /// `true` if this Mac is known to have a touch bar.
+  /// `true` if this Mac is _known to_ have a  [Touch Bar](https://support.apple.com/guide/mac-help/use-the-touch-bar-mchlbfd5b039/mac).
   ///
-  /// - Note: This is set based on whether `AppKit` has called `MakeTouchBar`, therefore it can, for example, be `false` for
-  ///         a MacBook that has a touch bar if the touch bar is asleep because the Mac is in closed clamshell mode.
+  /// In order to adhere to energy efficiency best practices IINA should stop the timer that synchronizes the UI when it is not needed.
+  /// As one job of the timer is to update the Touch Bar on Macs that have one, IINA needs information such as:
+  /// - Does this host have a Touch Bar?
+  /// - Is the Touch Bar configured to show app controls?
+  /// - Is the Touch Bar awake?
+  /// - Is the host being operated in closed clamshell mode?
+  ///
+  /// This is the kind of information needed to avoid running the timer and updating controls that are not visible. Unfortunately in the
+  /// documentation for [NSTouchBar](https://developer.apple.com/documentation/appkit/nstouchbar) Apple
+  /// indicates "There’s no need, and no API, for your app to know whether or not there’s a Touch Bar available". So this property is
+  /// set based off whether `AppKit` has requested that a `NSTouchBar` object be created by calling
+  /// [MakeTouchBar](https://developer.apple.com/documentation/appkit/nsresponder/2544690-maketouchbar).
+  /// This property is used to avoid running the timer on Macs that do not have a Touch Bar. It also may avoid running the timer when a
+  /// MacBook with a Touch Bar is being operated in closed clamshell mode as `AppKit` will not call `MakeTouchBar` when the
+  /// Touch Bar is asleep.
   var needsTouchBar = false
 
   /// A dispatch queue for auto load feature.
@@ -239,6 +252,9 @@ class PlayerCore: NSObject {
     self.miniPlayer = MiniPlayerWindowController(playerCore: self)
     self.initialWindow = InitialWindowController(playerCore: self)
     self._touchBarSupport = TouchBarSupport(playerCore: self)
+    TouchBarSettings.shared.addObserver(self, forKey: .PresentationModeFnModes)
+    TouchBarSettings.shared.addObserver(self, forKey: .PresentationModeGlobal)
+    TouchBarSettings.shared.addObserver(self, forKey: .PresentationModePerApp)
   }
 
   // MARK: - Plugins
@@ -2066,9 +2082,14 @@ class PlayerCore: NSObject {
 
   // MARK: - Sync with UI in MainWindow
 
+  /// Assess the need for the timer that synchronizes the UI and start or stop it as needed.
+  ///
   /// Call this when `syncUITimer` may need to be started, stopped, or needs its interval changed. It will figure out the correct action.
-  /// Just need to make sure that any state variables (e.g., `info.isPaused`, `isInMiniPlayer`,  etc.) are set *before* calling this method,
-  /// not after, so that it makes the correct decisions.
+  ///
+  /// This method is required to adhere to the best practices in the [Energy Efficiency Guide for Mac Apps](https://developer.apple.com/library/archive/documentation/Performance/Conceptual/power_efficiency_guidelines_osx/UsingEfficientGraphics.html#//apple_ref/doc/uid/TP40013929-CH27-SW1)
+  /// that call for an app to avoid needless energy use. [Minimizing Timer Usage](https://developer.apple.com/library/archive/documentation/Performance/Conceptual/power_efficiency_guidelines_osx/Timers.html#//apple_ref/doc/uid/TP40013929-CH5-SW1) is one of the recommended best practices.
+  /// - Important: Make sure that any state variables (e.g., `info.isPaused`, `isInMiniPlayer`,  etc.) are set *before*
+  ///     calling this method, not after, so that it makes the correct decisions.
   func refreshSyncUITimer() {
     // Check if timer should start/restart
 
@@ -2076,28 +2097,17 @@ class PlayerCore: NSObject {
     if !info.state.active {
       useTimer = false
     } else if info.state == .paused {
-      // Follow energy efficiency best practices and ensure IINA is absolutely idle when the
-      // video is paused to avoid wasting energy with needless processing. If paused shutdown
-      // the timer that synchronizes the UI and the high priority display link thread.
+      // Ensure IINA is absolutely idle when the video is paused.
       useTimer = false
-    } else if needsTouchBar || isInMiniPlayer {
-      // Follow energy efficiency best practices and stop the timer that updates the OSC while it is
-      // hidden. However the timer can't be stopped if the mini player is being used as it always
-      // displays the OSC or the timer is also updating the information being displayed in the
-      // touch bar. Does this host have a touch bar? Is the touch bar configured to show app controls?
-      // Is the touch bar awake? Is the host being operated in closed clamshell mode? This is the kind
-      // of information needed to avoid running the timer and updating controls that are not visible.
-      // Unfortunately in the documentation for NSTouchBar Apple indicates "There’s no need, and no
-      // API, for your app to know whether or not there’s a Touch Bar available". So this code keys
-      // off whether AppKit has requested that a NSTouchBar object be created. This avoids running the
-      // timer on Macs that do not have a touch bar. It also may avoid running the timer when a
-      // MacBook with a touch bar is being operated in closed clameshell mode.
+    } else if needsTouchBar && TouchBarSettings.shared.showAppControls || isInMiniPlayer {
+      // The timer can't be stopped if the mini player is being used as it always displays the OSC
+      // or if the timer is updating the information being displayed in the Touch Bar.
       useTimer = true
     } else if info.isNetworkResource {
-      // May need to show, hide, or update buffering indicator at any time
+      // May need to show, hide, or update buffering indicator at any time.
       useTimer = true
     } else {
-      // Need if fadeable views or OSD are visible
+      // Need if fadeable views or OSD are visible.
       useTimer = mainWindow.isUITimerNeeded()
     }
 
@@ -2431,6 +2441,36 @@ class PlayerCore: NSObject {
 
   func postNotification(_ name: Notification.Name) {
     NotificationCenter.default.post(Notification(name: name, object: self))
+  }
+
+  /// Observer for changes to the macOS Touch Bar settings.
+  /// - Parameters:
+  ///   - keyPath; The key path, relative to `object`, to the value that has changed.
+  ///   - object: The source object of the key path `keyPath`.
+  ///   - change: A dictionary that describes the changes that have been made to the value of the property at the key path
+  ///             `keyPath` relative to object. Entries are described in `Change Dictionary Keys`.
+  ///   - context: The value that was provided when the observer was registered to receive key-value observation notifications.
+  override func observeValue(forKeyPath keyPath: String?, of object: Any?,
+                             change: [NSKeyValueChangeKey: Any]?,
+                             context: UnsafeMutableRawPointer?) {
+    // The following guards are sanity checks and should never report an error.
+    guard let keyPath = keyPath else {
+      log("Observed key path is missing", level: .error)
+      return
+    }
+    guard let key = TouchBarSettings.Key(rawValue: keyPath) else {
+      log("Observed key path is not a touch bar setting: \(keyPath)", level: .error)
+      return
+    }
+    guard key == .PresentationModeFnModes || key == .PresentationModeGlobal ||
+          key == .PresentationModePerApp else {
+      log("Observed key path is unrecognized: \(keyPath)", level: .error)
+      return
+    }
+    log("Touch Bar \(key) setting has changed")
+    // The macOS settings that control what the Touch Bar displays has changed. May need to start or
+    // stop the timer that refreshes the UI.
+    refreshSyncUITimer()
   }
 
   // MARK: - Utils

--- a/iina/TouchBarSettings.swift
+++ b/iina/TouchBarSettings.swift
@@ -1,0 +1,185 @@
+//
+//  TouchBarSettings.swift
+//  iina
+//
+//  Created by low-batt on 9/6/24.
+//  Copyright © 2024 lhc. All rights reserved.
+//
+
+import Foundation
+
+/// Provides access to the macOS [Touch Bar](https://support.apple.com/guide/mac-help/use-the-touch-bar-mchlbfd5b039/mac)  settings.
+///
+/// The [Customize the Touch Bar on Mac](https://support.apple.com/guide/mac-help/customize-the-touch-bar-mchl5a63b060/mac)
+/// section of the [Mac User Guide](https://support.apple.com/guide/mac-help/welcome/mac) describes the
+/// [Touch Bar](https://support.apple.com/guide/mac-help/use-the-touch-bar-mchlbfd5b039/mac) settings
+/// provided by macOS. The user can choose to configure the Touch Bar such that it is not showing the app controls provided by IINA. In
+/// order to adhere to the best practices  in the [Energy Efficiency Guide for Mac Apps](https://developer.apple.com/library/archive/documentation/Performance/Conceptual/power_efficiency_guidelines_osx/UsingEfficientGraphics.html#//apple_ref/doc/uid/TP40013929-CH27-SW1)
+/// IINA needs to avoid drawing the Touch Bar if it is not displaying app controls. View attributes such as `visibleRect` indicate
+/// IINA's app controls are visible even when the Touch Bar is not displaying them. IINA must check the Touch Bar settings to determine
+/// if app controls are being displayed.
+///
+/// On Macs with a Touch Bar the settings are stored in `~/Library/Preferences/com.apple.touchbar.agent.plist`. The
+/// current settings can be seen by running the following command in
+/// [Terminal](https://support.apple.com/guide/terminal/welcome/mac):
+/// ````
+/// defaults read com.apple.touchbar.agent
+/// ````
+struct TouchBarSettings {
+  /// The `TouchBarSettings` singleton object.
+  static let shared = TouchBarSettings()
+  
+  /// The keys that are contained in the macOS Touch Bar settings property list.
+  enum Key: String {
+    
+    /// This key has a dictionary value that stores the `Press and hold fn key to` setting.
+    ///
+    /// The value of the `PresentationModeGlobal` setting is used as the key to obtain the active value of this setting. Using a
+    /// dictionary preserves the values of this setting for other values of the `PresentationModeGlobal` setting.
+    case PresentationModeFnModes
+    
+    /// This key has a string value that stores the `Touch Bar shows` setting along with the `Show Control Strip` setting,
+    /// indicated by a `WithControlStrip` suffix.
+    ///
+    /// The `Show Control Strip` setting is only applicable to a subset of the possible `Touch Bar shows` values. The
+    /// possible values are:
+    /// - App Controls ("app" or "appWithControlStrip")
+    /// - Expanded Control Strip ("fullControlStrip")
+    /// - F1, F2, etc. Keys ("functionKeys")
+    /// - Quick Actions ("workflows" or "workflowsWithControlStrip")
+    /// - Spaces ("spaces" or "spacesWithControlStrip")
+    case PresentationModeGlobal
+    
+    /// This key has a dictionary value that stores the `show function keys in Touch Bar instead of app controls`
+    /// setting.
+    ///
+    /// An app's [bundle ID](https://developer.apple.com/documentation/bundleresources/information_property_list/cfbundleidentifier_)
+    /// is used as the key to the dictionary. The value is always "functionKeys".
+    case PresentationModePerApp
+  }
+
+  /// The values that are contained in the macOS Touch Bar settings property list.
+  private enum Value: String {
+    case app
+    case appWithControlStrip
+    case fullControlStrip
+    case functionKeys
+    case spaces
+    case spacesWithControlStrip
+    case workflows
+    case workflowsWithControlStrip
+  }
+
+  /// Will be `false` if it is _known for certain_ that the Touch Bar is not configured to show app controls; otherwise `true`.
+  /// - Note: If the the `Press and hold fn key to` setting is set to `App Controls` IINA assumes app controls are being
+  ///         displayed all the time. It would be possible to optimize this further so that in this case IINA would draw the Touch Bar
+  ///         only when the `fn` key is pressed.
+  var showAppControls: Bool {
+    if hasPerAppSetting() { return false }
+    guard let globalSetting = getGlobalSetting() else { return true }
+    if globalSetting == Value.app || globalSetting == Value.appWithControlStrip {
+      return true
+    }
+    guard let fnModeSetting = getFnModeSetting(globalSetting) else { return true }
+    return fnModeSetting == Value.app || globalSetting == Value.appWithControlStrip
+  }
+  
+  /// The macOS TouchBar settings.
+  ///
+  /// This will be `nil` on Macs that do not have a Touch Bar.
+  private let defaults: UserDefaults?
+
+  /// Registers the observer object to receive notifications for the specified setting.
+  /// - Parameters:
+  ///   - observer: The object to register for notifications of changes to the specified setting. The observer must implement
+  ///               the key-value observing method [observeValue(forKeyPath:of:change:context:)](https://developer.apple.com/documentation/objectivec/nsobject/1416553-observevalue).
+  ///   - key: The setting to observe.
+  ///   - options: A combination of the `NSKeyValueObservingOptions` values that specifies what is included in
+  ///             observation notifications. For possible values, see [NSKeyValueObservingOptions](https://developer.apple.com/documentation/foundation/nskeyvalueobservingoptions).
+  ///   - context: Arbitrary data that is passed to observer in [observeValue(forKeyPath:of:change:context:)](https://developer.apple.com/documentation/objectivec/nsobject/1416553-observevalue).
+  func addObserver(_ observer: NSObject, forKey key: Key, options: NSKeyValueObservingOptions = [],
+                   context: UnsafeMutableRawPointer? = nil) {
+    defaults?.addObserver(observer, forKeyPath: key.rawValue, options: options, context: context)
+  }
+
+  // MARK: - Private Functions
+
+  /// Returns the value for the specified setting.
+  ///
+  /// This is a simple wrapper that merely allows the caller to specify the setting as a `Key` enumeration value instead of a String.
+  /// - Parameter key: The setting to return the value of.
+  /// - Returns: The value set for the specified setting.
+  private func dictionary(_ key: Key) -> [String : Any]? {
+    guard let defaults else { return nil }
+    return defaults.dictionary(forKey: key.rawValue)
+  }
+  
+  /// Returns the value of the `Press and hold fn key to` setting.
+  /// - Parameter globalSetting: The value the `Touch Bar shows` setting is set to.
+  /// - Returns: The value of the setting if known; otherwise `nil`.
+  private func getFnModeSetting(_ globalSetting: Value) -> Value? {
+    guard let dictionary = dictionary(Key.PresentationModeFnModes) else {
+      // Return the default for the associated with the global setting.
+      return globalSetting == .functionKeys ? .fullControlStrip : .functionKeys
+    }
+    guard let string = dictionary[globalSetting.rawValue] as? String else {
+      // Return the default for the associated with the global setting.
+      return globalSetting == .functionKeys ? .fullControlStrip : .functionKeys
+    }
+    guard let value = Value(rawValue: string) else {
+      // Internal error. Should never be logged.
+      Logger.log("PresentationModeFnModes value \(string) not recognized", level: .error)
+      return nil
+    }
+    return value
+  }
+  
+  /// Returns the value of the `Touch Bar shows` setting.
+  /// - Returns: The value of the setting if known; otherwise `nil`.
+  private func getGlobalSetting() -> Value? {
+    guard let string = string(Key.PresentationModeGlobal) else { return nil }
+    guard let value = Value(rawValue: string) else {
+      // Internal error. Should never be logged.
+      Logger.log("PresentationModeGlobal value \(string) not recognized", level: .error)
+      return nil
+    }
+    return value
+  }
+  
+  /// Returns `true` if the Touch Bar should show function keys for IINA instead of app controls.
+  /// - Returns: `true` if the user has added IINA to the `show function keys in Touch Bar instead of app controls`
+  ///             macOS setting; otherwise `false`.
+  private func hasPerAppSetting() -> Bool {
+    guard let dictionary = dictionary(Key.PresentationModePerApp),
+          let string = dictionary[InfoDictionary.shared.bundleIdentifier] as? String else {
+      return false
+    }
+    // The expectation is that the value can only ever be "functionKeys". Thus the mere presence of
+    // an app's bundle ID in the dictionary means the Touch Bar will display function keys for the
+    // app. Therefore following checks should not be needed. They are internal error checks that
+    // confirm our understanding of how the macOS Touch Bar settings property list operates.
+    guard let value = Value(rawValue: string) else {
+      Logger.log("PresentationModePerApp value \(string) not recognized", level: .error)
+      return false
+    }
+    guard value == Value.functionKeys else {
+      Logger.log("PresentationModePerApp value \(value) not functionKeys", level: .error)
+      return false
+    }
+    return true
+  }
+
+  /// Returns the value for the specified setting.
+  ///
+  /// This is a simple wrapper that merely allows the caller to specify the setting as a `Key` enumeration value instead of a String.
+  /// - Parameter key: The setting to return the value of.
+  /// - Returns: The value set for the specified setting.
+  private func string(_ key: Key) -> String? {
+    guard let defaults else { return nil }
+    return defaults.string(forKey: key.rawValue)
+  }
+
+  private init() {
+    defaults = UserDefaults(suiteName: "com.apple.touchbar.agent")
+  }
+}


### PR DESCRIPTION
This commit will:
- Add a new TouchBarSettings class for accessing the macOS Touch Bar settings
- Change PlayerCore.refreshSyncUITimer to not run the timer when the Touch Bar is not showing app controls
- Add an observer to PlayerCore for macOS Touch Bar settings changing

With these changes IINA will no longer needlessly draw the Touch Bar when the user has configured the Touch Bar to not show app controls.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4869.

---

**Description:**
