### PR TITLE
Fixed pause when opened allows playback to start, #5339

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -1210,25 +1210,7 @@ class MPVController: NSObject {
         logPropertyValueError(MPVOption.PlaybackControl.pause, property.format)
         break
       }
-      DispatchQueue.main.async { [self] in
-        if (player.info.state == .paused) != paused {
-          player.sendOSD(paused ? .pause : .resume)
-          player.info.state = paused ? .paused : .playing
-          player.refreshSyncUITimer()
-          // Follow energy efficiency best practices and ensure IINA is absolutely idle when the
-          // video is paused to avoid wasting energy with needless processing. If paused shutdown
-          // the timer that synchronizes the UI and the high priority display link thread.
-          if paused {
-            player.mainWindow.videoView.displayIdle()
-          } else {
-            player.mainWindow.videoView.displayActive()
-          }
-        }
-        if player.mainWindow.loaded && Preference.bool(for: .alwaysFloatOnTop) {
-          player.mainWindow.setWindowFloatingOnTop(!paused)
-        }
-        player.syncUI(.playButton)
-      }
+      DispatchQueue.main.async { self.player.pauseChanged(paused) }
 
     case MPVProperty.chapter:
       DispatchQueue.main.async { self.player.chapterChanged() }


### PR DESCRIPTION
This commit will:
- Move pausing mpv from `PlayerCore.fileLoaded` to `PlayerCore.openMainWindow` before the `loadfile` command is sent to mpv
- Move the code in `MPVController.handlePropertyChange` for processing a change to the `pause` property into a new `pauseChanged` method in `PlayerCore`
- Add a check that the main window has been loaded and the player state indicates the file has been loaded before processing the change to the pause property

These changes correct a race condition where mpv could start playback before IINA was able to pause playback in `fileLoaded`.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5339.

---

**Description:**
