### PR TITLE
Reset represented URL for network videos

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1837,6 +1837,7 @@ class MainWindowController: PlayerWindowController {
   @objc
   override func updateTitle() {
     if player.info.isNetworkResource {
+      window?.representedURL = nil
       window?.title = player.getMediaTitle()
     } else {
       window?.representedURL = player.info.currentURL


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5243 .

---

**Description:**

Represented URL is not reset when network video is played after the local one. Thus previous url is used as a title in battery and info section.