### PR TITLE
UTIs when setting app defaults

### DIFF
--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -504,6 +504,11 @@ extension String {
     return "\"\(self)\""
   }
 
+  func deletingPrefix(_ prefix: String) -> String {
+    guard self.hasPrefix(prefix) else { return self }
+    return String(self.dropFirst(prefix.count))
+  }
+
   mutating func deleteLast(_ num: Int) {
     removeLast(Swift.min(num, count))
   }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**

As noted in #5199, IINA's Set as Default feature currently associates itself with Typescript files. As a developer, this is rather embarrassing.

It does this because the `ts` file extension is used both for "transport stream" & "typescript" types.

Background: MacOS associates each file with a single Uniform Type Identifier. Unfortunately there can be many UTIs for a given file format (e.g. some UTIs for a FLAC file include `io.iina.flac` and `io.mpv.flac`) because each app may register its own UTI for it and may choose to associate it with the file when it is created. In addition, each UTI may be associated with multiple filename extensions (e.g. `flac`), but each filename extension can also have multiple associated UTIs.

To change the defaults, IINA currently starts with its list of "import UTIs" (e.g., `io.iina.mpeg-stream`, finds all the associated extensions (`m2p`, `ps`, `ts`, `m2ts`, `mts`, `mt2s`) then finds all the UTIs associated with each extension. But that last step yields some unwanted UTIs.

I analyzed the current search for UTIs, and found that modifying the last step in the search to be a subtype of `audiovisual-content` gets us nearly there. But 2 of IINA's 34 "import" UTIs do not: `io.iina.cue` & `io.iina.playlist`. I could not find a better way to search for them other than to manually include them. (I tried conformance to `playlist`, but that added many unrelated types).

In my testing, this results in 115 associations instead of 118. The following become omitted:
- `com.microsoft.typescript`
- `com.adobe.postscript`
- `com.real.ram`

See attached test results below.

[Defaults-Before-snippit.log](https://github.com/user-attachments/files/17541553/Defaults-Before.log)
[Defaults-After-snippit.log](https://github.com/user-attachments/files/17541555/Defaults-After.log)


Also note: this fix currently only works for MacOS 11+ because it's not clear how to fix the legacy code path. Maybe just explicitly removing `com.microsoft.typescript` from the search results would be good enough.