### PR TITLE
Fix IINA ignores config file, #5408

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -370,7 +370,8 @@ class MPVController: NSObject {
     chkErr(setOptionString("watch-later-directory", Utility.watchLaterURL.path, level: .verbose))
     setUserOption(PK.resumeLastPosition, type: .bool, forName: MPVOption.WatchLater.savePositionOnQuit,
                   verboseIfDefault: true)
-    setUserOption(PK.resumeLastPosition, type: .bool, forName: "resume-playback", verboseIfDefault: true)
+    setUserOption(PK.resumeLastPosition, type: .bool, forName: MPVOption.WatchLater.resumePlayback,
+                  verboseIfDefault: true)
 
     setUserOption(.initialWindowSizePosition, type: .string, forName: MPVOption.Window.geometry,
                   level: .verbose)

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1705,7 +1705,7 @@ class PlayerCore: NSObject {
   }
 
   func savePlaybackPosition() {
-    guard Preference.bool(for: .resumeLastPosition) else { return }
+    guard mpv.getFlag(MPVOption.WatchLater.savePositionOnQuit) else { return }
 
     // The player must be active to be able to save the watch later configuration.
     if info.state.active {


### PR DESCRIPTION
This commit will:
- Change `PlayerCore.savePlaybackPosition` to use the value of the mpv `save-position-on-quit` option instead of the value of IINA's `resumeLastPosition` setting
- Change `MVPController.mpvInit` to use the `MPVOption` constant for the `resume-playback` option instead of a hardcoded string

This change allows advanced users to override IINA's `Resume last playback position` setting using mpv configuration files.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5408.

---

**Description:**
