### PR TITLE
Add live update of color-related options in Settings > Codec, enforce valid values

### DIFF
--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -245,6 +245,8 @@
 "alert.error_saving_file" = "Error occurred when saving %@: %@";
 "alert.error_deleting_file" = "Cannot delete the file.";
 
+"alert.target_peak.bad_value" = "The value \"%@\" is invalid.\nPlease provide a value betwen 10 and 10000, or 0.";
+
 "alert.config.new.title" = "New Input Configuration";
 "alert.config.new.message" = "Please enter a name for the new configuration.";
 "alert.config.duplicate.title" = "Duplicate Configuration";

--- a/iina/Base.lproj/PrefCodecViewController.xib
+++ b/iina/Base.lproj/PrefCodecViewController.xib
@@ -215,11 +215,6 @@
                     <connections>
                         <action selector="toneMappingTargetPeakAction:" target="-2" id="tkO-UP-e0O"/>
                         <binding destination="pxc-7C-SGP" name="enabled" keyPath="values.enableToneMapping" id="mbf-5t-pSs"/>
-                        <binding destination="pxc-7C-SGP" name="value" keyPath="values.toneMappingTargetPeak" id="p2I-ha-v97">
-                            <dictionary key="options">
-                                <bool key="NSContinuouslyUpdatesValue" value="YES"/>
-                            </dictionary>
-                        </binding>
                     </connections>
                 </textField>
                 <textField focusRingType="none" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="bL4-aH-JLz">

--- a/iina/Base.lproj/PrefCodecViewController.xib
+++ b/iina/Base.lproj/PrefCodecViewController.xib
@@ -213,6 +213,7 @@
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                     <connections>
+                        <action selector="toneMappingTargetPeakAction:" target="-2" id="tkO-UP-e0O"/>
                         <binding destination="pxc-7C-SGP" name="enabled" keyPath="values.enableToneMapping" id="mbf-5t-pSs"/>
                         <binding destination="pxc-7C-SGP" name="value" keyPath="values.toneMappingTargetPeak" id="p2I-ha-v97">
                             <dictionary key="options">

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -48,6 +48,10 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
   internal lazy var verticalScrollAction: Preference.ScrollAction = Preference.enum(for: .verticalScrollAction)
   
   internal var observedPrefKeys: [Preference.Key] = [
+    .enableToneMapping,
+    .toneMappingTargetPeak,
+    .loadIccProfile,
+    .toneMappingAlgorithm,
     .themeMaterial,
     .showRemainingTime,
     .alwaysFloatOnTop,
@@ -68,6 +72,11 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
     guard let keyPath = keyPath, let change = change else { return }
     
     switch keyPath {
+    case PK.enableToneMapping.rawValue,
+      PK.toneMappingTargetPeak.rawValue,
+      PK.loadIccProfile.rawValue,
+      PK.toneMappingAlgorithm.rawValue:
+      videoView.refreshEdrMode()
     case PK.themeMaterial.rawValue:
       if let newValue = change[.newKey] as? Int {
         setMaterial(Preference.Theme(rawValue: newValue))

--- a/iina/PrefCodecViewController.swift
+++ b/iina/PrefCodecViewController.swift
@@ -110,8 +110,6 @@ class PrefCodecViewController: PreferenceViewController, PreferenceWindowEmbedda
     hwdecDescriptionTextField.stringValue = hwdec.localizedDescription
   }
 
-  // TODO: add "auto" option instead of 0 value
-  // TODO: add option to support "inf"
   @IBAction func toneMappingTargetPeakAction(_ sender: NSTextField) {
     let newValue = sender.integerValue
     // constrain to valid mpv values

--- a/iina/PrefCodecViewController.swift
+++ b/iina/PrefCodecViewController.swift
@@ -110,6 +110,17 @@ class PrefCodecViewController: PreferenceViewController, PreferenceWindowEmbedda
     hwdecDescriptionTextField.stringValue = hwdec.localizedDescription
   }
 
+  // TODO: add "auto" option instead of 0 value
+  // TODO: add option to support "inf"
+  @IBAction func toneMappingTargetPeakAction(_ sender: NSTextField) {
+    let newValue = sender.integerValue
+    // constrain to valid mpv values
+    let validValue = newValue == 0 ? 0 : newValue.clamped(to: 10...10000)
+    if newValue != validValue {
+      Preference.set(validValue, for: .toneMappingTargetPeak)
+    }
+  }
+
   @IBAction func toneMappingHelpAction(_ sender: Any) {
     NSWorkspace.shared.open(URL(string: AppData.toneMappingHelpLink)!)
   }

--- a/iina/PrefCodecViewController.swift
+++ b/iina/PrefCodecViewController.swift
@@ -49,6 +49,7 @@ class PrefCodecViewController: PreferenceViewController, PreferenceWindowEmbedda
     super.viewDidLoad()
     audioLangTokenField.commaSeparatedValues = Preference.string(for: .audioLanguage) ?? ""
     updateHwdecDescription()
+    updateToneMappingUI()
   }
 
   override func viewWillAppear() {
@@ -110,13 +111,24 @@ class PrefCodecViewController: PreferenceViewController, PreferenceWindowEmbedda
     hwdecDescriptionTextField.stringValue = hwdec.localizedDescription
   }
 
+  // Prefs → UI
+  private func updateToneMappingUI() {
+    toneMappingTargetPeakTextField.integerValue = Preference.integer(for: .toneMappingTargetPeak)
+  }
+
   @IBAction func toneMappingTargetPeakAction(_ sender: NSTextField) {
+    defer {
+      updateToneMappingUI()
+    }
     let newValue = sender.integerValue
     // constrain to valid mpv values
-    let validValue = newValue == 0 ? 0 : newValue.clamped(to: 10...10000)
-    if newValue != validValue {
-      Preference.set(validValue, for: .toneMappingTargetPeak)
+    let isValueValid = newValue == 0 || (newValue >= 10 && newValue <= 10000)
+    guard isValueValid else {
+      Utility.showAlert("target_peak.bad_value", arguments: [String(newValue)], sheetWindow: view.window)
+      sender.integerValue = Preference.integer(for: .toneMappingTargetPeak)
+      return
     }
+    Preference.set(newValue, for: .toneMappingTargetPeak)
   }
 
   @IBAction func toneMappingHelpAction(_ sender: Any) {

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -485,12 +485,11 @@ extension VideoView {
 
     guard player.info.hdrEnabled else { return nil }
 
-    if videoLayer.colorspace?.name == name {
-      logHDR("HDR mode already enabled, skipping")
-      return true
-    }
+    logHDR("Using HDR color space instead of ICC profile")
 
-    logHDR("Will activate HDR color space instead of using ICC profile")
+    if videoLayer.colorspace?.name != name {
+      videoLayer.colorspace = CGColorSpace(name: name!)
+    }
 
     videoLayer.colorspace = CGColorSpace(name: name!)
     mpv.setString(MPVOption.GPURendererOptions.iccProfile, "")

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -487,10 +487,6 @@ extension VideoView {
 
     logHDR("Using HDR color space instead of ICC profile")
 
-    if videoLayer.colorspace?.name != name {
-      videoLayer.colorspace = CGColorSpace(name: name!)
-    }
-
     videoLayer.colorspace = CGColorSpace(name: name!)
     mpv.setString(MPVOption.GPURendererOptions.iccProfile, "")
     mpv.setString(MPVOption.GPURendererOptions.targetPrim, primaries)

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -245,6 +245,8 @@
 "alert.error_saving_file" = "Error occurred when saving %@: %@";
 "alert.error_deleting_file" = "Cannot delete the file.";
 
+"alert.target_peak.bad_value" = "The value \"%@\" is invalid.\nPlease provide a value betwen 10 and 10000, or 0.";
+
 "alert.config.new.title" = "New Input Configuration";
 "alert.config.new.message" = "Please enter a name for the new configuration.";
 "alert.config.duplicate.title" = "Duplicate Configuration";


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
- Adds monitoring of the 4 color mapping related pref settings to `PlayerWindowController` and reloads them when changed, so the user doesn't have to quit & reopen IINA to guarantee they take effect.
- Modifies `VideoView.refreshEdrMode` so it doesn't cancel other changes if `colorspace` is already set, so the above can take effect.
- Add action to `PrefCodecViewController` to restrict `Target peak` user entry to valid values, instead of silently failing & using `400`.

The affected settings:
<img width="932" alt="Affected settings" src="https://github.com/user-attachments/assets/3fc42eed-ffe0-4521-9fde-10241bb7015b">
