### PR TITLE
Fix kCGColorSpaceITUR_2020_HLG not available warning

### DIFF
--- a/iina/FFmpegController.m
+++ b/iina/FFmpegController.m
@@ -622,8 +622,10 @@ return -1;\
           case AVCOL_TRC_ARIB_STD_B67:
             if (@available(macOS 11.0, *)) {
               cgColorSpace = CGColorSpaceCreateWithName(kCGColorSpaceITUR_2100_HLG);
-            } else {
+            } else if (@available(macOS 10.15.6, *)) {
               cgColorSpace = CGColorSpaceCreateWithName(kCGColorSpaceITUR_2020_HLG);
+            } else {
+              cgColorSpace = CGColorSpaceCreateWithName(kCGColorSpaceITUR_2020);
             }
             break;
           case AVCOL_TRC_SMPTE2084:


### PR DESCRIPTION
This commit will add an available check around the reference to `kCGColorSpaceITUR_2020_HLG` and fall back to using `kCGColorSpaceITUR_2020` if it is not available.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
