### PR TITLE
Fix SIGILL crash while selecting audio quality, #5341

### DIFF
--- a/iina/PlaySliderCell.swift
+++ b/iina/PlaySliderCell.swift
@@ -159,7 +159,9 @@ class PlaySliderCell: NSSliderCell {
     // draw chapters
     NSGraphicsContext.saveGraphicsState()
     if drawChapters {
-      if let totalSec = info.videoDuration?.second {
+      // When streaming if the audio stream is changed mpv will momentarily reset the video duration
+      // to zero. Not useful to draw the chapter marks when the duration is unknown.
+      if let totalSec = info.videoDuration?.second, totalSec != 0 {
         chapterStrokeColor.setStroke()
         let chapters = info.chapters
         if chapters.count > 1 {


### PR DESCRIPTION
This commit will change PlaySliderCell.drawBar to not draw chapter markers if the video duration is zero.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5341.

---

**Description:**
