### PR TITLE
Fix jump to timestamp error, #5335

### DIFF
--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -133,6 +133,8 @@ extension MainMenuActionHandler {
   }
 
   @objc func menuJumpTo(_ sender: NSMenuItem) {
+    // Make certain the cached video position in the playback info is up to date.
+    player.syncUI(.time)
     Utility.quickPromptPanel("jump_to", inputValue: self.player.info.videoPosition?.stringRepresentationWithPrecision(3)) { input in
       if let vt = VideoTime(input) {
         self.player.seek(absoluteSecond: vt.second)


### PR DESCRIPTION
This commit will add a call to `PlayerCore.syncUI` in `MainMenuActions.menuJumpTo` so that the current playback position displayed in the panel is up to date.

- [X] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [X] This implements/fixes issue #5335.

---

**Description:**
