### PR TITLE
Update CI Xcode version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - xcode: "15.4"
+          - xcode: "16.1"
             deployment_target: ""
-    runs-on:  macos-latest
+    runs-on:  macos-15
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**

Update to support new asset template version.

Actually we need to run CI in on macOS 15 instead of 14. Tried macOS 14 with Xcode 16.1 RC, and it didn't work as well.