### PR TITLE
Fix Hw Decoder inspector field not dynamic

### DIFF
--- a/iina/InspectorWindowController.swift
+++ b/iina/InspectorWindowController.swift
@@ -171,7 +171,6 @@ class InspectorWindowController: NSWindowController, NSWindowDelegate, NSTableVi
           // in mpv 0.38, video-codec-name is an alias of current-tracks/video/codec, etc
           MPVProperty.currentTracksVideoCodec: self.vformatField,
           MPVProperty.currentTracksVideoCodecDesc: self.vcodecField,
-          MPVProperty.hwdecCurrent: self.vdecoderField,
           MPVProperty.containerFps: self.vfpsField,
           MPVProperty.currentVo: self.voField,
           MPVProperty.currentTracksAudioCodecDesc: self.acodecField,
@@ -235,6 +234,9 @@ class InspectorWindowController: NSWindowController, NSWindowDelegate, NSTableVi
       self.abitrateField.stringValue = FloatingPointByteCountFormatter.string(fromByteCount: abitrate) + "bps"
 
       let dynamicStrProperties: [String: NSTextField] = [
+        // At any point in time while the video is playing hardware decoding may fail causing a fall
+        // back to software decoding.
+        MPVProperty.hwdecCurrent: self.vdecoderField,
         MPVProperty.avsync: self.avsyncField,
         MPVProperty.totalAvsyncChange: self.totalAvsyncField,
         MPVProperty.frameDropCount: self.droppedFramesField,


### PR DESCRIPTION
This commit will change `InspectorWindowController.updateInfo` to treat the `Hw Decoder` field as being dynamic. At any point in time while the video is playing hardware decoding may fail causing a fall back to software decoding. The inspector window needs to treat this field as dynamic to insure the type of decoding shown is current.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
