### PR TITLE
Fix XCode 16 warnings & improve Set as Default for MacOS 11+

### DIFF
--- a/iina/GuideWindowController.swift
+++ b/iina/GuideWindowController.swift
@@ -7,7 +7,7 @@
 //
 
 import Cocoa
-import WebKit
+@preconcurrency import WebKit
 
 fileprivate let highlightsLink = "https://iina.io/highlights"
 

--- a/iina/HistoryWindowController.swift
+++ b/iina/HistoryWindowController.swift
@@ -215,7 +215,7 @@ class HistoryWindowController: NSWindowController, NSOutlineViewDelegate, NSOutl
         let fileExists = !entry.url.isFileURL || FileManager.default.fileExists(atPath: entry.url.path)
         filenameView.textField?.stringValue = entry.url.isFileURL ? entry.name : entry.url.absoluteString
         filenameView.textField?.textColor = fileExists ? .controlTextColor : .disabledControlTextColor
-        filenameView.docImage.image = NSWorkspace.shared.icon(forFileType: entry.url.pathExtension)
+        filenameView.docImage.image = Utility.icon(for: entry.url)
       } else if identifier == .progress {
         // Progress cell
         let progressView = cell as! HistoryProgressCellView

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -710,7 +710,6 @@ class MainWindowController: PlayerWindowController {
   }
 
   private func setupOSCToolbarButtons(_ buttons: [Preference.ToolBarButton]) {
-    var buttons = buttons
     fragToolbarView.views.forEach { fragToolbarView.removeView($0) }
     for buttonType in buttons {
       let button = NSButton()

--- a/iina/OpenSubClient.swift
+++ b/iina/OpenSubClient.swift
@@ -117,10 +117,10 @@ class OpenSubClient {
   private let decoder: JSONDecoder = {
     let decoder = JSONDecoder()
     decoder.keyDecodingStrategy = .convertFromSnakeCase
-    let iso8601 = ISO8601DateFormatter()
-    let iso8601WithFractionalSeconds = ISO8601DateFormatter()
-    iso8601WithFractionalSeconds.formatOptions = [.withFractionalSeconds]
     decoder.dateDecodingStrategy = .custom({ (decoder) -> Date in
+      let iso8601 = ISO8601DateFormatter()
+      let iso8601WithFractionalSeconds = ISO8601DateFormatter()
+      iso8601WithFractionalSeconds.formatOptions = [.withFractionalSeconds]
       let container = try decoder.singleValueContainer()
       let dateStr = try container.decode(String.self)
       if let date = iso8601.date(from: dateStr) {

--- a/iina/PlaySliderCell.swift
+++ b/iina/PlaySliderCell.swift
@@ -46,32 +46,45 @@ class PlaySliderCell: NSSliderCell {
   // MARK:- Displaying the Cell
 
   override func drawKnob(_ knobRect: NSRect) {
+    let isLightTheme = !controlView!.window!.effectiveAppearance.isDark
+    if isLightTheme {
+      drawKnobWithShadow(knobRect: knobRect)
+    } else {
+      drawKnobOnly(knobRect: knobRect)
+    }
+  }
+
+  @discardableResult
+  private func drawKnobOnly(knobRect: NSRect) -> NSBezierPath {
     // Round the X position for cleaner drawing
     let rect = NSMakeRect(round(knobRect.origin.x),
                           knobRect.origin.y + 0.5 * (knobRect.height - knobHeight),
                           knobRect.width,
                           knobHeight)
-    let isLightTheme = !controlView!.window!.effectiveAppearance.isDark
-
-    if isLightTheme {
-      NSGraphicsContext.saveGraphicsState()
-      let shadow = NSShadow()
-      shadow.shadowBlurRadius = 1
-      shadow.shadowColor = .controlShadowColor
-      shadow.shadowOffset = NSSize(width: 0, height: -0.5)
-      shadow.set()
-    }
 
     let path = NSBezierPath(roundedRect: rect, xRadius: knobRadius, yRadius: knobRadius)
     (isHighlighted ? knobActiveColor : knobColor).setFill()
     path.fill()
+    return path
+  }
 
-    if isLightTheme {
+  private func drawKnobWithShadow(knobRect: NSRect) {
+    NSGraphicsContext.saveGraphicsState()
+
+    let shadow = NSShadow()
+    shadow.shadowBlurRadius = 1
+    shadow.shadowOffset = NSSize(width: 0, height: -0.5)
+    shadow.set()
+
+    let path = drawKnobOnly(knobRect: knobRect)
+
+    /// According to Apple's docs for `NSShadow`: `The default shadow color is black with an alpha of 1/3`
+    if let shadowColor = shadow.shadowColor {
       path.lineWidth = 0.4
-      NSColor.controlShadowColor.setStroke()
+      shadowColor.setStroke()
       path.stroke()
-      NSGraphicsContext.restoreGraphicsState()
     }
+    NSGraphicsContext.restoreGraphicsState()
   }
 
   override func knobRect(flipped: Bool) -> NSRect {

--- a/iina/PluginOverlayView.swift
+++ b/iina/PluginOverlayView.swift
@@ -7,7 +7,7 @@
 //
 
 import Cocoa
-import WebKit
+@preconcurrency import WebKit
 
 class PluginOverlayView: WKWebView, WKNavigationDelegate {
   weak private var pluginInstance: JavascriptPluginInstance!

--- a/iina/PluginSidebarView.swift
+++ b/iina/PluginSidebarView.swift
@@ -7,7 +7,7 @@
 //
 
 import Cocoa
-import WebKit
+@preconcurrency import WebKit
 
 class PluginSidebarView: WKWebView, WKNavigationDelegate {
   weak private var pluginInstance: JavascriptPluginInstance!

--- a/iina/PluginStandaloneWindow.swift
+++ b/iina/PluginStandaloneWindow.swift
@@ -7,7 +7,7 @@
 //
 
 import Cocoa
-import WebKit
+@preconcurrency import WebKit
 
 class PluginStandaloneWindow: NSWindow, WKNavigationDelegate {
   weak private var pluginInstance: JavascriptPluginInstance!

--- a/iina/PrefPluginViewController.swift
+++ b/iina/PrefPluginViewController.swift
@@ -7,7 +7,7 @@
 //
 
 import Cocoa
-import WebKit
+@preconcurrency import WebKit
 
 fileprivate let defaultPlugins = [
   ["url": "iina/plugin-demo", "id": "io.iina.demo"],

--- a/iina/PrefUtilsViewController.swift
+++ b/iina/PrefUtilsViewController.swift
@@ -108,7 +108,7 @@ class PrefUtilsViewController: PreferenceViewController, PreferenceWindowEmbedda
     }
 
     for identifier in utiTargetSet {
-      Logger.log("Seting default for UTI: \(identifier.quoted)", level: .verbose)
+      Logger.log("Setting default for UTI: \(identifier.quoted)", level: .verbose)
       let status = LSSetDefaultRoleHandlerForContentType(identifier as CFString, .all, cfBundleID)
       if status == kOSReturnSuccess {
         successCount += 1

--- a/iina/PreferenceWindowController.swift
+++ b/iina/PreferenceWindowController.swift
@@ -520,7 +520,7 @@ class PrefSearchResultMaskView: NSView {
 class PrefTabTitleLabelCell: NSTextFieldCell {
   override var backgroundStyle: NSView.BackgroundStyle {
     didSet {
-      if backgroundStyle == .dark {
+      if backgroundStyle == .emphasized {
         self.textColor = NSColor.white
       } else {
         self.textColor = NSColor.controlTextColor

--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -7,6 +7,7 @@
 //
 
 import Cocoa
+import UniformTypeIdentifiers
 
 typealias PK = Preference.Key
 
@@ -531,6 +532,19 @@ class Utility {
       }
     }
   }
+
+  static func icon(for url: URL) -> NSImage {
+    if #available(macOS 11.0, *) {
+      if let uttype = UTType.types(tag: url.pathExtension, tagClass: .filenameExtension, conformingTo: nil).first {
+        return NSWorkspace.shared.icon(for: uttype)
+      } else {
+        return NSWorkspace.shared.icon(for: .data)
+      }
+    } else {
+      return NSWorkspace.shared.icon(forFileType: url.pathExtension)
+    }
+  }
+
 
   // MARK: - Util classes
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
- Add `@preconcurrency` annotation to `import WebKit` to fix warnings
- Create Utility.icon() which uses `UTType`s, to quash deprecation warning about `NSWorkspace.shared.icon`
- Trivial updates to fix `@Sendable` warnings
- Minor refactor to use `NSShadow.shadowColor` instead of deprecated `NSColor.controlShadowColor` in `PlaySliderCell`
- Refactor `PrefUtilsViewController.setAsDefaultOKBtnAction` logic to use `UTType`s for MacOS 11+, and ensure that all UT identifiers for all supported suffixes are changed to IINA

This is a merge of various warnings-related fixes I made - sorry for not breaking it up.

IMO the only item which needs discussion is the last one. As I dug in deeper and did some tests. I found that:
- Modern MacOS (since when? Not sure) uses UTTypes, not file suffixes, to determine which application to open. But the system does store file suffix info with each UTType in a many-to-many relation, which means that each UTI can be associated with multiple suffixes, and each suffix can be associated with multiple UTIs.
- The present solution starts with the "import" UTIs listed in IINA's bundle, and grabs the file suffixes listed for each. It then uses the now-deprecated `UTTypeCreatePreferredIdentifierForTag` to get a single UTI from a single file suffix, and then uses the UTI to change the default app. But this seems to be...not completely correct? Its [documentation](https://developer.apple.com/documentation/coreservices/1448939-uttypecreatepreferredidentifierf) states: `If there is more than one possible UTI for the specified tag, the UTI that will be returned is undefined`. But most of the suffixes (or "tags") being passes have more than one UTI associated with them. In practice, this is more well-defined than the docs state, because it seems to send the most relevant one. But it does miss a lot.
- In this PR I created a solution for MacOS 11+ which grabs all UTIs associated with each file extension. This will include some duplicates so I store them all in a `Set`. Then I pass each of them to `LSSetDefaultRoleHandlerForContentType` as before. On my system, this solution finds and changes 118 UTIs, where formerly it found 65.
- Worth noting: it didn't work to use the "import" UTIs directly. These all start with `io.iina.`, which IINA already associates with. It seems that once a file is assigned a UTI by the OS, it keeps that UTI. So a given `.mkv` file's UTI may be `io.mpv.mkv`, `io.iina.mkv`, `org.matroska.mkv`, or so one.
- If reviewer(s) agree that this is correct solution for MacOS 11+, perhaps the pre-MacOS 11 solution should be modified as well? Looks like this would involve calling `UTTypeCreateAllIdentifiersForTag` instead of `UTTypeCreatePreferredIdentifierForTag`. Or if the previous solution is favored for some reason, I would likely modify the MacOS 11+ code to only grab the first UTI for each file extension.