### PR TITLE
Constrain init to BitwiseCopyable to remove the warning.

### DIFF
--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -443,7 +443,7 @@ extension Data {
     }
   }
 
-  init<T>(bytesOf thing: T) {
+  init<T: BitwiseCopyable>(bytesOf thing: T) {
     var copyOfThing = thing // Hopefully CoW?
     self.init(bytes: &copyOfThing, count: MemoryLayout.size(ofValue: thing))
   }

--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -444,8 +444,12 @@ extension Data {
   }
 
   init<T: BitwiseCopyable>(bytesOf thing: T) {
-    var copyOfThing = thing // Hopefully CoW?
-    self.init(bytes: &copyOfThing, count: MemoryLayout.size(ofValue: thing))
+    var mutableThing = thing
+    self.init(bytes: &mutableThing, count: MemoryLayout<T>.size)
+  }
+  
+  init<T: BitwiseCopyable>(bytesOf thing: [T]) {
+    self.init(bytes: thing, count: MemoryLayout<T>.size * thing.count)
   }
   
   func saveToFolder(_ url: URL, filename: String) -> URL? {

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1791,11 +1791,9 @@ class PlayerCore: NSObject {
 
     // set "date last opened" attribute
     if let url = info.currentURL, url.isFileURL {
-      // the required data is a timespec struct
-      var ts = timespec()
       let time = Date().timeIntervalSince1970
-      ts.tv_sec = Int(time)
-      ts.tv_nsec = Int(time.truncatingRemainder(dividingBy: 1) * 1_000_000_000)
+      // Data mimics timespec struct
+      let ts = [UInt64(time), UInt64(time.truncatingRemainder(dividingBy: 1) * 1_000_000_000)]
       let data = Data(bytesOf: ts)
       // set the attribute; the key is undocumented
       let name = "com.apple.lastuseddate#PS"


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #.

---

**Description:**
Data extension init produces a warning `Forming 'UnsafeRawPointer' to a variable of type 'T'; this is likely incorrect because 'T' may contain an object reference.`. It is used in several places for different types.
I found a way to remove the warning by constraining init to `BitwiseCopyable`. Project compiles and runs, no logic changes.
