### PR TITLE
Change the ASS override level default to be scale

### DIFF
--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -493,7 +493,7 @@ struct Preference {
     case scale
     case no
 
-    static var defaultValue = SubOverrideLevel.yes
+    static var defaultValue = SubOverrideLevel.scale
 
     init?(key: Key) {
       self.init(rawValue: Preference.integer(for: key))
@@ -875,8 +875,8 @@ struct Preference {
     .subAutoLoadPriorityString: "",
     .subAutoLoadSearchPath: "./*",
     .ignoreAssStyles: false,
-    .subOverrideLevel: SubOverrideLevel.strip.rawValue,
-    .secondarySubOverrideLevel: SubOverrideLevel.strip.rawValue,
+    .subOverrideLevel: SubOverrideLevel.scale.rawValue,
+    .secondarySubOverrideLevel: SubOverrideLevel.scale.rawValue,
     .subTextFont: "sans-serif",
     .subTextSize: Float(55),
     .subTextColorString: NSColor.white.usingColorSpace(.deviceRGB)!.mpvColorString,


### PR DESCRIPTION
This commit will change the default for the `subOverrideLevel` and `secondarySubOverrideLevel` settings to be `scale` instead of `strip`.

In 1.3.5 there was a checkbox that enabled this setting. When that checkbox was not checked the override level was `yes`, which with that version of mpv applied scaling. The default for the override level was `strip` as if you checked the checkbox it was likely you wanted to fully override the styles. With the elimination of the checkbox the default should be `scale` to match up with the behavior of 1.3.5.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
