### PR TITLE
Fix crash in JavascriptAPIUtils.exec, #5375

### DIFF
--- a/iina/JavascriptAPIUtils.swift
+++ b/iina/JavascriptAPIUtils.swift
@@ -102,7 +102,11 @@ class JavascriptAPIUtils: JavascriptAPI, JavascriptAPIUtilsExportable {
       if !file.contains("/") {
         if let url = searchBinary(file, in: Utility.binariesURL) ?? searchBinary(file, in: Utility.exeDirURL) {
           // a binary included in IINA's bundle?
-          path = url.absoluteString
+          if #available(macOS 13.0, *) {
+            path = url.path(percentEncoded: false)
+          } else {
+            path = url.path
+          }
         } else {
           // assume it's a system command
           let useBash = false
@@ -177,7 +181,13 @@ class JavascriptAPIUtils: JavascriptAPI, JavascriptAPIUtilsExportable {
         stderrContent += output
         stderrHook?.call(withArguments: [output])
       }
-      process.launch()
+      Logger.log("Executing \(path) \(args.joined(separator: " "))", subsystem: pluginInstance.subsystem)
+      do {
+        try process.run()
+      } catch {
+        reject.call(withArguments: ["Execution failed reporting: \(error.localizedDescription)"])
+        return
+      }
 
       self.pluginInstance.queue.async {
         process.waitUntilExit()


### PR DESCRIPTION
This commit will:
- Change the call to `URL.absoluteString` in `JavascriptAPIUtils.exec` method to call `URL.path` instead
- Change the call to `Process.launch` in `JavascriptAPIUtils.exec` method to call `Process.run` instead
- Add code to catch any error thrown by `run` and reject the call
- Add a log message indicating the file being executed

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5375.

---

**Description:**
