### PR TITLE
Fix system playback channel is occupied, #4331

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -1234,15 +1234,11 @@ class MPVController: NSObject {
       DispatchQueue.main.async { self.player.chapterChanged() }
 
     case MPVOption.PlaybackControl.speed:
-      guard let data = UnsafePointer<Double>(OpaquePointer(property.data))?.pointee else {
+      guard let speed = UnsafePointer<Double>(OpaquePointer(property.data))?.pointee else {
         logPropertyValueError(MPVOption.PlaybackControl.speed, property.format)
         break
       }
-      DispatchQueue.main.async { [self] in
-        player.info.playSpeed = data
-        player.sendOSD(.speed(data))
-        player.needReloadQuickSettingsView()
-      }
+      DispatchQueue.main.async { self.player.speedChanged(speed) }
 
     case MPVOption.PlaybackControl.loopPlaylist, MPVOption.PlaybackControl.loopFile:
       DispatchQueue.main.async { [self] in

--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -57,12 +57,11 @@ class PlaybackInfo {
       switch state {
       case .idle:
         PlayerCore.checkStatusForSleep()
+        NowPlayingInfoManager.shared.updateInfo()
       case .playing:
         PlayerCore.checkStatusForSleep()
         if player == PlayerCore.lastActive {
-          if RemoteCommandController.useSystemMediaControl {
-            NowPlayingInfoManager.updateInfo(state: .playing)
-          }
+          NowPlayingInfoManager.shared.updateInfo(state: .playing)
           if player.mainWindow.pipStatus == .inPIP {
             player.mainWindow.pip.playing = true
           }
@@ -70,9 +69,7 @@ class PlaybackInfo {
       case .paused:
         PlayerCore.checkStatusForSleep()
         if player == PlayerCore.lastActive {
-          if RemoteCommandController.useSystemMediaControl {
-            NowPlayingInfoManager.updateInfo(state: .paused)
-          }
+          NowPlayingInfoManager.shared.updateInfo(state: .paused)
           if player.mainWindow.pipStatus == .inPIP {
             player.mainWindow.pip.playing = false
           }

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -529,9 +529,7 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
 
   func windowDidBecomeMain(_ notification: Notification) {
     PlayerCore.lastActive = player
-    if RemoteCommandController.useSystemMediaControl {
-      NowPlayingInfoManager.updateInfo(withTitle: true)
-    }
+    NowPlayingInfoManager.shared.updateInfo(withTitle: true)
     AppDelegate.shared.menuController?.updatePluginMenu()
 
     NotificationCenter.default.post(name: .iinaMainWindowChanged, object: true)


### PR DESCRIPTION
This commit will:
- Refactor the `setup` and `disableAllCommands` methods in `RemoteCommandController` into `enable` and `disable` methods
- Add a `speedChanged` method to `PlayerCore` that calls `NowPlayingInfoManager.updateInfo`
- Change `MPVController.handlePropertyChange` to dispatch a call to `speedChanged` when the mpv `speed` property changes
- Change `PlaybackInfo.state` to call `NowPlayingInfoManager.updateInfo` when the state changes to `idle`
- Remove the calls to `RemoteCommandController.setup` and `NowPlayingInfoManager.updateInfo` from `applicationDidFinishLaunching`
- Change `NowPlayingInfoManager.updateInfo` to disable remote command and end the Now Playing session when no media is open
- Add setting of the `MPMediaItemPropertyAlbumTitle` and `MPMediaItemPropertyArtist` to the empty string in `NowPlayingInfoManager.updateInfo` when playing video

These changes correct 3 problems:
- They change IINA to not start using Now Playing until playing starts and to stop using Now Playing when IINA does not have any media open. This addresses #4331.
- They also correct a problem where the progress slider in Now Playing becomes out of sync if the playback speed is changed.
- And they correct a problem where the album title and artist from a previously played audio file is still shown when a video starts playing

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4331.

---

**Description:**
