### PR TITLE
Fix  colormanagement broken in 1.3.0, #3929

### DIFF
--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -305,7 +305,8 @@ class VideoView: NSView {
       logHDR("Not using ICC profile due to user preference")
       player.mpv.setFlag(MPVOption.GPURendererOptions.iccProfileAuto, false)
     } else if let screenColorSpace {
-      logHDR("Using ICC profile")
+      let name = screenColorSpace.localizedName ?? "unnamed"
+      logHDR("Using the ICC profile of the color space \(name)")
       player.mpv.setFlag(MPVOption.GPURendererOptions.iccProfileAuto, true)
       videoLayer.setRenderICCProfile(screenColorSpace)
     }

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -299,39 +299,17 @@ class VideoView: NSView {
     RunLoop.current.add(displayIdleTimer!, forMode: .default)
   }
 
-  func setICCProfile(_ displayId: UInt32) {
+  private func setICCProfile() {
+    let screenColorSpace = player.mainWindow.window?.screen?.colorSpace
     if !Preference.bool(for: .loadIccProfile) {
-      logHDR("Not using ICC due to user preference")
-      player.mpv.setString(MPVOption.GPURendererOptions.iccProfile, "")
-    } else {
-      logHDR("Loading ICC profile")
-      typealias ProfileData = (uuid: CFUUID, profileUrl: URL?)
-      guard let uuid = CGDisplayCreateUUIDFromDisplayID(displayId)?.takeRetainedValue() else { return }
-
-      var argResult: ProfileData = (uuid, nil)
-      withUnsafeMutablePointer(to: &argResult) { data in
-        ColorSyncIterateDeviceProfiles({ (dict: CFDictionary?, ptr: UnsafeMutableRawPointer?) -> Bool in
-          if let info = dict as? [String: Any], let current = info["DeviceProfileIsCurrent"] as? Int {
-            let deviceID = info["DeviceID"] as! CFUUID
-            let ptr = ptr!.bindMemory(to: ProfileData.self, capacity: 1)
-            let uuid = ptr.pointee.uuid
-
-            if current == 1, deviceID == uuid {
-              let profileURL = info["DeviceProfileURL"] as! URL
-              ptr.pointee.profileUrl = profileURL
-              return false
-            }
-          }
-          return true
-        }, data)
-      }
-
-      if let iccProfilePath = argResult.profileUrl?.path, FileManager.default.fileExists(atPath: iccProfilePath) {
-        player.mpv.setString(MPVOption.GPURendererOptions.iccProfile, iccProfilePath)
-      }
+      logHDR("Not using ICC profile due to user preference")
+      player.mpv.setFlag(MPVOption.GPURendererOptions.iccProfileAuto, false)
+    } else if let screenColorSpace {
+      logHDR("Using ICC profile")
+      player.mpv.setFlag(MPVOption.GPURendererOptions.iccProfileAuto, true)
+      videoLayer.setRenderICCProfile(screenColorSpace)
     }
 
-    let screenColorSpace = player.mainWindow.window?.screen?.colorSpace
     let sdrColorSpace = screenColorSpace?.cgColorSpace ?? VideoView.SRGB
     if videoLayer.colorspace != sdrColorSpace {
       let name: String = {
@@ -435,7 +413,7 @@ extension VideoView {
     if player.info.hdrAvailable != edrAvailable {
       player.mainWindow.quickSettingView.setHdrAvailability(to: edrAvailable)
     }
-    if edrEnabled != true { setICCProfile(displayId) }
+    if edrEnabled != true { setICCProfile() }
   }
 
   func requestEdrMode() -> Bool? {
@@ -493,7 +471,7 @@ extension VideoView {
     logHDR("Will activate HDR color space instead of using ICC profile")
 
     videoLayer.colorspace = CGColorSpace(name: name!)
-    mpv.setString(MPVOption.GPURendererOptions.iccProfile, "")
+    mpv.setFlag(MPVOption.GPURendererOptions.iccProfileAuto, false)
     mpv.setString(MPVOption.GPURendererOptions.targetPrim, primaries)
     // PQ videos will be display as it was, HLG videos will be converted to PQ
     mpv.setString(MPVOption.GPURendererOptions.targetTrc, "pq")

--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -359,6 +359,10 @@ class ViewLayer: CAOpenGLLayer {
   /// The IINA `Load ICC profile` setting is tied to the `--icc-profile-auto` option. This allows users to override IINA using
   /// the [--icc-profile](https://mpv.io/manual/stable/#options-icc-profile) option.
   func setRenderICCProfile(_ profile: NSColorSpace) {
+    // The OpenGL context must always be locked before locking the isUninited lock to avoid
+    // deadlocks.
+    videoView.player.mpv.lockAndSetOpenGLContext()
+    defer { videoView.player.mpv.unlockOpenGLContext() }
     videoView.$isUninited.withLock() { isUninited in
       guard !isUninited else { return }
 


### PR DESCRIPTION
This commit will:
- Add a new method `setRenderICCProfile` to `VideoLayer` that sets `MPV_RENDER_PARAM_ICC_PROFILE`
- Remove setting of the mpv option `icc-profile` from the `VideoView` method `setICCProfile`
- Change `VideoView` to use `icc-profile-auto` instead of `icc-profile` to control use of an ICC profile

Using `icc-profile-auto` frees `icc-profile` for use by users as  `icc-profile` overrides `icc-profile-auto`. IINA must set `MPV_RENDER_PARAM_ICC_PROFILE` in order for `icc-profile-auto` to work.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #3929.

---

**Description:**
