### PR TITLE
Fix audio stutter, dropped frames entering full-screen, #5352

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -1778,8 +1778,6 @@ fileprivate func mpvGetOpenGLFunc(_ ctx: UnsafeMutableRawPointer?, _ name: Unsaf
 
 fileprivate func mpvUpdateCallback(_ ctx: UnsafeMutableRawPointer?) {
   let layer = bridge(ptr: ctx!) as ViewLayer
-  guard !layer.blocked else { return }
-
   layer.mpvGLQueue.async {
     layer.draw()
   }

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1288,7 +1288,6 @@ class MainWindowController: PlayerWindowController {
     let isLegacyFullScreen = notification.name == .iinaLegacyFullScreen
     fsState.startAnimatingToFullScreen(legacy: isLegacyFullScreen, priorWindowedFrame: window!.frame)
 
-    videoView.videoLayer.suspend()
     // Let mpv decide the correct render region in full screen
     player.mpv.setFlag(MPVOption.Window.keepaspect, true)
   }
@@ -1302,7 +1301,6 @@ class MainWindowController: PlayerWindowController {
     videoViewConstraints.values.forEach { $0.constant = 0 }
     videoView.needsLayout = true
     videoView.layoutSubtreeIfNeeded()
-    videoView.videoLayer.resume()
 
     if Preference.bool(for: .blackOutMonitor) {
       blackOutOtherMonitors()
@@ -1369,7 +1367,6 @@ class MainWindowController: PlayerWindowController {
     // quitting then mpv could be in the process of shutting down. Must not access mpv while it is
     // asynchronously processing stop and quit commands.
     guard player.info.state.active else { return }
-    videoView.videoLayer.suspend()
     player.mpv.setFlag(MPVOption.Window.keepaspect, false)
   }
 
@@ -1410,7 +1407,6 @@ class MainWindowController: PlayerWindowController {
     videoViewConstraints.values.forEach { $0.constant = 0 }
     videoView.needsLayout = true
     videoView.layoutSubtreeIfNeeded()
-    videoView.videoLayer.resume()
 
     if Preference.bool(for: .pauseWhenLeavingFullScreen) && player.info.state == .playing {
       player.pause()

--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -69,7 +69,6 @@ class ViewLayer: CAOpenGLLayer {
   private weak var videoView: VideoView!
 
   let mpvGLQueue = DispatchQueue(label: "com.colliderli.iina.mpvgl", qos: .userInteractive)
-  @Atomic var blocked = false
 
   private var bufferDepth: GLint = 8
 
@@ -184,17 +183,6 @@ class ViewLayer: CAOpenGLLayer {
       }
       glFlush()
     }
-  }
-
-  func suspend() {
-    blocked = true
-    mpvGLQueue.suspend()
-  }
-
-  func resume() {
-    blocked = false
-    draw(forced: true)
-    mpvGLQueue.resume()
   }
 
   override func copyCGLPixelFormat(forDisplayMask mask: UInt32) -> CGLPixelFormatObj { cglPixelFormat }


### PR DESCRIPTION
This commit will:
- Remove the `suspend` and `resume` methods from `ViewLayer`
- Remove the `blocked` property from `ViewLayer`
- Remove the reference to the `blocked` property in `MPVController.mpvUpdateCallback`
- Remove the calls to `suspend` in the `windowWillEnterFullScreen` and `windowWillExitFullScreen` methods in `MainWindowController`
- Remove the calls to `resume` in the `windowDidEnterFullScreen` and `windowDidExitFullScreen` methods in `MainWindowController`

Possibly suspending video processing was useful in the past with low performance hardware, but it is consistently triggering audio device underrun and sometimes triggering full audio/video desynchronization. The mpv player does not suspend video processing like this and does not exhibit problems entering and leaving full screen mode. Removing this code significantly improved the behavior of entering and leaving full screen mode.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5352.

---

**Description:**
