### PR TITLE
Finer grained audio delay slider (fixes issue #5010)

### DIFF
--- a/iina/QuickSettingViewController.swift
+++ b/iina/QuickSettingViewController.swift
@@ -799,15 +799,20 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
 
   @IBAction func audioDelayChangedAction(_ sender: NSSlider) {
     let eventType = NSApp.currentEvent!.type
-    if eventType == .leftMouseDown {
-      sender.allowsTickMarkValuesOnly = true
+    let sliderValue: Double
+    switch eventType {
+    case .leftMouseDown, .leftMouseDragged, .leftMouseUp:
+      // When dragging slider with the mouse, snap to the nearest 50ms (1/20 sec)
+      // Although it is possible to show tick marks at every step of 0.05 in the slider, it is visually unpleasant.
+      // So we draw less tick marks, and keep "Only stop on tick marks" disabled, and add our own logic to stop on
+      // "virtual tick marks" for these values.
+      sliderValue = (sender.doubleValue * 20.0).rounded() / 20.0
+      sender.doubleValue = sliderValue
+    default:
+      sliderValue = sender.doubleValue
     }
-    if eventType == .leftMouseUp {
-      sender.allowsTickMarkValuesOnly = false
-    }
-    let sliderValue = sender.doubleValue
     customAudioDelayTextField.doubleValue = sliderValue
-    redraw(indicator: audioDelaySliderIndicator, constraint: audioDelaySliderConstraint, slider: audioDelaySlider, value: "\(customAudioDelayTextField.stringValue)s")
+    redraw(indicator: audioDelaySliderIndicator, constraint: audioDelaySliderConstraint, slider: audioDelaySlider, value: "\(sliderValue)s")
     if let event = NSApp.currentEvent {
       if event.type == .leftMouseUp {
         player.setAudioDelay(sliderValue)


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5010.

---

**Description:**
- Changes the audio delay slider so it uses increments of 50ms instead of 500ms.
- ~~The slider's is still required to land on tick marks as it moves, so it was necessary to increase the number of tick marks per second by 10x. This turns the slider into a millipede. I changed its control size from "small" to "mini" to reduce the prominence of the taller marks, and I think it looks a little better.~~
- ~~Reduces the slider's range (was: `-5` ↔︎ `+5`) to: `-3` ↔︎ `+3`. The slider's relatively small size made it difficult to move very precisely otherwise. But I think it should be a reasonable tradeoff because it should be very uncommon for an audio track to be farther out of sync than that.~~