### PR TITLE
Fix playback position does not match Now Playing, #5337

### DIFF
--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -328,6 +328,19 @@ extension Double {
     }
   }
 
+  /// Returns this value rounded half down to an integral value.
+  ///
+  /// For example 0.5 will be rounded to 0.0, 0.51 will be rounded to 1.0.
+  /// - Note: This method is needed because at this time the Swift
+  ///     [rounded](https://developer.apple.com/documentation/swift/double/rounded(_:)) method does not
+  ///     support a [rounding rule](https://developer.apple.com/documentation/swift/floatingpointroundingrule)
+  ///     for [rounding half down](https://en.wikipedia.org/wiki/Rounding#Rounding_half_down).
+  /// - Returns: The integral value found by rounding this value.
+  func roundedHalfDown() -> Double {
+    let floor = floor(self)
+    return self <= floor + 0.5 ? floor : ceil(self)
+  }
+
   func roundedTo2Decimals() -> Double {
     let scaledUp = self * 1e2
     let scaledUpRounded = scaledUp.rounded(.up)

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -2046,6 +2046,10 @@ class PlayerCore: NSObject {
 
   func playbackRestarted() {
     log("Playback restarted")
+
+    // Important to synchronize the time as mpv may slightly alter the playback position during a
+    // restart even while paused. See issue #5337.
+    syncUI(.time)
     reloadSavedIINAfilters()
     mainWindow.videoView.videoLayer.draw(forced: true)
 


### PR DESCRIPTION
This commit will:
- Add a new method `roundedHalfDown` to the `Double` extension
- Change the `stringRepresentationWithPrecision` method in the `VideoTime` class to round half down when converting to a string with 1 second precision
- Add a call to syncUI in the `playbackRestarted` method of the `PlayerCore` class to synchronize the playback time after mpv has restarted playback

When IINA's OSC is configured to use 1 second precision the time displayed must exactly match the time displayed by the macOS Control Center Now Playing module. This means IINA must use the same rounding method that Now Playing uses, rounding half down. IINA must round 0.5 to 0 and 0.51 to 1. As the Swift rounded method does not provide such a rounding rule IINA has to use its own rounding method.

Testing showed that mpv may slightly alter the playback position when playback is restarted resulting in `PlaybackInfo.videoPosition` being stale and not matching up with the actual position. The added call to `syncUI` in `playbackRestarted` ensures `PlaybackInfo.videoPosition` is up to date.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5337.

---

**Description:**
