### PR TITLE
Only request extended dynamic range for HDR

### DIFF
--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -341,6 +341,7 @@ class VideoView: NSView {
       }()
       log("Setting layer color space to \(name)")
       videoLayer.colorspace = sdrColorSpace
+      videoLayer.wantsExtendedDynamicRangeContent = false
       player.mpv.setString(MPVOption.GPURendererOptions.targetTrc, "auto")
       player.mpv.setString(MPVOption.GPURendererOptions.targetPrim, "auto")
       player.mpv.setString(MPVOption.GPURendererOptions.targetPeak, "auto")
@@ -492,6 +493,7 @@ extension VideoView {
 
     logHDR("Will activate HDR color space instead of using ICC profile")
 
+    videoLayer.wantsExtendedDynamicRangeContent = true
     videoLayer.colorspace = CGColorSpace(name: name!)
     mpv.setString(MPVOption.GPURendererOptions.iccProfile, "")
     mpv.setString(MPVOption.GPURendererOptions.targetPrim, primaries)

--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -98,7 +98,6 @@ class ViewLayer: CAOpenGLLayer {
     super.init()
     autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
     backgroundColor = NSColor.black.cgColor
-    wantsExtendedDynamicRangeContent = true
     if bufferDepth > 8 {
       contentsFormat = .RGBA16Float
     }


### PR DESCRIPTION
This commit will:
- Remove setting of `wantsExtendedDynamicRangeContent` from `ViewLayer`
- Add back in conditional setting of `wantsExtendedDynamicRangeContent` to the `VideoView` methods `requestEdrMode` and `setICCProfile`

This reverts a change picked up from mpv that always set `wantsExtendedDynamicRangeContent` to `true` as mpv has now reverted this change after performance drawbacks to enabling it when it was not required were observed.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
