### PR TITLE
Fix bug: alternate menu items without key bindings cannot be shown

### DIFF
--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -932,7 +932,10 @@ class MenuController: NSObject, NSMenuDelegate {
         // This is needed for the case where the menu item previously matched to a key binding, but now there is no match.
         // Obviously this is a little kludgey, but it avoids having to do a big refactor and/or writing a bunch of new code.
         let (_, value, extraData) = sameKeyAction(actions, actions, normalizeLastNum, numRange)
-        updateMenuItem(menuItem, kEqv: "", kMdf: [], l10nKey: l10nKey, value: value, extraData: extraData)
+        // An "alternate" menu item appear is intended to replace a "normal" menu item in the menu if its modifier key is held down
+        // (typically Option). But this key needs to be specified in its modifier flags, or the item may never appear.
+        let modifiers: NSEvent.ModifierFlags = menuItem.isAlternate ? [.option] : []
+        updateMenuItem(menuItem, kEqv: "", kMdf: modifiers, l10nKey: l10nKey, value: value, extraData: extraData)
       }
     }
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
Discovered while investigating #4875.

~~Looks like this was introduced by PR #4567.~~ It looks like when the "Alternate" flag is set for a menu item, the modifier key (e.g. `Option`) needs to be set in its `keyEquivalentModifierMask` for it to be activated. But the `updateMenuItem` method, when resetting the menu item's key equivalent, has been clearing all its flags. As a result, "alternate" menu items which do not have an explicit key binding will never appear.

This patch adds a check for the `isAlternate` property, and if present, sets its modifier to `option`:

1. This restores the "alternate" behavior of the menu items if they otherwise are not matched to a user key binding.

2. Did some more testing, and discovered that, if an "alternate" menu item does end up being bound to a user key binding, the behavior depends on the bindings of it & its associated "normal" item:
- If the "alternate" item has the same binding as the "normal" item but adds a modifier key, then the "alternate" item will replace the "normal" item in the menu when the user holds down that modifier key.
- If the "alternate" item & its "normal" item have different non-modifier keys in their binding, both items will be displayed in the menu.

Seems like reasonable behavior to me.