### PR TITLE
Fix does not update progress bar with .mkv videos, #5254

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -2251,14 +2251,14 @@ class PlayerCore: NSObject {
       }
     }
 
-    guard useTimer else { return }
-
-    // Timer will start
-
     if !wasTimerRunning {
       // Do not wait for first redraw
       syncUITime()
     }
+
+    guard useTimer else { return }
+
+    // Timer will start
 
     syncUITimer = Timer.scheduledTimer(
       timeInterval: timeInterval,

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -2251,8 +2251,10 @@ class PlayerCore: NSObject {
       }
     }
 
+    // When fadeable views are hidden the time can get out of sync. This method will be called when
+    // the view becomes visible to sync the time. If the timer was not running the view must be
+    // updated now. Playback may be paused. If that is the case then the timer will not be started.
     if !wasTimerRunning {
-      // Do not wait for first redraw
       syncUITime()
     }
 


### PR DESCRIPTION
This commit will change `PlayerCore.refreshSyncUITimer` to call `syncUITime` if the timer was not running even if the timer is not being restarted. This is needed to update the playback time when showing the OSD or OSC when playback is paused.

This regression also reintroduced issue #3331, "Progress bar does not reach end when i finish playing a video".

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5254.

---

**Description:**
