### PR TITLE
Fix play/pause button stops responding, #5343

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1867,7 +1867,15 @@ class PlayerCore: NSObject {
   func fileLoaded() {
     guard info.state.active else { return }
     log("File loaded")
-    info.state = .paused
+
+    // Normally playback will be paused at this point because PlayerCore sets playback to be paused
+    // before loading a file. This is required to be able to support the setting to pause when media
+    // is opened, otherwise there would be a race condition as to whether IINA can pause playback
+    // before mpv has starting playing the media. However plugins have direct access to mpv and can
+    // load files, therefore the mpv state must be checked.
+    info.state = mpv.getFlag(MPVOption.PlaybackControl.pause) ? .paused : .playing
+    syncUI(.playButton)
+
     // Get video size and set the initial window size
     let width = mpv.getInt(MPVProperty.width)
     let height = mpv.getInt(MPVProperty.height)

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1871,10 +1871,11 @@ class PlayerCore: NSObject {
     // Normally playback will be paused at this point because PlayerCore sets playback to be paused
     // before loading a file. This is required to be able to support the setting to pause when media
     // is opened, otherwise there would be a race condition as to whether IINA can pause playback
-    // before mpv has starting playing the media. However plugins have direct access to mpv and can
-    // load files, therefore the mpv state must be checked.
-    info.state = mpv.getFlag(MPVOption.PlaybackControl.pause) ? .paused : .playing
+    // before mpv has started playing the media. However plugins have direct access to mpv and can
+    // load files. Ensure mpv is paused so IINA and mpv are in sync on the state of playback.
+    info.state = .paused
     syncUI(.playButton)
+    mpv.setFlag(MPVOption.PlaybackControl.pause, true, level: .verbose)
 
     // Get video size and set the initial window size
     let width = mpv.getInt(MPVProperty.width)

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -227,11 +227,13 @@ class VideoView: NSView {
     checkResult(CVDisplayLinkSetOutputCallback(link, displayLinkCallback, mutableRawPointerOf(obj: self)),
                 "CVDisplayLinkSetOutputCallback")
     checkResult(CVDisplayLinkStart(link), "CVDisplayLinkStart")
+    log("Display link started", level: .verbose)
   }
 
   @objc func stopDisplayLink() {
     guard let link = link, CVDisplayLinkIsRunning(link) else { return }
     checkResult(CVDisplayLinkStop(link), "CVDisplayLinkStop")
+    log("Display link stopped", level: .verbose)
   }
 
   // This should only be called if the window has changed displays


### PR DESCRIPTION
This commit will change `PlayerCore.fileLoaded` to check to see if playback is in progress or is paused and then set the player state accordingly and synchronize the play/pause button.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5343.

---

**Description:**
