### PR TITLE
Seek to time in url if such query parameter is present

### DIFF
--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -547,9 +547,11 @@ extension URL {
     return (try? self.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
   }
   
+  static let queryTimeParameterNames = Set(["t", "time"])
+  
   var queryTimeSeconds: TimeInterval? {
     let queryItems = self.urlComponents?.queryItems
-    let timeString = queryItems?.first { Set(["t", "time"]).contains($0.name) }?.value
+    let timeString = queryItems?.first { URL.queryTimeParameterNames.contains($0.name) }?.value
     return timeString.flatMap(TimeInterval.init)
   }
 }

--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -546,6 +546,12 @@ extension URL {
   var isExistingDirectory: Bool {
     return (try? self.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory ?? false
   }
+  
+  var queryTimeSeconds: TimeInterval? {
+    let queryItems = self.urlComponents?.queryItems
+    let timeString = queryItems?.first { Set(["t", "time"]).contains($0.name) }?.value
+    return timeString.flatMap(TimeInterval.init)
+  }
 }
 
 

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1934,6 +1934,10 @@ class PlayerCore: NSObject {
       mpv.setFlag(MPVOption.PlaybackControl.pause, false, level: .verbose)
     }
     syncUI(.playlist)
+    
+    if let time = info.currentURL?.queryTimeSeconds {
+      seek(absoluteSecond: time)
+    }
   }
 
   func fileEnded(dueToStopCommand: Bool) {


### PR DESCRIPTION
- [ ] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5334.

---

**Description:**

Parse time parameters from URL query and seek to it of present.
Tested with pasting URL from youtube.
It might be nice to improve browser extension to support adding time somehow. But I dunno how it would get time from playing web video.