### PR TITLE
Fix SIGILL crash in PlayerWindowController.syncSlider, #5319

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2340,7 +2340,8 @@ class MainWindowController: PlayerWindowController {
         // sample aspect ratio (SAR). A typical configuration is SAR 1440x1080i (4:3) w/ DAR 1920x1080 (16:9). Here we try
         // to get the display aspect ratio from mpv to properly display the thumbnail.
         let displayAspectRatio: CGFloat
-        if let width = player.info.displayWidth, let height = player.info.displayHeight {
+        if let width = player.info.displayWidth, width != 0,
+           let height = player.info.displayHeight, height != 0 {
           displayAspectRatio = CGFloat(width) / CGFloat(height)
         } else {
           displayAspectRatio = thumbnailPeekView.imageView.image!.size.aspect

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1062,9 +1062,12 @@ class PlayerCore: NSObject {
       // A loop point has been set. B loop point must be set as well to activate looping.
       info.abLoopStatus = b == 0 ? .aSet : .bSet
     }
-    // The play slider has knobs representing the loop points, make insure the slider is in sync.
-    mainWindow?.syncSlider()
     log("Synchronized info.abLoopStatus \(info.abLoopStatus)")
+
+    // If window is not loaded the play slider knobs can't be synchronized.
+    guard mainWindow.loaded, info.state.active else { return }
+    // The play slider has knobs representing the loop points, make insure the slider is in sync.
+    mainWindow.syncSlider()
   }
 
   func togglePlaylistLoop() {

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -175,7 +175,10 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
   override func windowDidLoad() {
     super.windowDidLoad()
     loaded = true
-    
+    // Issue #5319 seemed to be triggered by the window not loading. Need to know when the window
+    // has loaded to be able to debug such issues.
+    log("Player window has been loaded")
+
     guard let window = window else { return }
     
     // Insert `menuActionHandler` into the responder chain


### PR DESCRIPTION
This commit will:
- Change `PlayerCore.syncAbLoop` to not call `PlayerWindowController.syncSlider` if the window has not been loaded
- Change `MainWindowController.updateTimeLabel` to fall back to obtaining the aspect ratio from the thumbnail image if the display height or width are zero
- Change `PlayerWindowController.windowDidLoad` to log a message indicating the player window has been loaded

This corrects the crashes but does not address the underlying root cause which at this time is unknown.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5319.

---

**Description:**
