### PR TITLE
Improve decimal formatting in OSD & menu items

### DIFF
--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pause";
 "osd.resume" = "Resume";
-"osd.volume" = "Volume: %i";
+"osd.volume" = "Volume: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Aspect Ratio: %@";
 "osd.crop" = "Crop: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deinterlace: %@";
 "osd.hwdec" = "Hardware Decoding: %@";
 "osd.audio_delay.nodelay" = "Audio Delay: No Delay";
-"osd.audio_delay.later" = "Audio Delay: %.2fs Later";
-"osd.audio_delay.earlier" = "Audio Delay: %.2fs Earlier";
+"osd.audio_delay.later" = "Audio Delay: %@s Later";
+"osd.audio_delay.earlier" = "Audio Delay: %@s Earlier";
 "osd.sub_delay.nodelay" = "Subtitle Delay: No Delay";
-"osd.sub_delay.later" = "Subtitle Delay: %.2fs Later";
-"osd.sub_delay.earlier" = "Subtitle Delay: %.2fs Earlier";
-"osd.subtitle_pos" = "Subtitle Position: %.1f";
+"osd.sub_delay.later" = "Subtitle Delay: %@s Later";
+"osd.sub_delay.earlier" = "Subtitle Delay: %@s Earlier";
+"osd.subtitle_pos" = "Subtitle Position: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-Loop: Cleared";
 "osd.stop" = "Stop";
 "osd.chapter" = "Chapter: %@";
-"osd.subtitle_scale" = "Subtitle Scale: %.2fx";
+"osd.subtitle_scale" = "Subtitle Scale: %@x";
 "osd.add_to_playlist" = "Added %i Files to Playlist";
 "osd.clear_playlist" = "Cleared Playlist";
 "osd.video_eq.contrast" = "Contrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volume: %d";
-"menu.volume_muted" = "Volume: %d (Muted)";
-"menu.audio_delay" = "Audio Delay: %.2fs";
-"menu.sub_delay" = "Subtitle Delay: %.2fs";
+"menu.volume" = "Volume: %@";
+"menu.volume_muted" = "Volume: %@ (Muted)";
+"menu.audio_delay" = "Audio Delay: %@s";
+"menu.sub_delay" = "Subtitle Delay: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Show Subtitles Panel";
 "menu.hide_subtitles" = "Hide Subtitles Panel";
 
-"menu.seek_forward" = "Step Forward %.0fs";
-"menu.seek_backward" = "Step Backward %.0fs";
+"menu.seek_forward" = "Step Forward %@s";
+"menu.seek_backward" = "Step Backward %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Volume - %.0f%%";
-"menu.audio_delay_up" = "Audio Delay + %.1fs";
-"menu.audio_delay_down" = "Audio Delay - %.1fs";
-"menu.sub_delay_up" = "Subtitle Delay + %.1fs";
-"menu.sub_delay_down" = "Subtitle Delay - %.1fs";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Volume - %@%%";
+"menu.audio_delay_up" = "Audio Delay + %@s";
+"menu.audio_delay_down" = "Audio Delay - %@s";
+"menu.sub_delay_up" = "Subtitle Delay + %@s";
+"menu.sub_delay_down" = "Subtitle Delay - %@s";
 
 "menu.crop_custom" = "Custom…";
 "menu.find_online_sub" = "Find Online Subtitles from %@";

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -1288,7 +1288,7 @@ class MPVController: NSObject {
       DispatchQueue.main.async { [self] in
         player.info.volume = data
         player.syncUI(.volume)
-        player.sendOSD(.volume(Int(data)))
+        player.sendOSD(.volume(data))
       }
 
     case MPVOption.Audio.audioDelay:

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -524,8 +524,10 @@ class MenuController: NSObject, NSMenuDelegate {
       volFmtString = NSLocalizedString("menu.volume", comment: "Volume:")
       mute.state = .off
     }
-    volumeIndicator.title = String(format: volFmtString, Int(player.info.volume))
-    audioDelayIndicator.title = String(format: NSLocalizedString("menu.audio_delay", comment: "Audio Delay:"), player.info.audioDelay)
+    let volumeString = player.info.volume.groupedStringUpTo6Decimals
+    volumeIndicator.title = String(format: volFmtString, volumeString)
+    let audioDelayString = player.info.audioDelay.groupedStringUpTo6Decimals
+    audioDelayIndicator.title = String(format: NSLocalizedString("menu.audio_delay", comment: "Audio Delay:"), audioDelayString)
   }
 
   private func updateAudioDevice() {
@@ -555,7 +557,8 @@ class MenuController: NSObject, NSMenuDelegate {
         Constants.String.showSubtitles
     hideSecondSubtitles.title = player.info.isSecondSubVisible ? Constants.String.hideSecondSubtitles :
         Constants.String.showSecondSubtitles
-    subDelayIndicator.title = String(format: NSLocalizedString("menu.sub_delay", comment: "Subtitle Delay:"), player.info.subDelay)
+    let subDelayString = player.info.subDelay.groupedStringUpTo6Decimals
+    subDelayIndicator.title = String(format: NSLocalizedString("menu.sub_delay", comment: "Subtitle Delay:"), subDelayString)
 
     let encodingCode = player.info.subEncoding ?? "auto"
     for encoding in AppData.encodings {
@@ -949,17 +952,7 @@ class MenuController: NSObject, NSMenuDelegate {
     menuItem.keyEquivalentModifierMask = kMdf
 
     if let value = value, let l10nKey = l10nKey {
-      let valObj: CVarArg
-      switch l10nKey {
-      case "speed_up",
-        "speed_down":
-        // Title format expects arg type: String
-        valObj = abs(value).groupedStringUpTo6Decimals
-      default:
-        // Title format expects numeric arg
-        valObj = abs(value)
-      }
-      menuItem.title = String(format: NSLocalizedString("menu." + l10nKey, comment: ""), valObj)
+      menuItem.title = String(format: NSLocalizedString("menu." + l10nKey, comment: ""), abs(value).groupedStringUpTo6Decimals)
       if let extraData = extraData {
         menuItem.representedObject = (value, extraData)
       } else {

--- a/iina/OSDMessage.swift
+++ b/iina/OSDMessage.swift
@@ -36,7 +36,7 @@ enum OSDMessage {
   case pause
   case resume
   case seek(String, Double)  // text, percentage
-  case volume(Int)
+  case volume(Double)
   case speed(Double)
   case aspect(String)
   case crop(String)
@@ -147,10 +147,8 @@ enum OSDMessage {
       return (text, .withPosition(percent))
 
     case .volume(let value):
-      return (
-        String(format: NSLocalizedString("osd.volume", comment: "Volume: %i"), value),
-        .withProgress(Double(value) / Double(Preference.integer(for: .maxVolume)))
-      )
+      let text = String(format: NSLocalizedString("osd.volume", comment: "Volume: %@"), value.stringWithMaxFractionDigits2)
+      return (text, .withProgress(value / Preference.double(for: .maxVolume)))
 
     case .speed(let value):
       return (
@@ -201,8 +199,14 @@ enum OSDMessage {
           .withProgress(0.5)
         )
       } else {
-        let str = value > 0 ? String(format: NSLocalizedString("osd.audio_delay.later", comment: "Audio Delay: %fs Later"),abs(value)) : String(format: NSLocalizedString("osd.audio_delay.earlier", comment: "Audio Delay: %fs Earlier"), abs(value))
-        return (str, .withProgress(toPercent(value, 10)))
+        let valueStr = abs(value).groupedStringUpTo6Decimals
+        let text: String
+        if value > 0 {
+          text = String(format: NSLocalizedString("osd.audio_delay.later", comment: "Audio Delay: %@s Later"), valueStr)
+        } else {
+          text = String(format: NSLocalizedString("osd.audio_delay.earlier", comment: "Audio Delay: %@s Earlier"), valueStr)
+        }
+        return (text, .withProgress(toPercent(value, 10)))
       }
 
     case .secondSubDelay(let value):
@@ -212,15 +216,19 @@ enum OSDMessage {
           .withProgress(0.5)
         )
       } else {
-        let str = value > 0 ? String(format: NSLocalizedString("osd.sub_second_delay.later", comment: "Secondary Subtitle Delay: %fs Later"),abs(value)) : String(format: NSLocalizedString("osd.sub_second_delay.earlier", comment: "Secondary Subtitle Delay: %fs Earlier"), abs(value))
-        return (str, .withProgress(toPercent(value, 10)))
+        let valueStr = abs(value).groupedStringUpTo6Decimals
+        let text: String
+        if value > 0 {
+          text = String(format: NSLocalizedString("osd.sub_second_delay.later", comment: "Secondary Subtitle Delay: %@s Later"), valueStr)
+        } else {
+          text = String(format: NSLocalizedString("osd.sub_second_delay.earlier", comment: "Secondary Subtitle Delay: %@s Earlier"), valueStr)
+        }
+        return (text, .withProgress(toPercent(value, 10)))
       }
 
     case .secondSubPos(let value):
-      return (
-        String(format: NSLocalizedString("osd.sub_second_pos", comment: "Secondary Subtitle Position: %f"), value),
-        .withProgress(value / 100)
-      )
+      let text = String(format: NSLocalizedString("osd.sub_second_pos", comment: "Secondary Subtitle Position: %@"), value.groupedStringUpTo6Decimals)
+      return (text, .withProgress(value / 100))
 
     case .subDelay(let value):
       if value == 0 {
@@ -229,15 +237,19 @@ enum OSDMessage {
           .withProgress(0.5)
         )
       } else {
-        let str = value > 0 ? String(format: NSLocalizedString("osd.sub_delay.later", comment: "Subtitle Delay: %fs Later"),abs(value)) : String(format: NSLocalizedString("osd.sub_delay.earlier", comment: "Subtitle Delay: %fs Earlier"), abs(value))
-        return (str, .withProgress(toPercent(value, 10)))
+        let valueStr = abs(value).groupedStringUpTo6Decimals
+        let text: String
+        if value > 0 {
+          text = String(format: NSLocalizedString("osd.sub_delay.later", comment: "Subtitle Delay: %@s Later"), valueStr)
+        } else {
+          text = String(format: NSLocalizedString("osd.sub_delay.earlier", comment: "Subtitle Delay: %@s Earlier"), valueStr)
+        }
+        return (text, .withProgress(toPercent(value, 10)))
       }
 
     case .subPos(let value):
-      return (
-        String(format: NSLocalizedString("osd.subtitle_pos", comment: "Subtitle Position: %f"), value),
-        .withProgress(value / 100)
-      )
+      let text = String(format: NSLocalizedString("osd.subtitle_pos", comment: "Subtitle Position: %@"), value.groupedStringUpTo6Decimals)
+      return (text, .withProgress(value / 100))
 
     case .subHidden:
       return (NSLocalizedString("osd.sub_hidden", comment: "Subtitles Hidden"), .normal)
@@ -312,10 +324,8 @@ enum OSDMessage {
       return (trackTypeStr + ": " + track.readableTitle, .normal)
 
     case .subScale(let value):
-      return (
-        String(format: NSLocalizedString("osd.subtitle_scale", comment: "Subtitle Scale: %.2fx"), value),
-        .normal
-      )
+      let text = String(format: NSLocalizedString("osd.subtitle_scale", comment: "Subtitle Scale: %@x"), value.groupedStringUpTo6Decimals)
+      return (text, .normal)
 
     case .addToPlaylist(let count):
       return (

--- a/iina/af.lproj/Localizable.strings
+++ b/iina/af.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Wag";
 "osd.resume" = "Hervat";
-"osd.volume" = "Volume: %i";
+"osd.volume" = "Volume: %@";
 "osd.speed" = "Snelheid: %@x";
 "osd.aspect" = "Aspekverhouding: %@";
 "osd.crop" = "Snoei: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deïnterlinieer: %@";
 "osd.hwdec" = "Apparatuurdekodering: %@";
 "osd.audio_delay.nodelay" = "Geen oudiovertraging";
-"osd.audio_delay.later" = "Oudio vertraag met %.2fs";
-"osd.audio_delay.earlier" = "Oudio versnel met %.2fs";
+"osd.audio_delay.later" = "Oudio vertraag met %@s";
+"osd.audio_delay.earlier" = "Oudio versnel met %@s";
 "osd.sub_delay.nodelay" = "Geen onderskrifvertraging";
-"osd.sub_delay.later" = "Onderskrif vertraag met %.2fs";
-"osd.sub_delay.earlier" = "Onderskrif versnel met %.2fs";
-"osd.subtitle_pos" = "Onderskrifposisie: %.1f";
+"osd.sub_delay.later" = "Onderskrif vertraag met %@s";
+"osd.sub_delay.earlier" = "Onderskrif versnel met %@s";
+"osd.subtitle_pos" = "Onderskrifposisie: %@";
 "osd.sub_hidden" = "Onderskrifte is versteek";
 "osd.sub_visible" = "Onderskrifte is sigbaar";
 "osd.sub_second_delay.nodelay" = "Sekondêreonderskrifvertraging: Geen vertraging";
-"osd.sub_second_delay.later" = "Sekondêreonderskrifvertraging: %.2fs later";
-"osd.sub_second_delay.earlier" = "Sekondêreonderskrifvertraging: %.2fs vroeër";
+"osd.sub_second_delay.later" = "Sekondêreonderskrifvertraging: %@s later";
+"osd.sub_second_delay.earlier" = "Sekondêreonderskrifvertraging: %@s vroeër";
 "osd.sub_second_hidden" = "Sekondêre onderskrifte is versteek";
-"osd.sub_second_pos" = "Sekondêreonderskfitposisie: %.1f";
+"osd.sub_second_pos" = "Sekondêreonderskfitposisie: %@";
 "osd.sub_second_visible" = "Sekondêre onderskrifte is sigbaar";
 "osd.mute" = "Demp";
 "osd.unmute" = "Ontdemp";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-lus: opgehef";
 "osd.stop" = "Stop";
 "osd.chapter" = "Hoofstuk: %@";
-"osd.subtitle_scale" = "Onderskrifskaal: %.2fx";
+"osd.subtitle_scale" = "Onderskrifskaal: %@x";
 "osd.add_to_playlist" = "%i lêers tot afspeellys toegevoeg";
 "osd.clear_playlist" = "Afspeellys gewis";
 "osd.video_eq.contrast" = "Kontras: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "Die ingeboude youtube-dl-ondersteuning is gedeaktiveer aangesien die Aanlen media-inprop geïnstalleer is.";
 
-"menu.volume" = "Volume: %d";
-"menu.volume_muted" = "Volume: %d (gedemp)";
-"menu.audio_delay" = "Oudiovertraging: %.2fs";
-"menu.sub_delay" = "Onderskrifvertraging: %.2fs";
+"menu.volume" = "Volume: %@";
+"menu.volume_muted" = "Volume: %@ (gedemp)";
+"menu.audio_delay" = "Oudiovertraging: %@s";
+"menu.sub_delay" = "Onderskrifvertraging: %@s";
 "menu.sub_hide" = "Versteek onderskrifte";
 "menu.sub_show" = "Toon onderskrifte";
 "menu.sub_second_hide" = "Versteek sekondêre onderskrifte";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Toon onderskritfepaneel";
 "menu.hide_subtitles" = "Versteek onderskritfepaneel";
 
-"menu.seek_forward" = "Gaan %.0fs vorentoe";
-"menu.seek_backward" = "Gaan %.0fs terug";
+"menu.seek_forward" = "Gaan %@s vorentoe";
+"menu.seek_backward" = "Gaan %@s terug";
 "menu.speed_up" = "Versnel met %@x";
 "menu.speed_down" = "Vertraag met %@x";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Volume - %.0f%%";
-"menu.audio_delay_up" = "Oudiovertraging + %.1fs";
-"menu.audio_delay_down" = "Oudiovertraging - %.1fs";
-"menu.sub_delay_up" = "Onderskrifvertraging + %.1fs";
-"menu.sub_delay_down" = "Onderskrifvertraging - %.1fs";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Volume - %@%%";
+"menu.audio_delay_up" = "Oudiovertraging + %@s";
+"menu.audio_delay_down" = "Oudiovertraging - %@s";
+"menu.sub_delay_up" = "Onderskrifvertraging + %@s";
+"menu.sub_delay_down" = "Onderskrifvertraging - %@s";
 
 "menu.crop_custom" = "Pasgemaak…";
 "menu.find_online_sub" = "Soek aanlyn na onderskrifte van %@";

--- a/iina/ar.lproj/Localizable.strings
+++ b/iina/ar.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "إيقاف مؤقت";
 "osd.resume" = "استئناف";
-"osd.volume" = "الصوت: %i";
+"osd.volume" = "الصوت: %@";
 "osd.speed" = "السرعة: %@x";
 "osd.aspect" = "نسبة العرض والارتفاع: %@";
 "osd.crop" = "قص صورة: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "تشابك: %@";
 "osd.hwdec" = "فك ترميز: %@";
 "osd.audio_delay.nodelay" = "تأخير الصوت: لا تأخير";
-"osd.audio_delay.later" = "تأخير الصوت: %.2fثانية لاحقاً";
-"osd.audio_delay.earlier" = "تأخير الصوت: %.2fثانية سابقة";
+"osd.audio_delay.later" = "تأخير الصوت: %@ثانية لاحقاً";
+"osd.audio_delay.earlier" = "تأخير الصوت: %@ثانية سابقة";
 "osd.sub_delay.nodelay" = "تأخير الترجمة: لا تأخير";
-"osd.sub_delay.later" = "تأخير الترجمة: %.2fث لاحقاً";
-"osd.sub_delay.earlier" = "تأخير الترجمة: %.2fثانية سابقة";
-"osd.subtitle_pos" = "موضع الترجمة: %.1f";
+"osd.sub_delay.later" = "تأخير الترجمة: %@ث لاحقاً";
+"osd.sub_delay.earlier" = "تأخير الترجمة: %@ثانية سابقة";
+"osd.subtitle_pos" = "موضع الترجمة: %@";
 "osd.sub_hidden" = "الترجمات مخفية";
 "osd.sub_visible" = "الترجمات مرئية";
 "osd.sub_second_delay.nodelay" = "الترجمة الثانوية: لا تأخير";
-"osd.sub_second_delay.later" = "تأخير الترجمة الثانوية: %.2fsثانية بعد";
-"osd.sub_second_delay.earlier" = "تأخير الترجمة: %.2fثانية قبل";
+"osd.sub_second_delay.later" = "تأخير الترجمة الثانوية: %@sثانية بعد";
+"osd.sub_second_delay.earlier" = "تأخير الترجمة: %@ثانية قبل";
 "osd.sub_second_hidden" = "الترجمة الثانوية مخفية";
-"osd.sub_second_pos" = "موقع الترجمة الثانوية: %.1f";
+"osd.sub_second_pos" = "موقع الترجمة الثانوية: %@";
 "osd.sub_second_visible" = "الترجمة الثانوية مرئية";
 "osd.mute" = "كتم";
 "osd.unmute" = "إلغاء الكتم";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-Loop: مسح";
 "osd.stop" = "إيقاف";
 "osd.chapter" = "الفصل: %@";
-"osd.subtitle_scale" = "حجم الترجمة: %.2fx";
+"osd.subtitle_scale" = "حجم الترجمة: %@x";
 "osd.add_to_playlist" = "تم إضافة %i ملفات إلى قائمة التشغيل";
 "osd.clear_playlist" = "مسح قائمة التشغيل";
 "osd.video_eq.contrast" = "التباين: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "قم بتثبيت ملحق الوسائط عبر الإنترنت من \"الإضافات > تثبيت من GitHub\" للاستمتاع بميزات متقدمة مثل تحميل الفيديو وتحديثات yt-dlp تلقائية.";
 "preference.ytdl_plugin_installed" = "تم تعطيل دعم youtube-dl المدمج نظرًا لتثبيت إضافة الوسائط عبر الإنترنت.";
 
-"menu.volume" = "الصوت: %d";
-"menu.volume_muted" = "الحجم: %d (مكتمل)";
-"menu.audio_delay" = "تأخير الصوت: %.2fث";
-"menu.sub_delay" = "تأخير الترجمه: %.2f ثانيه";
+"menu.volume" = "الصوت: %@";
+"menu.volume_muted" = "الحجم: %@ (مكتمل)";
+"menu.audio_delay" = "تأخير الصوت: %@ث";
+"menu.sub_delay" = "تأخير الترجمه: %@ ثانيه";
 "menu.sub_hide" = "إخفاء الترجمات";
 "menu.sub_show" = "إظهار الترجمات";
 "menu.sub_second_hide" = "إخفاء الترجمة الثانوية";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "إظهار لوحة الترجمات";
 "menu.hide_subtitles" = "إخفاء لوحة الترجمات";
 
-"menu.seek_forward" = "خطوة إلى الأمام %.0f ثانية";
-"menu.seek_backward" = "خطوة إلى الوراء %.0f ثانية";
+"menu.seek_forward" = "خطوة إلى الأمام %@ ثانية";
+"menu.seek_backward" = "خطوة إلى الوراء %@ ثانية";
 "menu.speed_up" = "تسريع ب %@x";
 "menu.speed_down" = "تبطيء ب %@x";
-"menu.volume_up" = "الصوت: %.0f";
-"menu.volume_down" = "الصوت: %.0f";
-"menu.audio_delay_up" = "تأخير الصوت: +%.1f ثانيه";
-"menu.audio_delay_down" = "تأخير الصوت: -%.1f ثانيه";
-"menu.sub_delay_up" = "تأخير الترجمه: +%.1f ثانيه";
-"menu.sub_delay_down" = "تأخير الترجمه: -%.1f ثانيه";
+"menu.volume_up" = "الصوت: %@";
+"menu.volume_down" = "الصوت: %@";
+"menu.audio_delay_up" = "تأخير الصوت: +%@ ثانيه";
+"menu.audio_delay_down" = "تأخير الصوت: -%@ ثانيه";
+"menu.sub_delay_up" = "تأخير الترجمه: +%@ ثانيه";
+"menu.sub_delay_down" = "تأخير الترجمه: -%@ ثانيه";
 
 "menu.crop_custom" = "مخصص…";
 "menu.find_online_sub" = "ابحث عن ترجمات على الإنترنت من %@";

--- a/iina/az.lproj/Localizable.strings
+++ b/iina/az.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Dayandır";
 "osd.resume" = "Davam etdir";
-"osd.volume" = "Səs: %i";
+"osd.volume" = "Səs: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Tərəflərin nisbəti: %@";
 "osd.crop" = "Kəs: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deinterlace: %@";
 "osd.hwdec" = "Hardware Decoding: %@";
 "osd.audio_delay.nodelay" = "Səs Gecikməsi: Gecikmə Yoxdur";
-"osd.audio_delay.later" = "Səs Gecikməsi: %.2fs Gecikir";
-"osd.audio_delay.earlier" = "Səs Gecikməsi: %.2fs Əvvəldədir";
+"osd.audio_delay.later" = "Səs Gecikməsi: %@s Gecikir";
+"osd.audio_delay.earlier" = "Səs Gecikməsi: %@s Əvvəldədir";
 "osd.sub_delay.nodelay" = "Altyazı Gecikməsi: Gecikmə Yoxdur";
-"osd.sub_delay.later" = "Altyazı Gecikməsi: %.2fs Gecikir";
-"osd.sub_delay.earlier" = "Altyazı Gecikməsi: %.2fs Əvvəldədir";
-"osd.subtitle_pos" = "Altyazı yerləşməsi: %.1f";
+"osd.sub_delay.later" = "Altyazı Gecikməsi: %@s Gecikir";
+"osd.sub_delay.earlier" = "Altyazı Gecikməsi: %@s Əvvəldədir";
+"osd.subtitle_pos" = "Altyazı yerləşməsi: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Səsi Bağla";
 "osd.unmute" = "Səsi aç";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-Loop: Sıfırlanmış";
 "osd.stop" = "Dayandır";
 "osd.chapter" = "Bölmə: %@";
-"osd.subtitle_scale" = "Subtitle Scale: %.2fx";
+"osd.subtitle_scale" = "Subtitle Scale: %@x";
 "osd.add_to_playlist" = "Added %i Files to Playlist";
 "osd.clear_playlist" = "Cleared Playlist";
 "osd.video_eq.contrast" = "Contrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volume: %d";
-"menu.volume_muted" = "Volume: %d (Muted)";
-"menu.audio_delay" = "Audio Delay: %.2fs";
-"menu.sub_delay" = "Subtitle Delay: %.2fs";
+"menu.volume" = "Volume: %@";
+"menu.volume_muted" = "Volume: %@ (Muted)";
+"menu.audio_delay" = "Audio Delay: %@s";
+"menu.sub_delay" = "Subtitle Delay: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Show Subtitles Panel";
 "menu.hide_subtitles" = "Hide Subtitles Panel";
 
-"menu.seek_forward" = "Step Forward %.0fs";
-"menu.seek_backward" = "Step Backward %.0fs";
+"menu.seek_forward" = "Step Forward %@s";
+"menu.seek_backward" = "Step Backward %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Volume - %.0f%%";
-"menu.audio_delay_up" = "Audio Delay + %.1fs";
-"menu.audio_delay_down" = "Audio Delay - %.1fs";
-"menu.sub_delay_up" = "Subtitle Delay + %.1fs";
-"menu.sub_delay_down" = "Subtitle Delay - %.1fs";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Volume - %@%%";
+"menu.audio_delay_up" = "Audio Delay + %@s";
+"menu.audio_delay_down" = "Audio Delay - %@s";
+"menu.sub_delay_up" = "Subtitle Delay + %@s";
+"menu.sub_delay_down" = "Subtitle Delay - %@s";
 
 "menu.crop_custom" = "Xüsusi...";
 "menu.find_online_sub" = "Find Online Subtitles from %@";

--- a/iina/be.lproj/Localizable.strings
+++ b/iina/be.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Паўза";
 "osd.resume" = "Аднавіць";
-"osd.volume" = "Volume: %i";
+"osd.volume" = "Volume: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Aspect Ratio: %@";
 "osd.crop" = "Crop: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deinterlace: %@";
 "osd.hwdec" = "Hardware Decoding: %@";
 "osd.audio_delay.nodelay" = "Audio Delay: No Delay";
-"osd.audio_delay.later" = "Audio Delay: %.2fs Later";
-"osd.audio_delay.earlier" = "Audio Delay: %.2fs Earlier";
+"osd.audio_delay.later" = "Audio Delay: %@s Later";
+"osd.audio_delay.earlier" = "Audio Delay: %@s Earlier";
 "osd.sub_delay.nodelay" = "Subtitle Delay: No Delay";
-"osd.sub_delay.later" = "Subtitle Delay: %.2fs Later";
-"osd.sub_delay.earlier" = "Subtitle Delay: %.2fs Earlier";
-"osd.subtitle_pos" = "Subtitle Position: %.1f";
+"osd.sub_delay.later" = "Subtitle Delay: %@s Later";
+"osd.sub_delay.earlier" = "Subtitle Delay: %@s Earlier";
+"osd.subtitle_pos" = "Subtitle Position: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-Loop: Cleared";
 "osd.stop" = "Спыніць";
 "osd.chapter" = "Chapter: %@";
-"osd.subtitle_scale" = "Subtitle Scale: %.2fx";
+"osd.subtitle_scale" = "Subtitle Scale: %@x";
 "osd.add_to_playlist" = "Added %i Files to Playlist";
 "osd.clear_playlist" = "Cleared Playlist";
 "osd.video_eq.contrast" = "Contrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volume: %d";
-"menu.volume_muted" = "Volume: %d (Muted)";
-"menu.audio_delay" = "Audio Delay: %.2fs";
-"menu.sub_delay" = "Subtitle Delay: %.2fs";
+"menu.volume" = "Volume: %@";
+"menu.volume_muted" = "Volume: %@ (Muted)";
+"menu.audio_delay" = "Audio Delay: %@s";
+"menu.sub_delay" = "Subtitle Delay: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Show Subtitles Panel";
 "menu.hide_subtitles" = "Hide Subtitles Panel";
 
-"menu.seek_forward" = "Step Forward %.0fs";
-"menu.seek_backward" = "Step Backward %.0fs";
+"menu.seek_forward" = "Step Forward %@s";
+"menu.seek_backward" = "Step Backward %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Volume - %.0f%%";
-"menu.audio_delay_up" = "Audio Delay + %.1fs";
-"menu.audio_delay_down" = "Audio Delay - %.1fs";
-"menu.sub_delay_up" = "Subtitle Delay + %.1fs";
-"menu.sub_delay_down" = "Subtitle Delay - %.1fs";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Volume - %@%%";
+"menu.audio_delay_up" = "Audio Delay + %@s";
+"menu.audio_delay_down" = "Audio Delay - %@s";
+"menu.sub_delay_up" = "Subtitle Delay + %@s";
+"menu.sub_delay_down" = "Subtitle Delay - %@s";
 
 "menu.crop_custom" = "Custom…";
 "menu.find_online_sub" = "Find Online Subtitles from %@";

--- a/iina/bg.lproj/Localizable.strings
+++ b/iina/bg.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pause";
 "osd.resume" = "Resume";
-"osd.volume" = "Volume: %i";
+"osd.volume" = "Volume: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Aspect Ratio: %@";
 "osd.crop" = "Crop: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deinterlace: %@";
 "osd.hwdec" = "Hardware Decoding: %@";
 "osd.audio_delay.nodelay" = "Audio Delay: No Delay";
-"osd.audio_delay.later" = "Audio Delay: %.2fs Later";
-"osd.audio_delay.earlier" = "Audio Delay: %.2fs Earlier";
+"osd.audio_delay.later" = "Audio Delay: %@s Later";
+"osd.audio_delay.earlier" = "Audio Delay: %@s Earlier";
 "osd.sub_delay.nodelay" = "Subtitle Delay: No Delay";
-"osd.sub_delay.later" = "Subtitle Delay: %.2fs Later";
-"osd.sub_delay.earlier" = "Subtitle Delay: %.2fs Earlier";
-"osd.subtitle_pos" = "Subtitle Position: %.1f";
+"osd.sub_delay.later" = "Subtitle Delay: %@s Later";
+"osd.sub_delay.earlier" = "Subtitle Delay: %@s Earlier";
+"osd.subtitle_pos" = "Subtitle Position: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-Loop: Cleared";
 "osd.stop" = "Stop";
 "osd.chapter" = "Chapter: %@";
-"osd.subtitle_scale" = "Subtitle Scale: %.2fx";
+"osd.subtitle_scale" = "Subtitle Scale: %@x";
 "osd.add_to_playlist" = "Added %i Files to Playlist";
 "osd.clear_playlist" = "Cleared Playlist";
 "osd.video_eq.contrast" = "Contrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volume: %d";
-"menu.volume_muted" = "Volume: %d (Muted)";
-"menu.audio_delay" = "Audio Delay: %.2fs";
-"menu.sub_delay" = "Subtitle Delay: %.2fs";
+"menu.volume" = "Volume: %@";
+"menu.volume_muted" = "Volume: %@ (Muted)";
+"menu.audio_delay" = "Audio Delay: %@s";
+"menu.sub_delay" = "Subtitle Delay: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Show Subtitles Panel";
 "menu.hide_subtitles" = "Hide Subtitles Panel";
 
-"menu.seek_forward" = "Step Forward %.0fs";
-"menu.seek_backward" = "Step Backward %.0fs";
+"menu.seek_forward" = "Step Forward %@s";
+"menu.seek_backward" = "Step Backward %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Volume - %.0f%%";
-"menu.audio_delay_up" = "Audio Delay + %.1fs";
-"menu.audio_delay_down" = "Audio Delay - %.1fs";
-"menu.sub_delay_up" = "Subtitle Delay + %.1fs";
-"menu.sub_delay_down" = "Subtitle Delay - %.1fs";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Volume - %@%%";
+"menu.audio_delay_up" = "Audio Delay + %@s";
+"menu.audio_delay_down" = "Audio Delay - %@s";
+"menu.sub_delay_up" = "Subtitle Delay + %@s";
+"menu.sub_delay_down" = "Subtitle Delay - %@s";
 
 "menu.crop_custom" = "Custom…";
 "menu.find_online_sub" = "Find Online Subtitles from %@";

--- a/iina/bn.lproj/Localizable.strings
+++ b/iina/bn.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pause";
 "osd.resume" = "Resume";
-"osd.volume" = "Volume: %i";
+"osd.volume" = "Volume: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Aspect Ratio: %@";
 "osd.crop" = "Crop: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deinterlace: %@";
 "osd.hwdec" = "Hardware Decoding: %@";
 "osd.audio_delay.nodelay" = "Audio Delay: No Delay";
-"osd.audio_delay.later" = "Audio Delay: %.2fs Later";
-"osd.audio_delay.earlier" = "Audio Delay: %.2fs Earlier";
+"osd.audio_delay.later" = "Audio Delay: %@s Later";
+"osd.audio_delay.earlier" = "Audio Delay: %@s Earlier";
 "osd.sub_delay.nodelay" = "Subtitle Delay: No Delay";
-"osd.sub_delay.later" = "Subtitle Delay: %.2fs Later";
-"osd.sub_delay.earlier" = "Subtitle Delay: %.2fs Earlier";
-"osd.subtitle_pos" = "Subtitle Position: %.1f";
+"osd.sub_delay.later" = "Subtitle Delay: %@s Later";
+"osd.sub_delay.earlier" = "Subtitle Delay: %@s Earlier";
+"osd.subtitle_pos" = "Subtitle Position: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-Loop: Cleared";
 "osd.stop" = "Stop";
 "osd.chapter" = "Chapter: %@";
-"osd.subtitle_scale" = "Subtitle Scale: %.2fx";
+"osd.subtitle_scale" = "Subtitle Scale: %@x";
 "osd.add_to_playlist" = "Added %i Files to Playlist";
 "osd.clear_playlist" = "Cleared Playlist";
 "osd.video_eq.contrast" = "Contrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volume: %d";
-"menu.volume_muted" = "Volume: %d (Muted)";
-"menu.audio_delay" = "Audio Delay: %.2fs";
-"menu.sub_delay" = "Subtitle Delay: %.2fs";
+"menu.volume" = "Volume: %@";
+"menu.volume_muted" = "Volume: %@ (Muted)";
+"menu.audio_delay" = "Audio Delay: %@s";
+"menu.sub_delay" = "Subtitle Delay: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Show Subtitles Panel";
 "menu.hide_subtitles" = "Hide Subtitles Panel";
 
-"menu.seek_forward" = "Step Forward %.0fs";
-"menu.seek_backward" = "Step Backward %.0fs";
+"menu.seek_forward" = "Step Forward %@s";
+"menu.seek_backward" = "Step Backward %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Volume - %.0f%%";
-"menu.audio_delay_up" = "Audio Delay + %.1fs";
-"menu.audio_delay_down" = "Audio Delay - %.1fs";
-"menu.sub_delay_up" = "Subtitle Delay + %.1fs";
-"menu.sub_delay_down" = "Subtitle Delay - %.1fs";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Volume - %@%%";
+"menu.audio_delay_up" = "Audio Delay + %@s";
+"menu.audio_delay_down" = "Audio Delay - %@s";
+"menu.sub_delay_up" = "Subtitle Delay + %@s";
+"menu.sub_delay_down" = "Subtitle Delay - %@s";
 
 "menu.crop_custom" = "Custom…";
 "menu.find_online_sub" = "Find Online Subtitles from %@";

--- a/iina/ca.lproj/Localizable.strings
+++ b/iina/ca.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pausa";
 "osd.resume" = "Reprèn";
-"osd.volume" = "Volum: %i";
+"osd.volume" = "Volum: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Relació d'aspecte: %@";
 "osd.crop" = "Escapça: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Desentrellaça: %@";
 "osd.hwdec" = "Decodificació per maquinari: %@";
 "osd.audio_delay.nodelay" = "Retard de l'àudio: sense retard";
-"osd.audio_delay.later" = "Retard de l'àudio: %.2fs després";
-"osd.audio_delay.earlier" = "Retard de l'àudio: %.2fs abans";
+"osd.audio_delay.later" = "Retard de l'àudio: %@s després";
+"osd.audio_delay.earlier" = "Retard de l'àudio: %@s abans";
 "osd.sub_delay.nodelay" = "Retard dels subtítols: sense retard";
-"osd.sub_delay.later" = "Retard dels subtítols: %.2fs després";
-"osd.sub_delay.earlier" = "Retard dels subtítols: %.2fs abans";
-"osd.subtitle_pos" = "Posició dels subtítols: %.1f";
+"osd.sub_delay.later" = "Retard dels subtítols: %@s després";
+"osd.sub_delay.earlier" = "Retard dels subtítols: %@s abans";
+"osd.subtitle_pos" = "Posició dels subtítols: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Retard Secundari de Subtítols: Sense Retard";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Retard Secundari de Subtítols: %.2fs Abans";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Retard Secundari de Subtítols: %@s Abans";
 "osd.sub_second_hidden" = "Subtítols Secundaris Amagats";
-"osd.sub_second_pos" = "Posició Secundària de Subtítols: %.1f";
+"osd.sub_second_pos" = "Posició Secundària de Subtítols: %@";
 "osd.sub_second_visible" = "Subtítols Secundaris Visibles";
 "osd.mute" = "Silencia";
 "osd.unmute" = "Amb so";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "Bucle-AB: suprimit";
 "osd.stop" = "Atura";
 "osd.chapter" = "Capítol: %@";
-"osd.subtitle_scale" = "Escala dels subtítols: %.2fx";
+"osd.subtitle_scale" = "Escala dels subtítols: %@x";
 "osd.add_to_playlist" = "%i fitxer afegits a la llista de reproducció";
 "osd.clear_playlist" = "Llista de reproducció suprimida";
 "osd.video_eq.contrast" = "Contrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volum: %d";
-"menu.volume_muted" = "Volum: %d (Silenciat)";
-"menu.audio_delay" = "Retard d'àudio: %.2fs";
-"menu.sub_delay" = "Retard en els subtítols: %.2fs";
+"menu.volume" = "Volum: %@";
+"menu.volume_muted" = "Volum: %@ (Silenciat)";
+"menu.audio_delay" = "Retard d'àudio: %@s";
+"menu.sub_delay" = "Retard en els subtítols: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Amagar Subtítols Secundaris";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Show Subtitles Panel";
 "menu.hide_subtitles" = "Hide Subtitles Panel";
 
-"menu.seek_forward" = "Avança %.0fs";
-"menu.seek_backward" = "Retrocedeix %.0fs";
+"menu.seek_forward" = "Avança %@s";
+"menu.seek_backward" = "Retrocedeix %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volum + %.0f%%";
-"menu.volume_down" = "Volum - %.0f%%";
-"menu.audio_delay_up" = "Retarda d'àudio + %.1fs";
-"menu.audio_delay_down" = "Retarda d'àudio - %.1fs";
-"menu.sub_delay_up" = "Retarda en els subtítols + %.1fs";
-"menu.sub_delay_down" = "Retarda en els subtítols - %.1fs";
+"menu.volume_up" = "Volum + %@%%";
+"menu.volume_down" = "Volum - %@%%";
+"menu.audio_delay_up" = "Retarda d'àudio + %@s";
+"menu.audio_delay_down" = "Retarda d'àudio - %@s";
+"menu.sub_delay_up" = "Retarda en els subtítols + %@s";
+"menu.sub_delay_down" = "Retarda en els subtítols - %@s";
 
 "menu.crop_custom" = "Personalitzat...";
 "menu.find_online_sub" = "Cerca subtítols en línia a %@";

--- a/iina/cs.lproj/Localizable.strings
+++ b/iina/cs.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pozastaveno";
 "osd.resume" = "Pokračování";
-"osd.volume" = "Hlasitost: %i";
+"osd.volume" = "Hlasitost: %@";
 "osd.speed" = "Rychlost: %@×";
 "osd.aspect" = "Poměr stran: %@";
 "osd.crop" = "Ořez: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Odebrání prokládání: %@";
 "osd.hwdec" = "Hardwarové dekódování: %@";
 "osd.audio_delay.nodelay" = "Zpoždění zvuku: Žádné";
-"osd.audio_delay.later" = "Zpoždění zvuku: %.2f s";
-"osd.audio_delay.earlier" = "Zpoždění zvuku: −%.2f s";
+"osd.audio_delay.later" = "Zpoždění zvuku: %@ s";
+"osd.audio_delay.earlier" = "Zpoždění zvuku: −%@ s";
 "osd.sub_delay.nodelay" = "Zpoždění titulků: Žádné";
-"osd.sub_delay.later" = "Zpoždění titulků: %.2f s";
-"osd.sub_delay.earlier" = "Zpoždění titulků: −%.2f s";
-"osd.subtitle_pos" = "Umístění titulků: %.1f";
+"osd.sub_delay.later" = "Zpoždění titulků: %@ s";
+"osd.sub_delay.earlier" = "Zpoždění titulků: −%@ s";
+"osd.subtitle_pos" = "Umístění titulků: %@";
 "osd.sub_hidden" = "Titulky skryty";
 "osd.sub_visible" = "Titulky zobrazeny";
 "osd.sub_second_delay.nodelay" = "Zpoždění druhých titulků: Žádné";
-"osd.sub_second_delay.later" = "Zpoždění druhých titulků: %.2f s";
-"osd.sub_second_delay.earlier" = "Zpoždění druhých titulků: −%.2f s";
+"osd.sub_second_delay.later" = "Zpoždění druhých titulků: %@ s";
+"osd.sub_second_delay.earlier" = "Zpoždění druhých titulků: −%@ s";
 "osd.sub_second_hidden" = "Druhé titulky skryty";
-"osd.sub_second_pos" = "Umístění druhých titulků: %.1f";
+"osd.sub_second_pos" = "Umístění druhých titulků: %@";
 "osd.sub_second_visible" = "Druhé titulky zobrazeny";
 "osd.mute" = "Ztlumeno";
 "osd.unmute" = "Zesíleno";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "Smyčka zrušena";
 "osd.stop" = "Zastaveno";
 "osd.chapter" = "Kapitola: %@";
-"osd.subtitle_scale" = "Velikost titulků: %.2f×";
+"osd.subtitle_scale" = "Velikost titulků: %@×";
 "osd.add_to_playlist" = "Souborů přidáno do playlistu: %i";
 "osd.clear_playlist" = "Playlist smazán";
 "osd.video_eq.contrast" = "Kontrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Pro pokročilé funkce jako jsou stahování videa a automatické aktualizace yt-dlp nainstalujte plug-in Online Media pomocí výběru „Instalovat z GitHub“ v Nastavení > Plug-iny.";
 "preference.ytdl_plugin_installed" = "Vestavěná podpora youtube-dl je zakázána, protože je nainstalován Online media plug-in.";
 
-"menu.volume" = "Hlasitost: %d";
-"menu.volume_muted" = "Hlasitost: %d (Ztlumeno)";
-"menu.audio_delay" = "Zpoždění zvuku: %.2f s";
-"menu.sub_delay" = "Zpoždění titulků: %.2f s";
+"menu.volume" = "Hlasitost: %@";
+"menu.volume_muted" = "Hlasitost: %@ (Ztlumeno)";
+"menu.audio_delay" = "Zpoždění zvuku: %@ s";
+"menu.sub_delay" = "Zpoždění titulků: %@ s";
 "menu.sub_hide" = "Skrýt titulky";
 "menu.sub_show" = "Zobrazit titulky";
 "menu.sub_second_hide" = "Skrýt druhé titulky";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Zobrazit panel titulků";
 "menu.hide_subtitles" = "Skrýt panel titulků";
 
-"menu.seek_forward" = "Posunout vpřed o %.0f s";
-"menu.seek_backward" = "Posunout vzad o %.0f s";
+"menu.seek_forward" = "Posunout vpřed o %@ s";
+"menu.seek_backward" = "Posunout vzad o %@ s";
 "menu.speed_up" = "Zrychlit %@×";
 "menu.speed_down" = "Zpomalit %@×";
-"menu.volume_up" = "Hlasitost +%.0f %%";
-"menu.volume_down" = "Hlasitost −%.0f %%";
-"menu.audio_delay_up" = "Zpoždění zvuku +%.1f s";
-"menu.audio_delay_down" = "Zpoždění zvuku −%.1f s";
-"menu.sub_delay_up" = "Zpoždění titulků +%.1f s";
-"menu.sub_delay_down" = "Zpoždění titulků −%.1f s";
+"menu.volume_up" = "Hlasitost +%@ %%";
+"menu.volume_down" = "Hlasitost −%@ %%";
+"menu.audio_delay_up" = "Zpoždění zvuku +%@ s";
+"menu.audio_delay_down" = "Zpoždění zvuku −%@ s";
+"menu.sub_delay_up" = "Zpoždění titulků +%@ s";
+"menu.sub_delay_down" = "Zpoždění titulků −%@ s";
 
 "menu.crop_custom" = "Vlastní…";
 "menu.find_online_sub" = "Vyhledat titulky online z %@";

--- a/iina/da.lproj/Localizable.strings
+++ b/iina/da.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pause";
 "osd.resume" = "Genoptag";
-"osd.volume" = "Lydstyrke: %i";
+"osd.volume" = "Lydstyrke: %@";
 "osd.speed" = "Hastighed: %@x";
 "osd.aspect" = "Billedformat: %@";
 "osd.crop" = "Beskær: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deinterlace: %@";
 "osd.hwdec" = "Hardwareafkodning: %@";
 "osd.audio_delay.nodelay" = "Lydforsinkelse: Ingen forsinkelse";
-"osd.audio_delay.later" = "Lydforsinkelse: %.2fs senere";
-"osd.audio_delay.earlier" = "Lydforsinkelse: %.2fs tidligere";
+"osd.audio_delay.later" = "Lydforsinkelse: %@s senere";
+"osd.audio_delay.earlier" = "Lydforsinkelse: %@s tidligere";
 "osd.sub_delay.nodelay" = "Undertekst forsinkelse: Ingen forsinkelse";
-"osd.sub_delay.later" = "Undertekst forsinkelse: %.2fs senere";
-"osd.sub_delay.earlier" = "Undertekst forsinkelse: %.2fs tidligere";
-"osd.subtitle_pos" = "Undertekst position: %.1f";
+"osd.sub_delay.later" = "Undertekst forsinkelse: %@s senere";
+"osd.sub_delay.earlier" = "Undertekst forsinkelse: %@s tidligere";
+"osd.subtitle_pos" = "Undertekst position: %@";
 "osd.sub_hidden" = "Undertekster er skjult";
 "osd.sub_visible" = "Undertekster er synlige";
 "osd.sub_second_delay.nodelay" = "Forsinkelse af sekundære undertekster: ingen forsinkelse";
-"osd.sub_second_delay.later" = "Forsinkelse af sekundære undertekster: %.2fs senere";
-"osd.sub_second_delay.earlier" = "Forsinkelse af sekundære undertekster: %.2fs tidligere";
+"osd.sub_second_delay.later" = "Forsinkelse af sekundære undertekster: %@s senere";
+"osd.sub_second_delay.earlier" = "Forsinkelse af sekundære undertekster: %@s tidligere";
 "osd.sub_second_hidden" = "Sekundære undertekster er skjulte";
-"osd.sub_second_pos" = "Sekundære underteksters position: %.1f";
+"osd.sub_second_pos" = "Sekundære underteksters position: %@";
 "osd.sub_second_visible" = "Sekundære undertekster er synlige";
 "osd.mute" = "Lydløs";
 "osd.unmute" = "Lydløs fra";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-Løkke: Ryddet";
 "osd.stop" = "Stop";
 "osd.chapter" = "Kapitel: %@";
-"osd.subtitle_scale" = "Undertekst skala: %.2fx";
+"osd.subtitle_scale" = "Undertekst skala: %@x";
 "osd.add_to_playlist" = "Tilføj %i filer til spilleliste";
 "osd.clear_playlist" = "Spilleliste ryddet";
 "osd.video_eq.contrast" = "Kontrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Installer Online Media-tilføjelsen fra \"Tilføjelser > Installer fra GitHub\" for at få fornøjelsen af nye avancerede funktioner såsom at hente videoer og automatiske youtube-dl-opdateringer.";
 "preference.ytdl_plugin_installed" = "Den indbyggede youtube-dl-understøttelse er slået fra, siden du har Online Media-tilføjelsen installeret.";
 
-"menu.volume" = "Lydstyrke: %d";
-"menu.volume_muted" = "Lydstyrke: %d (lydløs)";
-"menu.audio_delay" = "Lydforsinkelse: %.2fs";
-"menu.sub_delay" = "Undertekst forsinkelse: %.2fs";
+"menu.volume" = "Lydstyrke: %@";
+"menu.volume_muted" = "Lydstyrke: %@ (lydløs)";
+"menu.audio_delay" = "Lydforsinkelse: %@s";
+"menu.sub_delay" = "Undertekst forsinkelse: %@s";
 "menu.sub_hide" = "Skjul undertekster";
 "menu.sub_show" = "Vis undertekster";
 "menu.sub_second_hide" = "Skjul sekundære undertekster";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Vis undertekst panel";
 "menu.hide_subtitles" = "Skjul undertekst panel";
 
-"menu.seek_forward" = "Spol frem %.0fs";
-"menu.seek_backward" = "Spol tilbage %.0fs";
+"menu.seek_forward" = "Spol frem %@s";
+"menu.seek_backward" = "Spol tilbage %@s";
 "menu.speed_up" = "Øg hastighed med %@x";
 "menu.speed_down" = "Sænk hastighed med %@x";
-"menu.volume_up" = "Lydstyrke + %.0f%%";
-"menu.volume_down" = "Lydstyrke - %.0f%%";
-"menu.audio_delay_up" = "Lydforsinkelse + %.1fs";
-"menu.audio_delay_down" = "Lydforsinkelse - %.1fs";
-"menu.sub_delay_up" = "Undertekst forsinkelse + %.1fs";
-"menu.sub_delay_down" = "Undertekst forsinkelse - %.1fs";
+"menu.volume_up" = "Lydstyrke + %@%%";
+"menu.volume_down" = "Lydstyrke - %@%%";
+"menu.audio_delay_up" = "Lydforsinkelse + %@s";
+"menu.audio_delay_down" = "Lydforsinkelse - %@s";
+"menu.sub_delay_up" = "Undertekst forsinkelse + %@s";
+"menu.sub_delay_down" = "Undertekst forsinkelse - %@s";
 
 "menu.crop_custom" = "Brugerdefineret...";
 "menu.find_online_sub" = "Find online undertekster fra %@";

--- a/iina/de.lproj/Localizable.strings
+++ b/iina/de.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pausieren";
 "osd.resume" = "Wiedergabe";
-"osd.volume" = "Lautstärke: %i";
+"osd.volume" = "Lautstärke: %@";
 "osd.speed" = "Geschwindigkeit: %@x";
 "osd.aspect" = "Seitenverhältnis: %@";
 "osd.crop" = "Zuschneiden: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deinterlacing: %@";
 "osd.hwdec" = "Hardware-Dekodierung %@";
 "osd.audio_delay.nodelay" = "Audioverzögerung: Keine";
-"osd.audio_delay.later" = "Audioverzögerung: %.2f s später";
-"osd.audio_delay.earlier" = "Audioverzögerung: %.2f s früher";
+"osd.audio_delay.later" = "Audioverzögerung: %@ s später";
+"osd.audio_delay.earlier" = "Audioverzögerung: %@ s früher";
 "osd.sub_delay.nodelay" = "Untertitelverzögerung: Keine";
-"osd.sub_delay.later" = "Untertitelverzögerung: %.2f s später";
-"osd.sub_delay.earlier" = "Untertitelverzögerung: %.2f s früher";
-"osd.subtitle_pos" = "Untertitelposition: %.1f";
+"osd.sub_delay.later" = "Untertitelverzögerung: %@ s später";
+"osd.sub_delay.earlier" = "Untertitelverzögerung: %@ s früher";
+"osd.subtitle_pos" = "Untertitelposition: %@";
 "osd.sub_hidden" = "Untertitel ausgeblendet";
 "osd.sub_visible" = "Untertitel sichtbar";
 "osd.sub_second_delay.nodelay" = "Verzögerung des zweiten Untertitels: Keine Verzögerung";
-"osd.sub_second_delay.later" = "Verzögerung des zweiten Untertitels: %.2fs später";
-"osd.sub_second_delay.earlier" = "Verzögerung des zweiten Untertitels: %.2fs früher";
+"osd.sub_second_delay.later" = "Verzögerung des zweiten Untertitels: %@s später";
+"osd.sub_second_delay.earlier" = "Verzögerung des zweiten Untertitels: %@s früher";
 "osd.sub_second_hidden" = "Zweite Untertitel ausgeblendet";
-"osd.sub_second_pos" = "Position des zweiten Untertitels: %.1f";
+"osd.sub_second_pos" = "Position des zweiten Untertitels: %@";
 "osd.sub_second_visible" = "Zweite Untertitel sichtbar";
 "osd.mute" = "Stumm";
 "osd.unmute" = "Ton ein";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "A-B-Schleife: Aus";
 "osd.stop" = "Stopp";
 "osd.chapter" = "Kapitel: %@";
-"osd.subtitle_scale" = "Untertitelgröße: %.2fx";
+"osd.subtitle_scale" = "Untertitelgröße: %@x";
 "osd.add_to_playlist" = "%i Dateien zur Wiedergabeliste hinzugefügt";
 "osd.clear_playlist" = "Wiedergabeliste geleert";
 "osd.video_eq.contrast" = "Kontrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Lautstärke: %d";
-"menu.volume_muted" = "Lautstärke: %d (Stumm)";
-"menu.audio_delay" = "Audioverzögerung: %.2f s";
-"menu.sub_delay" = "Untertitelverzögerung: %.2f s";
+"menu.volume" = "Lautstärke: %@";
+"menu.volume_muted" = "Lautstärke: %@ (Stumm)";
+"menu.audio_delay" = "Audioverzögerung: %@ s";
+"menu.sub_delay" = "Untertitelverzögerung: %@ s";
 "menu.sub_hide" = "Untertitel ausblenden";
 "menu.sub_show" = "Untertitel anzeigen";
 "menu.sub_second_hide" = "Zweite Untertitel ausblenden";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Untertiteleinstellungen anzeigen";
 "menu.hide_subtitles" = "Untertiteleinstellungen verbergen";
 
-"menu.seek_forward" = "%.0f s vorspulen";
-"menu.seek_backward" = "%.0f s zurückspulen";
+"menu.seek_forward" = "%@ s vorspulen";
+"menu.seek_backward" = "%@ s zurückspulen";
 "menu.speed_up" = "Geschwindigkeit um %@x erhöhen";
 "menu.speed_down" = "Geschwindigkeit um %@x verlangsamen";
-"menu.volume_up" = "Lautstärke + %.0f%%";
-"menu.volume_down" = "Lautstärke − %.0f%%";
-"menu.audio_delay_up" = "Audioverzögerung + %.1f s";
-"menu.audio_delay_down" = "Audioverzögerung − %.1f s";
-"menu.sub_delay_up" = "Untertitelverzögerung + %.1f s";
-"menu.sub_delay_down" = "Untertitelverzögerung − %.1f s";
+"menu.volume_up" = "Lautstärke + %@%%";
+"menu.volume_down" = "Lautstärke − %@%%";
+"menu.audio_delay_up" = "Audioverzögerung + %@ s";
+"menu.audio_delay_down" = "Audioverzögerung − %@ s";
+"menu.sub_delay_up" = "Untertitelverzögerung + %@ s";
+"menu.sub_delay_down" = "Untertitelverzögerung − %@ s";
 
 "menu.crop_custom" = "Eigene …";
 "menu.find_online_sub" = "Online-Untertitel von „%@“ finden";

--- a/iina/el.lproj/Localizable.strings
+++ b/iina/el.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Παύση";
 "osd.resume" = "Συνέχιση";
-"osd.volume" = "Ένταση: %i";
+"osd.volume" = "Ένταση: %@";
 "osd.speed" = "Ταχύτητα: %@x";
 "osd.aspect" = "Αναλογία Προβολής: %@";
 "osd.crop" = "Περικοπή: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Αποπλεξία: %@";
 "osd.hwdec" = "Αποκωδικοποίηση Υλικού: %@";
 "osd.audio_delay.nodelay" = "Καθυστέρηση Ήχου: Χωρίς Καθυστέρηση";
-"osd.audio_delay.later" = "Καθυστέρηση Ήχου: %.2fs Αργότερα";
-"osd.audio_delay.earlier" = "Καθυστέρηση Ήχου: %.2fs Νωρίτερα";
+"osd.audio_delay.later" = "Καθυστέρηση Ήχου: %@s Αργότερα";
+"osd.audio_delay.earlier" = "Καθυστέρηση Ήχου: %@s Νωρίτερα";
 "osd.sub_delay.nodelay" = "Καθυστέρηση Υποτίτλων: Χωρίς Καθυστέρηση";
-"osd.sub_delay.later" = "Καθυστέρηση Υποτίτλων: %.2fs Αργότερα";
-"osd.sub_delay.earlier" = "Καθυστέρηση Υποτίτλων: %.2fs Νωρίτερα";
-"osd.subtitle_pos" = "Θέση Υποτίτλων: %.1f";
+"osd.sub_delay.later" = "Καθυστέρηση Υποτίτλων: %@s Αργότερα";
+"osd.sub_delay.earlier" = "Καθυστέρηση Υποτίτλων: %@s Νωρίτερα";
+"osd.subtitle_pos" = "Θέση Υποτίτλων: %@";
 "osd.sub_hidden" = "";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Δευτερεύων Καθυστέρηση Υπότιτλων: Χωρίς Καθυστέρηση";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Δευτερεύων Καθυστέρηση Υποτίτλων: %.2fs Νωρίτερα";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Δευτερεύων Καθυστέρηση Υποτίτλων: %@s Νωρίτερα";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Σίγαση";
 "osd.unmute" = "Αποσίγαση";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "Βρόχος Α-Β: Εκκαθαρίστηκε";
 "osd.stop" = "Διακοπή";
 "osd.chapter" = "Κεφάλαιο: %@";
-"osd.subtitle_scale" = "Κλίμακα Υποτίτλων: %.2fx";
+"osd.subtitle_scale" = "Κλίμακα Υποτίτλων: %@x";
 "osd.add_to_playlist" = "Προστέθηκαν %i Αρχεία στη Λίστα Αναπαραγωγής";
 "osd.clear_playlist" = "Λίστα Αναπαραγωγής Εκκαθαρίστηκε";
 "osd.video_eq.contrast" = "Αντίθεση: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Εγκατάσταση του Online Media plugin από \"Plugins > Εγκατάσταση από το GitHub\" για να απολαύσεις προηγμένες λειτουργίες όπως λήψη βίντεο και αυτόματες ενημερώσεις yt-dlp.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Ένταση: %d";
-"menu.volume_muted" = "Volume: %d (Muted)";
-"menu.audio_delay" = "Καθυστέρηση Ήχου: %.2fs";
-"menu.sub_delay" = "Καθυστέρηση Υποτίτλων: %.2fs";
+"menu.volume" = "Ένταση: %@";
+"menu.volume_muted" = "Volume: %@ (Muted)";
+"menu.audio_delay" = "Καθυστέρηση Ήχου: %@s";
+"menu.sub_delay" = "Καθυστέρηση Υποτίτλων: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Show Subtitles Panel";
 "menu.hide_subtitles" = "Hide Subtitles Panel";
 
-"menu.seek_forward" = "Βήμα Μπροστά %.0fs";
-"menu.seek_backward" = "Βήμα Πίσω %.0fs";
+"menu.seek_forward" = "Βήμα Μπροστά %@s";
+"menu.seek_backward" = "Βήμα Πίσω %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Ένταση + %.0f%%";
-"menu.volume_down" = "Ένταση - %.0f%%";
-"menu.audio_delay_up" = "Καθυστέρηση Ήχου + %.1fs";
-"menu.audio_delay_down" = "Καθυστέρηση Ήχου - %.1fs";
-"menu.sub_delay_up" = "Καθυστέρηση Υποτίτλων + %.1fs";
-"menu.sub_delay_down" = "Καθυστέρηση Υποτίτλων - %.1fs";
+"menu.volume_up" = "Ένταση + %@%%";
+"menu.volume_down" = "Ένταση - %@%%";
+"menu.audio_delay_up" = "Καθυστέρηση Ήχου + %@s";
+"menu.audio_delay_down" = "Καθυστέρηση Ήχου - %@s";
+"menu.sub_delay_up" = "Καθυστέρηση Υποτίτλων + %@s";
+"menu.sub_delay_down" = "Καθυστέρηση Υποτίτλων - %@s";
 
 "menu.crop_custom" = "Custom…";
 "menu.find_online_sub" = "Find Online Subtitles from %@";

--- a/iina/en-GB.lproj/Localizable.strings
+++ b/iina/en-GB.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pause";
 "osd.resume" = "Resume";
-"osd.volume" = "Volume: %i";
+"osd.volume" = "Volume: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Aspect Ratio: %@";
 "osd.crop" = "Crop: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deinterlace: %@";
 "osd.hwdec" = "Hardware Decoding: %@";
 "osd.audio_delay.nodelay" = "Audio Delay: No Delay";
-"osd.audio_delay.later" = "Audio Delay: %.2fs Later";
-"osd.audio_delay.earlier" = "Audio Delay: %.2fs Earlier";
+"osd.audio_delay.later" = "Audio Delay: %@s Later";
+"osd.audio_delay.earlier" = "Audio Delay: %@s Earlier";
 "osd.sub_delay.nodelay" = "Subtitle Delay: No Delay";
-"osd.sub_delay.later" = "Subtitle Delay: %.2fs Later";
-"osd.sub_delay.earlier" = "Subtitle Delay: %.2fs Earlier";
-"osd.subtitle_pos" = "Subtitle Position: %.1f";
+"osd.sub_delay.later" = "Subtitle Delay: %@s Later";
+"osd.sub_delay.earlier" = "Subtitle Delay: %@s Earlier";
+"osd.subtitle_pos" = "Subtitle Position: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-Loop: Cleared";
 "osd.stop" = "Stop";
 "osd.chapter" = "Chapter: %@";
-"osd.subtitle_scale" = "Subtitle Scale: %.2fx";
+"osd.subtitle_scale" = "Subtitle Scale: %@x";
 "osd.add_to_playlist" = "Added %i Files to Playlist";
 "osd.clear_playlist" = "Cleared Playlist";
 "osd.video_eq.contrast" = "Contrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volume: %d";
-"menu.volume_muted" = "Volume: %d (Muted)";
-"menu.audio_delay" = "Audio Delay: %.2fs";
-"menu.sub_delay" = "Subtitle Delay: %.2fs";
+"menu.volume" = "Volume: %@";
+"menu.volume_muted" = "Volume: %@ (Muted)";
+"menu.audio_delay" = "Audio Delay: %@s";
+"menu.sub_delay" = "Subtitle Delay: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Show Subtitles Panel";
 "menu.hide_subtitles" = "Hide Subtitles Panel";
 
-"menu.seek_forward" = "Step Forward %.0fs";
-"menu.seek_backward" = "Step Backward %.0fs";
+"menu.seek_forward" = "Step Forward %@s";
+"menu.seek_backward" = "Step Backward %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Volume - %.0f%%";
-"menu.audio_delay_up" = "Audio Delay + %.1fs";
-"menu.audio_delay_down" = "Audio Delay - %.1fs";
-"menu.sub_delay_up" = "Subtitle Delay + %.1fs";
-"menu.sub_delay_down" = "Subtitle Delay - %.1fs";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Volume - %@%%";
+"menu.audio_delay_up" = "Audio Delay + %@s";
+"menu.audio_delay_down" = "Audio Delay - %@s";
+"menu.sub_delay_up" = "Subtitle Delay + %@s";
+"menu.sub_delay_down" = "Subtitle Delay - %@s";
 
 "menu.crop_custom" = "Custom…";
 "menu.find_online_sub" = "Find Online Subtitles from %@";

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pause";
 "osd.resume" = "Resume";
-"osd.volume" = "Volume: %i";
+"osd.volume" = "Volume: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Aspect Ratio: %@";
 "osd.crop" = "Crop: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deinterlace: %@";
 "osd.hwdec" = "Hardware Decoding: %@";
 "osd.audio_delay.nodelay" = "Audio Delay: No Delay";
-"osd.audio_delay.later" = "Audio Delay: %.2fs Later";
-"osd.audio_delay.earlier" = "Audio Delay: %.2fs Earlier";
+"osd.audio_delay.later" = "Audio Delay: %@s Later";
+"osd.audio_delay.earlier" = "Audio Delay: %@s Earlier";
 "osd.sub_delay.nodelay" = "Subtitle Delay: No Delay";
-"osd.sub_delay.later" = "Subtitle Delay: %.2fs Later";
-"osd.sub_delay.earlier" = "Subtitle Delay: %.2fs Earlier";
-"osd.subtitle_pos" = "Subtitle Position: %.1f";
+"osd.sub_delay.later" = "Subtitle Delay: %@s Later";
+"osd.sub_delay.earlier" = "Subtitle Delay: %@s Earlier";
+"osd.subtitle_pos" = "Subtitle Position: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-Loop: Cleared";
 "osd.stop" = "Stop";
 "osd.chapter" = "Chapter: %@";
-"osd.subtitle_scale" = "Subtitle Scale: %.2fx";
+"osd.subtitle_scale" = "Subtitle Scale: %@x";
 "osd.add_to_playlist" = "Added %i Files to Playlist";
 "osd.clear_playlist" = "Cleared Playlist";
 "osd.video_eq.contrast" = "Contrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volume: %d";
-"menu.volume_muted" = "Volume: %d (Muted)";
-"menu.audio_delay" = "Audio Delay: %.2fs";
-"menu.sub_delay" = "Subtitle Delay: %.2fs";
+"menu.volume" = "Volume: %@";
+"menu.volume_muted" = "Volume: %@ (Muted)";
+"menu.audio_delay" = "Audio Delay: %@s";
+"menu.sub_delay" = "Subtitle Delay: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Show Subtitles Panel";
 "menu.hide_subtitles" = "Hide Subtitles Panel";
 
-"menu.seek_forward" = "Step Forward %.0fs";
-"menu.seek_backward" = "Step Backward %.0fs";
+"menu.seek_forward" = "Step Forward %@s";
+"menu.seek_backward" = "Step Backward %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Volume - %.0f%%";
-"menu.audio_delay_up" = "Audio Delay + %.1fs";
-"menu.audio_delay_down" = "Audio Delay - %.1fs";
-"menu.sub_delay_up" = "Subtitle Delay + %.1fs";
-"menu.sub_delay_down" = "Subtitle Delay - %.1fs";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Volume - %@%%";
+"menu.audio_delay_up" = "Audio Delay + %@s";
+"menu.audio_delay_down" = "Audio Delay - %@s";
+"menu.sub_delay_up" = "Subtitle Delay + %@s";
+"menu.sub_delay_down" = "Subtitle Delay - %@s";
 
 "menu.crop_custom" = "Custom…";
 "menu.find_online_sub" = "Find Online Subtitles from %@";

--- a/iina/es.lproj/Localizable.strings
+++ b/iina/es.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pausa";
 "osd.resume" = "Reanudar";
-"osd.volume" = "Volumen: %i";
+"osd.volume" = "Volumen: %@";
 "osd.speed" = "Velocidad: %@x";
 "osd.aspect" = "Proporción: %@";
 "osd.crop" = "Recortar: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Desentrelazar: %@";
 "osd.hwdec" = "Decodificación de hardware: %@";
 "osd.audio_delay.nodelay" = "Retraso de audio: Sin Retraso";
-"osd.audio_delay.later" = "Retraso de audio: %.2fs Después";
-"osd.audio_delay.earlier" = "Retraso de audio: %.2fs Antes";
+"osd.audio_delay.later" = "Retraso de audio: %@s Después";
+"osd.audio_delay.earlier" = "Retraso de audio: %@s Antes";
 "osd.sub_delay.nodelay" = "Retraso de subtítulos: Sin Retraso";
-"osd.sub_delay.later" = "Retraso de subtítulos: %.2fs Después";
-"osd.sub_delay.earlier" = "Retraso de subtítulos: %.2fs Antes";
-"osd.subtitle_pos" = "Posición de subtítulos: %.1f";
+"osd.sub_delay.later" = "Retraso de subtítulos: %@s Después";
+"osd.sub_delay.earlier" = "Retraso de subtítulos: %@s Antes";
+"osd.subtitle_pos" = "Posición de subtítulos: %@";
 "osd.sub_hidden" = "Subtítulos Visibles";
 "osd.sub_visible" = "Subtítulos Visibles";
 "osd.sub_second_delay.nodelay" = "Retraso secundario de subtítulos: Sin demora";
-"osd.sub_second_delay.later" = "Retraso de Subtítulo Secundario: %.2fs Después";
-"osd.sub_second_delay.earlier" = "Retraso Secundario de Subtítulos: %.2fs Antes";
+"osd.sub_second_delay.later" = "Retraso de Subtítulo Secundario: %@s Después";
+"osd.sub_second_delay.earlier" = "Retraso Secundario de Subtítulos: %@s Antes";
 "osd.sub_second_hidden" = "Subtítulos Secundarios Escondidos";
-"osd.sub_second_pos" = "Posición Secundaria de Subtítulos: %.1f";
+"osd.sub_second_pos" = "Posición Secundaria de Subtítulos: %@";
 "osd.sub_second_visible" = "Subtítulos Secundarios Visibles";
 "osd.mute" = "Silenciar";
 "osd.unmute" = "No silenciar";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "Bucle-AB: Borrado";
 "osd.stop" = "Detener";
 "osd.chapter" = "Capítulo: %@";
-"osd.subtitle_scale" = "Escala de subtítulos: %.2fx";
+"osd.subtitle_scale" = "Escala de subtítulos: %@x";
 "osd.add_to_playlist" = "Se añadieron %i archivos a la lista de reproducción";
 "osd.clear_playlist" = "Lista de reproducción borrada";
 "osd.video_eq.contrast" = "Contraste: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volumen: %d";
-"menu.volume_muted" = "Volumen: %d (Silenciado)";
-"menu.audio_delay" = "Retraso de audio: %.2fs";
-"menu.sub_delay" = "Retraso de subtítulos: %.2fs";
+"menu.volume" = "Volumen: %@";
+"menu.volume_muted" = "Volumen: %@ (Silenciado)";
+"menu.audio_delay" = "Retraso de audio: %@s";
+"menu.sub_delay" = "Retraso de subtítulos: %@s";
 "menu.sub_hide" = "Ocultar Subtítulos";
 "menu.sub_show" = "Mostrar Subtítulos";
 "menu.sub_second_hide" = "Esconder Subtítulos Secundarios";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Mostrar el panel de subtítulos";
 "menu.hide_subtitles" = "Ocultar el panel de subtítulos";
 
-"menu.seek_forward" = "Adelantar %.0fs";
-"menu.seek_backward" = "Retroceder %.0fs";
+"menu.seek_forward" = "Adelantar %@s";
+"menu.seek_backward" = "Retroceder %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volumen + %.0f%%";
-"menu.volume_down" = "Volumen - %.0f%%";
-"menu.audio_delay_up" = "Retrasar audio + %.1fs";
-"menu.audio_delay_down" = "Retrasar audio - %.1fs";
-"menu.sub_delay_up" = "Retrasar subtítulos + %.1fs";
-"menu.sub_delay_down" = "Retrasar subtítulos - %.1fs";
+"menu.volume_up" = "Volumen + %@%%";
+"menu.volume_down" = "Volumen - %@%%";
+"menu.audio_delay_up" = "Retrasar audio + %@s";
+"menu.audio_delay_down" = "Retrasar audio - %@s";
+"menu.sub_delay_up" = "Retrasar subtítulos + %@s";
+"menu.sub_delay_down" = "Retrasar subtítulos - %@s";
 
 "menu.crop_custom" = "Personalizado…";
 "menu.find_online_sub" = "Buscar subtítulos en línea desde %@";

--- a/iina/eu.lproj/Localizable.strings
+++ b/iina/eu.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pause";
 "osd.resume" = "Resume";
-"osd.volume" = "Volume: %i";
+"osd.volume" = "Volume: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Aspect Ratio: %@";
 "osd.crop" = "Crop: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deinterlace: %@";
 "osd.hwdec" = "Hardware Decoding: %@";
 "osd.audio_delay.nodelay" = "Audio Delay: No Delay";
-"osd.audio_delay.later" = "Audio Delay: %.2fs Later";
-"osd.audio_delay.earlier" = "Audio Delay: %.2fs Earlier";
+"osd.audio_delay.later" = "Audio Delay: %@s Later";
+"osd.audio_delay.earlier" = "Audio Delay: %@s Earlier";
 "osd.sub_delay.nodelay" = "Subtitle Delay: No Delay";
-"osd.sub_delay.later" = "Subtitle Delay: %.2fs Later";
-"osd.sub_delay.earlier" = "Subtitle Delay: %.2fs Earlier";
-"osd.subtitle_pos" = "Subtitle Position: %.1f";
+"osd.sub_delay.later" = "Subtitle Delay: %@s Later";
+"osd.sub_delay.earlier" = "Subtitle Delay: %@s Earlier";
+"osd.subtitle_pos" = "Subtitle Position: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-Loop: Cleared";
 "osd.stop" = "Stop";
 "osd.chapter" = "Chapter: %@";
-"osd.subtitle_scale" = "Subtitle Scale: %.2fx";
+"osd.subtitle_scale" = "Subtitle Scale: %@x";
 "osd.add_to_playlist" = "Added %i Files to Playlist";
 "osd.clear_playlist" = "Cleared Playlist";
 "osd.video_eq.contrast" = "Contrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volume: %d";
-"menu.volume_muted" = "Volume: %d (Muted)";
-"menu.audio_delay" = "Audio Delay: %.2fs";
-"menu.sub_delay" = "Subtitle Delay: %.2fs";
+"menu.volume" = "Volume: %@";
+"menu.volume_muted" = "Volume: %@ (Muted)";
+"menu.audio_delay" = "Audio Delay: %@s";
+"menu.sub_delay" = "Subtitle Delay: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Show Subtitles Panel";
 "menu.hide_subtitles" = "Hide Subtitles Panel";
 
-"menu.seek_forward" = "Step Forward %.0fs";
-"menu.seek_backward" = "Step Backward %.0fs";
+"menu.seek_forward" = "Step Forward %@s";
+"menu.seek_backward" = "Step Backward %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Volume - %.0f%%";
-"menu.audio_delay_up" = "Audio Delay + %.1fs";
-"menu.audio_delay_down" = "Audio Delay - %.1fs";
-"menu.sub_delay_up" = "Subtitle Delay + %.1fs";
-"menu.sub_delay_down" = "Subtitle Delay - %.1fs";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Volume - %@%%";
+"menu.audio_delay_up" = "Audio Delay + %@s";
+"menu.audio_delay_down" = "Audio Delay - %@s";
+"menu.sub_delay_up" = "Subtitle Delay + %@s";
+"menu.sub_delay_down" = "Subtitle Delay - %@s";
 
 "menu.crop_custom" = "Custom…";
 "menu.find_online_sub" = "Find Online Subtitles from %@";

--- a/iina/fa.lproj/Localizable.strings
+++ b/iina/fa.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "مکث";
 "osd.resume" = "ادامه";
-"osd.volume" = "بلندی صدا: %i";
+"osd.volume" = "بلندی صدا: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "نسبت تصویر: %@";
 "osd.crop" = "برش: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "تبدیل تصویر به غیر interlace: %@";
 "osd.hwdec" = "استفاده از تبدیل سخت‌افزاری: %@";
 "osd.audio_delay.nodelay" = "تاخیر صدا: بدون تاخیر";
-"osd.audio_delay.later" = "تاخیر صوت: %.2f ثانيه";
-"osd.audio_delay.earlier" = "تاخیر صوت: %.2f ثانيه زودتر";
+"osd.audio_delay.later" = "تاخیر صوت: %@ ثانيه";
+"osd.audio_delay.earlier" = "تاخیر صوت: %@ ثانيه زودتر";
 "osd.sub_delay.nodelay" = "تاخیر صدا: بدون تاخیر";
-"osd.sub_delay.later" = "تاخیر زیرنویس: %.2f ثانیه بعدتر";
-"osd.sub_delay.earlier" = "تاخیر زیرنویس: %.2f ثانیه زودتر";
-"osd.subtitle_pos" = "جایگذاری زیرنویس: %.1f";
+"osd.sub_delay.later" = "تاخیر زیرنویس: %@ ثانیه بعدتر";
+"osd.sub_delay.earlier" = "تاخیر زیرنویس: %@ ثانیه زودتر";
+"osd.subtitle_pos" = "جایگذاری زیرنویس: %@";
 "osd.sub_hidden" = "مخفی کردن زیرنویس";
 "osd.sub_visible" = "نمایش دادن زیرنویس";
 "osd.sub_second_delay.nodelay" = "تاخیر زیرنویس دوم: بدون تاخیر";
-"osd.sub_second_delay.later" = "تاخیر زیرنویس دوم: %.2f ثانیه دیرتر";
-"osd.sub_second_delay.earlier" = "تاخیر زیرنویس دوم: %.2f ثانیه زودتر";
+"osd.sub_second_delay.later" = "تاخیر زیرنویس دوم: %@ ثانیه دیرتر";
+"osd.sub_second_delay.earlier" = "تاخیر زیرنویس دوم: %@ ثانیه زودتر";
 "osd.sub_second_hidden" = "زیرنویس دوم مخفی";
-"osd.sub_second_pos" = "جایگاه زیرنویس دوم: %.1f";
+"osd.sub_second_pos" = "جایگاه زیرنویس دوم: %@";
 "osd.sub_second_visible" = "زیرنویس دوم مشخص";
 "osd.mute" = "بی صدا";
 "osd.unmute" = "با صدا";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "حلقه AB: پاک سازی شد";
 "osd.stop" = "توقف";
 "osd.chapter" = "قسمت: %@";
-"osd.subtitle_scale" = "بزرگنمایی زیرنویس: %.2f برابر";
+"osd.subtitle_scale" = "بزرگنمایی زیرنویس: %@ برابر";
 "osd.add_to_playlist" = "%i فایل به لیست پخش اضافه شد";
 "osd.clear_playlist" = "پاک کردن لیست پخش";
 "osd.video_eq.contrast" = "کنتراست: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "بلندی صدا: %d";
-"menu.volume_muted" = "صدا: %d (بی صدا)";
-"menu.audio_delay" = "تاخیر صوت: %.2f ثانيه";
-"menu.sub_delay" = "تاخیر زیرنویس: %.2f ثانیه";
+"menu.volume" = "بلندی صدا: %@";
+"menu.volume_muted" = "صدا: %@ (بی صدا)";
+"menu.audio_delay" = "تاخیر صوت: %@ ثانيه";
+"menu.sub_delay" = "تاخیر زیرنویس: %@ ثانیه";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "پنل زیرنویس رو نشون بده";
 "menu.hide_subtitles" = "پنل زیرنویس رو پنهان کن";
 
-"menu.seek_forward" = "%.0f ثانیه به جلو";
-"menu.seek_backward" = "%.0f ثانیه به عقب";
+"menu.seek_forward" = "%@ ثانیه به جلو";
+"menu.seek_backward" = "%@ ثانیه به عقب";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "افزایش صدا + %.0f%%";
-"menu.volume_down" = "کاهش صدا - %.0f%%";
-"menu.audio_delay_up" = "تاخیر صدا + %.1f ثانيه";
-"menu.audio_delay_down" = "تاخیر صدا - %.1f ثانيه";
-"menu.sub_delay_up" = "تاخیر زیرنویس + %.1f ثانیه";
-"menu.sub_delay_down" = "تاخیر زیرنویس - %.1f ثانیه";
+"menu.volume_up" = "افزایش صدا + %@%%";
+"menu.volume_down" = "کاهش صدا - %@%%";
+"menu.audio_delay_up" = "تاخیر صدا + %@ ثانيه";
+"menu.audio_delay_down" = "تاخیر صدا - %@ ثانيه";
+"menu.sub_delay_up" = "تاخیر زیرنویس + %@ ثانیه";
+"menu.sub_delay_down" = "تاخیر زیرنویس - %@ ثانیه";
 
 "menu.crop_custom" = "سفارشی…";
 "menu.find_online_sub" = "Find Online Subtitles from %@";

--- a/iina/fi.lproj/Localizable.strings
+++ b/iina/fi.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Tauko";
 "osd.resume" = "Jatka";
-"osd.volume" = "Äänenvoimakkuus: %i";
+"osd.volume" = "Äänenvoimakkuus: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Kuvasuhde: %@";
 "osd.crop" = "Rajaus: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Lomituksenpoisto: %@";
 "osd.hwdec" = "Laitteistopohjainen purku: %@";
 "osd.audio_delay.nodelay" = "Äänen viive: Ei viivästystä";
-"osd.audio_delay.later" = "Äänen viive: %.2fs myöhemmin";
-"osd.audio_delay.earlier" = "Äänen viive: %.2fs aiemmin";
+"osd.audio_delay.later" = "Äänen viive: %@s myöhemmin";
+"osd.audio_delay.earlier" = "Äänen viive: %@s aiemmin";
 "osd.sub_delay.nodelay" = "Äänen viive: Ei viivästystä";
-"osd.sub_delay.later" = "Tekstityksen viive: %.2fs myöhemmin";
-"osd.sub_delay.earlier" = "Tekstityksen viive: %.2fs aiemmin";
-"osd.subtitle_pos" = "Tekstityksen sijainti: %.1f";
+"osd.sub_delay.later" = "Tekstityksen viive: %@s myöhemmin";
+"osd.sub_delay.earlier" = "Tekstityksen viive: %@s aiemmin";
+"osd.subtitle_pos" = "Tekstityksen sijainti: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Mykistä";
 "osd.unmute" = "Poista mykistys";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-silmukka: Tyhjennetty";
 "osd.stop" = "Pysäytä";
 "osd.chapter" = "Kappale: %@";
-"osd.subtitle_scale" = "Tekstityksen skaalaus: %.2fx";
+"osd.subtitle_scale" = "Tekstityksen skaalaus: %@x";
 "osd.add_to_playlist" = "Lisätty %i tiedostoa soittolistaan";
 "osd.clear_playlist" = "Soittolista tyhjennetty";
 "osd.video_eq.contrast" = "Kontrasti: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Äänenvoimakkuus: %d";
-"menu.volume_muted" = "Volume: %d (Muted)";
-"menu.audio_delay" = "Äänen viive: %.2fs";
-"menu.sub_delay" = "Tekstityksen viive: %.2fs";
+"menu.volume" = "Äänenvoimakkuus: %@";
+"menu.volume_muted" = "Volume: %@ (Muted)";
+"menu.audio_delay" = "Äänen viive: %@s";
+"menu.sub_delay" = "Tekstityksen viive: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Näytä Tekstityspaneeli";
 "menu.hide_subtitles" = "Hide Subtitles Panel";
 
-"menu.seek_forward" = "Astu eteenpäin %.0fs";
-"menu.seek_backward" = "Siirry taaksepäin %.0fs";
+"menu.seek_forward" = "Astu eteenpäin %@s";
+"menu.seek_backward" = "Siirry taaksepäin %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Äänenvoimakkuus + %.0f%%";
-"menu.volume_down" = "Äänenvoimakkuus - %.0f%%";
-"menu.audio_delay_up" = "Äänen viive + %.1fs";
-"menu.audio_delay_down" = "Äänen viive - %.1fs";
-"menu.sub_delay_up" = "Tekstityksen viive + %.1fs";
-"menu.sub_delay_down" = "Tekstityksen viive - %.1fs";
+"menu.volume_up" = "Äänenvoimakkuus + %@%%";
+"menu.volume_down" = "Äänenvoimakkuus - %@%%";
+"menu.audio_delay_up" = "Äänen viive + %@s";
+"menu.audio_delay_down" = "Äänen viive - %@s";
+"menu.sub_delay_up" = "Tekstityksen viive + %@s";
+"menu.sub_delay_down" = "Tekstityksen viive - %@s";
 
 "menu.crop_custom" = "Mukautettu…";
 "menu.find_online_sub" = "Find Online Subtitles from %@";

--- a/iina/fr.lproj/Localizable.strings
+++ b/iina/fr.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "En pause";
 "osd.resume" = "Reprendre";
-"osd.volume" = "Volume : %i";
+"osd.volume" = "Volume : %@";
 "osd.speed" = "Vitesse : %@x";
 "osd.aspect" = "Format d'image : %@";
 "osd.crop" = "Rognage : %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Désentrelacer : %@";
 "osd.hwdec" = "Décodage matériel : %@";
 "osd.audio_delay.nodelay" = "Délai audio : aucun";
-"osd.audio_delay.later" = "Délai audio : %.2fs en avance";
-"osd.audio_delay.earlier" = "Délai audio : %.2fs en retard";
+"osd.audio_delay.later" = "Délai audio : %@s en avance";
+"osd.audio_delay.earlier" = "Délai audio : %@s en retard";
 "osd.sub_delay.nodelay" = "Délai des sous-titres : aucun";
-"osd.sub_delay.later" = "Délai des sous-titres : %.2fs en avance";
-"osd.sub_delay.earlier" = "Délai des sous-titres : %.2fs en retard";
-"osd.subtitle_pos" = "Position des sous-titres : %.1f";
+"osd.sub_delay.later" = "Délai des sous-titres : %@s en avance";
+"osd.sub_delay.earlier" = "Délai des sous-titres : %@s en retard";
+"osd.subtitle_pos" = "Position des sous-titres : %@";
 "osd.sub_hidden" = "Sous-titres masqués";
 "osd.sub_visible" = "Sous-titres visibles";
 "osd.sub_second_delay.nodelay" = "Délai des sous-titres secondaires : aucun";
-"osd.sub_second_delay.later" = "Délai des sous-titres secondaires : %.2fs en retard";
-"osd.sub_second_delay.earlier" = "Délai des sous-titres secondaires : %.2fs en avance";
+"osd.sub_second_delay.later" = "Délai des sous-titres secondaires : %@s en retard";
+"osd.sub_second_delay.earlier" = "Délai des sous-titres secondaires : %@s en avance";
 "osd.sub_second_hidden" = "Sous-titres secondaires masqués";
-"osd.sub_second_pos" = "Position de sous-titre secondaire : %.1f";
+"osd.sub_second_pos" = "Position de sous-titre secondaire : %@";
 "osd.sub_second_visible" = "Sous-titres secondaires visibles";
 "osd.mute" = "Son coupé";
 "osd.unmute" = "Son rétabli";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "Boucle AB: vidée";
 "osd.stop" = "Arrêté";
 "osd.chapter" = "Chapitre : %@";
-"osd.subtitle_scale" = "Échelle des sous-titres : %.2fx";
+"osd.subtitle_scale" = "Échelle des sous-titres : %@x";
 "osd.add_to_playlist" = "%i fichiers ajoutés à la liste de lecture";
 "osd.clear_playlist" = "Liste de lecture vidée";
 "osd.video_eq.contrast" = "Contraste : %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Installez le plugin Media en ligne à partir de \"Plugins > Installer à partir de GitHub\" pour profiter des fonctionnalités avancées telles que le téléchargement vidéo et les mises à jour automatiques de yt-dlp.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volume : %d";
-"menu.volume_muted" = "Volume : %d (coupé)";
-"menu.audio_delay" = "Délai audio : %.2fs";
-"menu.sub_delay" = "Délai des sous-titres : %.2fs";
+"menu.volume" = "Volume : %@";
+"menu.volume_muted" = "Volume : %@ (coupé)";
+"menu.audio_delay" = "Délai audio : %@s";
+"menu.sub_delay" = "Délai des sous-titres : %@s";
 "menu.sub_hide" = "Masquer les sous-titres";
 "menu.sub_show" = "Afficher les sous-titres";
 "menu.sub_second_hide" = "Masquer les sous-titres secondaires";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Afficher le panneau des sous-titres";
 "menu.hide_subtitles" = "Masquer le panneau des sous-titres";
 
-"menu.seek_forward" = "Reculer de %.0fs";
-"menu.seek_backward" = "Avancer de %.0fs";
+"menu.seek_forward" = "Reculer de %@s";
+"menu.seek_backward" = "Avancer de %@s";
 "menu.speed_up" = "Accélérer de %@x";
 "menu.speed_down" = "Ralentir de %@x";
-"menu.volume_up" = "Volume +%.0f%%";
-"menu.volume_down" = "Volume -%.0f%%";
-"menu.audio_delay_up" = "Délai audio +%.1fs";
-"menu.audio_delay_down" = "Délai audio -%.1fs";
-"menu.sub_delay_up" = "Délai des sous-titres +%.1fs";
-"menu.sub_delay_down" = "Délai des sous-titres -%.1fs";
+"menu.volume_up" = "Volume +%@%%";
+"menu.volume_down" = "Volume -%@%%";
+"menu.audio_delay_up" = "Délai audio +%@s";
+"menu.audio_delay_down" = "Délai audio -%@s";
+"menu.sub_delay_up" = "Délai des sous-titres +%@s";
+"menu.sub_delay_down" = "Délai des sous-titres -%@s";
 
 "menu.crop_custom" = "Perso…";
 "menu.find_online_sub" = "Chercher des sous-titres en ligne sur %@";

--- a/iina/he.lproj/Localizable.strings
+++ b/iina/he.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "מושהה";
 "osd.resume" = "התחדש";
-"osd.volume" = "עוצמת שמע: %i";
+"osd.volume" = "עוצמת שמע: %@";
 "osd.speed" = "מהירות: x%@";
 "osd.aspect" = "יחס גובה-רוחב: %@";
 "osd.crop" = "חיתוך: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "ביטול שזירה: %@";
 "osd.hwdec" = "פענוח חומרה: %@";
 "osd.audio_delay.nodelay" = "עיכוב שמע: ללא עיכוב";
-"osd.audio_delay.later" = "עיכוב שמע: %.2f שניות איחור";
-"osd.audio_delay.earlier" = "עיכוב שמע: %.2f שניות הקדמה";
+"osd.audio_delay.later" = "עיכוב שמע: %@ שניות איחור";
+"osd.audio_delay.earlier" = "עיכוב שמע: %@ שניות הקדמה";
 "osd.sub_delay.nodelay" = "עיכוב כתוביות: ללא עיכוב";
-"osd.sub_delay.later" = "עיכוב כתוביות: %.2f שניות איחור";
-"osd.sub_delay.earlier" = "עיכוב כתוביות: %.2f שניות הקדמה";
-"osd.subtitle_pos" = "מיקום כתוביות: %.1f";
+"osd.sub_delay.later" = "עיכוב כתוביות: %@ שניות איחור";
+"osd.sub_delay.earlier" = "עיכוב כתוביות: %@ שניות הקדמה";
+"osd.subtitle_pos" = "מיקום כתוביות: %@";
 "osd.sub_hidden" = "כתוביות מוסתרות";
 "osd.sub_visible" = "כתוביות מוצגות";
 "osd.sub_second_delay.nodelay" = "עיכוב כתוביות משניות: ללא עיכוב";
-"osd.sub_second_delay.later" = "עיכוב כתוביות משניות: %.2f שניות איחור";
-"osd.sub_second_delay.earlier" = "עיכוב כתוביות משניות: %.2f שניות הקדמה";
+"osd.sub_second_delay.later" = "עיכוב כתוביות משניות: %@ שניות איחור";
+"osd.sub_second_delay.earlier" = "עיכוב כתוביות משניות: %@ שניות הקדמה";
 "osd.sub_second_hidden" = "כתוביות משניות מוסתרות";
-"osd.sub_second_pos" = "מיקום כתוביות משניות: %.1f";
+"osd.sub_second_pos" = "מיקום כתוביות משניות: %@";
 "osd.sub_second_visible" = "כתוביות משניות מוצגות";
 "osd.mute" = "מושתק";
 "osd.unmute" = "לא מושתק";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "לולאת א-ב: בוטלה";
 "osd.stop" = "עצור";
 "osd.chapter" = "פרק: %@";
-"osd.subtitle_scale" = "קנה מידה כתוביות: %.2fx";
+"osd.subtitle_scale" = "קנה מידה כתוביות: %@x";
 "osd.add_to_playlist" = "נוספו %i קבצים לרשימת ההשמעה";
 "osd.clear_playlist" = "רשימת ההשמעה אופסה";
 "osd.video_eq.contrast" = "ניגודיות: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "עוצמת שמע: %d";
-"menu.volume_muted" = "עוצמת שמע: %d (מושתק)";
-"menu.audio_delay" = "עיכוב שמע: %.2f שניות";
-"menu.sub_delay" = "עיכוב כתוביות: %.2f שניות";
+"menu.volume" = "עוצמת שמע: %@";
+"menu.volume_muted" = "עוצמת שמע: %@ (מושתק)";
+"menu.audio_delay" = "עיכוב שמע: %@ שניות";
+"menu.sub_delay" = "עיכוב כתוביות: %@ שניות";
 "menu.sub_hide" = "הסתר כתוביות";
 "menu.sub_show" = "הצג כתוביות";
 "menu.sub_second_hide" = "הסתר כתוביות משניות";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "הצג פאנל כתוביות";
 "menu.hide_subtitles" = "הסתר פאנל כתוביות";
 
-"menu.seek_forward" = "דלג קדימה %.0f שניות";
-"menu.seek_backward" = "חזרה %.0f שניות אחורה";
+"menu.seek_forward" = "דלג קדימה %@ שניות";
+"menu.seek_backward" = "חזרה %@ שניות אחורה";
 "menu.speed_up" = "הגבר מהירות ב%@x";
 "menu.speed_down" = "הפחת מהירות ב%@x";
-"menu.volume_up" = "הגבר עוצמת שמע ב%.0f%";
-"menu.volume_down" = "הפחת עוצמת שמע ב%.0f%";
-"menu.audio_delay_up" = "עיכוב שמע: הוסף %.1f שניות";
-"menu.audio_delay_down" = "עיכוב שמע: הפחת %.1f שניות";
-"menu.sub_delay_up" = "עיכוב כתוביות: הוסף %.1f שניות";
-"menu.sub_delay_down" = "עיכוב כתוביות: הפחת %.1f שניות";
+"menu.volume_up" = "הגבר עוצמת שמע ב%@%";
+"menu.volume_down" = "הפחת עוצמת שמע ב%@%";
+"menu.audio_delay_up" = "עיכוב שמע: הוסף %@ שניות";
+"menu.audio_delay_down" = "עיכוב שמע: הפחת %@ שניות";
+"menu.sub_delay_up" = "עיכוב כתוביות: הוסף %@ שניות";
+"menu.sub_delay_down" = "עיכוב כתוביות: הפחת %@ שניות";
 
 "menu.crop_custom" = "מותאם אישית…";
 "menu.find_online_sub" = "מצא כתוביות מקוונות מ-%@";

--- a/iina/hi.lproj/Localizable.strings
+++ b/iina/hi.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "रोकें";
 "osd.resume" = "पुनः आरंभ";
-"osd.volume" = "ध्वनि: %i";
+"osd.volume" = "ध्वनि: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "आस्पेक्ट अनुपात: %@";
 "osd.crop" = "क्रॉप: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "डीइंटरलेस: %@";
 "osd.hwdec" = "Hardware Decoding: %@";
 "osd.audio_delay.nodelay" = "ऑडियो विलंब: विलंब न करें";
-"osd.audio_delay.later" = "ऑडियो विलंब: %.2fs बाद में";
-"osd.audio_delay.earlier" = "ऑडियो विलंब: %.2fs पूर्व";
+"osd.audio_delay.later" = "ऑडियो विलंब: %@s बाद में";
+"osd.audio_delay.earlier" = "ऑडियो विलंब: %@s पूर्व";
 "osd.sub_delay.nodelay" = "उपशीर्षक देरी: विलंब न करें";
-"osd.sub_delay.later" = "उपशीर्षक देरी: %.2fs बाद में";
-"osd.sub_delay.earlier" = "उपशीर्षक देरी: %.2fs पूर्व";
-"osd.subtitle_pos" = "उपशीर्षक पद: %.1f";
+"osd.sub_delay.later" = "उपशीर्षक देरी: %@s बाद में";
+"osd.sub_delay.earlier" = "उपशीर्षक देरी: %@s पूर्व";
+"osd.subtitle_pos" = "उपशीर्षक पद: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "म्यूट";
 "osd.unmute" = "Unmute";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-लूप: साफ़ किया गया";
 "osd.stop" = "रुकें";
 "osd.chapter" = "अध्याय: %@";
-"osd.subtitle_scale" = "उपशीर्षक स्केल: %.2fx";
+"osd.subtitle_scale" = "उपशीर्षक स्केल: %@x";
 "osd.add_to_playlist" = " प्लेलिस्ट में %i फ़ाइलें जोड़ी गईं";
 "osd.clear_playlist" = "क्लीयर प्लेलिस्ट";
 "osd.video_eq.contrast" = "कन्ट्रास्ट: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "ध्वनि: %d";
-"menu.volume_muted" = "Volume: %d (Muted)";
-"menu.audio_delay" = "ऑडियो विलंब: %.2fs";
-"menu.sub_delay" = "उपशीर्षक देरी: %.2fs";
+"menu.volume" = "ध्वनि: %@";
+"menu.volume_muted" = "Volume: %@ (Muted)";
+"menu.audio_delay" = "ऑडियो विलंब: %@s";
+"menu.sub_delay" = "उपशीर्षक देरी: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Show Subtitles Panel";
 "menu.hide_subtitles" = "Hide Subtitles Panel";
 
-"menu.seek_forward" = "आगे कदम %.0fs";
-"menu.seek_backward" = "पीछे जाओ %.0fs";
+"menu.seek_forward" = "आगे कदम %@s";
+"menu.seek_backward" = "पीछे जाओ %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "ध्वनि + %.0f%%";
-"menu.volume_down" = "ध्वनि - %.0f%%";
-"menu.audio_delay_up" = "ऑडियो विलंब + %.1fs";
-"menu.audio_delay_down" = "ऑडियो विलंब - %.1fs";
-"menu.sub_delay_up" = "उपशीर्षक देरी + %.1fs";
-"menu.sub_delay_down" = "उपशीर्षक देरी - %.1fs";
+"menu.volume_up" = "ध्वनि + %@%%";
+"menu.volume_down" = "ध्वनि - %@%%";
+"menu.audio_delay_up" = "ऑडियो विलंब + %@s";
+"menu.audio_delay_down" = "ऑडियो विलंब - %@s";
+"menu.sub_delay_up" = "उपशीर्षक देरी + %@s";
+"menu.sub_delay_down" = "उपशीर्षक देरी - %@s";
 
 "menu.crop_custom" = "कस्टम…";
 "menu.find_online_sub" = "Find Online Subtitles from %@";

--- a/iina/hr.lproj/Localizable.strings
+++ b/iina/hr.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Zaustavi";
 "osd.resume" = "Nastavi";
-"osd.volume" = "Glasnoća: %i";
+"osd.volume" = "Glasnoća: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Omjer: %@";
 "osd.crop" = "Obreži: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Ukloni preplitanje: %@";
 "osd.hwdec" = "Hardversko dekodiranje: %@";
 "osd.audio_delay.nodelay" = "Kašnjenje zvuka: bez kašnjenja";
-"osd.audio_delay.later" = "Kašnjenje zvuka: %.2fs kasnije";
-"osd.audio_delay.earlier" = "Kašnjenje zvuka: %.2fs ranije";
+"osd.audio_delay.later" = "Kašnjenje zvuka: %@s kasnije";
+"osd.audio_delay.earlier" = "Kašnjenje zvuka: %@s ranije";
 "osd.sub_delay.nodelay" = "Kašnjenje titla: bez kašnjenja";
-"osd.sub_delay.later" = "Kašnjenje titla: %.2fs kasnije";
-"osd.sub_delay.earlier" = "Kašnjenje titla: %.2fs ranije";
-"osd.subtitle_pos" = "Položaj titla: %.1f";
+"osd.sub_delay.later" = "Kašnjenje titla: %@s kasnije";
+"osd.sub_delay.earlier" = "Kašnjenje titla: %@s ranije";
+"osd.subtitle_pos" = "Položaj titla: %@";
 "osd.sub_hidden" = "Titlovi skriveni";
 "osd.sub_visible" = "Titlovi vidljivi";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Isključi zvuk";
 "osd.unmute" = "Uključi zvuk";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "A-B petlja: izbrisana";
 "osd.stop" = "Prekini";
 "osd.chapter" = "Poglavlje: %@";
-"osd.subtitle_scale" = "Skaliranje titla: %.2fx";
+"osd.subtitle_scale" = "Skaliranje titla: %@x";
 "osd.add_to_playlist" = "Dodane datoteke u playlistu: %i";
 "osd.clear_playlist" = "Playlista je izbrisana";
 "osd.video_eq.contrast" = "Kontrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Glasnoća: %d";
-"menu.volume_muted" = "Glasnoća: %d (Isključen zvuk)";
-"menu.audio_delay" = "Kašnjenje zvuka: %.2fs";
-"menu.sub_delay" = "Kašnjenje titlova: %.2fs";
+"menu.volume" = "Glasnoća: %@";
+"menu.volume_muted" = "Glasnoća: %@ (Isključen zvuk)";
+"menu.audio_delay" = "Kašnjenje zvuka: %@s";
+"menu.sub_delay" = "Kašnjenje titlova: %@s";
 "menu.sub_hide" = "Sakrij titlove";
 "menu.sub_show" = "Prikaži titlove";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Prikaži postavke titlova";
 "menu.hide_subtitles" = "Sakrij postavke titlova";
 
-"menu.seek_forward" = "Korak naprijed %.0fs";
-"menu.seek_backward" = "Korak natrag %.0fs";
+"menu.seek_forward" = "Korak naprijed %@s";
+"menu.seek_backward" = "Korak natrag %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Glasnoća + %.0f% %";
-"menu.volume_down" = "Glasnoća − %.0f% %";
-"menu.audio_delay_up" = "Kašnjenje zvuka + %.1fs";
-"menu.audio_delay_down" = "Kašnjenje zvuka − %.1fs";
-"menu.sub_delay_up" = "Kašnjenje titlova + %.1fs";
-"menu.sub_delay_down" = "Kašnjenje titlova − %.1fs";
+"menu.volume_up" = "Glasnoća + %@% %";
+"menu.volume_down" = "Glasnoća − %@% %";
+"menu.audio_delay_up" = "Kašnjenje zvuka + %@s";
+"menu.audio_delay_down" = "Kašnjenje zvuka − %@s";
+"menu.sub_delay_up" = "Kašnjenje titlova + %@s";
+"menu.sub_delay_down" = "Kašnjenje titlova − %@s";
 
 "menu.crop_custom" = "Prilagođeno …";
 "menu.find_online_sub" = "Pronađi titlove na internetu iz %@";

--- a/iina/hu.lproj/Localizable.strings
+++ b/iina/hu.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Szünet";
 "osd.resume" = "Folytatás";
-"osd.volume" = "Hangerő: %i";
+"osd.volume" = "Hangerő: %@";
 "osd.speed" = "Sebesség: %@x";
 "osd.aspect" = "Képarány: %@";
 "osd.crop" = "Vágás: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Váltottsoros képszűrő: %@";
 "osd.hwdec" = "Hardveres dekódolás: %@";
 "osd.audio_delay.nodelay" = "Hangkésleltetés: Nincs késleltetés";
-"osd.audio_delay.later" = "Hangkésleltetés: %.2fmp-vel később";
-"osd.audio_delay.earlier" = "Hangkésleltetés: %.2fmp-vel hamarabb";
+"osd.audio_delay.later" = "Hangkésleltetés: %@mp-vel később";
+"osd.audio_delay.earlier" = "Hangkésleltetés: %@mp-vel hamarabb";
 "osd.sub_delay.nodelay" = "Felirat késleltetés: Nincs késleltetés";
-"osd.sub_delay.later" = "Felirat késleltetés: %.2fmp-vel később";
-"osd.sub_delay.earlier" = "Felirat késleltetés: %.2fmp-vel hamarabb";
-"osd.subtitle_pos" = "Felirat pozíciója: %.1f";
+"osd.sub_delay.later" = "Felirat késleltetés: %@mp-vel később";
+"osd.sub_delay.earlier" = "Felirat késleltetés: %@mp-vel hamarabb";
+"osd.subtitle_pos" = "Felirat pozíciója: %@";
 "osd.sub_hidden" = "Feliratok elrejtve";
 "osd.sub_visible" = "Feliratok megjelenítve";
 "osd.sub_second_delay.nodelay" = "Másodlagos felirat késleltetés: Nincs késleltetés";
-"osd.sub_second_delay.later" = "Másodlagos felirat késleltetés: %.2fmp-vel később";
-"osd.sub_second_delay.earlier" = "Másodlagos felirat késleltetés: %.2fmp-vel előbb";
+"osd.sub_second_delay.later" = "Másodlagos felirat késleltetés: %@mp-vel később";
+"osd.sub_second_delay.earlier" = "Másodlagos felirat késleltetés: %@mp-vel előbb";
 "osd.sub_second_hidden" = "Másodlagos feliratok elrejtve";
-"osd.sub_second_pos" = "Másodlagos felirat pozíció: %.1f";
+"osd.sub_second_pos" = "Másodlagos felirat pozíció: %@";
 "osd.sub_second_visible" = "Másodlagos feliratok megjelenítve";
 "osd.mute" = "Némítás";
 "osd.unmute" = "Némítás feloldása";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-Ciklus: Tiszta";
 "osd.stop" = "Leállítás";
 "osd.chapter" = "Fejezet: %@";
-"osd.subtitle_scale" = "Felirat méret: %.2fx";
+"osd.subtitle_scale" = "Felirat méret: %@x";
 "osd.add_to_playlist" = "%i fájl hozzáadva a lejátszási listához";
 "osd.clear_playlist" = "Lejátszási lista ürítése";
 "osd.video_eq.contrast" = "Kontraszt: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Hangerő: %d";
-"menu.volume_muted" = "Hangerő: %d (Némítva)";
-"menu.audio_delay" = "Hangkésleltetés: %.2fmp-vel később";
-"menu.sub_delay" = "Felirat késleltetés: %.2fmp-vel később";
+"menu.volume" = "Hangerő: %@";
+"menu.volume_muted" = "Hangerő: %@ (Némítva)";
+"menu.audio_delay" = "Hangkésleltetés: %@mp-vel később";
+"menu.sub_delay" = "Felirat késleltetés: %@mp-vel később";
 "menu.sub_hide" = "Feliratok elrejtése";
 "menu.sub_show" = "Feliratok megjelenítése";
 "menu.sub_second_hide" = "Másodlagos feliratok elrejtése";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Mutasd a feliratok panelt";
 "menu.hide_subtitles" = "Rejtsd a feliratok panelt";
 
-"menu.seek_forward" = "Előre ugrás %.0f másodpercet";
-"menu.seek_backward" = "Hátra ugrás %.0f másodpercet";
+"menu.seek_forward" = "Előre ugrás %@ másodpercet";
+"menu.seek_backward" = "Hátra ugrás %@ másodpercet";
 "menu.speed_up" = "Gyorsítás ennyivel: %@x";
 "menu.speed_down" = "Lassítás ennyivel: %@x";
-"menu.volume_up" = "Hangerő: %.0f";
-"menu.volume_down" = "Hangerő: %.0f";
-"menu.audio_delay_up" = "Hangkésleltetés + %.1f másodperccel";
-"menu.audio_delay_down" = "Hangkésleltetés: %.1fmp-el később";
-"menu.sub_delay_up" = "Felirat késleltetés + %.1f másodperccel";
-"menu.sub_delay_down" = "Felirat késleltetés - %.1f másodperccel";
+"menu.volume_up" = "Hangerő: %@";
+"menu.volume_down" = "Hangerő: %@";
+"menu.audio_delay_up" = "Hangkésleltetés + %@ másodperccel";
+"menu.audio_delay_down" = "Hangkésleltetés: %@mp-el később";
+"menu.sub_delay_up" = "Felirat késleltetés + %@ másodperccel";
+"menu.sub_delay_down" = "Felirat késleltetés - %@ másodperccel";
 
 "menu.crop_custom" = "Egyéni…";
 "menu.find_online_sub" = "Online feliratok keresése innen: %@";

--- a/iina/hy.lproj/Localizable.strings
+++ b/iina/hy.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pause";
 "osd.resume" = "Resume";
-"osd.volume" = "Volume: %i";
+"osd.volume" = "Volume: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Aspect Ratio: %@";
 "osd.crop" = "Crop: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deinterlace: %@";
 "osd.hwdec" = "Hardware Decoding: %@";
 "osd.audio_delay.nodelay" = "Audio Delay: No Delay";
-"osd.audio_delay.later" = "Audio Delay: %.2fs Later";
-"osd.audio_delay.earlier" = "Audio Delay: %.2fs Earlier";
+"osd.audio_delay.later" = "Audio Delay: %@s Later";
+"osd.audio_delay.earlier" = "Audio Delay: %@s Earlier";
 "osd.sub_delay.nodelay" = "Subtitle Delay: No Delay";
-"osd.sub_delay.later" = "Subtitle Delay: %.2fs Later";
-"osd.sub_delay.earlier" = "Subtitle Delay: %.2fs Earlier";
-"osd.subtitle_pos" = "Subtitle Position: %.1f";
+"osd.sub_delay.later" = "Subtitle Delay: %@s Later";
+"osd.sub_delay.earlier" = "Subtitle Delay: %@s Earlier";
+"osd.subtitle_pos" = "Subtitle Position: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-Loop: Cleared";
 "osd.stop" = "Stop";
 "osd.chapter" = "Chapter: %@";
-"osd.subtitle_scale" = "Subtitle Scale: %.2fx";
+"osd.subtitle_scale" = "Subtitle Scale: %@x";
 "osd.add_to_playlist" = "Added %i Files to Playlist";
 "osd.clear_playlist" = "Cleared Playlist";
 "osd.video_eq.contrast" = "Contrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volume: %d";
-"menu.volume_muted" = "Volume: %d (Muted)";
-"menu.audio_delay" = "Audio Delay: %.2fs";
-"menu.sub_delay" = "Subtitle Delay: %.2fs";
+"menu.volume" = "Volume: %@";
+"menu.volume_muted" = "Volume: %@ (Muted)";
+"menu.audio_delay" = "Audio Delay: %@s";
+"menu.sub_delay" = "Subtitle Delay: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Show Subtitles Panel";
 "menu.hide_subtitles" = "Hide Subtitles Panel";
 
-"menu.seek_forward" = "Step Forward %.0fs";
-"menu.seek_backward" = "Step Backward %.0fs";
+"menu.seek_forward" = "Step Forward %@s";
+"menu.seek_backward" = "Step Backward %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Volume - %.0f%%";
-"menu.audio_delay_up" = "Audio Delay + %.1fs";
-"menu.audio_delay_down" = "Audio Delay - %.1fs";
-"menu.sub_delay_up" = "Subtitle Delay + %.1fs";
-"menu.sub_delay_down" = "Subtitle Delay - %.1fs";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Volume - %@%%";
+"menu.audio_delay_up" = "Audio Delay + %@s";
+"menu.audio_delay_down" = "Audio Delay - %@s";
+"menu.sub_delay_up" = "Subtitle Delay + %@s";
+"menu.sub_delay_down" = "Subtitle Delay - %@s";
 
 "menu.crop_custom" = "Custom…";
 "menu.find_online_sub" = "Find Online Subtitles from %@";

--- a/iina/id.lproj/Localizable.strings
+++ b/iina/id.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Jeda";
 "osd.resume" = "Lanjutkan";
-"osd.volume" = "Volume: %i";
+"osd.volume" = "Volume: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Rasio Aspek: %@";
 "osd.crop" = "Crop: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deinterlace: %@";
 "osd.hwdec" = "Hardware Decoding: %@";
 "osd.audio_delay.nodelay" = "Penundaan Audio: Tanpa Penundaan";
-"osd.audio_delay.later" = "Penundaan Audio: %.2f dtk lebih cepat";
-"osd.audio_delay.earlier" = "Jeda Audio: %.2f dtk lebih lambat";
+"osd.audio_delay.later" = "Penundaan Audio: %@ dtk lebih cepat";
+"osd.audio_delay.earlier" = "Jeda Audio: %@ dtk lebih lambat";
 "osd.sub_delay.nodelay" = "Penundaan Terjemahan: Tanpa Penundaan";
-"osd.sub_delay.later" = "Penundaan Terjemahan: %.2f dtk lebih cepat";
-"osd.sub_delay.earlier" = "Penundaan Terjemahan: %.2f dtk lebih lambat";
-"osd.subtitle_pos" = "Posisi Terjemahan: %.1f";
+"osd.sub_delay.later" = "Penundaan Terjemahan: %@ dtk lebih cepat";
+"osd.sub_delay.earlier" = "Penundaan Terjemahan: %@ dtk lebih lambat";
+"osd.subtitle_pos" = "Posisi Terjemahan: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Bisukan Suara";
 "osd.unmute" = "Nyalakan Suara";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "Pengulangan-AB: Dibersihkan";
 "osd.stop" = "Berhenti";
 "osd.chapter" = "Bab: %@";
-"osd.subtitle_scale" = "Skala Terjemahan: %.2fx";
+"osd.subtitle_scale" = "Skala Terjemahan: %@x";
 "osd.add_to_playlist" = "Menambahkan %i file ke Daftar Putar";
 "osd.clear_playlist" = "Daftar Putar Dihapus";
 "osd.video_eq.contrast" = "Kontras: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volume: %d";
-"menu.volume_muted" = "Volume: %d (Dimatikan)";
-"menu.audio_delay" = "Penundaan Audio: %.2f dtk";
-"menu.sub_delay" = "Penundaan Terjemahan: %.2f dtk";
+"menu.volume" = "Volume: %@";
+"menu.volume_muted" = "Volume: %@ (Dimatikan)";
+"menu.audio_delay" = "Penundaan Audio: %@ dtk";
+"menu.sub_delay" = "Penundaan Terjemahan: %@ dtk";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Tampilkan Panel Terjemahan";
 "menu.hide_subtitles" = "Sembunyikan Panel Terjemahan";
 
-"menu.seek_forward" = "Majukan %.0fdtk";
-"menu.seek_backward" = "Mundurkan %.0fdtk";
+"menu.seek_forward" = "Majukan %@dtk";
+"menu.seek_backward" = "Mundurkan %@dtk";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Volume - %.0f%%";
-"menu.audio_delay_up" = "Penundaan Audio + %.1fdtk";
-"menu.audio_delay_down" = "Penundaan Audio - %.1fdtk";
-"menu.sub_delay_up" = "Penundaan Terjemahan + %.1fdtk";
-"menu.sub_delay_down" = "Penundaan Terjemahan - %.1fdtk";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Volume - %@%%";
+"menu.audio_delay_up" = "Penundaan Audio + %@dtk";
+"menu.audio_delay_down" = "Penundaan Audio - %@dtk";
+"menu.sub_delay_up" = "Penundaan Terjemahan + %@dtk";
+"menu.sub_delay_down" = "Penundaan Terjemahan - %@dtk";
 
 "menu.crop_custom" = "Kustom…";
 "menu.find_online_sub" = "Cari Terjemahan Online dari %@";

--- a/iina/is.lproj/Localizable.strings
+++ b/iina/is.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Hlé";
 "osd.resume" = "Halda áfram";
-"osd.volume" = "Volume: %i";
+"osd.volume" = "Volume: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Aspect Ratio: %@";
 "osd.crop" = "Crop: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deinterlace: %@";
 "osd.hwdec" = "Hardware Decoding: %@";
 "osd.audio_delay.nodelay" = "Audio Delay: No Delay";
-"osd.audio_delay.later" = "Audio Delay: %.2fs Later";
-"osd.audio_delay.earlier" = "Audio Delay: %.2fs Earlier";
+"osd.audio_delay.later" = "Audio Delay: %@s Later";
+"osd.audio_delay.earlier" = "Audio Delay: %@s Earlier";
 "osd.sub_delay.nodelay" = "Subtitle Delay: No Delay";
-"osd.sub_delay.later" = "Subtitle Delay: %.2fs Later";
-"osd.sub_delay.earlier" = "Subtitle Delay: %.2fs Earlier";
-"osd.subtitle_pos" = "Subtitle Position: %.1f";
+"osd.sub_delay.later" = "Subtitle Delay: %@s Later";
+"osd.sub_delay.earlier" = "Subtitle Delay: %@s Earlier";
+"osd.subtitle_pos" = "Subtitle Position: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Þagga";
 "osd.unmute" = "Unmute";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-Loop: Cleared";
 "osd.stop" = "Stöðva";
 "osd.chapter" = "Chapter: %@";
-"osd.subtitle_scale" = "Subtitle Scale: %.2fx";
+"osd.subtitle_scale" = "Subtitle Scale: %@x";
 "osd.add_to_playlist" = "Added %i Files to Playlist";
 "osd.clear_playlist" = "Cleared Playlist";
 "osd.video_eq.contrast" = "Contrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volume: %d";
-"menu.volume_muted" = "Volume: %d (Muted)";
-"menu.audio_delay" = "Audio Delay: %.2fs";
-"menu.sub_delay" = "Subtitle Delay: %.2fs";
+"menu.volume" = "Volume: %@";
+"menu.volume_muted" = "Volume: %@ (Muted)";
+"menu.audio_delay" = "Audio Delay: %@s";
+"menu.sub_delay" = "Subtitle Delay: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Show Subtitles Panel";
 "menu.hide_subtitles" = "Hide Subtitles Panel";
 
-"menu.seek_forward" = "Step Forward %.0fs";
-"menu.seek_backward" = "Step Backward %.0fs";
+"menu.seek_forward" = "Step Forward %@s";
+"menu.seek_backward" = "Step Backward %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Volume - %.0f%%";
-"menu.audio_delay_up" = "Audio Delay + %.1fs";
-"menu.audio_delay_down" = "Audio Delay - %.1fs";
-"menu.sub_delay_up" = "Subtitle Delay + %.1fs";
-"menu.sub_delay_down" = "Subtitle Delay - %.1fs";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Volume - %@%%";
+"menu.audio_delay_up" = "Audio Delay + %@s";
+"menu.audio_delay_down" = "Audio Delay - %@s";
+"menu.sub_delay_up" = "Subtitle Delay + %@s";
+"menu.sub_delay_down" = "Subtitle Delay - %@s";
 
 "menu.crop_custom" = "Custom…";
 "menu.find_online_sub" = "Find Online Subtitles from %@";

--- a/iina/it.lproj/Localizable.strings
+++ b/iina/it.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pausa";
 "osd.resume" = "Riprendi";
-"osd.volume" = "Volume: %i";
+"osd.volume" = "Volume: %@";
 "osd.speed" = "Velocità: %@x";
 "osd.aspect" = "Proporzioni: %@";
 "osd.crop" = "Ritaglio: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deinterlacciamento: %@";
 "osd.hwdec" = "Decodifica dell'Hardware: %@";
 "osd.audio_delay.nodelay" = "Differenza audio: 0.00s";
-"osd.audio_delay.later" = "Differenza audio: %.2fs dopo";
-"osd.audio_delay.earlier" = "Differenza audio: %.2fs prima";
+"osd.audio_delay.later" = "Differenza audio: %@s dopo";
+"osd.audio_delay.earlier" = "Differenza audio: %@s prima";
 "osd.sub_delay.nodelay" = "Differenza sottotitoli: 0.00s";
-"osd.sub_delay.later" = "Differenza sottotitoli: %.2fs dopo";
-"osd.sub_delay.earlier" = "Differenza sottotitoli: %.2fs prima";
-"osd.subtitle_pos" = "Posizione sottotitoli: %.1f";
+"osd.sub_delay.later" = "Differenza sottotitoli: %@s dopo";
+"osd.sub_delay.earlier" = "Differenza sottotitoli: %@s prima";
+"osd.subtitle_pos" = "Posizione sottotitoli: %@";
 "osd.sub_hidden" = "Nascondere Sottotitoli";
 "osd.sub_visible" = "Mostrare Sottotitoli";
 "osd.sub_second_delay.nodelay" = "Ritardo Sottotitoli Secondari: Nessun Ritardo";
-"osd.sub_second_delay.later" = "Ritardo Sottotitoli Secondari: %.2fs Dopo";
-"osd.sub_second_delay.earlier" = "Ritardo Sottotitoli Secondari: %.2fs Prima";
+"osd.sub_second_delay.later" = "Ritardo Sottotitoli Secondari: %@s Dopo";
+"osd.sub_second_delay.earlier" = "Ritardo Sottotitoli Secondari: %@s Prima";
 "osd.sub_second_hidden" = "Nascondere Sottotitoli Secondari";
-"osd.sub_second_pos" = "Posizione Sottotitoli Secondari: %.1f";
+"osd.sub_second_pos" = "Posizione Sottotitoli Secondari: %@";
 "osd.sub_second_visible" = "Mostrare Sottotitoli Secondari";
 "osd.mute" = "Muto";
 "osd.unmute" = "Attiva";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "Ripeti A-B: azzerato";
 "osd.stop" = "Ferma";
 "osd.chapter" = "Capitolo: %@";
-"osd.subtitle_scale" = "Scala sottotitoli: %.2fx";
+"osd.subtitle_scale" = "Scala sottotitoli: %@x";
 "osd.add_to_playlist" = "Aggiungi %i file alla playlist";
 "osd.clear_playlist" = "Playlist cancellata";
 "osd.video_eq.contrast" = "Contrasto: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Installa il plug-in Media Online da 'Plug-in → Installa' da GitHub per godere di funzionalità avanzate come il download di video e aggiornamenti automatici di yt-dlp.";
 "preference.ytdl_plugin_installed" = "Il supporto youtube-dl integrato è disabilitato perché è installato il plug-in Media Online.";
 
-"menu.volume" = "Volume: %d";
-"menu.volume_muted" = "Volume: %d (Spento)";
-"menu.audio_delay" = "Differenza audio: %.2fs";
-"menu.sub_delay" = "Differenza sottotitoli: %.2fs";
+"menu.volume" = "Volume: %@";
+"menu.volume_muted" = "Volume: %@ (Spento)";
+"menu.audio_delay" = "Differenza audio: %@s";
+"menu.sub_delay" = "Differenza sottotitoli: %@s";
 "menu.sub_hide" = "Nascondere Sottotitoli";
 "menu.sub_show" = "Mostra sottotitoli";
 "menu.sub_second_hide" = "Nascondi Sottotitoli Secondari";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Mostra pannello sottotitoli";
 "menu.hide_subtitles" = "Nascondi pannello sottotitoli";
 
-"menu.seek_forward" = "Avanti %.0fs";
-"menu.seek_backward" = "Indietro %.0fs";
+"menu.seek_forward" = "Avanti %@s";
+"menu.seek_backward" = "Indietro %@s";
 "menu.speed_up" = "Aumenta la velocità di %@x";
 "menu.speed_down" = "Riduci la velocità di %@x";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Volume - %.0f%%";
-"menu.audio_delay_up" = "Ritarda audio + %.1fs";
-"menu.audio_delay_down" = "Anticipa audio - %.1fs";
-"menu.sub_delay_up" = "Ritarda sottotitoli + %.1fs";
-"menu.sub_delay_down" = "Anticipa sottotitoli - %.1fs";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Volume - %@%%";
+"menu.audio_delay_up" = "Ritarda audio + %@s";
+"menu.audio_delay_down" = "Anticipa audio - %@s";
+"menu.sub_delay_up" = "Ritarda sottotitoli + %@s";
+"menu.sub_delay_down" = "Anticipa sottotitoli - %@s";
 
 "menu.crop_custom" = "Altro…";
 "menu.find_online_sub" = "Trova sottotitoli online da %@";

--- a/iina/ja.lproj/Localizable.strings
+++ b/iina/ja.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "一時停止";
 "osd.resume" = "再開";
-"osd.volume" = "音量: %i";
+"osd.volume" = "音量: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "アスペクト比: %@";
 "osd.crop" = "クロップ: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "インターレース解除: %@";
 "osd.hwdec" = "ハードウェアデコード中: %@";
 "osd.audio_delay.nodelay" = "オーディオディレイ: ディレイなし";
-"osd.audio_delay.later" = "オーディオディレイ: %.2f秒 遅く";
-"osd.audio_delay.earlier" = "オーディオディレイ: %.2f秒 早く";
+"osd.audio_delay.later" = "オーディオディレイ: %@秒 遅く";
+"osd.audio_delay.earlier" = "オーディオディレイ: %@秒 早く";
 "osd.sub_delay.nodelay" = "字幕ディレイ: ディレイなし";
-"osd.sub_delay.later" = "字幕ディレイ: %.2f秒 遅く";
-"osd.sub_delay.earlier" = "字幕ディレイ: %.2f秒 早く";
-"osd.subtitle_pos" = "字幕の位置: %.1f";
+"osd.sub_delay.later" = "字幕ディレイ: %@秒 遅く";
+"osd.sub_delay.earlier" = "字幕ディレイ: %@秒 早く";
+"osd.subtitle_pos" = "字幕の位置: %@";
 "osd.sub_hidden" = "字幕を隠す";
 "osd.sub_visible" = "字幕を表示する";
 "osd.sub_second_delay.nodelay" = "副字幕の遅延: 遅延なし";
-"osd.sub_second_delay.later" = "副字幕の遅延: %.2f秒遅く";
-"osd.sub_second_delay.earlier" = "副字幕の遅延: %.2f秒早く";
+"osd.sub_second_delay.later" = "副字幕の遅延: %@秒遅く";
+"osd.sub_second_delay.earlier" = "副字幕の遅延: %@秒早く";
 "osd.sub_second_hidden" = "副字幕を隠す";
-"osd.sub_second_pos" = "副字幕の表示位置: %.1f";
+"osd.sub_second_pos" = "副字幕の表示位置: %@";
 "osd.sub_second_visible" = "副字幕を表示する";
 "osd.mute" = "ミュート";
 "osd.unmute" = "ミュート解除";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-リピート: リセット";
 "osd.stop" = "一時停止";
 "osd.chapter" = "チャプター: %@";
-"osd.subtitle_scale" = "字幕の大きさ: %.2fx";
+"osd.subtitle_scale" = "字幕の大きさ: %@x";
 "osd.add_to_playlist" = "%i個のファイルをプレイリストに追加しました";
 "osd.clear_playlist" = "プレイリストをクリアしました";
 "osd.video_eq.contrast" = "コントラスト: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "Online メディア プラグインがインストールされているため、組み込みの youtube-dl サポートは無効になっています。";
 
-"menu.volume" = "音量: %d";
-"menu.volume_muted" = "ボリューム: %d (ミュート中)";
-"menu.audio_delay" = "オーディオディレイ: %.2fs";
-"menu.sub_delay" = "字幕ディレイ: %.2fs";
+"menu.volume" = "音量: %@";
+"menu.volume_muted" = "ボリューム: %@ (ミュート中)";
+"menu.audio_delay" = "オーディオディレイ: %@s";
+"menu.sub_delay" = "字幕ディレイ: %@s";
 "menu.sub_hide" = "字幕を隠す";
 "menu.sub_show" = "字幕を表示する";
 "menu.sub_second_hide" = "副字幕を隠す";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "字幕パネルを表示";
 "menu.hide_subtitles" = "字幕パネルを隠す";
 
-"menu.seek_forward" = "%.0f秒進む";
-"menu.seek_backward" = "%.0f秒戻る";
+"menu.seek_forward" = "%@秒進む";
+"menu.seek_backward" = "%@秒戻る";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "音量 + %.0f%%";
-"menu.volume_down" = "音量 - %.0f%%";
-"menu.audio_delay_up" = "オーディオディレイ + %.1fs";
-"menu.audio_delay_down" = "オーディオディレイ - %.1fs";
-"menu.sub_delay_up" = "字幕ディレイ + %.1f秒";
-"menu.sub_delay_down" = "字幕ディレイ - %.1f秒";
+"menu.volume_up" = "音量 + %@%%";
+"menu.volume_down" = "音量 - %@%%";
+"menu.audio_delay_up" = "オーディオディレイ + %@s";
+"menu.audio_delay_down" = "オーディオディレイ - %@s";
+"menu.sub_delay_up" = "字幕ディレイ + %@秒";
+"menu.sub_delay_down" = "字幕ディレイ - %@秒";
 
 "menu.crop_custom" = "カスタム…";
 "menu.find_online_sub" = "%@ からオンライン字幕を探す";

--- a/iina/kn.lproj/Localizable.strings
+++ b/iina/kn.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pause";
 "osd.resume" = "Resume";
-"osd.volume" = "Volume: %i";
+"osd.volume" = "Volume: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Aspect Ratio: %@";
 "osd.crop" = "Crop: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deinterlace: %@";
 "osd.hwdec" = "Hardware Decoding: %@";
 "osd.audio_delay.nodelay" = "Audio Delay: No Delay";
-"osd.audio_delay.later" = "Audio Delay: %.2fs Later";
-"osd.audio_delay.earlier" = "Audio Delay: %.2fs Earlier";
+"osd.audio_delay.later" = "Audio Delay: %@s Later";
+"osd.audio_delay.earlier" = "Audio Delay: %@s Earlier";
 "osd.sub_delay.nodelay" = "Subtitle Delay: No Delay";
-"osd.sub_delay.later" = "Subtitle Delay: %.2fs Later";
-"osd.sub_delay.earlier" = "Subtitle Delay: %.2fs Earlier";
-"osd.subtitle_pos" = "Subtitle Position: %.1f";
+"osd.sub_delay.later" = "Subtitle Delay: %@s Later";
+"osd.sub_delay.earlier" = "Subtitle Delay: %@s Earlier";
+"osd.subtitle_pos" = "Subtitle Position: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-Loop: Cleared";
 "osd.stop" = "Stop";
 "osd.chapter" = "Chapter: %@";
-"osd.subtitle_scale" = "Subtitle Scale: %.2fx";
+"osd.subtitle_scale" = "Subtitle Scale: %@x";
 "osd.add_to_playlist" = "Added %i Files to Playlist";
 "osd.clear_playlist" = "Cleared Playlist";
 "osd.video_eq.contrast" = "Contrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volume: %d";
-"menu.volume_muted" = "Volume: %d (Muted)";
-"menu.audio_delay" = "Audio Delay: %.2fs";
-"menu.sub_delay" = "Subtitle Delay: %.2fs";
+"menu.volume" = "Volume: %@";
+"menu.volume_muted" = "Volume: %@ (Muted)";
+"menu.audio_delay" = "Audio Delay: %@s";
+"menu.sub_delay" = "Subtitle Delay: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Show Subtitles Panel";
 "menu.hide_subtitles" = "Hide Subtitles Panel";
 
-"menu.seek_forward" = "Step Forward %.0fs";
-"menu.seek_backward" = "Step Backward %.0fs";
+"menu.seek_forward" = "Step Forward %@s";
+"menu.seek_backward" = "Step Backward %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Volume - %.0f%%";
-"menu.audio_delay_up" = "Audio Delay + %.1fs";
-"menu.audio_delay_down" = "Audio Delay - %.1fs";
-"menu.sub_delay_up" = "Subtitle Delay + %.1fs";
-"menu.sub_delay_down" = "Subtitle Delay - %.1fs";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Volume - %@%%";
+"menu.audio_delay_up" = "Audio Delay + %@s";
+"menu.audio_delay_down" = "Audio Delay - %@s";
+"menu.sub_delay_up" = "Subtitle Delay + %@s";
+"menu.sub_delay_down" = "Subtitle Delay - %@s";
 
 "menu.crop_custom" = "Custom…";
 "menu.find_online_sub" = "Find Online Subtitles from %@";

--- a/iina/ko.lproj/Localizable.strings
+++ b/iina/ko.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "일시 정지됨";
 "osd.resume" = "재생 복원됨";
-"osd.volume" = "음량: %i";
+"osd.volume" = "음량: %@";
 "osd.speed" = "속도: %@배속";
 "osd.aspect" = "화면비: %@";
 "osd.crop" = "화면 자르기: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "디인터레이스: %@";
 "osd.hwdec" = "하드웨어 디코딩: %@";
 "osd.audio_delay.nodelay" = "오디오 지연: 없음";
-"osd.audio_delay.later" = "오디오 지연: %.2f초 느리게";
-"osd.audio_delay.earlier" = "오디오 지연: %.2f초 빠르게";
+"osd.audio_delay.later" = "오디오 지연: %@초 느리게";
+"osd.audio_delay.earlier" = "오디오 지연: %@초 빠르게";
 "osd.sub_delay.nodelay" = "자막 지연: 없음";
-"osd.sub_delay.later" = "자막 지연: %.2f초 느리게";
-"osd.sub_delay.earlier" = "자막 지연: %.2f초 빠르게";
-"osd.subtitle_pos" = "자막 위치: %.1f";
+"osd.sub_delay.later" = "자막 지연: %@초 느리게";
+"osd.sub_delay.earlier" = "자막 지연: %@초 빠르게";
+"osd.subtitle_pos" = "자막 위치: %@";
 "osd.sub_hidden" = "자막 숨김";
 "osd.sub_visible" = "자막 보임";
 "osd.sub_second_delay.nodelay" = "두번째 자막 지연: 없음";
-"osd.sub_second_delay.later" = "두번째 자막 지연: %.2f초 느리게";
-"osd.sub_second_delay.earlier" = "두번째 자막 지연: %.2f초 빠르게";
+"osd.sub_second_delay.later" = "두번째 자막 지연: %@초 느리게";
+"osd.sub_second_delay.earlier" = "두번째 자막 지연: %@초 빠르게";
 "osd.sub_second_hidden" = "두번째 자막 숨김";
-"osd.sub_second_pos" = "두번째 자막 위치: %.1f";
+"osd.sub_second_pos" = "두번째 자막 위치: %@";
 "osd.sub_second_visible" = "두번째 자막 보임";
 "osd.mute" = "소리 끔";
 "osd.unmute" = "음소거 해제";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "구간 반복: 해제됨";
 "osd.stop" = "정지됨";
 "osd.chapter" = "챕터: %@";
-"osd.subtitle_scale" = "자막 크기: %.2f배";
+"osd.subtitle_scale" = "자막 크기: %@배";
 "osd.add_to_playlist" = "%i 파일이 재생목록에 추가되었습니다";
 "osd.clear_playlist" = "재생목록 비움";
 "osd.video_eq.contrast" = "대비: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "음량: %d";
-"menu.volume_muted" = "음량: %d (음소거 됨)";
-"menu.audio_delay" = "오디오 지연: %.2f초";
-"menu.sub_delay" = "자막 지연: %.2f초";
+"menu.volume" = "음량: %@";
+"menu.volume_muted" = "음량: %@ (음소거 됨)";
+"menu.audio_delay" = "오디오 지연: %@초";
+"menu.sub_delay" = "자막 지연: %@초";
 "menu.sub_hide" = "자막 숨기기";
 "menu.sub_show" = "자막 보이기";
 "menu.sub_second_hide" = "두번째 자막 숨기기";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "자막 패널 보기";
 "menu.hide_subtitles" = "자막 패널 숨기기";
 
-"menu.seek_forward" = "앞으로 탐색 %.0f초";
-"menu.seek_backward" = "뒤로 탐색 %.0f초";
+"menu.seek_forward" = "앞으로 탐색 %@초";
+"menu.seek_backward" = "뒤로 탐색 %@초";
 "menu.speed_up" = "%@배 빠르게 재생";
 "menu.speed_down" = "%@배 느리게 재생";
-"menu.volume_up" = "음량 +%.0f%%";
-"menu.volume_down" = "음량 -%.0f%%";
-"menu.audio_delay_up" = "오디오 지연 +%.1f초";
-"menu.audio_delay_down" = "오디오 지연 -%.1f초";
-"menu.sub_delay_up" = "자막 지연 +%.1f초";
-"menu.sub_delay_down" = "자막 지연 -%.1f초";
+"menu.volume_up" = "음량 +%@%%";
+"menu.volume_down" = "음량 -%@%%";
+"menu.audio_delay_up" = "오디오 지연 +%@초";
+"menu.audio_delay_down" = "오디오 지연 -%@초";
+"menu.sub_delay_up" = "자막 지연 +%@초";
+"menu.sub_delay_down" = "자막 지연 -%@초";
 
 "menu.crop_custom" = "사용자 설정…";
 "menu.find_online_sub" = "%@에서 온라인 자막 찾기";

--- a/iina/lv.lproj/Localizable.strings
+++ b/iina/lv.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pauze";
 "osd.resume" = "Turpināt";
-"osd.volume" = "Volume: %i";
+"osd.volume" = "Volume: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Aspect Ratio: %@";
 "osd.crop" = "Crop: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deinterlace: %@";
 "osd.hwdec" = "Aparatūras dekodēšana: %@";
 "osd.audio_delay.nodelay" = "Audio Delay: No Delay";
-"osd.audio_delay.later" = "Audio Delay: %.2fs Later";
-"osd.audio_delay.earlier" = "Audio Delay: %.2fs Earlier";
+"osd.audio_delay.later" = "Audio Delay: %@s Later";
+"osd.audio_delay.earlier" = "Audio Delay: %@s Earlier";
 "osd.sub_delay.nodelay" = "Subtitle Delay: No Delay";
-"osd.sub_delay.later" = "Subtitle Delay: %.2fs Later";
-"osd.sub_delay.earlier" = "Subtitle Delay: %.2fs Earlier";
-"osd.subtitle_pos" = "Subtitle Position: %.1f";
+"osd.sub_delay.later" = "Subtitle Delay: %@s Later";
+"osd.sub_delay.earlier" = "Subtitle Delay: %@s Earlier";
+"osd.subtitle_pos" = "Subtitle Position: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Izslēgt skaņu";
 "osd.unmute" = "Unmute";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-Loop: Cleared";
 "osd.stop" = "Apturēt";
 "osd.chapter" = "Chapter: %@";
-"osd.subtitle_scale" = "Subtitle Scale: %.2fx";
+"osd.subtitle_scale" = "Subtitle Scale: %@x";
 "osd.add_to_playlist" = "Added %i Files to Playlist";
 "osd.clear_playlist" = "Cleared Playlist";
 "osd.video_eq.contrast" = "Contrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volume: %d";
-"menu.volume_muted" = "Volume: %d (Muted)";
-"menu.audio_delay" = "Audio Delay: %.2fs";
-"menu.sub_delay" = "Subtitle Delay: %.2fs";
+"menu.volume" = "Volume: %@";
+"menu.volume_muted" = "Volume: %@ (Muted)";
+"menu.audio_delay" = "Audio Delay: %@s";
+"menu.sub_delay" = "Subtitle Delay: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Show Subtitles Panel";
 "menu.hide_subtitles" = "Hide Subtitles Panel";
 
-"menu.seek_forward" = "Step Forward %.0fs";
-"menu.seek_backward" = "Step Backward %.0fs";
+"menu.seek_forward" = "Step Forward %@s";
+"menu.seek_backward" = "Step Backward %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Volume - %.0f%%";
-"menu.audio_delay_up" = "Audio Delay + %.1fs";
-"menu.audio_delay_down" = "Audio Delay - %.1fs";
-"menu.sub_delay_up" = "Subtitle Delay + %.1fs";
-"menu.sub_delay_down" = "Subtitle Delay - %.1fs";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Volume - %@%%";
+"menu.audio_delay_up" = "Audio Delay + %@s";
+"menu.audio_delay_down" = "Audio Delay - %@s";
+"menu.sub_delay_up" = "Subtitle Delay + %@s";
+"menu.sub_delay_down" = "Subtitle Delay - %@s";
 
 "menu.crop_custom" = "Custom…";
 "menu.find_online_sub" = "Find Online Subtitles from %@";

--- a/iina/mk.lproj/Localizable.strings
+++ b/iina/mk.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pause";
 "osd.resume" = "Resume";
-"osd.volume" = "Volume: %i";
+"osd.volume" = "Volume: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Aspect Ratio: %@";
 "osd.crop" = "Crop: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deinterlace: %@";
 "osd.hwdec" = "Hardware Decoding: %@";
 "osd.audio_delay.nodelay" = "Audio Delay: No Delay";
-"osd.audio_delay.later" = "Audio Delay: %.2fs Later";
-"osd.audio_delay.earlier" = "Audio Delay: %.2fs Earlier";
+"osd.audio_delay.later" = "Audio Delay: %@s Later";
+"osd.audio_delay.earlier" = "Audio Delay: %@s Earlier";
 "osd.sub_delay.nodelay" = "Subtitle Delay: No Delay";
-"osd.sub_delay.later" = "Subtitle Delay: %.2fs Later";
-"osd.sub_delay.earlier" = "Subtitle Delay: %.2fs Earlier";
-"osd.subtitle_pos" = "Subtitle Position: %.1f";
+"osd.sub_delay.later" = "Subtitle Delay: %@s Later";
+"osd.sub_delay.earlier" = "Subtitle Delay: %@s Earlier";
+"osd.subtitle_pos" = "Subtitle Position: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-Loop: Cleared";
 "osd.stop" = "Stop";
 "osd.chapter" = "Chapter: %@";
-"osd.subtitle_scale" = "Subtitle Scale: %.2fx";
+"osd.subtitle_scale" = "Subtitle Scale: %@x";
 "osd.add_to_playlist" = "Added %i Files to Playlist";
 "osd.clear_playlist" = "Cleared Playlist";
 "osd.video_eq.contrast" = "Contrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volume: %d";
-"menu.volume_muted" = "Volume: %d (Muted)";
-"menu.audio_delay" = "Audio Delay: %.2fs";
-"menu.sub_delay" = "Subtitle Delay: %.2fs";
+"menu.volume" = "Volume: %@";
+"menu.volume_muted" = "Volume: %@ (Muted)";
+"menu.audio_delay" = "Audio Delay: %@s";
+"menu.sub_delay" = "Subtitle Delay: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Show Subtitles Panel";
 "menu.hide_subtitles" = "Hide Subtitles Panel";
 
-"menu.seek_forward" = "Step Forward %.0fs";
-"menu.seek_backward" = "Step Backward %.0fs";
+"menu.seek_forward" = "Step Forward %@s";
+"menu.seek_backward" = "Step Backward %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Volume - %.0f%%";
-"menu.audio_delay_up" = "Audio Delay + %.1fs";
-"menu.audio_delay_down" = "Audio Delay - %.1fs";
-"menu.sub_delay_up" = "Subtitle Delay + %.1fs";
-"menu.sub_delay_down" = "Subtitle Delay - %.1fs";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Volume - %@%%";
+"menu.audio_delay_up" = "Audio Delay + %@s";
+"menu.audio_delay_down" = "Audio Delay - %@s";
+"menu.sub_delay_up" = "Subtitle Delay + %@s";
+"menu.sub_delay_down" = "Subtitle Delay - %@s";
 
 "menu.crop_custom" = "Custom…";
 "menu.find_online_sub" = "Find Online Subtitles from %@";

--- a/iina/ml.lproj/Localizable.strings
+++ b/iina/ml.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pause";
 "osd.resume" = "പുനരാരംഭിക്കുക";
-"osd.volume" = "Volume: %i";
+"osd.volume" = "Volume: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Aspect Ratio: %@";
 "osd.crop" = "Crop: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deinterlace: %@";
 "osd.hwdec" = "Hardware Decoding: %@";
 "osd.audio_delay.nodelay" = "Audio Delay: No Delay";
-"osd.audio_delay.later" = "Audio Delay: %.2fs Later";
-"osd.audio_delay.earlier" = "Audio Delay: %.2fs Earlier";
+"osd.audio_delay.later" = "Audio Delay: %@s Later";
+"osd.audio_delay.earlier" = "Audio Delay: %@s Earlier";
 "osd.sub_delay.nodelay" = "Subtitle Delay: No Delay";
-"osd.sub_delay.later" = "Subtitle Delay: %.2fs Later";
-"osd.sub_delay.earlier" = "Subtitle Delay: %.2fs Earlier";
-"osd.subtitle_pos" = "Subtitle Position: %.1f";
+"osd.sub_delay.later" = "Subtitle Delay: %@s Later";
+"osd.sub_delay.earlier" = "Subtitle Delay: %@s Earlier";
+"osd.subtitle_pos" = "Subtitle Position: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-Loop: Cleared";
 "osd.stop" = "Stop";
 "osd.chapter" = "Chapter: %@";
-"osd.subtitle_scale" = "Subtitle Scale: %.2fx";
+"osd.subtitle_scale" = "Subtitle Scale: %@x";
 "osd.add_to_playlist" = "Added %i Files to Playlist";
 "osd.clear_playlist" = "Cleared Playlist";
 "osd.video_eq.contrast" = "Contrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volume: %d";
-"menu.volume_muted" = "Volume: %d (Muted)";
-"menu.audio_delay" = "Audio Delay: %.2fs";
-"menu.sub_delay" = "Subtitle Delay: %.2fs";
+"menu.volume" = "Volume: %@";
+"menu.volume_muted" = "Volume: %@ (Muted)";
+"menu.audio_delay" = "Audio Delay: %@s";
+"menu.sub_delay" = "Subtitle Delay: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Show Subtitles Panel";
 "menu.hide_subtitles" = "Hide Subtitles Panel";
 
-"menu.seek_forward" = "Step Forward %.0fs";
-"menu.seek_backward" = "Step Backward %.0fs";
+"menu.seek_forward" = "Step Forward %@s";
+"menu.seek_backward" = "Step Backward %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Volume - %.0f%%";
-"menu.audio_delay_up" = "Audio Delay + %.1fs";
-"menu.audio_delay_down" = "Audio Delay - %.1fs";
-"menu.sub_delay_up" = "Subtitle Delay + %.1fs";
-"menu.sub_delay_down" = "Subtitle Delay - %.1fs";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Volume - %@%%";
+"menu.audio_delay_up" = "Audio Delay + %@s";
+"menu.audio_delay_down" = "Audio Delay - %@s";
+"menu.sub_delay_up" = "Subtitle Delay + %@s";
+"menu.sub_delay_down" = "Subtitle Delay - %@s";
 
 "menu.crop_custom" = "Custom…";
 "menu.find_online_sub" = "Find Online Subtitles from %@";

--- a/iina/ne.lproj/Localizable.strings
+++ b/iina/ne.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pause";
 "osd.resume" = "Resume";
-"osd.volume" = "Volume: %i";
+"osd.volume" = "Volume: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Aspect Ratio: %@";
 "osd.crop" = "Crop: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deinterlace: %@";
 "osd.hwdec" = "Hardware Decoding: %@";
 "osd.audio_delay.nodelay" = "Audio Delay: No Delay";
-"osd.audio_delay.later" = "Audio Delay: %.2fs Later";
-"osd.audio_delay.earlier" = "Audio Delay: %.2fs Earlier";
+"osd.audio_delay.later" = "Audio Delay: %@s Later";
+"osd.audio_delay.earlier" = "Audio Delay: %@s Earlier";
 "osd.sub_delay.nodelay" = "Subtitle Delay: No Delay";
-"osd.sub_delay.later" = "Subtitle Delay: %.2fs Later";
-"osd.sub_delay.earlier" = "Subtitle Delay: %.2fs Earlier";
-"osd.subtitle_pos" = "Subtitle Position: %.1f";
+"osd.sub_delay.later" = "Subtitle Delay: %@s Later";
+"osd.sub_delay.earlier" = "Subtitle Delay: %@s Earlier";
+"osd.subtitle_pos" = "Subtitle Position: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-Loop: Cleared";
 "osd.stop" = "Stop";
 "osd.chapter" = "Chapter: %@";
-"osd.subtitle_scale" = "Subtitle Scale: %.2fx";
+"osd.subtitle_scale" = "Subtitle Scale: %@x";
 "osd.add_to_playlist" = "Added %i Files to Playlist";
 "osd.clear_playlist" = "Cleared Playlist";
 "osd.video_eq.contrast" = "Contrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volume: %d";
-"menu.volume_muted" = "Volume: %d (Muted)";
-"menu.audio_delay" = "Audio Delay: %.2fs";
-"menu.sub_delay" = "Subtitle Delay: %.2fs";
+"menu.volume" = "Volume: %@";
+"menu.volume_muted" = "Volume: %@ (Muted)";
+"menu.audio_delay" = "Audio Delay: %@s";
+"menu.sub_delay" = "Subtitle Delay: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Show Subtitles Panel";
 "menu.hide_subtitles" = "Hide Subtitles Panel";
 
-"menu.seek_forward" = "Step Forward %.0fs";
-"menu.seek_backward" = "Step Backward %.0fs";
+"menu.seek_forward" = "Step Forward %@s";
+"menu.seek_backward" = "Step Backward %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Volume - %.0f%%";
-"menu.audio_delay_up" = "Audio Delay + %.1fs";
-"menu.audio_delay_down" = "Audio Delay - %.1fs";
-"menu.sub_delay_up" = "Subtitle Delay + %.1fs";
-"menu.sub_delay_down" = "Subtitle Delay - %.1fs";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Volume - %@%%";
+"menu.audio_delay_up" = "Audio Delay + %@s";
+"menu.audio_delay_down" = "Audio Delay - %@s";
+"menu.sub_delay_up" = "Subtitle Delay + %@s";
+"menu.sub_delay_down" = "Subtitle Delay - %@s";
 
 "menu.crop_custom" = "Custom…";
 "menu.find_online_sub" = "Find Online Subtitles from %@";

--- a/iina/nl.lproj/Localizable.strings
+++ b/iina/nl.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pauzeer";
 "osd.resume" = "Hervat";
-"osd.volume" = "Volume: %i";
+"osd.volume" = "Volume: %@";
 "osd.speed" = "Snelheid: %@x";
 "osd.aspect" = "Beeldverhouding: %@";
 "osd.crop" = "Bijsnijden: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deinterlace: %@";
 "osd.hwdec" = "Hardware acceleratie: %@";
 "osd.audio_delay.nodelay" = "Geen audiovertraging";
-"osd.audio_delay.later" = "Audio vertraagd met %.2fs";
-"osd.audio_delay.earlier" = "Audio versneld met %.2fs";
+"osd.audio_delay.later" = "Audio vertraagd met %@s";
+"osd.audio_delay.earlier" = "Audio versneld met %@s";
 "osd.sub_delay.nodelay" = "Geen ondertitelingvertraging";
-"osd.sub_delay.later" = "Ondertiteling versneld met %.2fs";
-"osd.sub_delay.earlier" = "Ondertiteling vertraagd met %.2fs";
-"osd.subtitle_pos" = "Ondertitelingspositie: %.1f";
+"osd.sub_delay.later" = "Ondertiteling versneld met %@s";
+"osd.sub_delay.earlier" = "Ondertiteling vertraagd met %@s";
+"osd.subtitle_pos" = "Ondertitelingspositie: %@";
 "osd.sub_hidden" = "Ondertitels Verborgen";
 "osd.sub_visible" = "Ondertitels zichtbaar";
 "osd.sub_second_delay.nodelay" = "Secundaire ondertitel vertraging: Geen vertraging";
-"osd.sub_second_delay.later" = "Secundaire ondertitel vertraging: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secundaire ondertitel vertraging: %.2fs eerder";
+"osd.sub_second_delay.later" = "Secundaire ondertitel vertraging: %@s Later";
+"osd.sub_second_delay.earlier" = "Secundaire ondertitel vertraging: %@s eerder";
 "osd.sub_second_hidden" = "Secundaire ondertitels verborgen";
-"osd.sub_second_pos" = "Secundaire ondertitelingspositie: %.1f";
+"osd.sub_second_pos" = "Secundaire ondertitelingspositie: %@";
 "osd.sub_second_visible" = "Secundaire ondertitels zichtbaar";
 "osd.mute" = "Geluid uit";
 "osd.unmute" = "Geluid aan";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "Herhaalgedeelte opgeheven";
 "osd.stop" = "Stop";
 "osd.chapter" = "Hoofdstuk: %@";
-"osd.subtitle_scale" = "Ondertitelingsschaal: %.2fx";
+"osd.subtitle_scale" = "Ondertitelingsschaal: %@x";
 "osd.add_to_playlist" = "%i bestanden toegevoegd aan afspeellijst";
 "osd.clear_playlist" = "Afspeellijst gewist";
 "osd.video_eq.contrast" = "Contrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volume: %d";
-"menu.volume_muted" = "Volume: %d (Muted)";
-"menu.audio_delay" = "Audiovertraging: %.2fs";
-"menu.sub_delay" = "Ondertitelingvertraging: %.2fs";
+"menu.volume" = "Volume: %@";
+"menu.volume_muted" = "Volume: %@ (Muted)";
+"menu.audio_delay" = "Audiovertraging: %@s";
+"menu.sub_delay" = "Ondertitelingvertraging: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Show Subtitles Panel";
 "menu.hide_subtitles" = "Hide Subtitles Panel";
 
-"menu.seek_forward" = "Ga %.0fs vooruit";
-"menu.seek_backward" = "Ga %.0fs terug";
+"menu.seek_forward" = "Ga %@s vooruit";
+"menu.seek_backward" = "Ga %@s terug";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Volume - %.0f%%";
-"menu.audio_delay_up" = "Audiovertraging + %.1fs";
-"menu.audio_delay_down" = "Audiovertraging - %.1fs";
-"menu.sub_delay_up" = "Ondertitelingvertraging + %.1fs";
-"menu.sub_delay_down" = "Ondertitelingingvertraging - %.1fs";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Volume - %@%%";
+"menu.audio_delay_up" = "Audiovertraging + %@s";
+"menu.audio_delay_down" = "Audiovertraging - %@s";
+"menu.sub_delay_up" = "Ondertitelingvertraging + %@s";
+"menu.sub_delay_down" = "Ondertitelingingvertraging - %@s";
 
 "menu.crop_custom" = "Pas aan…";
 "menu.find_online_sub" = "Find Online Subtitles from %@";

--- a/iina/no.lproj/Localizable.strings
+++ b/iina/no.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pause";
 "osd.resume" = "Gjenoppta";
-"osd.volume" = "Volum: %i";
+"osd.volume" = "Volum: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Bildeformat: %@";
 "osd.crop" = "Beskjæring: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Fjern sammenfletting: %@";
 "osd.hwdec" = "Maskinvaredekoding: %@";
 "osd.audio_delay.nodelay" = "Lydforsinkelse: ingen forsinkelse";
-"osd.audio_delay.later" = "Lydforsinkelse: %.2fs senere";
-"osd.audio_delay.earlier" = "Lydforsinkelse: %.2fs tidligere";
+"osd.audio_delay.later" = "Lydforsinkelse: %@s senere";
+"osd.audio_delay.earlier" = "Lydforsinkelse: %@s tidligere";
 "osd.sub_delay.nodelay" = "Undertekstforsinkelse: ingen forsinkelse";
-"osd.sub_delay.later" = "Undertekstforsinkelse: %.2fs senere";
-"osd.sub_delay.earlier" = "Undertekstforsinkelse: %.2fs tidligere";
-"osd.subtitle_pos" = "Undertekstposisjon: %.1f";
+"osd.sub_delay.later" = "Undertekstforsinkelse: %@s senere";
+"osd.sub_delay.earlier" = "Undertekstforsinkelse: %@s tidligere";
+"osd.subtitle_pos" = "Undertekstposisjon: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Demp";
 "osd.unmute" = "Opphev demping";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-løkke: fjernet";
 "osd.stop" = "Stopp";
 "osd.chapter" = "Kapittel: %@";
-"osd.subtitle_scale" = "Undertekstskala: %.2fs";
+"osd.subtitle_scale" = "Undertekstskala: %@s";
 "osd.add_to_playlist" = "La til %i filer i spillelisten";
 "osd.clear_playlist" = "Tømte spilleliste";
 "osd.video_eq.contrast" = "Kontrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volum: %d";
-"menu.volume_muted" = "Volum: %d (dempet)";
-"menu.audio_delay" = "Lydforsinkelse: %.2fs";
-"menu.sub_delay" = "Undertekstforsinkelse: %.2fs";
+"menu.volume" = "Volum: %@";
+"menu.volume_muted" = "Volum: %@ (dempet)";
+"menu.audio_delay" = "Lydforsinkelse: %@s";
+"menu.sub_delay" = "Undertekstforsinkelse: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Vis undertekstpanel";
 "menu.hide_subtitles" = "Skjul undertekstpanel";
 
-"menu.seek_forward" = "Steg fremover: %.0fs";
-"menu.seek_backward" = "Steg bakover: %.0fs";
+"menu.seek_forward" = "Steg fremover: %@s";
+"menu.seek_backward" = "Steg bakover: %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volum + %.0f%%";
-"menu.volume_down" = "Volum - %.0f%%";
-"menu.audio_delay_up" = "Lydforsinkelse + %.1fs";
-"menu.audio_delay_down" = "Lydforsinkelse - %.1fs";
-"menu.sub_delay_up" = "Undertekstforsinkelse + %.1fs";
-"menu.sub_delay_down" = "Undertekstforsinkelse - %.1fs";
+"menu.volume_up" = "Volum + %@%%";
+"menu.volume_down" = "Volum - %@%%";
+"menu.audio_delay_up" = "Lydforsinkelse + %@s";
+"menu.audio_delay_down" = "Lydforsinkelse - %@s";
+"menu.sub_delay_up" = "Undertekstforsinkelse + %@s";
+"menu.sub_delay_down" = "Undertekstforsinkelse - %@s";
 
 "menu.crop_custom" = "Custom…";
 "menu.find_online_sub" = "Finn undertekster på nettet fra %@";

--- a/iina/pl.lproj/Localizable.strings
+++ b/iina/pl.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pauza";
 "osd.resume" = "Wznów";
-"osd.volume" = "Głośność: %i";
+"osd.volume" = "Głośność: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Proporcje obrazu: %@";
 "osd.crop" = "Kadrowanie obrazu: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Usuwanie przeplotu: %@";
 "osd.hwdec" = "Dekodowanie sprzętowe: %@";
 "osd.audio_delay.nodelay" = "Opóźnienie dźwięku: Brak";
-"osd.audio_delay.later" = "Opóźnienie dźwięku: %.2fs pózniej";
-"osd.audio_delay.earlier" = "Opóźnienie dźwięku: %.2fs wcześniej";
+"osd.audio_delay.later" = "Opóźnienie dźwięku: %@s pózniej";
+"osd.audio_delay.earlier" = "Opóźnienie dźwięku: %@s wcześniej";
 "osd.sub_delay.nodelay" = "Opóźnienie napisów: Brak";
-"osd.sub_delay.later" = "Opóźnienie napisów: %.2fs później";
-"osd.sub_delay.earlier" = "Opóźnienie napisów: %.2fs wcześniej";
-"osd.subtitle_pos" = "Pozycja napisów: %.1f";
+"osd.sub_delay.later" = "Opóźnienie napisów: %@s później";
+"osd.sub_delay.earlier" = "Opóźnienie napisów: %@s wcześniej";
+"osd.subtitle_pos" = "Pozycja napisów: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = ".";
 "osd.mute" = "Wycisz dźwięk";
 "osd.unmute" = "Włącz dźwięk";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "Pętla-AB: wyczyszczono";
 "osd.stop" = "Zatrzymaj";
 "osd.chapter" = "Rozdział: %@";
-"osd.subtitle_scale" = "Skala napisów: %.2fx";
+"osd.subtitle_scale" = "Skala napisów: %@x";
 "osd.add_to_playlist" = "Dodano %i plików do playlisty";
 "osd.clear_playlist" = "Wyczyszczono playlistę";
 "osd.video_eq.contrast" = "Kontrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Głośność: %d";
-"menu.volume_muted" = "Głośność: %d (Wyciszono)";
-"menu.audio_delay" = "Opóźnienie audio: %.2fs";
-"menu.sub_delay" = "Opóźnienie napisów: %.2fs";
+"menu.volume" = "Głośność: %@";
+"menu.volume_muted" = "Głośność: %@ (Wyciszono)";
+"menu.audio_delay" = "Opóźnienie audio: %@s";
+"menu.sub_delay" = "Opóźnienie napisów: %@s";
 "menu.sub_hide" = "Ukryj napisy";
 "menu.sub_show" = "Pokaż napisy";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Pokaż panel napisów";
 "menu.hide_subtitles" = "Ukryj panel napisów";
 
-"menu.seek_forward" = "Przewiń w przód o %.0fs";
-"menu.seek_backward" = "Przewiń w tył o %.0fs";
+"menu.seek_forward" = "Przewiń w przód o %@s";
+"menu.seek_backward" = "Przewiń w tył o %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Głośność +%.0f%%";
-"menu.volume_down" = "Głośność -%.0f%%";
-"menu.audio_delay_up" = "Opóźnienie audio +%.1fs";
-"menu.audio_delay_down" = "Opóźnienie audio -%.1fs";
-"menu.sub_delay_up" = "Opóźnienie napisów +%.1fs";
-"menu.sub_delay_down" = "Opóźnienie napisów -%.1fs";
+"menu.volume_up" = "Głośność +%@%%";
+"menu.volume_down" = "Głośność -%@%%";
+"menu.audio_delay_up" = "Opóźnienie audio +%@s";
+"menu.audio_delay_down" = "Opóźnienie audio -%@s";
+"menu.sub_delay_up" = "Opóźnienie napisów +%@s";
+"menu.sub_delay_down" = "Opóźnienie napisów -%@s";
 
 "menu.crop_custom" = "Własne…";
 "menu.find_online_sub" = "Znajdź napisy online z %@";

--- a/iina/pt-BR.lproj/Localizable.strings
+++ b/iina/pt-BR.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Em Pausa";
 "osd.resume" = "Reproduzindo";
-"osd.volume" = "Volume: %i";
+"osd.volume" = "Volume: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Proporção: %@";
 "osd.crop" = "Cortar: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Desentrelaçar: %@";
 "osd.hwdec" = "Decodificação por hardware: %@";
 "osd.audio_delay.nodelay" = "Atraso de Audio: Sem Atraso";
-"osd.audio_delay.later" = "Atraso de Audio: %.2fs Atrasado";
-"osd.audio_delay.earlier" = "Atraso de Audio: %.2fs Antecipado";
+"osd.audio_delay.later" = "Atraso de Audio: %@s Atrasado";
+"osd.audio_delay.earlier" = "Atraso de Audio: %@s Antecipado";
 "osd.sub_delay.nodelay" = "Atraso de Legenda: Sem Atraso";
-"osd.sub_delay.later" = "Atraso de Legenda: %.2fs Atrasada";
-"osd.sub_delay.earlier" = "Atraso de Legenda: %.2fs Antecipada";
-"osd.subtitle_pos" = "Posição da Legenda: %.1f";
+"osd.sub_delay.later" = "Atraso de Legenda: %@s Atrasada";
+"osd.sub_delay.earlier" = "Atraso de Legenda: %@s Antecipada";
+"osd.subtitle_pos" = "Posição da Legenda: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Sem Audio";
 "osd.unmute" = "Audio Ligado";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-Loop: Desfeito";
 "osd.stop" = "Parado";
 "osd.chapter" = "Capítulo: %@";
-"osd.subtitle_scale" = "Escala da Legenda: %.2fx";
+"osd.subtitle_scale" = "Escala da Legenda: %@x";
 "osd.add_to_playlist" = "%i Arquivos Adicionados à Lista de Reprodução";
 "osd.clear_playlist" = "Lista de Reprodução Esvaziada";
 "osd.video_eq.contrast" = "Contraste: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volume: %d";
-"menu.volume_muted" = "Volume: %d (Mudo)";
-"menu.audio_delay" = "Atraso de Áudio: %.2fs";
-"menu.sub_delay" = "Atraso de Legenda: %.2fs";
+"menu.volume" = "Volume: %@";
+"menu.volume_muted" = "Volume: %@ (Mudo)";
+"menu.audio_delay" = "Atraso de Áudio: %@s";
+"menu.sub_delay" = "Atraso de Legenda: %@s";
 "menu.sub_hide" = "Ocultar legenda";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Mostrar Painel de Legendas";
 "menu.hide_subtitles" = "Ocultar Painel de Legendas";
 
-"menu.seek_forward" = "Ir adiante %.0fs";
-"menu.seek_backward" = "Ir pra trás %.0fs";
+"menu.seek_forward" = "Ir adiante %@s";
+"menu.seek_backward" = "Ir pra trás %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Volume - %.0f%%";
-"menu.audio_delay_up" = "Atraso de Áudio + %.1fs";
-"menu.audio_delay_down" = "Atraso de Áudio - %.1fs";
-"menu.sub_delay_up" = "Atraso de legenda + %.1fs";
-"menu.sub_delay_down" = "Atraso de legenda - %.1fs";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Volume - %@%%";
+"menu.audio_delay_up" = "Atraso de Áudio + %@s";
+"menu.audio_delay_down" = "Atraso de Áudio - %@s";
+"menu.sub_delay_up" = "Atraso de legenda + %@s";
+"menu.sub_delay_down" = "Atraso de legenda - %@s";
 
 "menu.crop_custom" = "Outro..";
 "menu.find_online_sub" = "Encontrar Legendas on-line em %@";

--- a/iina/pt.lproj/Localizable.strings
+++ b/iina/pt.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pausa";
 "osd.resume" = "Retomar";
-"osd.volume" = "Volume: %i";
+"osd.volume" = "Volume: %@";
 "osd.speed" = "Velocidade: %@x";
 "osd.aspect" = "Proporção: %@";
 "osd.crop" = "Cortar: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Desentrelaçar: %@";
 "osd.hwdec" = "Descodificação de Hardware: %@";
 "osd.audio_delay.nodelay" = "Atraso de Áudio: Sem Atraso";
-"osd.audio_delay.later" = "Atraso de Áudio: %.2fs Depois";
-"osd.audio_delay.earlier" = "Atraso de Áudio: %.2fs Antes";
+"osd.audio_delay.later" = "Atraso de Áudio: %@s Depois";
+"osd.audio_delay.earlier" = "Atraso de Áudio: %@s Antes";
 "osd.sub_delay.nodelay" = "Atraso da legenda: Sem atraso";
-"osd.sub_delay.later" = "Atraso da legenda: %.2fs Depois";
-"osd.sub_delay.earlier" = "Atraso da Legenda: %.2fs Antes";
-"osd.subtitle_pos" = "Posição da Legenda: %.1f";
+"osd.sub_delay.later" = "Atraso da legenda: %@s Depois";
+"osd.sub_delay.earlier" = "Atraso da Legenda: %@s Antes";
+"osd.subtitle_pos" = "Posição da Legenda: %@";
 "osd.sub_hidden" = "Legendas ocultas";
 "osd.sub_visible" = "Legendas visíveis";
 "osd.sub_second_delay.nodelay" = "Atraso da legenda secundária: Sem atraso";
-"osd.sub_second_delay.later" = "Atraso da legenda secundária: %.2fs Depois";
-"osd.sub_second_delay.earlier" = "Atraso da legenda secundária: %.2fs Antes";
+"osd.sub_second_delay.later" = "Atraso da legenda secundária: %@s Depois";
+"osd.sub_second_delay.earlier" = "Atraso da legenda secundária: %@s Antes";
 "osd.sub_second_hidden" = "Legendas secundárias ocultas";
-"osd.sub_second_pos" = "Posição da legenda secundária: %.1f";
+"osd.sub_second_pos" = "Posição da legenda secundária: %@";
 "osd.sub_second_visible" = "Legendas secundárias visíveis";
 "osd.mute" = "Sem som";
 "osd.unmute" = "Ligar som";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "Loop-AB: Limpo";
 "osd.stop" = "Parar";
 "osd.chapter" = "Capítulo: %@";
-"osd.subtitle_scale" = "Tamanho da legenda: %.2fx";
+"osd.subtitle_scale" = "Tamanho da legenda: %@x";
 "osd.add_to_playlist" = "%i Ficheiros Adicionados à Playlist";
 "osd.clear_playlist" = "Lista de Reprodução Limpa";
 "osd.video_eq.contrast" = "Contraste: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volume: %d";
-"menu.volume_muted" = "Volume: %d (Sem som)";
-"menu.audio_delay" = "Atraso de Áudio: %.2fs";
-"menu.sub_delay" = "Atraso da legenda: %.2fs";
+"menu.volume" = "Volume: %@";
+"menu.volume_muted" = "Volume: %@ (Sem som)";
+"menu.audio_delay" = "Atraso de Áudio: %@s";
+"menu.sub_delay" = "Atraso da legenda: %@s";
 "menu.sub_hide" = "Ocultar legendas";
 "menu.sub_show" = "Mostrar legendas";
 "menu.sub_second_hide" = "Ocultar legendas secundárias";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Mostrar painel de legendas";
 "menu.hide_subtitles" = "Ocultar painel de legendas";
 
-"menu.seek_forward" = "Avançar %.0fs";
-"menu.seek_backward" = "Recuar %.0fs";
+"menu.seek_forward" = "Avançar %@s";
+"menu.seek_backward" = "Recuar %@s";
 "menu.speed_up" = "Acelerar em %@x";
 "menu.speed_down" = "Desacelerar em %@x";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Volume - %.0f%%";
-"menu.audio_delay_up" = "Atraso do áudio + %.1fs";
-"menu.audio_delay_down" = "Atraso de Áudio - %.1fs";
-"menu.sub_delay_up" = "Atraso da legenda + %.1fs";
-"menu.sub_delay_down" = "Atraso da legenda - %.1fs";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Volume - %@%%";
+"menu.audio_delay_up" = "Atraso do áudio + %@s";
+"menu.audio_delay_down" = "Atraso de Áudio - %@s";
+"menu.sub_delay_up" = "Atraso da legenda + %@s";
+"menu.sub_delay_down" = "Atraso da legenda - %@s";
 
 "menu.crop_custom" = "Personalizado…";
 "menu.find_online_sub" = "Find Online Subtitles from %@";

--- a/iina/ro.lproj/Localizable.strings
+++ b/iina/ro.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pauză";
 "osd.resume" = "Reia";
-"osd.volume" = "Volum: %i";
+"osd.volume" = "Volum: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Raport de aspect: %@";
 "osd.crop" = "Decupare: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deîntrețesere: %@";
 "osd.hwdec" = "Decodare hardware: %@";
 "osd.audio_delay.nodelay" = "Întârziere audio: Fără întârziere";
-"osd.audio_delay.later" = "Întârziere audio: %.2fs mai târziu";
-"osd.audio_delay.earlier" = "Întârziere audio: %.2fs mai devreme";
+"osd.audio_delay.later" = "Întârziere audio: %@s mai târziu";
+"osd.audio_delay.earlier" = "Întârziere audio: %@s mai devreme";
 "osd.sub_delay.nodelay" = "Întârziere subtitrare: Fără întârziere";
-"osd.sub_delay.later" = "Întârziere subtitrare: %.2fs mai târziu";
-"osd.sub_delay.earlier" = "Întârziere subtitrare: %.2fs mai devreme";
-"osd.subtitle_pos" = "Poziție subtitrare: %.1f";
+"osd.sub_delay.later" = "Întârziere subtitrare: %@s mai târziu";
+"osd.sub_delay.earlier" = "Întârziere subtitrare: %@s mai devreme";
+"osd.subtitle_pos" = "Poziție subtitrare: %@";
 "osd.sub_hidden" = "Subtitrări ascunse";
 "osd.sub_visible" = "Subtitrări vizibile";
 "osd.sub_second_delay.nodelay" = "Decalaj subtitrări secundare: fără decalaj";
-"osd.sub_second_delay.later" = "Decalaj subtitrări secundare: %.2fs după";
-"osd.sub_second_delay.earlier" = "Decalaj subtitrări secundare: %.2fs înainte";
+"osd.sub_second_delay.later" = "Decalaj subtitrări secundare: %@s după";
+"osd.sub_second_delay.earlier" = "Decalaj subtitrări secundare: %@s înainte";
 "osd.sub_second_hidden" = "Subtitrări secundare ascunse";
-"osd.sub_second_pos" = "Poziție subtitrări secundare: %.1f";
+"osd.sub_second_pos" = "Poziție subtitrări secundare: %@";
 "osd.sub_second_visible" = "Subtitrări secundare vizibile";
 "osd.mute" = "Mut";
 "osd.unmute" = "Activează sunetul";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-Loop: Șters";
 "osd.stop" = "Oprire";
 "osd.chapter" = "Capitol: %@";
-"osd.subtitle_scale" = "Scală subtitrare: %.2fx";
+"osd.subtitle_scale" = "Scală subtitrare: %@x";
 "osd.add_to_playlist" = "Fișierul %i a fost adăugat la lista de redare";
 "osd.clear_playlist" = "Listă de redare ștearsă";
 "osd.video_eq.contrast" = "Contrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volum: %d";
-"menu.volume_muted" = "Volum: %d (Mut)";
-"menu.audio_delay" = "Întârziere audio: %.2fs";
-"menu.sub_delay" = "Întârziere subtitrare: %.2fs";
+"menu.volume" = "Volum: %@";
+"menu.volume_muted" = "Volum: %@ (Mut)";
+"menu.audio_delay" = "Întârziere audio: %@s";
+"menu.sub_delay" = "Întârziere subtitrare: %@s";
 "menu.sub_hide" = "Ascunde subtitrările";
 "menu.sub_show" = "Arată subtitrările";
 "menu.sub_second_hide" = "Ascunde subtitrările secundare";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Arată panoul Subtitrări";
 "menu.hide_subtitles" = "Ascunde panoul Subtitrări";
 
-"menu.seek_forward" = "Sari înainte %.0fs";
-"menu.seek_backward" = "Sari înapoi %.0fs";
+"menu.seek_forward" = "Sari înainte %@s";
+"menu.seek_backward" = "Sari înapoi %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volum +%.0f%%";
-"menu.volume_down" = "Volum -%.0f%%";
-"menu.audio_delay_up" = "Întârziere audio +%.1fs";
-"menu.audio_delay_down" = "Întârziere audio -%.1fs";
-"menu.sub_delay_up" = "Întârziere subitrare +%.1fs";
-"menu.sub_delay_down" = "Întârziere subitrare -%.1fs";
+"menu.volume_up" = "Volum +%@%%";
+"menu.volume_down" = "Volum -%@%%";
+"menu.audio_delay_up" = "Întârziere audio +%@s";
+"menu.audio_delay_down" = "Întârziere audio -%@s";
+"menu.sub_delay_up" = "Întârziere subitrare +%@s";
+"menu.sub_delay_down" = "Întârziere subitrare -%@s";
 
 "menu.crop_custom" = "Personalizat…";
 "menu.find_online_sub" = "Găsește subtitrări online din %@";

--- a/iina/ru.lproj/Localizable.strings
+++ b/iina/ru.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Приостановить";
 "osd.resume" = "Возобновить";
-"osd.volume" = "Громкость: %i";
+"osd.volume" = "Громкость: %@";
 "osd.speed" = "Скорость: %@×";
 "osd.aspect" = "Соотношение сторон: %@";
 "osd.crop" = "Кадрирование: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Деинтерлейсинг: %@";
 "osd.hwdec" = "Аппаратное декодирование: %@";
 "osd.audio_delay.nodelay" = "Задержка аудио: нет задержки";
-"osd.audio_delay.later" = "Задержка аудио: на %.2f с позже";
-"osd.audio_delay.earlier" = "Задержка аудио: на %.2f с раньше";
+"osd.audio_delay.later" = "Задержка аудио: на %@ с позже";
+"osd.audio_delay.earlier" = "Задержка аудио: на %@ с раньше";
 "osd.sub_delay.nodelay" = "Задержка субтитров: нет задержки";
-"osd.sub_delay.later" = "Задержка субтитров: на %.2f с позже";
-"osd.sub_delay.earlier" = "Задержка субтитров: на %.2f с раньше";
-"osd.subtitle_pos" = "Позиция субтитров: %.1f";
+"osd.sub_delay.later" = "Задержка субтитров: на %@ с позже";
+"osd.sub_delay.earlier" = "Задержка субтитров: на %@ с раньше";
+"osd.subtitle_pos" = "Позиция субтитров: %@";
 "osd.sub_hidden" = "Субтитры скрыты";
 "osd.sub_visible" = "Субтитры отображаются";
 "osd.sub_second_delay.nodelay" = "Задержка вторых субтитров: без задержки";
-"osd.sub_second_delay.later" = "Задержка вторых субтитров: %.2f сек. позже";
-"osd.sub_second_delay.earlier" = "Задержка вторых субтитров: %.2f сек. раньше";
+"osd.sub_second_delay.later" = "Задержка вторых субтитров: %@ сек. позже";
+"osd.sub_second_delay.earlier" = "Задержка вторых субтитров: %@ сек. раньше";
 "osd.sub_second_hidden" = "Вторые субтитры скрыты";
-"osd.sub_second_pos" = "Позиция вторых субтитров: %.1f";
+"osd.sub_second_pos" = "Позиция вторых субтитров: %@";
 "osd.sub_second_visible" = "Вторые субтитры видны";
 "osd.mute" = "Выключить звук";
 "osd.unmute" = "Включение звука";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "Цикл: сброшен";
 "osd.stop" = "Остановить";
 "osd.chapter" = "Глава: %@";
-"osd.subtitle_scale" = "Масштаб субтитров: %.2f×";
+"osd.subtitle_scale" = "Масштаб субтитров: %@×";
 "osd.add_to_playlist" = "Добавлено %i файлов в плейлист";
 "osd.clear_playlist" = "Плейлист очищен";
 "osd.video_eq.contrast" = "Контраст: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Установите плагин Online Media из меню «Плагины > Установить с GitHub», чтобы получить дополнительные возможности, такие как загрузка видео и автоматическое обновление yt-dlp.";
 "preference.ytdl_plugin_installed" = "Встроенная поддержка youtube-dl отключена, так как у вас установлен плагин Online Media.";
 
-"menu.volume" = "Громкость: %d";
-"menu.volume_muted" = "Громкость: %d (без звука)";
-"menu.audio_delay" = "Задержка аудио: %.2f с";
-"menu.sub_delay" = "Задержка субтитров: %.2f с";
+"menu.volume" = "Громкость: %@";
+"menu.volume_muted" = "Громкость: %@ (без звука)";
+"menu.audio_delay" = "Задержка аудио: %@ с";
+"menu.sub_delay" = "Задержка субтитров: %@ с";
 "menu.sub_hide" = "Скрыть субтитры";
 "menu.sub_show" = "Показать субтитры";
 "menu.sub_second_hide" = "Скрыть вторые субтитры";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Показывать панель субтитров";
 "menu.hide_subtitles" = "Скрыть панель субтитров";
 
-"menu.seek_forward" = "Шаг вперед %.0f с";
-"menu.seek_backward" = "Шаг назад %.0f с";
+"menu.seek_forward" = "Шаг вперед %@ с";
+"menu.seek_backward" = "Шаг назад %@ с";
 "menu.speed_up" = "Повысить скорость до %@x";
 "menu.speed_down" = "Снизить скорость до %@x";
-"menu.volume_up" = "Громкость + %.0f%%";
-"menu.volume_down" = "Громкость - %.0f%%";
-"menu.audio_delay_up" = "Задержка аудио + %.1f с";
-"menu.audio_delay_down" = "Задержка аудио - %.1f с";
-"menu.sub_delay_up" = "Задержка субтитров + %.1f с";
-"menu.sub_delay_down" = "Задержка субтитров - %.1f с";
+"menu.volume_up" = "Громкость + %@%%";
+"menu.volume_down" = "Громкость - %@%%";
+"menu.audio_delay_up" = "Задержка аудио + %@ с";
+"menu.audio_delay_down" = "Задержка аудио - %@ с";
+"menu.sub_delay_up" = "Задержка субтитров + %@ с";
+"menu.sub_delay_down" = "Задержка субтитров - %@ с";
 
 "menu.crop_custom" = "Другое…";
 "menu.find_online_sub" = "Найти субтитры онлайн на %@";

--- a/iina/sk.lproj/Localizable.strings
+++ b/iina/sk.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pozastaviť";
 "osd.resume" = "Pokračovať";
-"osd.volume" = "Hlasitosť: %i";
+"osd.volume" = "Hlasitosť: %@";
 "osd.speed" = "Rýchlosť: %@x";
 "osd.aspect" = "Pomer strán: %@";
 "osd.crop" = "Orezať: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deinterlace: %@";
 "osd.hwdec" = "Hardvérové dekódovanie: %@";
 "osd.audio_delay.nodelay" = "Posunutie zvuku: Žiadne";
-"osd.audio_delay.later" = "Posunutie zvuku: +%.2f s";
-"osd.audio_delay.earlier" = "Posunutie zvuku: -%.2f s";
+"osd.audio_delay.later" = "Posunutie zvuku: +%@ s";
+"osd.audio_delay.earlier" = "Posunutie zvuku: -%@ s";
 "osd.sub_delay.nodelay" = "Posunutie titulkov: Žiadne";
-"osd.sub_delay.later" = "Posunutie titulkov: +%.2f s";
-"osd.sub_delay.earlier" = "Posunutie titulkov: -%.2f s";
-"osd.subtitle_pos" = "Umiestnenie titulkov: %.1f";
+"osd.sub_delay.later" = "Posunutie titulkov: +%@ s";
+"osd.sub_delay.earlier" = "Posunutie titulkov: -%@ s";
+"osd.subtitle_pos" = "Umiestnenie titulkov: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Oneskorenie sekundárnych titulkov: bez oneskorenia";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Stlmiť";
 "osd.unmute" = "Zosilniť";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-slučka: Vymazaná";
 "osd.stop" = "Zastaviť";
 "osd.chapter" = "Kapitola: %@";
-"osd.subtitle_scale" = "Veľkosť titulkov: %.2fx";
+"osd.subtitle_scale" = "Veľkosť titulkov: %@x";
 "osd.add_to_playlist" = "Súbory pridané do playlistu: %i";
 "osd.clear_playlist" = "Playlist vymazaný";
 "osd.video_eq.contrast" = "Kontrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Hlasitosť: %d";
-"menu.volume_muted" = "Hlasitosť: %d (stíšene)";
-"menu.audio_delay" = "Posunutie zvuku: %.2f s";
-"menu.sub_delay" = "Posunutie titulkov: %.2f s";
+"menu.volume" = "Hlasitosť: %@";
+"menu.volume_muted" = "Hlasitosť: %@ (stíšene)";
+"menu.audio_delay" = "Posunutie zvuku: %@ s";
+"menu.sub_delay" = "Posunutie titulkov: %@ s";
 "menu.sub_hide" = "Skryť titulky";
 "menu.sub_show" = "Zobraziť titulky";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Zobraziť panel tituliek";
 "menu.hide_subtitles" = "Skryť panel tituliek";
 
-"menu.seek_forward" = "Posunúť dopredu %.0f s";
-"menu.seek_backward" = "Posunúť dozadu %.0f s";
+"menu.seek_forward" = "Posunúť dopredu %@ s";
+"menu.seek_backward" = "Posunúť dozadu %@ s";
 "menu.speed_up" = "Zrýchliť na %@x";
 "menu.speed_down" = "Spomaliť na %@x";
-"menu.volume_up" = "Hlasitosť +%.0f%%";
-"menu.volume_down" = "Hlasitosť -%.0f%%";
-"menu.audio_delay_up" = "Posunutie zvuku +%.1f s";
-"menu.audio_delay_down" = "Posunutie zvuku -%.1f s";
-"menu.sub_delay_up" = "Posunutie titulkov +%.1f s";
-"menu.sub_delay_down" = "Posunutie titulkov -%.1f s";
+"menu.volume_up" = "Hlasitosť +%@%%";
+"menu.volume_down" = "Hlasitosť -%@%%";
+"menu.audio_delay_up" = "Posunutie zvuku +%@ s";
+"menu.audio_delay_down" = "Posunutie zvuku -%@ s";
+"menu.sub_delay_up" = "Posunutie titulkov +%@ s";
+"menu.sub_delay_down" = "Posunutie titulkov -%@ s";
 
 "menu.crop_custom" = "Vlastné…";
 "menu.find_online_sub" = "Nájsť titulky online na %@";

--- a/iina/sl.lproj/Localizable.strings
+++ b/iina/sl.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pause";
 "osd.resume" = "Resume";
-"osd.volume" = "Volume: %i";
+"osd.volume" = "Volume: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Aspect Ratio: %@";
 "osd.crop" = "Crop: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deinterlace: %@";
 "osd.hwdec" = "Hardware Decoding: %@";
 "osd.audio_delay.nodelay" = "Audio Delay: No Delay";
-"osd.audio_delay.later" = "Audio Delay: %.2fs Later";
-"osd.audio_delay.earlier" = "Audio Delay: %.2fs Earlier";
+"osd.audio_delay.later" = "Audio Delay: %@s Later";
+"osd.audio_delay.earlier" = "Audio Delay: %@s Earlier";
 "osd.sub_delay.nodelay" = "Subtitle Delay: No Delay";
-"osd.sub_delay.later" = "Subtitle Delay: %.2fs Later";
-"osd.sub_delay.earlier" = "Subtitle Delay: %.2fs Earlier";
-"osd.subtitle_pos" = "Subtitle Position: %.1f";
+"osd.sub_delay.later" = "Subtitle Delay: %@s Later";
+"osd.sub_delay.earlier" = "Subtitle Delay: %@s Earlier";
+"osd.subtitle_pos" = "Subtitle Position: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-Loop: Cleared";
 "osd.stop" = "Stop";
 "osd.chapter" = "Chapter: %@";
-"osd.subtitle_scale" = "Subtitle Scale: %.2fx";
+"osd.subtitle_scale" = "Subtitle Scale: %@x";
 "osd.add_to_playlist" = "Added %i Files to Playlist";
 "osd.clear_playlist" = "Cleared Playlist";
 "osd.video_eq.contrast" = "Contrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volume: %d";
-"menu.volume_muted" = "Volume: %d (Muted)";
-"menu.audio_delay" = "Audio Delay: %.2fs";
-"menu.sub_delay" = "Subtitle Delay: %.2fs";
+"menu.volume" = "Volume: %@";
+"menu.volume_muted" = "Volume: %@ (Muted)";
+"menu.audio_delay" = "Audio Delay: %@s";
+"menu.sub_delay" = "Subtitle Delay: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Show Subtitles Panel";
 "menu.hide_subtitles" = "Hide Subtitles Panel";
 
-"menu.seek_forward" = "Step Forward %.0fs";
-"menu.seek_backward" = "Step Backward %.0fs";
+"menu.seek_forward" = "Step Forward %@s";
+"menu.seek_backward" = "Step Backward %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Volume - %.0f%%";
-"menu.audio_delay_up" = "Audio Delay + %.1fs";
-"menu.audio_delay_down" = "Audio Delay - %.1fs";
-"menu.sub_delay_up" = "Subtitle Delay + %.1fs";
-"menu.sub_delay_down" = "Subtitle Delay - %.1fs";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Volume - %@%%";
+"menu.audio_delay_up" = "Audio Delay + %@s";
+"menu.audio_delay_down" = "Audio Delay - %@s";
+"menu.sub_delay_up" = "Subtitle Delay + %@s";
+"menu.sub_delay_down" = "Subtitle Delay - %@s";
 
 "menu.crop_custom" = "Custom…";
 "menu.find_online_sub" = "Find Online Subtitles from %@";

--- a/iina/sr-CS.lproj/Localizable.strings
+++ b/iina/sr-CS.lproj/Localizable.strings
@@ -40,7 +40,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pauziraj";
 "osd.resume" = "Nastavi";
-"osd.volume" = "Jačina zvuka: %i";
+"osd.volume" = "Jačina zvuka: %@";
 "osd.speed" = "Brzina: %.2fx";
 "osd.aspect" = "Odnos širina/visina: %@";
 "osd.crop" = "Iseci: %@";
@@ -48,12 +48,12 @@
 "osd.deinterlace" = "Rasplitanje: %@";
 "osd.hwdec" = "Hardversko dekodiranje: %@";
 "osd.audio_delay.nodelay" = "Kašnjenje zvuka: bez kašnjenja";
-"osd.audio_delay.later" = "Kašnjenje zvuka: %.2fs kasnije";
-"osd.audio_delay.earlier" = "Kašnjenje zvuka: %.2fs ranije";
+"osd.audio_delay.later" = "Kašnjenje zvuka: %@s kasnije";
+"osd.audio_delay.earlier" = "Kašnjenje zvuka: %@s ranije";
 "osd.sub_delay.nodelay" = "Kašnjenje titla: bez kašnjenja";
-"osd.sub_delay.later" = "Kašnjenje titla: %.2fs kasnije";
-"osd.sub_delay.earlier" = "Kašnjenje titla: %.2fs ranije";
-"osd.subtitle_pos" = "Položaj titla: %.1f";
+"osd.sub_delay.later" = "Kašnjenje titla: %@s kasnije";
+"osd.sub_delay.earlier" = "Kašnjenje titla: %@s ranije";
+"osd.subtitle_pos" = "Položaj titla: %@";
 "osd.mute" = "Isključi zvuk";
 "osd.unmute" = "Ponovo uključi zvuk";
 "osd.screenshot" = "Snimak ekrana je napravljen";
@@ -62,7 +62,7 @@
 "osd.abloop.clear" = "A-B petlja: očišćena";
 "osd.stop" = "Zaustavi";
 "osd.chapter" = "Poglavlje: %@";
-"osd.subtitle_scale" = "Razmera titla: %.2fx";
+"osd.subtitle_scale" = "Razmera titla: %@x";
 "osd.add_to_playlist" = "Datoteka dodato u plejlistu: %i";
 "osd.clear_playlist" = "Očišćena plejlista";
 "osd.video_eq.contrast" = "Kontrast: %i";
@@ -103,9 +103,9 @@
 
 "preference.enable_adv_settings" = "Omogući napredne postavke";
 
-"menu.volume" = "Jačina zvuka: %d";
-"menu.audio_delay" = "Kašnjenje zvuka: %.2fs";
-"menu.sub_delay" = "Kašnjenje titla: %.2fs";
+"menu.volume" = "Jačina zvuka: %@";
+"menu.audio_delay" = "Kašnjenje zvuka: %@s";
+"menu.sub_delay" = "Kašnjenje titla: %@s";
 "menu.fullscreen" = "Uđi u režim celog ekrana";
 "menu.exit_fullscreen" = "Izađi iz rеžima cеlog еkrana";
 "menu.pip" = "Uđi u režim slike u slici";
@@ -114,16 +114,16 @@
 "menu.resume" = "Nastavi";
 "menu.speed" = "Brzina: %.2fx";
 
-"menu.seek_forward" = "Korak unapred: %.0fs";
-"menu.seek_backward" = "Korak unazad: %.0fs";
+"menu.seek_forward" = "Korak unapred: %@s";
+"menu.seek_backward" = "Korak unazad: %@s";
 "menu.speed_up" = "Ubrzaj za %.1fx";
 "menu.speed_down" = "Uspori za %.1fx";
-"menu.volume_up" = "Jačina zvuka + %.0f%%";
-"menu.volume_down" = "Jačina zvuka - %.0f%%";
-"menu.audio_delay_up" = "Kašnjenje zvuka + %.1fs";
-"menu.audio_delay_down" = "Kašnjenje zvuka - %.1fs";
-"menu.sub_delay_up" = "Kašnjenje titla + %.1fs";
-"menu.sub_delay_down" = "Kašnjenje titla - %.1fs";
+"menu.volume_up" = "Jačina zvuka + %@%%";
+"menu.volume_down" = "Jačina zvuka - %@%%";
+"menu.audio_delay_up" = "Kašnjenje zvuka + %@s";
+"menu.audio_delay_down" = "Kašnjenje zvuka - %@s";
+"menu.sub_delay_up" = "Kašnjenje titla + %@s";
+"menu.sub_delay_down" = "Kašnjenje titla - %@s";
 
 "menu.crop_custom" = "Prilagođeno...";
 

--- a/iina/sr-Cyrl.lproj/Localizable.strings
+++ b/iina/sr-Cyrl.lproj/Localizable.strings
@@ -27,19 +27,19 @@
 // OSDMessage.swift
 "osd.pause" = "Pause";
 "osd.resume" = "Resume";
-"osd.volume" = "Volume: %i";
+"osd.volume" = "Volume: %@";
 "osd.speed" = "Speed: %.2fx";
 "osd.aspect" = "Aspect Ratio: %@";
 "osd.crop" = "Crop: %@";
 "osd.rotate" = "Rotate: %i°";
 "osd.deinterlace" = "Deinterlace: %@";
 "osd.audio_delay.nodelay" = "Audio Delay: No Delay";
-"osd.audio_delay.later" = "Audio Delay: %.2fs Later";
-"osd.audio_delay.earlier" = "Audio Delay: %.2fs Earlier";
+"osd.audio_delay.later" = "Audio Delay: %@s Later";
+"osd.audio_delay.earlier" = "Audio Delay: %@s Earlier";
 "osd.sub_delay.nodelay" = "Subtitle Delay: No Delay";
-"osd.sub_delay.later" = "Subtitle Delay: %.2fs Later";
-"osd.sub_delay.earlier" = "Subtitle Delay: %.2fs Earlier";
-"osd.subtitle_pos" = "Subtitle Position: %.1f";
+"osd.sub_delay.later" = "Subtitle Delay: %@s Later";
+"osd.sub_delay.earlier" = "Subtitle Delay: %@s Earlier";
+"osd.subtitle_pos" = "Subtitle Position: %@";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
 "osd.screenshot" = "Screenshot Captured";
@@ -48,7 +48,7 @@
 "osd.abloop.clear" = "AB-Loop: Cleared";
 "osd.stop" = "Stop";
 "osd.chapter" = "Chapter: %@";
-"osd.subtitle_scale" = "Subtitle Scale: %.2fx";
+"osd.subtitle_scale" = "Subtitle Scale: %@x";
 "osd.add_to_playlist" = "Added %i Files to Playlist";
 "osd.clear_playlist" = "Cleared Playlist";
 "osd.video_eq.contrast" = "Contrast: %i";
@@ -87,9 +87,9 @@
 "preference.key_binding_hint_1" = "To edit key bindings in current configuration file, click \"Duplicate…\" button first to create a copy.";
 "preference.key_binding_hint_2" = "Double click a row at the right side to edit the corresponding key binding.";
 
-"menu.volume" = "Volume: %d";
-"menu.audio_delay" = "Audio Delay: %.2fs";
-"menu.sub_delay" = "Subtitle Delay: %.2fs";
+"menu.volume" = "Volume: %@";
+"menu.audio_delay" = "Audio Delay: %@s";
+"menu.sub_delay" = "Subtitle Delay: %@s";
 "menu.fullscreen" = "Enter Full Screen";
 "menu.exit_fullscreen" = "Exit Full Screen";
 "menu.pip" = "Enter Picture-in-Picture";
@@ -98,16 +98,16 @@
 "menu.resume" = "Resume";
 "menu.speed" = "Speed: %.2fx";
 
-"menu.seek_forward" = "Step Forward %.0fs";
-"menu.seek_backward" = "Step Backward %.0fs";
+"menu.seek_forward" = "Step Forward %@s";
+"menu.seek_backward" = "Step Backward %@s";
 "menu.speed_up" = "Speed Up by %.1fx";
 "menu.speed_down" = "Speed Down by %.1fx";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Volume - %.0f%%";
-"menu.audio_delay_up" = "Audio Delay + %.1fs";
-"menu.audio_delay_down" = "Audio Delay - %.1fs";
-"menu.sub_delay_up" = "Subtitle Delay + %.1fs";
-"menu.sub_delay_down" = "Subtitle Delay - %.1fs";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Volume - %@%%";
+"menu.audio_delay_up" = "Audio Delay + %@s";
+"menu.audio_delay_down" = "Audio Delay - %@s";
+"menu.sub_delay_up" = "Subtitle Delay + %@s";
+"menu.sub_delay_down" = "Subtitle Delay - %@s";
 
 "track.none" = "<None>";
 

--- a/iina/sr-Latn.lproj/Localizable.strings
+++ b/iina/sr-Latn.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pauziraj";
 "osd.resume" = "Nastavi";
-"osd.volume" = "Jačina zvuka: %i";
+"osd.volume" = "Jačina zvuka: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Odnos širina/visina: %@";
 "osd.crop" = "Iseci: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Rasplitanje: %@";
 "osd.hwdec" = "Hardversko dekodiranje: %@";
 "osd.audio_delay.nodelay" = "Kašnjenje zvuka: bez kašnjenja";
-"osd.audio_delay.later" = "Kašnjenje zvuka: %.2fs kasnije";
-"osd.audio_delay.earlier" = "Kašnjenje zvuka: %.2fs ranije";
+"osd.audio_delay.later" = "Kašnjenje zvuka: %@s kasnije";
+"osd.audio_delay.earlier" = "Kašnjenje zvuka: %@s ranije";
 "osd.sub_delay.nodelay" = "Kašnjenje titla: bez kašnjenja";
-"osd.sub_delay.later" = "Kašnjenje titla: %.2fs kasnije";
-"osd.sub_delay.earlier" = "Kašnjenje titla: %.2fs ranije";
-"osd.subtitle_pos" = "Položaj titla: %.1f";
+"osd.sub_delay.later" = "Kašnjenje titla: %@s kasnije";
+"osd.sub_delay.earlier" = "Kašnjenje titla: %@s ranije";
+"osd.subtitle_pos" = "Položaj titla: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Isključi zvuk";
 "osd.unmute" = "Ponovo uključi zvuk";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "A-B petlja: očišćena";
 "osd.stop" = "Zaustavi";
 "osd.chapter" = "Poglavlje: %@";
-"osd.subtitle_scale" = "Razmera titla: %.2fx";
+"osd.subtitle_scale" = "Razmera titla: %@x";
 "osd.add_to_playlist" = "Datoteka dodato u plejlistu: %i";
 "osd.clear_playlist" = "Očišćena plejlista";
 "osd.video_eq.contrast" = "Kontrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Jačina zvuka: %d";
-"menu.volume_muted" = "Jačina zvuka: %d (isključen zvuk)";
-"menu.audio_delay" = "Kašnjenje zvuka: %.2fs";
-"menu.sub_delay" = "Kašnjenje titla: %.2fs";
+"menu.volume" = "Jačina zvuka: %@";
+"menu.volume_muted" = "Jačina zvuka: %@ (isključen zvuk)";
+"menu.audio_delay" = "Kašnjenje zvuka: %@s";
+"menu.sub_delay" = "Kašnjenje titla: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Prikaži tablu Titlovi";
 "menu.hide_subtitles" = "Sakrij tablu Titlovi";
 
-"menu.seek_forward" = "Korak unapred: %.0fs";
-"menu.seek_backward" = "Korak unazad: %.0fs";
+"menu.seek_forward" = "Korak unapred: %@s";
+"menu.seek_backward" = "Korak unazad: %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Jačina zvuka + %.0f%%";
-"menu.volume_down" = "Jačina zvuka - %.0f%%";
-"menu.audio_delay_up" = "Kašnjenje zvuka + %.1fs";
-"menu.audio_delay_down" = "Kašnjenje zvuka - %.1fs";
-"menu.sub_delay_up" = "Kašnjenje titla + %.1fs";
-"menu.sub_delay_down" = "Kašnjenje titla - %.1fs";
+"menu.volume_up" = "Jačina zvuka + %@%%";
+"menu.volume_down" = "Jačina zvuka - %@%%";
+"menu.audio_delay_up" = "Kašnjenje zvuka + %@s";
+"menu.audio_delay_down" = "Kašnjenje zvuka - %@s";
+"menu.sub_delay_up" = "Kašnjenje titla + %@s";
+"menu.sub_delay_down" = "Kašnjenje titla - %@s";
 
 "menu.crop_custom" = "Prilagođeno…";
 "menu.find_online_sub" = "Pronađi titlove na mreži s lokacije %@";

--- a/iina/sr.lproj/Localizable.strings
+++ b/iina/sr.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pause";
 "osd.resume" = "Resume";
-"osd.volume" = "Volume: %i";
+"osd.volume" = "Volume: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Aspect Ratio: %@";
 "osd.crop" = "Crop: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deinterlace: %@";
 "osd.hwdec" = "Hardware Decoding: %@";
 "osd.audio_delay.nodelay" = "Audio Delay: No Delay";
-"osd.audio_delay.later" = "Audio Delay: %.2fs Later";
-"osd.audio_delay.earlier" = "Audio Delay: %.2fs Earlier";
+"osd.audio_delay.later" = "Audio Delay: %@s Later";
+"osd.audio_delay.earlier" = "Audio Delay: %@s Earlier";
 "osd.sub_delay.nodelay" = "Subtitle Delay: No Delay";
-"osd.sub_delay.later" = "Subtitle Delay: %.2fs Later";
-"osd.sub_delay.earlier" = "Subtitle Delay: %.2fs Earlier";
-"osd.subtitle_pos" = "Subtitle Position: %.1f";
+"osd.sub_delay.later" = "Subtitle Delay: %@s Later";
+"osd.sub_delay.earlier" = "Subtitle Delay: %@s Earlier";
+"osd.subtitle_pos" = "Subtitle Position: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-Loop: Cleared";
 "osd.stop" = "Stop";
 "osd.chapter" = "Chapter: %@";
-"osd.subtitle_scale" = "Subtitle Scale: %.2fx";
+"osd.subtitle_scale" = "Subtitle Scale: %@x";
 "osd.add_to_playlist" = "Added %i Files to Playlist";
 "osd.clear_playlist" = "Cleared Playlist";
 "osd.video_eq.contrast" = "Contrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volume: %d";
-"menu.volume_muted" = "Volume: %d (Muted)";
-"menu.audio_delay" = "Audio Delay: %.2fs";
-"menu.sub_delay" = "Subtitle Delay: %.2fs";
+"menu.volume" = "Volume: %@";
+"menu.volume_muted" = "Volume: %@ (Muted)";
+"menu.audio_delay" = "Audio Delay: %@s";
+"menu.sub_delay" = "Subtitle Delay: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Show Subtitles Panel";
 "menu.hide_subtitles" = "Hide Subtitles Panel";
 
-"menu.seek_forward" = "Step Forward %.0fs";
-"menu.seek_backward" = "Step Backward %.0fs";
+"menu.seek_forward" = "Step Forward %@s";
+"menu.seek_backward" = "Step Backward %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Volume - %.0f%%";
-"menu.audio_delay_up" = "Audio Delay + %.1fs";
-"menu.audio_delay_down" = "Audio Delay - %.1fs";
-"menu.sub_delay_up" = "Subtitle Delay + %.1fs";
-"menu.sub_delay_down" = "Subtitle Delay - %.1fs";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Volume - %@%%";
+"menu.audio_delay_up" = "Audio Delay + %@s";
+"menu.audio_delay_down" = "Audio Delay - %@s";
+"menu.sub_delay_up" = "Subtitle Delay + %@s";
+"menu.sub_delay_down" = "Subtitle Delay - %@s";
 
 "menu.crop_custom" = "Custom…";
 "menu.find_online_sub" = "Find Online Subtitles from %@";

--- a/iina/sv.lproj/Localizable.strings
+++ b/iina/sv.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pausa";
 "osd.resume" = "Fortsätt";
-"osd.volume" = "Volym: %i";
+"osd.volume" = "Volym: %@";
 "osd.speed" = "Hastighet: %@x";
 "osd.aspect" = "Förhållande: %@";
 "osd.crop" = "Beskär: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Avfläta: %@";
 "osd.hwdec" = "Hårdvaruavkodning: %@";
 "osd.audio_delay.nodelay" = "Ljudfördröjning: ingen fördröjning";
-"osd.audio_delay.later" = "Ljudfördröjning: %.2fs senare";
-"osd.audio_delay.earlier" = "Ljudfördröjning: %.2fs tidigare";
+"osd.audio_delay.later" = "Ljudfördröjning: %@s senare";
+"osd.audio_delay.earlier" = "Ljudfördröjning: %@s tidigare";
 "osd.sub_delay.nodelay" = "Undertextsfördröjning: Ingen fördröjning";
-"osd.sub_delay.later" = "Undertextsfördröjning: %.2fs senare";
-"osd.sub_delay.earlier" = "Undertextsfördröjning: %.2fs tidigare";
-"osd.subtitle_pos" = "Undertextposition: %.1f";
+"osd.sub_delay.later" = "Undertextsfördröjning: %@s senare";
+"osd.sub_delay.earlier" = "Undertextsfördröjning: %@s tidigare";
+"osd.subtitle_pos" = "Undertextposition: %@";
 "osd.sub_hidden" = "Undertexter dolda";
 "osd.sub_visible" = "Undertexter synliga";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Tysta";
 "osd.unmute" = "Tysta av";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "A–B-loop: rensad";
 "osd.stop" = "Stoppa";
 "osd.chapter" = "Kapitel: %@";
-"osd.subtitle_scale" = "Undertextskala: %.2fx";
+"osd.subtitle_scale" = "Undertextskala: %@x";
 "osd.add_to_playlist" = "La till %i filer till spellistan";
 "osd.clear_playlist" = "Spellista rensad";
 "osd.video_eq.contrast" = "Kontrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Installera Online Media-tillägget från \"Tillägg > Installera från GitHub\" för att få tillgång till avancerade funktioner som videonedladdning och automatiska yt-dlp-uppdateringar.";
 "preference.ytdl_plugin_installed" = "Det inbyggda youtube-dl-stödet är inaktiverat då du har installerat Online Media-tillägget.";
 
-"menu.volume" = "Volym: %d";
-"menu.volume_muted" = "Volym: %d (Tystat)";
-"menu.audio_delay" = "Ljudfördröjning: %.2fs";
-"menu.sub_delay" = "Undertextsfördröjning: %.2fs";
+"menu.volume" = "Volym: %@";
+"menu.volume_muted" = "Volym: %@ (Tystat)";
+"menu.audio_delay" = "Ljudfördröjning: %@s";
+"menu.sub_delay" = "Undertextsfördröjning: %@s";
 "menu.sub_hide" = "Dölj undertexter";
 "menu.sub_show" = "Visa undertexter";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Visa undertextspanelen";
 "menu.hide_subtitles" = "Dölj undertextspanelen";
 
-"menu.seek_forward" = "Gå framåt %.0f s";
-"menu.seek_backward" = "Gå bakåt %.0f s";
+"menu.seek_forward" = "Gå framåt %@ s";
+"menu.seek_backward" = "Gå bakåt %@ s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volym +%.0f%%";
-"menu.volume_down" = "Volym -%.0f%%";
-"menu.audio_delay_up" = "Ljudfördröjning +%.1fs";
-"menu.audio_delay_down" = "Ljudfördröjning -%.1fs";
-"menu.sub_delay_up" = "Undertextsfördröjning +%.1fs";
-"menu.sub_delay_down" = "Undertextsfördröjning -%.1fs";
+"menu.volume_up" = "Volym +%@%%";
+"menu.volume_down" = "Volym -%@%%";
+"menu.audio_delay_up" = "Ljudfördröjning +%@s";
+"menu.audio_delay_down" = "Ljudfördröjning -%@s";
+"menu.sub_delay_up" = "Undertextsfördröjning +%@s";
+"menu.sub_delay_down" = "Undertextsfördröjning -%@s";
 
 "menu.crop_custom" = "Anpassad…";
 "menu.find_online_sub" = "Hitta undertexter online från %@";

--- a/iina/ta.lproj/Localizable.strings
+++ b/iina/ta.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "இடைநிறுத்து";
 "osd.resume" = "Resume";
-"osd.volume" = "ஒலியளவு: %i";
+"osd.volume" = "ஒலியளவு: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Aspect Ratio: %@";
 "osd.crop" = "Crop: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deinterlace: %@";
 "osd.hwdec" = "Hardware Decoding: %@";
 "osd.audio_delay.nodelay" = "Audio Delay: No Delay";
-"osd.audio_delay.later" = "Audio Delay: %.2fs Later";
-"osd.audio_delay.earlier" = "Audio Delay: %.2fs Earlier";
+"osd.audio_delay.later" = "Audio Delay: %@s Later";
+"osd.audio_delay.earlier" = "Audio Delay: %@s Earlier";
 "osd.sub_delay.nodelay" = "Subtitle Delay: No Delay";
-"osd.sub_delay.later" = "Subtitle Delay: %.2fs Later";
-"osd.sub_delay.earlier" = "Subtitle Delay: %.2fs Earlier";
-"osd.subtitle_pos" = "Subtitle Position: %.1f";
+"osd.sub_delay.later" = "Subtitle Delay: %@s Later";
+"osd.sub_delay.earlier" = "Subtitle Delay: %@s Earlier";
+"osd.subtitle_pos" = "Subtitle Position: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-Loop: Cleared";
 "osd.stop" = "Stop";
 "osd.chapter" = "Chapter: %@";
-"osd.subtitle_scale" = "Subtitle Scale: %.2fx";
+"osd.subtitle_scale" = "Subtitle Scale: %@x";
 "osd.add_to_playlist" = "Added %i Files to Playlist";
 "osd.clear_playlist" = "Cleared Playlist";
 "osd.video_eq.contrast" = "Contrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "ஒலியளவு: %d";
-"menu.volume_muted" = "Volume: %d (Muted)";
-"menu.audio_delay" = "Audio Delay: %.2fs";
-"menu.sub_delay" = "Subtitle Delay: %.2fs";
+"menu.volume" = "ஒலியளவு: %@";
+"menu.volume_muted" = "Volume: %@ (Muted)";
+"menu.audio_delay" = "Audio Delay: %@s";
+"menu.sub_delay" = "Subtitle Delay: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Show Subtitles Panel";
 "menu.hide_subtitles" = "Hide Subtitles Panel";
 
-"menu.seek_forward" = "Step Forward %.0fs";
-"menu.seek_backward" = "Step Backward %.0fs";
+"menu.seek_forward" = "Step Forward %@s";
+"menu.seek_backward" = "Step Backward %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Volume - %.0f%%";
-"menu.audio_delay_up" = "Audio Delay + %.1fs";
-"menu.audio_delay_down" = "Audio Delay - %.1fs";
-"menu.sub_delay_up" = "Subtitle Delay + %.1fs";
-"menu.sub_delay_down" = "Subtitle Delay - %.1fs";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Volume - %@%%";
+"menu.audio_delay_up" = "Audio Delay + %@s";
+"menu.audio_delay_down" = "Audio Delay - %@s";
+"menu.sub_delay_up" = "Subtitle Delay + %@s";
+"menu.sub_delay_down" = "Subtitle Delay - %@s";
 
 "menu.crop_custom" = "தனிப்பயன்…";
 "menu.find_online_sub" = "Find Online Subtitles from %@";

--- a/iina/th.lproj/Localizable.strings
+++ b/iina/th.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pause";
 "osd.resume" = "Resume";
-"osd.volume" = "Volume: %i";
+"osd.volume" = "Volume: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Aspect Ratio: %@";
 "osd.crop" = "Crop: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deinterlace: %@";
 "osd.hwdec" = "Hardware Decoding: %@";
 "osd.audio_delay.nodelay" = "Audio Delay: No Delay";
-"osd.audio_delay.later" = "Audio Delay: %.2fs Later";
-"osd.audio_delay.earlier" = "Audio Delay: %.2fs Earlier";
+"osd.audio_delay.later" = "Audio Delay: %@s Later";
+"osd.audio_delay.earlier" = "Audio Delay: %@s Earlier";
 "osd.sub_delay.nodelay" = "Subtitle Delay: No Delay";
-"osd.sub_delay.later" = "Subtitle Delay: %.2fs Later";
-"osd.sub_delay.earlier" = "Subtitle Delay: %.2fs Earlier";
-"osd.subtitle_pos" = "Subtitle Position: %.1f";
+"osd.sub_delay.later" = "Subtitle Delay: %@s Later";
+"osd.sub_delay.earlier" = "Subtitle Delay: %@s Earlier";
+"osd.subtitle_pos" = "Subtitle Position: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-Loop: Cleared";
 "osd.stop" = "Stop";
 "osd.chapter" = "Chapter: %@";
-"osd.subtitle_scale" = "Subtitle Scale: %.2fx";
+"osd.subtitle_scale" = "Subtitle Scale: %@x";
 "osd.add_to_playlist" = "Added %i Files to Playlist";
 "osd.clear_playlist" = "Cleared Playlist";
 "osd.video_eq.contrast" = "Contrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volume: %d";
-"menu.volume_muted" = "Volume: %d (Muted)";
-"menu.audio_delay" = "Audio Delay: %.2fs";
-"menu.sub_delay" = "Subtitle Delay: %.2fs";
+"menu.volume" = "Volume: %@";
+"menu.volume_muted" = "Volume: %@ (Muted)";
+"menu.audio_delay" = "Audio Delay: %@s";
+"menu.sub_delay" = "Subtitle Delay: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Show Subtitles Panel";
 "menu.hide_subtitles" = "Hide Subtitles Panel";
 
-"menu.seek_forward" = "Step Forward %.0fs";
-"menu.seek_backward" = "Step Backward %.0fs";
+"menu.seek_forward" = "Step Forward %@s";
+"menu.seek_backward" = "Step Backward %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Volume - %.0f%%";
-"menu.audio_delay_up" = "Audio Delay + %.1fs";
-"menu.audio_delay_down" = "Audio Delay - %.1fs";
-"menu.sub_delay_up" = "Subtitle Delay + %.1fs";
-"menu.sub_delay_down" = "Subtitle Delay - %.1fs";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Volume - %@%%";
+"menu.audio_delay_up" = "Audio Delay + %@s";
+"menu.audio_delay_down" = "Audio Delay - %@s";
+"menu.sub_delay_up" = "Subtitle Delay + %@s";
+"menu.sub_delay_down" = "Subtitle Delay - %@s";
 
 "menu.crop_custom" = "Custom…";
 "menu.find_online_sub" = "Find Online Subtitles from %@";

--- a/iina/tr.lproj/Localizable.strings
+++ b/iina/tr.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Duraklat";
 "osd.resume" = "Sürdür";
-"osd.volume" = "Ses Yüksekliği: %i";
+"osd.volume" = "Ses Yüksekliği: %@";
 "osd.speed" = "Hız: %@×";
 "osd.aspect" = "En–boy oranı: %@";
 "osd.crop" = "Kırp: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Taramasızlık: %@";
 "osd.hwdec" = "Donanımsal kod çözücü: %@";
 "osd.audio_delay.nodelay" = "Ses gecikmesi: Gecikme yok";
-"osd.audio_delay.later" = "Ses gecikmesi: %.2f sn geç";
-"osd.audio_delay.earlier" = "Ses gecikmesi: %.2f sn erken";
+"osd.audio_delay.later" = "Ses gecikmesi: %@ sn geç";
+"osd.audio_delay.earlier" = "Ses gecikmesi: %@ sn erken";
 "osd.sub_delay.nodelay" = "Altyazı gecikmesi: Gecikme yok";
-"osd.sub_delay.later" = "Altyazı gecikmesi: %.2f sn geç";
-"osd.sub_delay.earlier" = "Altyazı gecikmesi: %.2f sn erken";
-"osd.subtitle_pos" = "Altyazı konumu: %.1f";
+"osd.sub_delay.later" = "Altyazı gecikmesi: %@ sn geç";
+"osd.sub_delay.earlier" = "Altyazı gecikmesi: %@ sn erken";
+"osd.subtitle_pos" = "Altyazı konumu: %@";
 "osd.sub_hidden" = "Altyazılar Gizli";
 "osd.sub_visible" = "Altyazılar Görünür";
 "osd.sub_second_delay.nodelay" = "İkincil altyazı gecikmesi: Gecikme yok";
-"osd.sub_second_delay.later" = "İkincil altyazı gecikmesi: %.2f sn geç";
-"osd.sub_second_delay.earlier" = "İkincil altyazı gecikmesi: %.2f sn erken";
+"osd.sub_second_delay.later" = "İkincil altyazı gecikmesi: %@ sn geç";
+"osd.sub_second_delay.earlier" = "İkincil altyazı gecikmesi: %@ sn erken";
 "osd.sub_second_hidden" = "İkincil Altyazılar Gizli";
-"osd.sub_second_pos" = "İkincil altyazı konumu: %.1f";
+"osd.sub_second_pos" = "İkincil altyazı konumu: %@";
 "osd.sub_second_visible" = "İkincil Altyazılar Görünür";
 "osd.mute" = "Sesi Kapat";
 "osd.unmute" = "Sesi Aç";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "A–B döngüsü: Temizlendi";
 "osd.stop" = "Durdur";
 "osd.chapter" = "Fasıl: %@";
-"osd.subtitle_scale" = "Altyazı ölçeği: %.2f×";
+"osd.subtitle_scale" = "Altyazı ölçeği: %@×";
 "osd.add_to_playlist" = "%i Dosya Oynatma Listesine Eklendi";
 "osd.clear_playlist" = "Oynatma Listesi Temizlendi";
 "osd.video_eq.contrast" = "Karşıtlık: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "“Eklentiler” → “GitHub’dan Yükle” yolunu izleyerek Online Media eklentisini kurun ve video indirme ve kendiliğinden yt-dlp güncellemelerini indirme gibi gelişmiş özelliklerin keyfini çıkarın.";
 "preference.ytdl_plugin_installed" = "Online Media eklentisi yüklü olduğundan yerleşik youtube-dl desteği devre dışı bırakıldı.";
 
-"menu.volume" = "Ses düzeyi: %d";
-"menu.volume_muted" = "Ses düzeyi: %d (sessiz)";
-"menu.audio_delay" = "Ses gecikmesi: %.2f sn";
-"menu.sub_delay" = "Altyazı gecikmesi: %.2f sn";
+"menu.volume" = "Ses düzeyi: %@";
+"menu.volume_muted" = "Ses düzeyi: %@ (sessiz)";
+"menu.audio_delay" = "Ses gecikmesi: %@ sn";
+"menu.sub_delay" = "Altyazı gecikmesi: %@ sn";
 "menu.sub_hide" = "Altyazıları Gizle";
 "menu.sub_show" = "Altyazıları Göster";
 "menu.sub_second_hide" = "İkincil Altyazıları Gizle";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Altyazı Panelini Göster";
 "menu.hide_subtitles" = "Altyazı Panelini Gizle";
 
-"menu.seek_forward" = "%.0f sn İleri Sar";
-"menu.seek_backward" = "%.0f sn Geri Sar";
+"menu.seek_forward" = "%@ sn İleri Sar";
+"menu.seek_backward" = "%@ sn Geri Sar";
 "menu.speed_up" = "%@× Hızlandır";
 "menu.speed_down" = "%@× Yavaşlat";
-"menu.volume_up" = "Ses Düzeyi +%%%.0f";
-"menu.volume_down" = "Ses Seviyesi −%%%.0f";
-"menu.audio_delay_up" = "Ses Gecikmesi +%.1f sn";
-"menu.audio_delay_down" = "Ses Gecikmesi −%.1f sn";
-"menu.sub_delay_up" = "Altyazı Gecikmesi +%.1f sn";
-"menu.sub_delay_down" = "Altyazı Gecikmesi −%.1f sn";
+"menu.volume_up" = "Ses Düzeyi +%%%@";
+"menu.volume_down" = "Ses Seviyesi −%%%@";
+"menu.audio_delay_up" = "Ses Gecikmesi +%@ sn";
+"menu.audio_delay_down" = "Ses Gecikmesi −%@ sn";
+"menu.sub_delay_up" = "Altyazı Gecikmesi +%@ sn";
+"menu.sub_delay_down" = "Altyazı Gecikmesi −%@ sn";
 
 "menu.crop_custom" = "Özel...";
 "menu.find_online_sub" = "%@ Konumundan Çevrimiçi Altyazı Bul";

--- a/iina/ug.lproj/Localizable.strings
+++ b/iina/ug.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pause";
 "osd.resume" = "Resume";
-"osd.volume" = "Volume: %i";
+"osd.volume" = "Volume: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Aspect Ratio: %@";
 "osd.crop" = "Crop: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deinterlace: %@";
 "osd.hwdec" = "Hardware Decoding: %@";
 "osd.audio_delay.nodelay" = "Audio Delay: No Delay";
-"osd.audio_delay.later" = "Audio Delay: %.2fs Later";
-"osd.audio_delay.earlier" = "Audio Delay: %.2fs Earlier";
+"osd.audio_delay.later" = "Audio Delay: %@s Later";
+"osd.audio_delay.earlier" = "Audio Delay: %@s Earlier";
 "osd.sub_delay.nodelay" = "Subtitle Delay: No Delay";
-"osd.sub_delay.later" = "Subtitle Delay: %.2fs Later";
-"osd.sub_delay.earlier" = "Subtitle Delay: %.2fs Earlier";
-"osd.subtitle_pos" = "Subtitle Position: %.1f";
+"osd.sub_delay.later" = "Subtitle Delay: %@s Later";
+"osd.sub_delay.earlier" = "Subtitle Delay: %@s Earlier";
+"osd.subtitle_pos" = "Subtitle Position: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-Loop: Cleared";
 "osd.stop" = "Stop";
 "osd.chapter" = "Chapter: %@";
-"osd.subtitle_scale" = "Subtitle Scale: %.2fx";
+"osd.subtitle_scale" = "Subtitle Scale: %@x";
 "osd.add_to_playlist" = "Added %i Files to Playlist";
 "osd.clear_playlist" = "Cleared Playlist";
 "osd.video_eq.contrast" = "Contrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volume: %d";
-"menu.volume_muted" = "Volume: %d (Muted)";
-"menu.audio_delay" = "Audio Delay: %.2fs";
-"menu.sub_delay" = "Subtitle Delay: %.2fs";
+"menu.volume" = "Volume: %@";
+"menu.volume_muted" = "Volume: %@ (Muted)";
+"menu.audio_delay" = "Audio Delay: %@s";
+"menu.sub_delay" = "Subtitle Delay: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Show Subtitles Panel";
 "menu.hide_subtitles" = "Hide Subtitles Panel";
 
-"menu.seek_forward" = "Step Forward %.0fs";
-"menu.seek_backward" = "Step Backward %.0fs";
+"menu.seek_forward" = "Step Forward %@s";
+"menu.seek_backward" = "Step Backward %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Volume - %.0f%%";
-"menu.audio_delay_up" = "Audio Delay + %.1fs";
-"menu.audio_delay_down" = "Audio Delay - %.1fs";
-"menu.sub_delay_up" = "Subtitle Delay + %.1fs";
-"menu.sub_delay_down" = "Subtitle Delay - %.1fs";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Volume - %@%%";
+"menu.audio_delay_up" = "Audio Delay + %@s";
+"menu.audio_delay_down" = "Audio Delay - %@s";
+"menu.sub_delay_up" = "Subtitle Delay + %@s";
+"menu.sub_delay_down" = "Subtitle Delay - %@s";
 
 "menu.crop_custom" = "Custom…";
 "menu.find_online_sub" = "Find Online Subtitles from %@";

--- a/iina/uk.lproj/Localizable.strings
+++ b/iina/uk.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Пауза";
 "osd.resume" = "Відновити";
-"osd.volume" = "Гучність: %i";
+"osd.volume" = "Гучність: %@";
 "osd.speed" = "Швидкість: %@x";
 "osd.aspect" = "Пропорції: %@";
 "osd.crop" = "Обрізання: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Черезрядкова розгортка: %@";
 "osd.hwdec" = "Апаратне декодування: %@";
 "osd.audio_delay.nodelay" = "Затримка звуку: без затримки";
-"osd.audio_delay.later" = "Затримка звуку: +%.2f с";
-"osd.audio_delay.earlier" = "Затримка звуку: –%.2f с";
+"osd.audio_delay.later" = "Затримка звуку: +%@ с";
+"osd.audio_delay.earlier" = "Затримка звуку: –%@ с";
 "osd.sub_delay.nodelay" = "Затримка субтитрів: без затримки";
-"osd.sub_delay.later" = "Затримка субтитрів: +%.2f с";
-"osd.sub_delay.earlier" = "Затримка субтитрів: –%.2f с";
-"osd.subtitle_pos" = "Позиція субтитрів: %.1f";
+"osd.sub_delay.later" = "Затримка субтитрів: +%@ с";
+"osd.sub_delay.earlier" = "Затримка субтитрів: –%@ с";
+"osd.subtitle_pos" = "Позиція субтитрів: %@";
 "osd.sub_hidden" = "Субтитри приховано";
 "osd.sub_visible" = "Видимість субтитрів";
 "osd.sub_second_delay.nodelay" = "Затримка додаткових субтитрів: Без затримки";
-"osd.sub_second_delay.later" = "Затримка додаткових субтитрів: %.2fс пізніше";
-"osd.sub_second_delay.earlier" = "Затримка додаткових субтитрів: %.2fс раніше";
+"osd.sub_second_delay.later" = "Затримка додаткових субтитрів: %@с пізніше";
+"osd.sub_second_delay.earlier" = "Затримка додаткових субтитрів: %@с раніше";
 "osd.sub_second_hidden" = "Додаткові субтитри приховані";
-"osd.sub_second_pos" = "Позиціювання додаткових субтитрів: %.1f";
+"osd.sub_second_pos" = "Позиціювання додаткових субтитрів: %@";
 "osd.sub_second_visible" = "Додаткові субтитри видимі";
 "osd.mute" = "Заглушити";
 "osd.unmute" = "Зі звуком";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "Цикл A—B: очищено";
 "osd.stop" = "Зупинити";
 "osd.chapter" = "Розділ: %@";
-"osd.subtitle_scale" = "Розмір субтитрів: %.2fx";
+"osd.subtitle_scale" = "Розмір субтитрів: %@x";
 "osd.add_to_playlist" = "Додано %i файлів до плейлиста";
 "osd.clear_playlist" = "Плейлист очищено";
 "osd.video_eq.contrast" = "Контрастність: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Установіть плагін для онлайн-медіа в розділі «Плагіни > Установлення з GitHub» та отримайте функції завантаження відео та автоматичного оновлення yt-dlp.";
 "preference.ytdl_plugin_installed" = "Вбудована підтримка youtube-dl вимкнена, оскільки ви маєте встановленим плагін для онлайн-медіа.";
 
-"menu.volume" = "Гучність: %d";
-"menu.volume_muted" = "Гучність: %d (Без звуку)";
-"menu.audio_delay" = "Затримка звуку: %.2f с";
-"menu.sub_delay" = "Затримка субтитрів: %.2f с";
+"menu.volume" = "Гучність: %@";
+"menu.volume_muted" = "Гучність: %@ (Без звуку)";
+"menu.audio_delay" = "Затримка звуку: %@ с";
+"menu.sub_delay" = "Затримка субтитрів: %@ с";
 "menu.sub_hide" = "Приховати субтитри";
 "menu.sub_show" = "Показати субтитри";
 "menu.sub_second_hide" = "Приховати додаткові субтитри";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Показати панель субтитрів";
 "menu.hide_subtitles" = "Приховати панель субтитрів";
 
-"menu.seek_forward" = "Крок уперед на %.0f с";
-"menu.seek_backward" = "Крок назад на %.0f с";
+"menu.seek_forward" = "Крок уперед на %@ с";
+"menu.seek_backward" = "Крок назад на %@ с";
 "menu.speed_up" = "Прискорити до %@x";
 "menu.speed_down" = "Сповільнити до %@x";
-"menu.volume_up" = "Гучність +%.0f% %";
-"menu.volume_down" = "Гучність –%.0f% %";
-"menu.audio_delay_up" = "Затримка звуку на +%.1f с";
-"menu.audio_delay_down" = "Затримка звуку на –%.1f с";
-"menu.sub_delay_up" = "Затримка субтитрів на +%.1f с";
-"menu.sub_delay_down" = "Затримка субтитрів на –%.1f с";
+"menu.volume_up" = "Гучність +%@% %";
+"menu.volume_down" = "Гучність –%@% %";
+"menu.audio_delay_up" = "Затримка звуку на +%@ с";
+"menu.audio_delay_down" = "Затримка звуку на –%@ с";
+"menu.sub_delay_up" = "Затримка субтитрів на +%@ с";
+"menu.sub_delay_down" = "Затримка субтитрів на –%@ с";
 
 "menu.crop_custom" = "Інше…";
 "menu.find_online_sub" = "Знайти онлайн субтитри з %@";

--- a/iina/ur.lproj/Localizable.strings
+++ b/iina/ur.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Pause";
 "osd.resume" = "Resume";
-"osd.volume" = "Volume: %i";
+"osd.volume" = "Volume: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Aspect Ratio: %@";
 "osd.crop" = "Crop: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Deinterlace: %@";
 "osd.hwdec" = "Hardware Decoding: %@";
 "osd.audio_delay.nodelay" = "Audio Delay: No Delay";
-"osd.audio_delay.later" = "Audio Delay: %.2fs Later";
-"osd.audio_delay.earlier" = "Audio Delay: %.2fs Earlier";
+"osd.audio_delay.later" = "Audio Delay: %@s Later";
+"osd.audio_delay.earlier" = "Audio Delay: %@s Earlier";
 "osd.sub_delay.nodelay" = "Subtitle Delay: No Delay";
-"osd.sub_delay.later" = "Subtitle Delay: %.2fs Later";
-"osd.sub_delay.earlier" = "Subtitle Delay: %.2fs Earlier";
-"osd.subtitle_pos" = "Subtitle Position: %.1f";
+"osd.sub_delay.later" = "Subtitle Delay: %@s Later";
+"osd.sub_delay.earlier" = "Subtitle Delay: %@s Earlier";
+"osd.subtitle_pos" = "Subtitle Position: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Mute";
 "osd.unmute" = "Unmute";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB-Loop: Cleared";
 "osd.stop" = "Stop";
 "osd.chapter" = "Chapter: %@";
-"osd.subtitle_scale" = "Subtitle Scale: %.2fx";
+"osd.subtitle_scale" = "Subtitle Scale: %@x";
 "osd.add_to_playlist" = "Added %i Files to Playlist";
 "osd.clear_playlist" = "Cleared Playlist";
 "osd.video_eq.contrast" = "Contrast: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Volume: %d";
-"menu.volume_muted" = "Volume: %d (Muted)";
-"menu.audio_delay" = "Audio Delay: %.2fs";
-"menu.sub_delay" = "Subtitle Delay: %.2fs";
+"menu.volume" = "Volume: %@";
+"menu.volume_muted" = "Volume: %@ (Muted)";
+"menu.audio_delay" = "Audio Delay: %@s";
+"menu.sub_delay" = "Subtitle Delay: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Show Subtitles Panel";
 "menu.hide_subtitles" = "Hide Subtitles Panel";
 
-"menu.seek_forward" = "Step Forward %.0fs";
-"menu.seek_backward" = "Step Backward %.0fs";
+"menu.seek_forward" = "Step Forward %@s";
+"menu.seek_backward" = "Step Backward %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Volume - %.0f%%";
-"menu.audio_delay_up" = "Audio Delay + %.1fs";
-"menu.audio_delay_down" = "Audio Delay - %.1fs";
-"menu.sub_delay_up" = "Subtitle Delay + %.1fs";
-"menu.sub_delay_down" = "Subtitle Delay - %.1fs";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Volume - %@%%";
+"menu.audio_delay_up" = "Audio Delay + %@s";
+"menu.audio_delay_down" = "Audio Delay - %@s";
+"menu.sub_delay_up" = "Subtitle Delay + %@s";
+"menu.sub_delay_down" = "Subtitle Delay - %@s";
 
 "menu.crop_custom" = "Custom…";
 "menu.find_online_sub" = "Find Online Subtitles from %@";

--- a/iina/vi.lproj/Localizable.strings
+++ b/iina/vi.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "Tạm dừng";
 "osd.resume" = "Tiếp tục";
-"osd.volume" = "Âm lượng: %i";
+"osd.volume" = "Âm lượng: %@";
 "osd.speed" = "Speed: %@x";
 "osd.aspect" = "Tỉ lệ khung hình: %@";
 "osd.crop" = "Cắt: %@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "Khử nhoè: %@";
 "osd.hwdec" = "Bộ giải mã phần cứng: %@";
 "osd.audio_delay.nodelay" = "Độ trễ âm thanh: Không trễ";
-"osd.audio_delay.later" = "Độ trễ âm thanh: %.2fs trễ";
-"osd.audio_delay.earlier" = "Độ trễ âm thanh: %.2fs nhanh";
+"osd.audio_delay.later" = "Độ trễ âm thanh: %@s trễ";
+"osd.audio_delay.earlier" = "Độ trễ âm thanh: %@s nhanh";
 "osd.sub_delay.nodelay" = "Độ trễ phụ đề: Không trễ";
-"osd.sub_delay.later" = "Độ trễ phụ đề: %.2fs trễ hơn";
-"osd.sub_delay.earlier" = "Độ trễ phụ đề: %.2fs sớm hơn";
-"osd.subtitle_pos" = "Vị trí phụ đề: %.1f";
+"osd.sub_delay.later" = "Độ trễ phụ đề: %@s trễ hơn";
+"osd.sub_delay.earlier" = "Độ trễ phụ đề: %@s sớm hơn";
+"osd.subtitle_pos" = "Vị trí phụ đề: %@";
 "osd.sub_hidden" = "Subtitles Hidden";
 "osd.sub_visible" = "Subtitles Visible";
 "osd.sub_second_delay.nodelay" = "Secondary Subtitle Delay: No Delay";
-"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %.2fs Later";
-"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %.2fs Earlier";
+"osd.sub_second_delay.later" = "Secondary Subtitle Delay: %@s Later";
+"osd.sub_second_delay.earlier" = "Secondary Subtitle Delay: %@s Earlier";
 "osd.sub_second_hidden" = "Secondary Subtitles Hidden";
-"osd.sub_second_pos" = "Secondary Subtitle Position: %.1f";
+"osd.sub_second_pos" = "Secondary Subtitle Position: %@";
 "osd.sub_second_visible" = "Secondary Subtitles Visible";
 "osd.mute" = "Tắt tiếng";
 "osd.unmute" = "Bật tiếng";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "Vòng lặp AB: Đã xóa";
 "osd.stop" = "Dừng";
 "osd.chapter" = "Chương: %@";
-"osd.subtitle_scale" = "Tỷ lệ phụ đề: %.2fx";
+"osd.subtitle_scale" = "Tỷ lệ phụ đề: %@x";
 "osd.add_to_playlist" = "Đã thêm %i tệp vào danh sách phát";
 "osd.clear_playlist" = "Đã xóa danh sách phát";
 "osd.video_eq.contrast" = "Tương phản: %i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
 "preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
 
-"menu.volume" = "Âm lượng: %d";
-"menu.volume_muted" = "Âm lượng: %d (Đã tắt tiếng)";
-"menu.audio_delay" = "Độ trễ âm thanh: %.2fs";
-"menu.sub_delay" = "Độ trễ phụ đề: %.2fs";
+"menu.volume" = "Âm lượng: %@";
+"menu.volume_muted" = "Âm lượng: %@ (Đã tắt tiếng)";
+"menu.audio_delay" = "Độ trễ âm thanh: %@s";
+"menu.sub_delay" = "Độ trễ phụ đề: %@s";
 "menu.sub_hide" = "Hide Subtitles";
 "menu.sub_show" = "Show Subtitles";
 "menu.sub_second_hide" = "Hide Secondary Subtitles";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "Show Subtitles Panel";
 "menu.hide_subtitles" = "Hide Subtitles Panel";
 
-"menu.seek_forward" = "Step Forward %.0fs";
-"menu.seek_backward" = "Step Backward %.0fs";
+"menu.seek_forward" = "Step Forward %@s";
+"menu.seek_backward" = "Step Backward %@s";
 "menu.speed_up" = "Speed Up by %@x";
 "menu.speed_down" = "Speed Down by %@x";
-"menu.volume_up" = "Volume + %.0f%%";
-"menu.volume_down" = "Âm lượng - %.0f%%";
-"menu.audio_delay_up" = "Audio Delay + %.1fs";
-"menu.audio_delay_down" = "Audio Delay - %.1fs";
-"menu.sub_delay_up" = "Subtitle Delay + %.1fs";
-"menu.sub_delay_down" = "Subtitle Delay - %.1fs";
+"menu.volume_up" = "Volume + %@%%";
+"menu.volume_down" = "Âm lượng - %@%%";
+"menu.audio_delay_up" = "Audio Delay + %@s";
+"menu.audio_delay_down" = "Audio Delay - %@s";
+"menu.sub_delay_up" = "Subtitle Delay + %@s";
+"menu.sub_delay_down" = "Subtitle Delay - %@s";
 
 "menu.crop_custom" = "Tuỳ chỉnh…";
 "menu.find_online_sub" = "Find Online Subtitles from %@";

--- a/iina/zh-Hans.lproj/Localizable.strings
+++ b/iina/zh-Hans.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "暂停";
 "osd.resume" = "继续";
-"osd.volume" = "音量：%i";
+"osd.volume" = "音量：%@";
 "osd.speed" = "速度：%@x";
 "osd.aspect" = "长宽比：%@";
 "osd.crop" = "裁切：%@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "反交错：%@";
 "osd.hwdec" = "正在硬件解码: %@";
 "osd.audio_delay.nodelay" = "音频延迟：无延迟";
-"osd.audio_delay.later" = "音频延迟：延迟 %.2f 秒";
-"osd.audio_delay.earlier" = "音频延迟：提前 %.2f 秒";
+"osd.audio_delay.later" = "音频延迟：延迟 %@ 秒";
+"osd.audio_delay.earlier" = "音频延迟：提前 %@ 秒";
 "osd.sub_delay.nodelay" = "字幕延迟：无延迟";
-"osd.sub_delay.later" = "字幕延迟：延迟 %.2f 秒";
-"osd.sub_delay.earlier" = "字幕延迟：提前 %.2f 秒";
-"osd.subtitle_pos" = "字幕位置：%.1f";
+"osd.sub_delay.later" = "字幕延迟：延迟 %@ 秒";
+"osd.sub_delay.earlier" = "字幕延迟：提前 %@ 秒";
+"osd.subtitle_pos" = "字幕位置：%@";
 "osd.sub_hidden" = "字幕已隐藏";
 "osd.sub_visible" = "字幕可见";
 "osd.sub_second_delay.nodelay" = "二级字幕延迟：无延迟";
-"osd.sub_second_delay.later" = "二级字幕延迟：延迟 %.2f 秒";
-"osd.sub_second_delay.earlier" = "二级字幕延迟：提前 %.2f 秒";
+"osd.sub_second_delay.later" = "二级字幕延迟：延迟 %@ 秒";
+"osd.sub_second_delay.earlier" = "二级字幕延迟：提前 %@ 秒";
 "osd.sub_second_hidden" = "隐藏二级字幕";
-"osd.sub_second_pos" = "二级字幕位置：%.1f";
+"osd.sub_second_pos" = "二级字幕位置：%@";
 "osd.sub_second_visible" = "开启二级字幕";
 "osd.mute" = "静音";
 "osd.unmute" = "取消静音";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB循环：清除";
 "osd.stop" = "停止";
 "osd.chapter" = "章节：%@";
-"osd.subtitle_scale" = "字幕缩放：%.2fx";
+"osd.subtitle_scale" = "字幕缩放：%@x";
 "osd.add_to_playlist" = "已添加 %i 个文件至播放列表";
 "osd.clear_playlist" = "清除播放列表";
 "osd.video_eq.contrast" = "对比度：%i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "从 \"Plugins > 安装 GitHub\" 中安装在线媒体插件以享受高级功能，例如视频下载和自动yt-dlp 更新。";
 "preference.ytdl_plugin_installed" = "由于安装了在线媒体插件，内置的 youtube-dl 支持已被禁用。";
 
-"menu.volume" = "音量: %d";
-"menu.volume_muted" = "音量：%d （静音）";
-"menu.audio_delay" = "音频延迟: %.2f秒";
-"menu.sub_delay" = "字幕延迟: %.2f秒";
+"menu.volume" = "音量: %@";
+"menu.volume_muted" = "音量：%@ （静音）";
+"menu.audio_delay" = "音频延迟: %@秒";
+"menu.sub_delay" = "字幕延迟: %@秒";
 "menu.sub_hide" = "隐藏字幕";
 "menu.sub_show" = "显示字幕";
 "menu.sub_second_hide" = "隐藏二级字幕";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "显示字幕面板";
 "menu.hide_subtitles" = "隐藏字幕面板";
 
-"menu.seek_forward" = "渐进 %.0f秒";
-"menu.seek_backward" = "渐退 %.0f秒";
+"menu.seek_forward" = "渐进 %@秒";
+"menu.seek_backward" = "渐退 %@秒";
 "menu.speed_up" = "加快播放速度快捷键";
 "menu.speed_down" = "降低播放速度快捷键";
-"menu.volume_up" = "音量 + %.0f%%";
-"menu.volume_down" = "音量 - %.0f%%";
-"menu.audio_delay_up" = "音频延迟 + %.1f秒";
-"menu.audio_delay_down" = "音频延迟 - %.1f秒";
-"menu.sub_delay_up" = "字幕延迟 + %.1f秒";
-"menu.sub_delay_down" = "字幕延迟 - %.1f秒";
+"menu.volume_up" = "音量 + %@%%";
+"menu.volume_down" = "音量 - %@%%";
+"menu.audio_delay_up" = "音频延迟 + %@秒";
+"menu.audio_delay_down" = "音频延迟 - %@秒";
+"menu.sub_delay_up" = "字幕延迟 + %@秒";
+"menu.sub_delay_down" = "字幕延迟 - %@秒";
 
 "menu.crop_custom" = "自定义…";
 "menu.find_online_sub" = "从 %@ 查找在线字幕";

--- a/iina/zh-Hant.lproj/Localizable.strings
+++ b/iina/zh-Hant.lproj/Localizable.strings
@@ -84,7 +84,7 @@
 // OSDMessage.swift
 "osd.pause" = "暫停";
 "osd.resume" = "繼續";
-"osd.volume" = "音量：%i";
+"osd.volume" = "音量：%@";
 "osd.speed" = "速度：%@x";
 "osd.aspect" = "顯示比例：%@";
 "osd.crop" = "裁切：%@";
@@ -92,19 +92,19 @@
 "osd.deinterlace" = "去交錯：%@";
 "osd.hwdec" = "硬體解碼: %@";
 "osd.audio_delay.nodelay" = "音訊延遲：無";
-"osd.audio_delay.later" = "音訊延遲：延遲 %.2f 秒";
-"osd.audio_delay.earlier" = "音訊延遲：提前 %.2f 秒";
+"osd.audio_delay.later" = "音訊延遲：延遲 %@ 秒";
+"osd.audio_delay.earlier" = "音訊延遲：提前 %@ 秒";
 "osd.sub_delay.nodelay" = "字幕延遲：無";
-"osd.sub_delay.later" = "字幕延遲：延遲 %.2f 秒";
-"osd.sub_delay.earlier" = "字幕延遲：提前 %.2f 秒";
-"osd.subtitle_pos" = "字幕位置：%.1f";
+"osd.sub_delay.later" = "字幕延遲：延遲 %@ 秒";
+"osd.sub_delay.earlier" = "字幕延遲：提前 %@ 秒";
+"osd.subtitle_pos" = "字幕位置：%@";
 "osd.sub_hidden" = "已隱藏字幕";
 "osd.sub_visible" = "已顯示字幕";
 "osd.sub_second_delay.nodelay" = "小字幕延遲：無";
-"osd.sub_second_delay.later" = "小字幕間隔：延遲 %.2f 秒";
-"osd.sub_second_delay.earlier" = "小字幕間隔：提前 %.2f 秒";
+"osd.sub_second_delay.later" = "小字幕間隔：延遲 %@ 秒";
+"osd.sub_second_delay.earlier" = "小字幕間隔：提前 %@ 秒";
 "osd.sub_second_hidden" = "已隱藏小字幕";
-"osd.sub_second_pos" = "小字幕位置：%.1f";
+"osd.sub_second_pos" = "小字幕位置：%@";
 "osd.sub_second_visible" = "已顯示小字幕";
 "osd.mute" = "靜音";
 "osd.unmute" = "取消靜音";
@@ -114,7 +114,7 @@
 "osd.abloop.clear" = "AB循環：清除";
 "osd.stop" = "停止";
 "osd.chapter" = "章節：%@";
-"osd.subtitle_scale" = "字幕縮放：%.2f 倍";
+"osd.subtitle_scale" = "字幕縮放：%@ 倍";
 "osd.add_to_playlist" = "已新增%i個檔案至播放列表";
 "osd.clear_playlist" = "播放列表已清除";
 "osd.video_eq.contrast" = "對比度：%i";
@@ -177,10 +177,10 @@
 "preference.ytdl_plugin_not_installed" = "從「設定」中切換至外掛程式分頁，點擊「Install from GitHub」安裝線上媒體插件；即可啟用影片下載及 yt-dlp 自動更新等進階功能。";
 "preference.ytdl_plugin_installed" = "由於已經安裝了「線上媒體外掛」，因此將內建的 youtube-dl 做禁用。";
 
-"menu.volume" = "音量：%d";
-"menu.volume_muted" = "音量：%d (靜音)";
-"menu.audio_delay" = "音訊延遲：%.2f 秒";
-"menu.sub_delay" = "字幕延遲：%.2f 秒";
+"menu.volume" = "音量：%@";
+"menu.volume_muted" = "音量：%@ (靜音)";
+"menu.audio_delay" = "音訊延遲：%@ 秒";
+"menu.sub_delay" = "字幕延遲：%@ 秒";
 "menu.sub_hide" = "隱藏字幕";
 "menu.sub_show" = "顯示字幕";
 "menu.sub_second_hide" = "隱藏副字幕";
@@ -205,16 +205,16 @@
 "menu.subtitles" = "顯示字幕面板";
 "menu.hide_subtitles" = "隱藏字幕面板";
 
-"menu.seek_forward" = "快轉 %.0fs";
-"menu.seek_backward" = "倒轉 %.0fs";
+"menu.seek_forward" = "快轉 %@s";
+"menu.seek_backward" = "倒轉 %@s";
 "menu.speed_up" = "加速%@倍";
 "menu.speed_down" = "減速%@倍";
-"menu.volume_up" = "音量 + %.0f%%";
-"menu.volume_down" = "音量 - %.0f%%";
-"menu.audio_delay_up" = "音訊延遲 + %.1f 秒";
-"menu.audio_delay_down" = "音訊延遲 - %.1f 秒";
-"menu.sub_delay_up" = "字幕延遲 + %.1f 秒";
-"menu.sub_delay_down" = "字幕延遲 - %.1f 秒";
+"menu.volume_up" = "音量 + %@%%";
+"menu.volume_down" = "音量 - %@%%";
+"menu.audio_delay_up" = "音訊延遲 + %@ 秒";
+"menu.audio_delay_down" = "音訊延遲 - %@ 秒";
+"menu.sub_delay_up" = "字幕延遲 + %@ 秒";
+"menu.sub_delay_down" = "字幕延遲 - %@ 秒";
 
 "menu.crop_custom" = "自定⋯";
 "menu.find_online_sub" = "從 %@ 尋找線上字幕";


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

<img width="220" alt="Decimal-formatting" src="https://github.com/user-attachments/assets/6b75d685-7ef6-46c2-8fa5-9f2d7c20804b">

**Description:**

Adding to the fix for #5147, here is the "remaining" work that I could find in relation to decimal-to-string number formatting issues.
- Replace decimal formatting specifiers with '%@' in i18n strings & use Double.string property extension in most places to ensure proper localized decimal & grouping separator punctuation.
- This commit extends to audio & subtitles (& seek menu items) what was already changed for speed-related items.
- Removal of rounding/truncation allows for more precise number display.

In many of these cases I needed to replace `Integer` values with `Double`s to support additional precision. It was unclear to me whether some things (e.g., volume display in the menu) were truncated/rounded to whole numbers for aesthetic or other reasons. It seems to me that they should support fractional digits of numbers wherever mpv is able to store them as such.