### PR TITLE
Use default values to reduce logging of mpv options

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -157,6 +157,7 @@
 		49542982216C34950058F680 /* ToolbarItemIcon.pdf in Resources */ = {isa = PBXBuildFile; fileRef = 49542981216C34950058F680 /* ToolbarItemIcon.pdf */; };
 		49542986216C34950058F680 /* OpenInIINA.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 49542973216C34950058F680 /* OpenInIINA.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		496B19921E2968530035AF10 /* PIP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 496B19911E2968530035AF10 /* PIP.framework */; };
+		51096C0B2CD88BEC00702C31 /* MPVOptionDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51096C0A2CD88BEC00702C31 /* MPVOptionDefaults.swift */; };
 		5111B18B2C8BCEAC00DEC0AC /* TouchBarSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5111B18A2C8BCEAC00DEC0AC /* TouchBarSettings.swift */; };
 		512B8FDD2BC2376E00AF41BF /* OutlineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512B8FDC2BC2376E00AF41BF /* OutlineView.swift */; };
 		513A4FFA29B53F8100A8EA7D /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513A4FF929B53F8100A8EA7D /* Atomic.swift */; };
@@ -1182,6 +1183,7 @@
 		4964988E2919E47900CD61A5 /* OpenInIINA.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = OpenInIINA.xcconfig; sourceTree = "<group>"; };
 		496B19911E2968530035AF10 /* PIP.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = PIP.framework; path = /System/Library/PrivateFrameworks/PIP.framework; sourceTree = "<group>"; };
 		49F7E3BF2920D65C002DA28E /* Availability.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Availability.xcconfig; sourceTree = "<group>"; };
+		51096C0A2CD88BEC00702C31 /* MPVOptionDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MPVOptionDefaults.swift; sourceTree = "<group>"; };
 		5111B18A2C8BCEAC00DEC0AC /* TouchBarSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchBarSettings.swift; sourceTree = "<group>"; };
 		512B8FDC2BC2376E00AF41BF /* OutlineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutlineView.swift; sourceTree = "<group>"; };
 		513A4FF929B53F8100A8EA7D /* Atomic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
@@ -2568,6 +2570,7 @@
 		84D377681D7413D8007F7396 /* Accessories */ = {
 			isa = PBXGroup;
 			children = (
+				51096C0A2CD88BEC00702C31 /* MPVOptionDefaults.swift */,
 				E3DBD23C218EF4F100B3AFBF /* AboutWindowContributorAvatarItem.swift */,
 				E3DBD23D218EF4F100B3AFBF /* AboutWindowContributorAvatarItem.xib */,
 				9E47DABF1E3CFA6D00457420 /* DurationDisplayTextField.swift */,
@@ -3207,6 +3210,7 @@
 				51CACB9529D500290034CEE5 /* VideoPIPViewController.swift in Sources */,
 				512B8FDD2BC2376E00AF41BF /* OutlineView.swift in Sources */,
 				8460FBA91D6497490081841B /* PlaylistViewController.swift in Sources */,
+				51096C0B2CD88BEC00702C31 /* MPVOptionDefaults.swift in Sources */,
 				D17504A82918F13E005C3DD0 /* OSCToolbarButton.swift in Sources */,
 				8450404A1E0B13230079C194 /* CropBoxView.swift in Sources */,
 				84F7258F1D486185000DEF1B /* MPVProperty.swift in Sources */,

--- a/iina/AboutWindowController.swift
+++ b/iina/AboutWindowController.swift
@@ -65,7 +65,7 @@ class AboutWindowController: NSWindowController {
     let (version, build) = InfoDictionary.shared.version
     versionLabel.stringValue = "\(version) Build \(build)"
 
-    mpvVersionLabel.stringValue = PlayerCore.active.mpv.mpvVersion
+    mpvVersionLabel.stringValue = MPVOptionDefaults.shared.mpvVersion
     ffmpegVersionLabel.stringValue = "FFmpeg \(String(cString: av_version_info()))"
 
     // Use a localized date for the build date.

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -194,12 +194,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 
     // Useful to know the versions of significant dependencies that are being used so log that
     // information as well when it can be obtained.
-
-    // The version of mpv is not logged at this point because mpv does not provide a static
-    // method that returns the version. To obtain version related information you must
-    // construct a mpv object, which has side effects. So the mpv version is logged in
-    // applicationDidFinishLaunching to preserve the existing order of initialization.
-
+    Logger.log(MPVOptionDefaults.shared.mpvVersion)
     Logger.log("FFmpeg \(String(cString: av_version_info()))")
     // FFmpeg libraries and their versions in alphabetical order.
     let libraries: [(name: String, version: UInt32)] = [("libavcodec", avcodec_version()), ("libavformat", avformat_version()), ("libavutil", avutil_version()), ("libswscale", swscale_version())]
@@ -208,6 +203,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
       // format which needs to be decoded into a string for display.
       Logger.log("  \(library.name) \(AppDelegate.versionAsString(library.version))")
     }
+    Logger.log("libass \(MPVOptionDefaults.shared.libassVersion)")
+
     logBuildDetails()
     logPlatformDetails()
 
@@ -312,7 +309,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     JavascriptPlugin.loadGlobalInstances()
 
     let mpv = PlayerCore.active.mpv!
-    Logger.log("Using \(mpv.mpvVersion) and libass \(mpv.libassVersion)")
     Logger.log("Configuration when building mpv: \(mpv.getString(MPVProperty.mpvConfiguration)!)", level: .verbose)
 
     if RemoteCommandController.useSystemMediaControl {

--- a/iina/JavascriptAPICore.swift
+++ b/iina/JavascriptAPICore.swift
@@ -132,7 +132,7 @@ class JavascriptAPICore: JavascriptAPI, JavascriptAPICoreExportable {
     return [
       "iina": iinaVersion,
       "build": build,
-      "mpv": player!.mpv.mpvVersion
+      "mpv": MPVOptionDefaults.shared.mpvVersion
     ]
   }
 }

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -80,24 +80,11 @@ class MPVController: NSObject {
     static let screenshot: UInt64 = 1000000
   }
 
-  /// Version number of the libass library.
-  ///
-  /// The mpv libass version property returns an integer encoded as a hex binary-coded decimal.
-  var libassVersion: String {
-    let version = getInt(MPVProperty.libassVersion)
-    let major = String(version >> 28 & 0xF, radix: 16)
-    let minor = String(version >> 20 & 0xFF, radix: 16)
-    let patch = String(version >> 12 & 0xFF, radix: 16)
-    return "\(major).\(minor).\(patch)"
-  }
-
   // The mpv_handle
   var mpv: OpaquePointer!
   var mpvRenderContext: OpaquePointer?
 
   private var openGLContext: CGLContextObj! = nil
-
-  var mpvVersion: String { getString(MPVProperty.mpvVersion)! }
 
   /// [DispatchQueue](https://developer.apple.com/documentation/dispatch/dispatchqueue) for reading `mpv`
   /// events.
@@ -347,19 +334,20 @@ class MPVController: NSObject {
                   level: .verbose, transformer: setScreenshotPath)
 
     setUserOption(PK.screenshotFormat, type: .other, forName: MPVOption.Screenshot.screenshotFormat,
-                  level: .verbose) { key in
+                  verboseIfDefault: true) { key in
       let v = Preference.integer(for: key)
       let format = Preference.ScreenshotFormat(rawValue: v)
       // Workaround for mpv issue  #15107, HDR screenshots are unimplemented (gpu/gpu-next).
       // If the screenshot format is set to JPEG XL then set the screenshot-sw option to yes. This
       // causes the screenshot to be rendered by software instead of the VO. If a HDR video is being
       // displayed in HDR then the resulting screenshot will be HDR.
-      self.chkErr(self.setOptionFlag(MPVOption.Screenshot.screenshotSw, format == .jxl))
+      self.chkErr(self.setOptionFlag(MPVOption.Screenshot.screenshotSw, format == .jxl,
+                                     verboseIfDefault: true))
       return format?.string
     }
 
-    setUserOption(PK.screenshotTemplate, type: .string, forName: MPVOption.Screenshot.screenshotTemplate,
-                  level: .verbose)
+    setUserOption(PK.screenshotTemplate, type: .string,
+                  forName: MPVOption.Screenshot.screenshotTemplate)
 
     // Disable mpv's media key system as it now uses the MediaPlayer Framework.
     // Dropped media key support in 10.11 and 10.12.
@@ -381,19 +369,21 @@ class MPVController: NSObject {
 
     chkErr(setOptionString("watch-later-directory", Utility.watchLaterURL.path, level: .verbose))
     setUserOption(PK.resumeLastPosition, type: .bool, forName: MPVOption.WatchLater.savePositionOnQuit,
-                  level: .verbose)
-    setUserOption(PK.resumeLastPosition, type: .bool, forName: "resume-playback", level: .verbose)
+                  verboseIfDefault: true)
+    setUserOption(PK.resumeLastPosition, type: .bool, forName: "resume-playback", verboseIfDefault: true)
 
     setUserOption(.initialWindowSizePosition, type: .string, forName: MPVOption.Window.geometry,
                   level: .verbose)
 
     // - Codec
 
-    setUserOption(PK.videoThreads, type: .int, forName: MPVOption.Video.vdLavcThreads, level: .verbose)
-    setUserOption(PK.audioThreads, type: .int, forName: MPVOption.Audio.adLavcThreads, level: .verbose)
+    setUserOption(PK.videoThreads, type: .int, forName: MPVOption.Video.vdLavcThreads,
+                  verboseIfDefault: true)
+    setUserOption(PK.audioThreads, type: .int, forName: MPVOption.Audio.adLavcThreads,
+                  verboseIfDefault: true)
 
     setUserOption(PK.hardwareDecoder, type: .other, forName: MPVOption.Video.hwdec,
-                  level: .verbose) { key in
+                  verboseIfDefault: true) { key in
       let value = Preference.integer(for: key)
       return Preference.HardwareDecoderOption(rawValue: value)?.mpvString ?? "auto"
     }
@@ -406,106 +396,126 @@ class MPVController: NSObject {
     if Preference.bool(for: PK.spdifAC3) { spdif.append("ac3") }
     if Preference.bool(for: PK.spdifDTS){ spdif.append("dts") }
     if Preference.bool(for: PK.spdifDTSHD) { spdif.append("dts-hd") }
-    chkErr(setOptionString(MPVOption.Audio.audioSpdif, spdif.joined(separator: ","), level: .verbose))
+    chkErr(setOptionString(MPVOption.Audio.audioSpdif, spdif.joined(separator: ","),
+                           verboseIfDefault: true))
 
-    setUserOption(PK.audioDevice, type: .string, forName: MPVOption.Audio.audioDevice, level: .verbose)
+    setUserOption(PK.audioDevice, type: .string, forName: MPVOption.Audio.audioDevice,
+                  verboseIfDefault: true)
 
-    setUserOption(PK.replayGain, type: .other, forName: MPVOption.Audio.replaygain) { key in
+    setUserOption(PK.replayGain, type: .other, forName: MPVOption.Audio.replaygain,
+                  verboseIfDefault: true) { key in
       let value = Preference.integer(for: key)
       return Preference.ReplayGainOption(rawValue: value)?.mpvString ?? "no"
     }
-    setUserOption(PK.replayGainPreamp, type: .float, forName: MPVOption.Audio.replaygainPreamp)
-    setUserOption(PK.replayGainClip, type: .bool, forName: MPVOption.Audio.replaygainClip)
-    setUserOption(PK.replayGainFallback, type: .float, forName: MPVOption.Audio.replaygainFallback)
+    setUserOption(PK.replayGainPreamp, type: .float, forName: MPVOption.Audio.replaygainPreamp,
+                  verboseIfDefault: true)
+    setUserOption(PK.replayGainClip, type: .bool, forName: MPVOption.Audio.replaygainClip,
+                  verboseIfDefault: true)
+    setUserOption(PK.replayGainFallback, type: .float, forName: MPVOption.Audio.replaygainFallback,
+                  verboseIfDefault: true)
 
     // - Sub
 
     chkErr(setOptionString(MPVOption.Subtitles.subAuto, "no", level: .verbose))
     chkErr(setOptionalOptionString(MPVOption.Subtitles.subCodepage,
-                                   Preference.string(for: .defaultEncoding), level: .verbose))
+                                   Preference.string(for: .defaultEncoding), verboseIfDefault: true))
     player.info.subEncoding = Preference.string(for: .defaultEncoding)
 
     let subOverrideHandler: OptionObserverInfo.Transformer = { key in
       (Preference.enum(for: key) as Preference.SubOverrideLevel).string
     }
     setUserOption(PK.subOverrideLevel, type: .other, forName: MPVOption.Subtitles.subAssOverride,
-                  level: .verbose, transformer: subOverrideHandler)
+                  verboseIfDefault: true, transformer: subOverrideHandler)
     setUserOption(PK.secondarySubOverrideLevel, type: .other,
-                  forName: MPVOption.Subtitles.secondarySubAssOverride, level: .verbose,
+                  forName: MPVOption.Subtitles.secondarySubAssOverride, verboseIfDefault: true,
                   transformer: subOverrideHandler)
 
-    setUserOption(PK.subTextFont, type: .string, forName: MPVOption.Subtitles.subFont, level: .verbose)
-    setUserOption(PK.subTextSize, type: .float, forName: MPVOption.Subtitles.subFontSize, level: .verbose)
+    setUserOption(PK.subTextFont, type: .string, forName: MPVOption.Subtitles.subFont,
+                  verboseIfDefault: true)
+    setUserOption(PK.subTextSize, type: .float, forName: MPVOption.Subtitles.subFontSize,
+                  verboseIfDefault: true)
 
-    setUserOption(PK.subTextColorString, type: .color, forName: MPVOption.Subtitles.subColor, level: .verbose)
-    setUserOption(PK.subBgColorString, type: .color, forName: MPVOption.Subtitles.subBackColor, level: .verbose)
+    setUserOption(PK.subTextColorString, type: .color, forName: MPVOption.Subtitles.subColor,
+                  verboseIfDefault: true)
+    setUserOption(PK.subBgColorString, type: .color, forName: MPVOption.Subtitles.subBackColor,
+                  verboseIfDefault: true)
 
-    setUserOption(PK.subBold, type: .bool, forName: MPVOption.Subtitles.subBold, level: .verbose)
-    setUserOption(PK.subItalic, type: .bool, forName: MPVOption.Subtitles.subItalic, level: .verbose)
+    setUserOption(PK.subBold, type: .bool, forName: MPVOption.Subtitles.subBold,
+                  verboseIfDefault: true)
+    setUserOption(PK.subItalic, type: .bool, forName: MPVOption.Subtitles.subItalic,
+                  verboseIfDefault: true)
 
-    setUserOption(PK.subBlur, type: .float, forName: MPVOption.Subtitles.subBlur, level: .verbose)
-    setUserOption(PK.subSpacing, type: .float, forName: MPVOption.Subtitles.subSpacing, level: .verbose)
+    setUserOption(PK.subBlur, type: .float, forName: MPVOption.Subtitles.subBlur,
+                  verboseIfDefault: true)
+    setUserOption(PK.subSpacing, type: .float, forName: MPVOption.Subtitles.subSpacing,
+                  verboseIfDefault: true)
 
     setUserOption(PK.subBorderSize, type: .float, forName: MPVOption.Subtitles.subBorderSize,
-                  level: .verbose)
+                  verboseIfDefault: true)
     setUserOption(PK.subBorderColorString, type: .color, forName: MPVOption.Subtitles.subBorderColor,
-                  level: .verbose)
+                  verboseIfDefault: true)
 
     setUserOption(PK.subShadowSize, type: .float, forName: MPVOption.Subtitles.subShadowOffset,
-                  level: .verbose)
+                  verboseIfDefault: true)
     setUserOption(PK.subShadowColorString, type: .color, forName: MPVOption.Subtitles.subShadowColor,
-                  level: .verbose)
+                  verboseIfDefault: true)
 
     setUserOption(PK.subAlignX, type: .other, forName: MPVOption.Subtitles.subAlignX,
-                  level: .verbose) { key in
+                  verboseIfDefault: true) { key in
       let v = Preference.integer(for: key)
       return Preference.SubAlign(rawValue: v)?.stringForX
     }
 
     setUserOption(PK.subAlignY, type: .other, forName: MPVOption.Subtitles.subAlignY,
-                  level: .verbose) { key in
+                  verboseIfDefault: true) { key in
       let v = Preference.integer(for: key)
       return Preference.SubAlign(rawValue: v)?.stringForY
     }
 
-    setUserOption(PK.subMarginX, type: .int, forName: MPVOption.Subtitles.subMarginX, level: .verbose)
-    setUserOption(PK.subMarginY, type: .int, forName: MPVOption.Subtitles.subMarginY, level: .verbose)
+    setUserOption(PK.subMarginX, type: .int, forName: MPVOption.Subtitles.subMarginX,
+                  verboseIfDefault: true)
+    setUserOption(PK.subMarginY, type: .int, forName: MPVOption.Subtitles.subMarginY,
+                  verboseIfDefault: true)
 
-    setUserOption(PK.subPos, type: .float, forName: MPVOption.Subtitles.subPos, level: .verbose)
+    setUserOption(PK.subPos, type: .float, forName: MPVOption.Subtitles.subPos, verboseIfDefault: true)
 
     setUserOption(PK.subLang, type: .string, forName: MPVOption.TrackSelection.slang, level: .verbose)
 
-    setUserOption(PK.displayInLetterBox, type: .bool, forName: MPVOption.Subtitles.subUseMargins, level: .verbose)
-    setUserOption(PK.displayInLetterBox, type: .bool, forName: MPVOption.Subtitles.subAssForceMargins, level: .verbose)
+    setUserOption(PK.displayInLetterBox, type: .bool, forName: MPVOption.Subtitles.subUseMargins,
+                  verboseIfDefault: true)
+    setUserOption(PK.displayInLetterBox, type: .bool, forName: MPVOption.Subtitles.subAssForceMargins,
+                  verboseIfDefault: true)
 
-    setUserOption(PK.subScaleWithWindow, type: .bool, forName: MPVOption.Subtitles.subScaleByWindow, level: .verbose)
+    setUserOption(PK.subScaleWithWindow, type: .bool, forName: MPVOption.Subtitles.subScaleByWindow,
+                  verboseIfDefault: true)
 
     // - Network / cache settings
 
     setUserOption(PK.enableCache, type: .other, forName: MPVOption.Cache.cache,
-                  level: .verbose) { key in
+                  verboseIfDefault: true) { key in
       return Preference.bool(for: key) ? nil : "no"
     }
 
     setUserOption(PK.defaultCacheSize, type: .other, forName: MPVOption.Demuxer.demuxerMaxBytes,
-                  level: .verbose) { key in
+                  verboseIfDefault: true) { key in
       return "\(Preference.integer(for: key))KiB"
     }
-    setUserOption(PK.secPrefech, type: .int, forName: MPVOption.Cache.cacheSecs, level: .verbose)
+    setUserOption(PK.secPrefech, type: .int, forName: MPVOption.Cache.cacheSecs, verboseIfDefault: true)
 
     setUserOption(PK.userAgent, type: .other, forName: MPVOption.Network.userAgent,
-                  level: .verbose) { key in
+                  verboseIfDefault: true) { key in
       let ua = Preference.string(for: key)!
       return ua.isEmpty ? nil : ua
     }
 
     setUserOption(PK.transportRTSPThrough, type: .other, forName: MPVOption.Network.rtspTransport,
-                  level: .verbose) { key in
+                  verboseIfDefault: true) { key in
       let v: Preference.RTSPTransportation = Preference.enum(for: .transportRTSPThrough)
       return v.string
     }
 
-    setUserOption(PK.ytdlEnabled, type: .other, forName: MPVOption.ProgramBehavior.ytdl, level: .verbose) { key in
+    setUserOption(PK.ytdlEnabled, type: .other, forName: MPVOption.ProgramBehavior.ytdl,
+                  verboseIfDefault: true) { key in
       let v = Preference.bool(for: .ytdlEnabled)
       if JavascriptPlugin.hasYTDL {
         return "no"
@@ -513,12 +523,12 @@ class MPVController: NSObject {
       return v ? "yes" : "no"
     }
     setUserOption(PK.ytdlRawOptions, type: .string, forName: MPVOption.ProgramBehavior.ytdlRawOptions,
-                  level: .verbose)
+                  verboseIfDefault: true)
     chkErr(setOptionString(MPVOption.ProgramBehavior.resetOnNextFile,
             "\(MPVOption.PlaybackControl.abLoopA),\(MPVOption.PlaybackControl.abLoopB)", level: .verbose))
 
     setUserOption(PK.audioDriverEnableAVFoundation, type: .other, forName: MPVOption.Audio.ao,
-                  level: .verbose) { key in
+                  verboseIfDefault: true) { key in
       Preference.bool(for: key) ? "avfoundation" : "coreaudio"
     }
 
@@ -527,7 +537,7 @@ class MPVController: NSObject {
        Preference.bool(for: .useUserDefinedConfDir),
        var userConfDir = Preference.string(for: .userDefinedConfDir) {
       userConfDir = NSString(string: userConfDir).standardizingPath
-      setOptionString("config", "yes", level: .verbose)
+      setOptionString("config", "yes")
       let status = setOptionString(MPVOption.ProgramBehavior.configDir, userConfDir)
       if status < 0 {
         Utility.showAlert("extra_option.config_folder", arguments: [userConfDir], disableMenus: true)
@@ -546,7 +556,7 @@ class MPVController: NSObject {
                                   [op[0], op[1], status], disableMenus: true)
             }
           }
-          log("Set user configured mpv option values")
+          log("Set \(userOptions.count) user configured mpv option values")
         }
       } else {
         Utility.showAlert("extra_option.cannot_read", disableMenus: true)
@@ -1518,37 +1528,84 @@ class MPVController: NSObject {
 
   private var optionObservers: [String: [OptionObserverInfo]] = [:]
 
-  private func setOptionFlag(_ name: String, _ flag: Bool, level: Logger.Level = .debug) -> Int32 {
+  private func setOptionFlag(_ name: String, _ flag: Bool, level: Logger.Level = .debug,
+                             verboseIfDefault: Bool = false) -> Int32 {
     let value = flag ? yes_str : no_str
-    return setOptionString(name, value, level: level)
+    return setOptionString(name, value, level: level, verboseIfDefault: verboseIfDefault)
   }
 
-  private func setOptionFloat(_ name: String, _ value: Float, level: Logger.Level = .debug) -> Int32 {
-    log("Set option: \(name)=\(value)", level: level)
+  private func setOptionFloat(_ name: String, _ value: Float, level: Logger.Level = .debug,
+                              verboseIfDefault: Bool = false) -> Int32 {
+    let levelToUse: Logger.Level = {
+      guard verboseIfDefault, let defaultValue = MPVOptionDefaults.shared.getDouble(name),
+            abs(Double(value).distance(to: defaultValue)) <= Double.leastNonzeroMagnitude else {
+        return level
+      }
+      return .verbose
+    }()
+    log("Set option: \(name)=\(value)", level: levelToUse)
     var data = Double(value)
     return mpv_set_option(mpv, name, MPV_FORMAT_DOUBLE, &data)
   }
 
-  private func setOptionInt(_ name: String, _ value: Int, level: Logger.Level = .debug) -> Int32 {
-    log("Set option: \(name)=\(value)", level: level)
+  private func setOptionInt(_ name: String, _ value: Int, level: Logger.Level = .debug,
+                            verboseIfDefault: Bool = false) -> Int32 {
+    let levelToUse: Logger.Level = verboseIfDefault &&
+      MPVOptionDefaults.shared.getInt(name) == value ? .verbose  : level
+    log("Set option: \(name)=\(value)", level: levelToUse)
     var data = Int64(value)
     return mpv_set_option(mpv, name, MPV_FORMAT_INT64, &data)
   }
 
   @discardableResult
-  private func setOptionString(_ name: String, _ value: String, level: Logger.Level = .debug) -> Int32 {
-    log("Set option: \(name)=\(value)", level: level)
+  private func setOptionString(_ name: String, _ value: String, level: Logger.Level = .debug,
+                               verboseIfDefault: Bool = false) -> Int32 {
+    let levelToUse: Logger.Level = verboseIfDefault &&
+      MPVOptionDefaults.shared.getString(name) == value ? .verbose  : level
+    log("Set option: \(name)=\(value)", level: levelToUse)
     return mpv_set_option_string(mpv, name, value)
   }
 
-  private func setOptionalOptionString(_ name: String, _ value: String?,
-                                       level: Logger.Level = .debug) -> Int32 {
+  private func setOptionalOptionColor(_ name: String, _ value: String?,
+                                       level: Logger.Level = .debug,
+                                       verboseIfDefault: Bool = false) -> Int32 {
     guard let value = value else { return 0 }
-    return setOptionString(name, value, level: level)
+    let levelToUse: Logger.Level = {
+      // The default value for options of type color is currently returned by mpv in the alternative
+      // string format that specifies component values in hex. Must convert to the form that uses
+      // floating point to be able to compare the strings.
+      guard verboseIfDefault, let defaultValue = MPVOptionDefaults.shared.getString(name),
+            hexColorToFloat(defaultValue) == value else {
+        return level
+      }
+      return .verbose
+    }()
+    return setOptionString(name, value, level: levelToUse)
   }
 
+  private func setOptionalOptionString(_ name: String, _ value: String?, level: Logger.Level = .debug,
+                                       verboseIfDefault: Bool = false) -> Int32 {
+    guard let value = value else { return 0 }
+    return setOptionString(name, value, level: level, verboseIfDefault: verboseIfDefault)
+  }
+
+  /// Set the given mpv option to the value of the given IINA setting.
+  ///
+  /// To reduce the amount of logging that occurs when `MPVController` initializes a mpv core this method provides a
+  /// `verboseIfDefault` parameter. If this parameter is set to `true` then the value to set the mpv option to is compared to the
+  /// default value for the mpv option and if the values match then the value of the `level` parameter will be ignored and the
+  /// message will be logged using the `verbose` level.
+  /// - Parameters:
+  ///   - key: Key for the IINA setting.
+  ///   - type: Type of the value of the mpv option.
+  ///   - name: Name of the mpv option.
+  ///   - sync: Whether to add an observer for the IINA setting that updates the mpv option when the IINA setting changes.
+  ///   - level: Log level to use when logging the setting of the option.
+  ///   - verboseIfDefault: Whether to use log level `verbose` if the value matches the default for the mpv option.
+  ///   - transformer: Optional transformer that changes the IINA setting value to be usable as the mpv option value.
   private func setUserOption(_ key: Preference.Key, type: UserOptionType, forName name: String,
                              sync: Bool = true, level: Logger.Level = .debug,
+                             verboseIfDefault: Bool = false,
                              transformer: OptionObserverInfo.Transformer? = nil) {
     var code: Int32 = 0
 
@@ -1556,24 +1613,28 @@ class MPVController: NSObject {
 
     switch type {
     case .int:
-      code = setOptionInt(name, Preference.integer(for: key), level: level)
+      code = setOptionInt(name, Preference.integer(for: key), level: level,
+                          verboseIfDefault: verboseIfDefault)
 
     case .float:
-      code = setOptionFloat(name, Preference.float(for: key), level: level)
+      code = setOptionFloat(name, Preference.float(for: key), level: level,
+                            verboseIfDefault: verboseIfDefault)
 
     case .bool:
-      code = setOptionFlag(name, Preference.bool(for: key), level: level)
+      code = setOptionFlag(name, Preference.bool(for: key), level: level,
+                           verboseIfDefault: verboseIfDefault)
 
     case .string:
-      code = setOptionalOptionString(name, Preference.string(for: key), level: level)
+      code = setOptionalOptionString(name, Preference.string(for: key), level: level,
+                                     verboseIfDefault: verboseIfDefault)
 
     case .color:
       let value = Preference.string(for: key)
-      code = setOptionalOptionString(name, value, level: level)
+      code = setOptionalOptionColor(name, value, level: level, verboseIfDefault: verboseIfDefault)
       // Random error here (perhaps a Swift or mpv one), so set it twice
       // 「没有什么是 set 不了的；如果有，那就 set 两次」
       if code < 0 {
-        code = setOptionalOptionString(name, value, level: level)
+        code = setOptionalOptionColor(name, value, level: level, verboseIfDefault: verboseIfDefault)
       }
 
     case .other:
@@ -1582,7 +1643,7 @@ class MPVController: NSObject {
         return
       }
       if let value = tr(key) {
-        code = setOptionString(name, value, level: level)
+        code = setOptionString(name, value, level: level, verboseIfDefault: verboseIfDefault)
       } else {
         code = 0
       }
@@ -1684,6 +1745,35 @@ class MPVController: NSObject {
       Value of property \(property) in the property change event could not be converted from
       \(format) to the expected type
       """, level: .error)
+  }
+
+  /// Convert the given mpv color string containing color components specified in hex to floating point.
+  ///
+  /// Normally color is specified in the form r/g/b, where each color component is specified as number in the range 0.0 to 1.0. It's also
+  /// possible to specify the transparency by using r/g/b/a, where the alpha value 0 means fully transparent, and 1.0 means opaque.
+  /// If the alpha component is not given, the color is 100% opaque. Alternatively, the color can be specified as a RGB hex triplet in the
+  /// form #RRGGBB, where each 2-digit group expresses a color value in the range 0 (00) to 255 (FF). Alpha is given with #AARRGGBB.
+  /// This method converts from the hex based alternative form to the floating point form.
+  /// - Parameter color: Color with components specified in hex.
+  /// - Returns: Color with components specified in floating point.
+  private func hexColorToFloat(_ color: String) -> String {
+    guard color.starts(with: "#"), color.count == 7 || color.count == 9 else {
+      log("Invalid mpv hex color string: \(color)", level: .error)
+      return color
+    }
+    var components: [String] = []
+    for offset in stride(from: 1, to: color.count, by: 2) {
+      let range = color.index(color.startIndex, offsetBy: offset)...color.index(color.startIndex, offsetBy: offset + 1)
+      let value = Double(Int(color[range], radix: 16)!)
+      components.append(String(value / 255))
+    }
+    guard components.count == 4 else {
+      return components.joined(separator: "/")
+    }
+    // The alpha compoment comes first in the hex based form, last in the floating point form.
+    let alpha = components[0]
+    components.remove(at: 0)
+    return "\(components.joined(separator: "/"))/\(alpha)"
   }
 
   /// Searches the list of user configured `mpv` options and returns `true` if the given option is present.

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -1770,7 +1770,7 @@ class MPVController: NSObject {
     guard components.count == 4 else {
       return components.joined(separator: "/")
     }
-    // The alpha compoment comes first in the hex based form, last in the floating point form.
+    // The alpha component comes first in the hex based form, last in the floating point form.
     let alpha = components[0]
     components.remove(at: 0)
     return "\(components.joined(separator: "/"))/\(alpha)"

--- a/iina/MPVOptionDefaults.swift
+++ b/iina/MPVOptionDefaults.swift
@@ -15,7 +15,7 @@ import Foundation
 /// _Unfortunately_, this property is not available until a mpv instance has been initialized. IINA uses the default values when setting
 /// options in order to reduce the number of log messages emitted by only logging options that are not being set to the default value.
 /// The options are set in `MVPController.mpvInit`  before the mpv instance is initialized and the property containing the option
-/// defaults is available. To work around this mpv restriction this class uses its own mpv instance dedicated to providing thie defaults.
+/// defaults is available. To work around this mpv restriction this class uses its own mpv instance dedicated to providing the defaults.
 ///
 /// A similar issue exists for the mpv properties that provide the mpv and libass version numbers, which IINA would like log near the
 /// start of the log file. So this class also provides the version numbers.

--- a/iina/MPVOptionDefaults.swift
+++ b/iina/MPVOptionDefaults.swift
@@ -1,0 +1,143 @@
+//
+//  MPVDefaults.swift
+//  iina
+//
+//  Created by low-batt on 10/24/24.
+//  Copyright © 2024 lhc. All rights reserved.
+//
+
+import Foundation
+
+/// Default values for mpv options.
+///
+/// The default value for a mpv option can be obtained using the mpv property 
+/// [option-info/\<name>/default-value](https://mpv.io/manual/stable/#command-interface-option-info/%3Cname%3E/default-value).
+/// _Unfortunately_, this property is not available until a mpv instance has been initialized. IINA uses the default values when setting
+/// options in order to reduce the number of log messages emitted by only logging options that are not being set to the default value.
+/// The options are set in `MVPController.mpvInit`  before the mpv instance is initialized and the property containing the option
+/// defaults is available. To work around this mpv restriction this class uses its own mpv instance dedicated to providing thie defaults.
+///
+/// A similar issue exists for the mpv properties that provide the mpv and libass version numbers, which IINA would like log near the
+/// start of the log file. So this class also provides the version numbers.
+class MPVOptionDefaults {
+  /// The `MPVDefaults` singleton object.
+  static let shared = MPVOptionDefaults()
+
+  /// Version number of the libass library.
+  ///
+  /// The mpv libass version property returns an integer encoded as a hex binary-coded decimal.
+  var libassVersion: String {
+    guard mpv != nil, let version = getPropertyAsInt(MPVProperty.libassVersion) else {
+      return "Unable to obtain libass version number"
+    }
+    let major = String(version >> 28 & 0xF, radix: 16)
+    let minor = String(version >> 20 & 0xFF, radix: 16)
+    let patch = String(version >> 12 & 0xFF, radix: 16)
+    return "\(major).\(minor).\(patch)"
+  }
+
+  /// Version number of the mpv library.
+  var mpvVersion: String {
+    guard mpv != nil, let version = getPropertyAsString(MPVProperty.mpvVersion) else {
+      return "Unable to obtain mpv version number"
+    }
+    return version
+  }
+
+  private let mpv: OpaquePointer?
+
+  private init() {
+    mpv = mpv_create()
+    guard mpv != nil else {
+      MPVOptionDefaults.log("Failed to create a mpv instance", level: .error)
+      return
+    }
+    logError(mpv_set_option_string(mpv, MPVOption.ProgramBehavior.loadAutoProfiles, "no"))
+    logError(mpv_set_option_string(mpv, MPVOption.ProgramBehavior.loadOsdConsole, "no"))
+    logError(mpv_set_option_string(mpv, MPVOption.ProgramBehavior.loadScripts, "no"))
+    logError(mpv_set_option_string(mpv, MPVOption.ProgramBehavior.loadStatsOverlay, "no"))
+    logError(mpv_initialize(mpv))
+  }
+
+  // MARK: - Default Value Getters
+
+  func getDouble(_ name: String) -> Double? {
+    var data = Double()
+    let errorCode = getDefaultValue(name, MPV_FORMAT_DOUBLE, &data)
+    guard errorCode >= 0 else { return nil }
+    return data
+  }
+
+  func getFlag(_ name: String) -> Bool? {
+    var data = Int64()
+    let errorCode = getDefaultValue(name, MPV_FORMAT_FLAG, &data)
+    guard errorCode >= 0 else { return nil }
+    return data > 0
+  }
+
+  func getInt(_ name: String) -> Int? {
+    var data = Int64()
+    let errorCode = getDefaultValue(name, MPV_FORMAT_INT64, &data)
+    guard errorCode >= 0 else { return nil }
+    return Int(data)
+  }
+
+  func getString(_ name: String) -> String? {
+    guard mpv != nil else { return nil }
+    let cstr = mpv_get_property_string(mpv, formPropertyName(name))
+    let str: String? = cstr == nil ? nil : String(cString: cstr!)
+    mpv_free(cstr)
+    return str
+  }
+
+  // MARK: - Supporting Methods
+  
+  /// Forms the name of the mpv property containing the default value for the given mpv option.
+  /// - Parameter name: Name of the mpv option.
+  /// - Returns: Name of property to get the value of.
+  private func formPropertyName(_ name: String) -> String { "option-info/\(name)/default-value" }
+  
+  /// Get the default value for the given option.
+  /// - Note: If a mpv instance could not be created when this class was initialized then this method will return `Int32.min` as an
+  ///         error code. That number was chosen to make it clear this it is not a mpv error code.
+  /// - Parameters:
+  ///   - name: Name of the mpv option.
+  ///   - format: Format of the given option.
+  ///   - data: Pointer to the variable that will holdErr the option value.
+  /// - Returns: Error code, 0 and positive values mean success, negative values are always errors.
+  private func getDefaultValue(_ name: String, _ format: mpv_format, _ data: UnsafeMutableRawPointer) -> Int32 {
+    guard mpv != nil else { return Int32.min }
+    return logError(mpv_get_property(mpv, formPropertyName(name), format, data))
+  }
+
+  private func getPropertyAsInt(_ name: String) -> Int? {
+    guard mpv != nil else { return nil }
+    var data = Int64()
+    let errorCode = logError(mpv_get_property(mpv, name, MPV_FORMAT_INT64, &data))
+    guard errorCode >= 0 else { return nil }
+    return Int(data)
+  }
+
+  private func getPropertyAsString(_ name: String) -> String? {
+    guard mpv != nil else { return nil }
+    let cstr = mpv_get_property_string(mpv, name)
+    let str: String? = cstr == nil ? nil : String(cString: cstr!)
+    mpv_free(cstr)
+    return str
+  }
+
+  @discardableResult
+  private func logError(_ errorCode: Int32) -> Int32 {
+    guard errorCode < 0 else { return errorCode }
+    MPVOptionDefaults.log("mpv API error: \"\(String(cString: mpv_error_string(errorCode)))\", Return value: \(errorCode)", level: .error)
+    return errorCode
+  }
+
+  private static func log(_ message: String, level: Logger.Level = .debug) {
+    Logger.log(message, level: level, subsystem: Logger.Sub.mpvDefaults)
+  }
+}
+
+extension Logger.Sub {
+  static let mpvDefaults = Logger.makeSubsystem("mpv-defaults")
+}


### PR DESCRIPTION
This commit will:
- Add a new `MPVOptionDefaults` class that provides access to the default values for mpv options
- Change `MPVController.mpvInit` to log the setting of mpv options at verbose level if the value being set matches the default value for the option
- Move the `mpvVersion` and `libassVersion` properties from `MPVController` to `MPVOptionDefaults`
- Change `AppDelegate.applicationWillFinishLaunching` to log the mpv and libass versions when the FFmpeg versions are being logged

The mpv and libass version numbers were not being emitted early in the log file because these mpv properties are not available until the mpv instance is initialized. This is also true for the mpv property that contains the default values for options. To workaround this mvp restriction the new singleton class `MPVOptionDefaults` contains its own mpv instance that is dedicated to providing access to these properties. This allows `AppDelegate` to log the mpv and libass at the start of the log file. And allows `MPVController` to avoid logging the setting of mpv options when the mpv instance is being initialized. This makes it easier to identify the mpv options IINA has changed.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
