### PR TITLE
fix: crash when keybinding config file is missing

### DIFF
--- a/iina/PrefKeyBindingViewController.swift
+++ b/iina/PrefKeyBindingViewController.swift
@@ -101,10 +101,12 @@ class PrefKeyBindingViewController: PreferenceViewController, PreferenceWindowEm
 
     useMediaKeysButton.title = NSLocalizedString("preference.system_media_control", comment: "Use system media control")
 
-    // Load the config file saved in user default
-    loadConfigFile(Preference.string(for: .currentInputConfigName), true)
+    DispatchQueue.main.async {
+      // Load the config file saved in user default
+      self.loadConfigFile(Preference.string(for: .currentInputConfigName), true)
 
-    NotificationCenter.default.addObserver(forName: .iinaKeyBindingChanged, object: nil, queue: .main, using: saveToConfFile)
+      NotificationCenter.default.addObserver(forName: .iinaKeyBindingChanged, object: nil, queue: .main, using: self.saveToConfFile)
+    }
   }
 
   // MARK: - IBActions
@@ -272,12 +274,12 @@ class PrefKeyBindingViewController: PreferenceViewController, PreferenceWindowEm
     
     func fallback() {
       isLoadingConfig = false
-      Utility.showAlert("keybinding_config.error", arguments: [currentConfName], sheetWindow: view.window)
+      Utility.showAlert("keybinding_config.error", arguments: [configName ?? "Unknown"], sheetWindow: view.window)
       loadConfigFile(fallbackDefault)
     }
 
     guard let configName = configName,
-          let confFilePath = getFilePath(forConfig: configName) else { fallback(); return }
+          let confFilePath = getFilePath(forConfig: configName, showAlert: false) else { fallback(); return }
     
     cachedConfigNames = configNames
     confTableView.reloadData()

--- a/iina/PrefKeyBindingViewController.swift
+++ b/iina/PrefKeyBindingViewController.swift
@@ -276,7 +276,8 @@ class PrefKeyBindingViewController: PreferenceViewController, PreferenceWindowEm
       loadConfigFile(fallbackDefault)
     }
 
-    guard let configName = configName else { fallback(); return }
+    guard let configName = configName,
+          let confFilePath = getFilePath(forConfig: configName) else { fallback(); return }
     
     cachedConfigNames = configNames
     confTableView.reloadData()
@@ -284,10 +285,10 @@ class PrefKeyBindingViewController: PreferenceViewController, PreferenceWindowEm
       confTableView.selectRowIndexes(IndexSet(integer: index), byExtendingSelection: false)
     }
     currentConfName = configName
-    currentConfFilePath = getFilePath(forConfig: configName)!
+    currentConfFilePath = confFilePath
     
     guard let mapping = KeyMapping.parseInputConf(at: currentConfFilePath) else { fallback(); return }
-
+    
     mappingController.content = nil
     mappingController.add(contentsOf: mapping)
     mappingController.setSelectionIndexes(IndexSet())


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**

##### env

- develop branch 245faa6
- macOS 15.1.1
- Xcode 16.1
- v1.3.5 works well

##### Reproduce:

1. Delete config files in `~/Library/Application Support/com.colliderli.iina/input_conf`
2. Preferences - Key Binding

``` Crash Log
Thread 0 Crashed::  Dispatch queue: com.apple.main-thread
0   IINA                          	       0x1047f3e88 PrefKeyBindingViewController.loadConfigFile(_:_:) + 1268
1   IINA                          	       0x1047f0fc4 PrefKeyBindingViewController.viewDidLoad() + 752
2   IINA                          	       0x1047f1164 @objc PrefKeyBindingViewController.viewDidLoad() + 24
3   AppKit                        	       0x1845a5b40 -[NSViewController _sendViewDidLoad] + 84
4   AppKit                        	       0x1845938f8 -[NSViewController _loadViewIfRequired] + 236
5   AppKit                        	       0x184b84d9c __24-[NSViewController view]_block_invoke + 28
6   AppKit                        	       0x18458d5e0 NSPerformVisuallyAtomicChange + 108
7   AppKit                        	       0x1845937c4 -[NSViewController view] + 160
8   IINA                          	       0x104722bf8 PreferenceWindowController.loadTab(at:thenFindLabelTitled:) + 632
9   IINA                          	       0x1047244d8 PreferenceWindowController.tableViewSelectionDidChange(_:) + 272
10  IINA                          	       0x104724860 @objc PreferenceWindowController.tableViewSelectionDidChange(_:) + 116
11  CoreFoundation                	       0x180a16800 __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ + 148
12  CoreFoundation                	       0x180aa766c ___CFXRegistrationPost_block_invoke + 88
13  CoreFoundation                	       0x180aa75b4 _CFXRegistrationPost + 436
14  CoreFoundation                	       0x1809e543c _CFXNotificationPost + 732
15  Foundation                    	       0x181b8db14 -[NSNotificationCenter postNotificationName:object:userInfo:] + 88
16  AppKit                        	       0x18463857c -[NSTableView _sendSelectionChangedNotificationForRows:columns:] + 304
17  AppKit                        	       0x1845eb64c -[NSTableView _enableSelectionPostingAndPost] + 232
18  AppKit                        	       0x1847ea108 -[NSTableView mouseDown:] + 3812
19  AppKit                        	       0x1846e749c -[NSWindow(NSEventRouting) _handleMouseDownEvent:isDelayedEvent:] + 3672
20  AppKit                        	       0x184672f90 -[NSWindow(NSEventRouting) _reallySendEvent:isDelayedEvent:] + 384
21  AppKit                        	       0x184672c40 -[NSWindow(NSEventRouting) sendEvent:] + 284
22  AppKit                        	       0x184e8abc0 -[NSApplication(NSEventRouting) sendEvent:] + 1656
23  AppKit                        	       0x184a98820 -[NSApplication _handleEvent:] + 60
24  AppKit                        	       0x18453ea8c -[NSApplication run] + 520
25  AppKit                        	       0x1845152e8 NSApplicationMain + 888
26  IINA                          	       0x1046d3830 main + 12
27  dyld                          	       0x1805b8274 start + 2840
```





#####  Additional bugs:

`Utility.showAlert` in `getFilePath` function not working

```
  private func getFilePath(forConfig conf: String, showAlert: Bool = true) -> String? {
    let path = KC.defaultConfigs[conf] ?? KC.userConfigs[conf]
    if path == nil {    
      if showAlert {
        // ⬇️⬇️⬇️  NOT WORKING
        Utility.showAlert("error_finding_file", arguments: ["config"], sheetWindow: view.window)
      }
    }
    return path
  }
```


``` Xcode console
Suppressing invocation of -[NSAlert runModal]. -[NSAlert runModal] cannot run inside a transaction begin/commit pair, or inside a transaction commit. Consider switching to an asynchronous equivalent.
(
	0   AppKit                              0x00000001847e6560 -[NSAlert runModal] + 180
	1   IINA.debug.dylib                    0x0000000105fdd85c $s4IINA7UtilityC9showAlert_7comment9arguments5style11sheetWindow14suppressionKey12disableMenusySS_SSSgSays7CVarArg_pGSgSo12NSAlertStyleVSo8NSWindowCSgAA10PreferenceV0K0VSgSbtFZ + 3276
	2   IINA.debug.dylib                    0x000000010646af18 $s4IINA28PrefKeyBindingViewControllerC11getFilePath028_33B0E3DBCAC57BABBAE76BA0478J3CE2LL9forConfig9showAlertSSSgSS_SbtF + 864
	3   IINA.debug.dylib                    0x0000000106468ebc $s4IINA28PrefKeyBindingViewControllerC14loadConfigFile028_33B0E3DBCAC57BABBAE76BA0478J3CE2LLyySSSg_SbtF + 1032
	4   IINA.debug.dylib                    0x000000010646326c $s4IINA28PrefKeyBindingViewControllerC11viewDidLoadyyF + 2004
	5   IINA.debug.dylib                    0x00000001064635f0 $s4IINA28PrefKeyBindingViewControllerC11viewDidLoadyyFTo + 36
	6   AppKit                              0x00000001845a5b40 -[NSViewController _sendViewDidLoad] + 84
	7   AppKit                              0x00000001845938f8 -[NSViewController _loadViewIfRequired] + 236
	8   AppKit                              0x0000000184b84d9c __24-[NSViewController view]_block_invoke + 28
	9   AppKit                              0x000000018458d5e0 NSPerformVisuallyAtomicChange + 108
	10  AppKit                              0x00000001845937c4 -[NSViewController view] + 160
	11  IINA.debug.dylib                    0x0000000106265e30 $s4IINA26PreferenceWindowControllerC7loadTab33_512B5F1AE7687047F3CE55F91E9B466CLL2at19thenFindLabelTitledAA0bC10Embeddable_pSgSi_SSSgtF + 1548
	12  IINA.debug.dylib                    0x000000010626a574 $s4IINA26PreferenceWindowControllerC27tableViewSelectionDidChangeyy10Foundation12NotificationVF + 836
	13  IINA.debug.dylib                    0x000000010626ade4 $s4IINA26PreferenceWindowControllerC27tableViewSelectionDidChangeyy10Foundation12NotificationVFTo + 140
	14  CoreFoundation                      0x0000000180a16800 __CFNOTIFICATIONCENTER_IS_CALLING_OUT_TO_AN_OBSERVER__ + 148
	15  CoreFoundation                      0x0000000180aa766c ___CFXRegistrationPost_block_invoke + 88
	16  CoreFoundation                      0x0000000180aa75b4 _CFXRegistrationPost + 436
	17  CoreFoundation                      0x00000001809e543c _CFXNotificationPost + 732
	18  Foundation                          0x0000000181b8db14 -[NSNotificationCenter postNotificationName:object:userInfo:] + 88
	19  AppKit                              0x000000018463857c -[NSTableView _sendSelectionChangedNotificationForRows:columns:] + 304
	20  AppKit                              0x00000001845eb64c -[NSTableView _enableSelectionPostingAndPost] + 232
	21  AppKit                              0x00000001847ea108 -[NSTableView mouseDown:] + 3812
	22  AppKit                              0x00000001846e749c -[NSWindow(NSEventRouting) _handleMouseDownEvent:isDelayedEvent:] + 3672
	23  AppKit                              0x0000000184672f90 -[NSWindow(NSEventRouting) _reallySendEvent:isDelayedEvent:] + 384
	24  AppKit                              0x0000000184672c40 -[NSWindow(NSEventRouting) sendEvent:] + 284
	25  AppKit                              0x0000000184e8abc0 -[NSApplication(NSEventRouting) sendEvent:] + 1656
	26  AppKit                              0x0000000184a98820 -[NSApplication _handleEvent:] + 60
	27  AppKit                              0x000000018453ea8c -[NSApplication run] + 520
	28  AppKit                              0x00000001845152e8 NSApplicationMain + 888
	29  IINA.debug.dylib                    0x0000000106174590 __debug_main_executable_dylib_entry_point + 12
	30  dyld                                0x00000001805b8274 start + 2840
)
```