### PR TITLE
Fix incorrect use of MPMediaItemPropertyMediaType, #5318

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -2815,13 +2815,13 @@ class NowPlayingInfoManager {
 
     if withTitle {
       if activePlayer.currentMediaIsAudio == .isAudio {
-        info[MPMediaItemPropertyMediaType] = MPNowPlayingInfoMediaType.audio.rawValue
+        info[MPNowPlayingInfoPropertyMediaType] = MPNowPlayingInfoMediaType.audio.rawValue
         let (title, album, artist) = activePlayer.getMusicMetadata()
         info[MPMediaItemPropertyTitle] = title
         info[MPMediaItemPropertyAlbumTitle] = album
         info[MPMediaItemPropertyArtist] = artist
       } else {
-        info[MPMediaItemPropertyMediaType] = MPNowPlayingInfoMediaType.video.rawValue
+        info[MPNowPlayingInfoPropertyMediaType] = MPNowPlayingInfoMediaType.video.rawValue
         info[MPMediaItemPropertyTitle] = activePlayer.getMediaTitle(withExtension: false)
       }
     }


### PR DESCRIPTION
This commit will change NowPlayingInfoManager.updateInfo to use MPNowPlayingInfoPropertyMediaType instead of
MPMediaItemPropertyMediaType.

This corrects a problem where MPMediaItemPropertyMediaType was being set to a MPNowPlayingInfoMediaType value which is only intended to be used with MPNowPlayingInfoPropertyMediaType.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5318.

---

**Description:**
