### PR TITLE
Fix default will never be executed warning

### DIFF
--- a/iina/QuickSettingViewController.swift
+++ b/iina/QuickSettingViewController.swift
@@ -65,7 +65,6 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
       case .video: return 0
       case .audio: return 1
       case .sub: return 2
-      default: return 0
       }
     }
 


### PR DESCRIPTION
This commit will remove an extraneous default in a switch for the `buttonTag` property of the `QuickSettingViewController` class.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
