### PR TITLE
Update copyright to 2025

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -4681,7 +4681,7 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "GL_SILENCE_DEPRECATION=1";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.video";
-				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2017-2024\nCollider LI, et al.\nReleased under GPLv3.";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2017-2025\nCollider LI, et al.\nReleased under GPLv3.";
 				INFOPLIST_KEY_NSMainNibFile = MainMenu;
 				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
 				LIBRARY_SEARCH_PATHS = (
@@ -4720,7 +4720,7 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "GL_SILENCE_DEPRECATION=1";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.video";
-				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2017-2024\nCollider LI, et al.\nReleased under GPLv3.";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2017-2025\nCollider LI, et al.\nReleased under GPLv3.";
 				INFOPLIST_KEY_NSMainNibFile = MainMenu;
 				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
 				LIBRARY_SEARCH_PATHS = (
@@ -4770,7 +4770,7 @@
 					"$(inherited)",
 				);
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.video";
-				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2017-2024\nCollider LI, et al.\nReleased under GPLv3.";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2017-2025\nCollider LI, et al.\nReleased under GPLv3.";
 				INFOPLIST_KEY_NSMainNibFile = MainMenu;
 				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
 				LIBRARY_SEARCH_PATHS = (
@@ -4787,7 +4787,7 @@
 			buildSettings = {
 				GCC_PREPROCESSOR_DEFINITIONS = "GL_SILENCE_DEPRECATION=1";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.video";
-				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2017-2024\nCollider LI, et al.\nReleased under GPLv3.";
+				INFOPLIST_KEY_NSHumanReadableCopyright = "Copyright © 2017-2025\nCollider LI, et al.\nReleased under GPLv3.";
 				INFOPLIST_KEY_NSMainNibFile = MainMenu;
 				INFOPLIST_KEY_NSPrincipalClass = NSApplication;
 				LIBRARY_SEARCH_PATHS = (

--- a/iina/Contribution.rtf
+++ b/iina/Contribution.rtf
@@ -11,7 +11,7 @@
 \ulnone \
 
 \f1\b0 The modern video player for macOS.\
-Copyright \'a9 2017-2024  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
+Copyright \'a9 2017-2025  {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000"}}{\fldrslt Collider LI}}, {\field{\*\fldinst{HYPERLINK "https://github.com/lhc70000/iina/graphs/contributors"}}{\fldrslt et al}}.\
 \
 \pard\tx566\tx1133\tx1700\tx2267\tx2834\tx3401\tx3968\tx4535\tx5102\tx5669\tx6236\tx6803\pardirnatural\qc\partightenfactor0
 

--- a/iina/en.lproj/InfoPlist.strings
+++ b/iina/en.lproj/InfoPlist.strings
@@ -1,1 +1,1 @@
-NSHumanReadableCopyright = "Copyright © 2017-2024\nCollider LI, et al.\nReleased under GPLv3.";
+NSHumanReadableCopyright = "Copyright © 2017-2025\nCollider LI, et al.\nReleased under GPLv3.";

--- a/other/update_copyright.sh
+++ b/other/update_copyright.sh
@@ -22,13 +22,10 @@ function update () {
     find "$(cd $srcdir/$dir; pwd)" -name "$file" -exec sed -i '' "s/ 2017-2[0-9]\{3\}/ 2017-$year/" {} +
 }
 
-# Update the copyright displayed in the macOS "Get Info" window for the application.
+# Update the copyright displayed in the macOS "Get Info" window for
+# the application and at the start of the log file.
 update ../iina.xcodeproj project.pbxproj
+update en.lproj InfoPlist.strings
 
 # Update the copyright displayed in the about window.
-# This copyright text is contained in Contribution.rtf which is localized.
-# To avoid conflicts when merging translations from Crowdin the procedure for
-# modifying localized source is to only update the base and English source in
-# GitHub. Changes for other languages must then be made using Crowdin.
-update Base.lproj Contribution.rtf
-update en.lproj Contribution.rtf
+update . Contribution.rtf


### PR DESCRIPTION
The commit in the pull request will:
- Update the copyright displayed in the about window
- Update the copyright displayed in the macOS "Get Info" window
- Update the copyright in the log message at startup
- Change `update_copyright.sh` to update `en.lproj/InfoPlist.strings`
- Change `update_copyright.sh` to handle `Contribution.rtf` no longer being localized

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
