### PR TITLE
Fix OSC doesn't appear when in full screen mode, #5288

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1520,6 +1520,18 @@ class MainWindowController: PlayerWindowController {
     NSApp.presentationOptions.insert(.autoHideDock)
     // set window frame and in some cases content view frame
     setWindowFrameForLegacyFullScreen()
+
+    // Workaround for issue #5288, OSC doesn't appear when playing in full screen. Starting with
+    // macOS 15 Sequoia AppKit sometimes fails to call mouseMoved after entering full screen mode.
+    // Recreating the tracking area corrects whatever is going wrong in AppKit.
+    if #available(macOS 15, *), let cv = window.contentView, cv.trackingAreas.count == 1 {
+      log("Recreating tracking area")
+      cv.removeTrackingArea(cv.trackingAreas[0])
+      cv.addTrackingArea(NSTrackingArea(rect: cv.bounds,
+        options: [.activeAlways, .enabledDuringMouseDrag, .inVisibleRect, .mouseEnteredAndExited, .mouseMoved],
+        owner: self, userInfo: ["obj": 0]))
+    }
+
     // call delegate
     windowDidEnterFullScreen(Notification(name: .iinaLegacyFullScreen))
   }


### PR DESCRIPTION
This commit will add a workaround to the `legacyAnimateToFullscreen` method in the `MainWindowController` class that recreates the tracking area for the content view. This works around a problem where apparently something goes wrong with the tracking area and AppKit stops calling `mouseMoved`.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5288.

---

**Description:**
