### PR TITLE
Fix JPEG-XL screenshot contains wrong color attributes, #5212

### DIFF
--- a/iina/FFmpegController.m
+++ b/iina/FFmpegController.m
@@ -7,6 +7,7 @@
 //
 
 #import "FFmpegController.h"
+#import <Accelerate/Accelerate.h>
 #import <Cocoa/Cocoa.h>
 
 #pragma clang diagnostic push
@@ -528,6 +529,7 @@ return -1;\
              pFrame->format);
       case AV_PIX_FMT_ARGB: // WebP with screenshot-webp-lossless mpv option enabled.
       case AV_PIX_FMT_RGB24: // JPEG XL SDR video.
+      case AV_PIX_FMT_RGBA64LE: // JPEG XL SDR video.
       case AV_PIX_FMT_YUV420P: // WebP default.
         pFrameRGB->format = AV_PIX_FMT_RGBA;
         bitmapInfo = (CGBitmapInfo)kCGImageAlphaPremultipliedLast;
@@ -582,22 +584,21 @@ return -1;\
     const int bytesPerPixel = bitsPerPixel / 8;
 
     if (pFrameRGB->format == AV_PIX_FMT_RGBA64LE) {
-      // Apply the second part of the workaround for the FFmpeg scalar not supporting conversion to
-      // the pixel format AV_PIX_FMT_RGBAF16LE. Traverse the frame converting the pixel components
-      // to short floating point values.
       const int bytesPerComponent = bitsPerComponent / 8;
-      const int bytesPerRow = pFrameRGB->width * bytesPerPixel;
+
       // Each row of pixels in memory may contain extra padding for performance reasons. The
       // linesize gives the actual number of bytes each row consumes in the frame buffer.
       const int strideInBytes = pFrameRGB->linesize[0];
-      for (int rowOffset = 0; rowOffset < size; rowOffset += strideInBytes) {
-        // Convert each pixel component in the row.
-        for (int index = rowOffset; index < rowOffset + bytesPerRow; index += bytesPerComponent) {
-          uint16_t componentValue;
-          memcpy(&componentValue, &pFrameRGB->data[0][index], sizeof componentValue);
-          const _Float16 asFloat = (float)componentValue / USHRT_MAX;
-          memcpy(&pFrameRGB->data[0][index], &asFloat, sizeof asFloat);
-        }
+
+      // Apply the second part of the workaround for the FFmpeg scalar not supporting conversion to
+      // the pixel format AV_PIX_FMT_RGBAF16LE. Convert the pixel components to short floating point
+      // values.
+      const vImage_Buffer inputBuffer = {.width = pFrameRGB->width * bytesPerPixel / bytesPerComponent,
+        .height = pFrameRGB->height, .rowBytes = strideInBytes, .data = pFrameRGB->data[0]};
+      const vImage_Error error = vImageConvert_16Uto16F(&inputBuffer, &inputBuffer, kvImageDoNotTile);
+      if (error != kvImageNoError) {
+        LOG_ERROR(@"Method vImageConvert_16Uto16F failed: %ld", error);
+        return NULL;
       }
     }
 
@@ -613,23 +614,41 @@ return -1;\
         cgColorSpace = CGColorSpaceCreateDeviceRGB();
         break;
       case AVCOL_PRI_BT2020:
-        if (@available(macOS 11.0, *)) {
-          cgColorSpace = CGColorSpaceCreateWithName(kCGColorSpaceITUR_2100_PQ);
-        } else if (@available(macOS 10.15.4, *)) {
-            cgColorSpace = CGColorSpaceCreateWithName(kCGColorSpaceITUR_2020_PQ);
-        } else if (@available(macOS 10.14.6, *)) {
-            cgColorSpace = CGColorSpaceCreateWithName(kCGColorSpaceITUR_2020_PQ_EOTF);
-        } else {
-          cgColorSpace = CGColorSpaceCreateDeviceRGB();
+        switch (pFrame->color_trc) {
+          default:
+            cgColorSpace = CGColorSpaceCreateWithName(kCGColorSpaceITUR_2020);
+            break;
+          case AVCOL_TRC_ARIB_STD_B67:
+            if (@available(macOS 11.0, *)) {
+              cgColorSpace = CGColorSpaceCreateWithName(kCGColorSpaceITUR_2100_HLG);
+            } else {
+              cgColorSpace = CGColorSpaceCreateWithName(kCGColorSpaceITUR_2020_HLG);
+            }
+            break;
+          case AVCOL_TRC_SMPTE2084:
+            if (@available(macOS 11.0, *)) {
+              cgColorSpace = CGColorSpaceCreateWithName(kCGColorSpaceITUR_2100_PQ);
+            } else if (@available(macOS 10.15.4, *)) {
+              cgColorSpace = CGColorSpaceCreateWithName(kCGColorSpaceITUR_2020_PQ);
+            } else {
+              cgColorSpace = CGColorSpaceCreateWithName(kCGColorSpaceITUR_2020_PQ_EOTF);
+            }
         }
         break;
       case AVCOL_PRI_SMPTE432:
-        if (@available(macOS 10.15.4, *)) {
-          cgColorSpace = CGColorSpaceCreateWithName(kCGColorSpaceDisplayP3_PQ);
-        } else if (@available(macOS 10.14.6, *)) {
-          cgColorSpace = CGColorSpaceCreateWithName(kCGColorSpaceDisplayP3_PQ_EOTF);
-        } else {
-          cgColorSpace = CGColorSpaceCreateDeviceRGB();
+        switch (pFrame->color_trc) {
+          default:
+            cgColorSpace = CGColorSpaceCreateWithName(kCGColorSpaceDisplayP3);
+            break;
+          case AVCOL_TRC_ARIB_STD_B67:
+            cgColorSpace = CGColorSpaceCreateWithName(kCGColorSpaceDisplayP3_HLG);
+            break;
+          case AVCOL_TRC_SMPTE2084:
+            if (@available(macOS 10.15.4, *)) {
+              cgColorSpace = CGColorSpaceCreateWithName(kCGColorSpaceDisplayP3_PQ);
+            } else {
+              cgColorSpace = CGColorSpaceCreateWithName(kCGColorSpaceDisplayP3_PQ_EOTF);
+            }
         }
     }
     if (!cgColorSpace) {

--- a/iina/FFmpegController.m
+++ b/iina/FFmpegController.m
@@ -592,10 +592,11 @@ return -1;\
 
       // Apply the second part of the workaround for the FFmpeg scalar not supporting conversion to
       // the pixel format AV_PIX_FMT_RGBAF16LE. Convert the pixel components to short floating point
-      // values.
-      const vImage_Buffer inputBuffer = {.width = pFrameRGB->width * bytesPerPixel / bytesPerComponent,
+      // values. This is an in-place conversion, which is supported by vImageConvert_16Uto16F, so
+      // only one buffer is used.
+      const vImage_Buffer buffer = {.width = pFrameRGB->width * bytesPerPixel / bytesPerComponent,
         .height = pFrameRGB->height, .rowBytes = strideInBytes, .data = pFrameRGB->data[0]};
-      const vImage_Error error = vImageConvert_16Uto16F(&inputBuffer, &inputBuffer, kvImageDoNotTile);
+      const vImage_Error error = vImageConvert_16Uto16F(&buffer, &buffer, kvImageNoFlags);
       if (error != kvImageNoError) {
         LOG_ERROR(@"Method vImageConvert_16Uto16F failed: %ld", error);
         return NULL;

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -349,7 +349,13 @@ class MPVController: NSObject {
     setUserOption(PK.screenshotFormat, type: .other, forName: MPVOption.Screenshot.screenshotFormat,
                   level: .verbose) { key in
       let v = Preference.integer(for: key)
-      return Preference.ScreenshotFormat(rawValue: v)?.string
+      let format = Preference.ScreenshotFormat(rawValue: v)
+      // Workaround for mpv issue  #15107, HDR screenshots are unimplemented (gpu/gpu-next).
+      // If the screenshot format is set to JPEG XL then set the screenshot-sw option to yes. This
+      // causes the screenshot to be rendered by software instead of the VO. If a HDR video is being
+      // displayed in HDR then the resulting screenshot will be HDR.
+      self.setFlag(MPVOption.Screenshot.screenshotSw, format == .jxl)
+      return format?.string
     }
 
     setUserOption(PK.screenshotTemplate, type: .string, forName: MPVOption.Screenshot.screenshotTemplate,


### PR DESCRIPTION
This commit will:
- Change `MPVController.mpvInit` to configure mpv to use software rendering for screenshots in JPEG XL format
- Change `FFmpegController.createNSImageWithContentsOfURL` to take into account the gamma when choosing the color space
- Change `createNSImageWithContentsOfURL` to use the Accelerate Framework method `vImageConvert_16Uto16F` to convert pixel components to short floating point

Using software rendering for JPEG XL screenshots is a workaround for mpv issue #15107, HDR screenshots are unimplemented (gpu/gpu-next).

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5212.

---

**Description:**
