### PR TITLE
Fix holding down seek keys leads to IINA freezing, #5403

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1302,6 +1302,7 @@ class MainWindowController: PlayerWindowController {
     videoViewConstraints.values.forEach { $0.constant = 0 }
     videoView.needsLayout = true
     videoView.layoutSubtreeIfNeeded()
+    videoView.videoLayer.draw(forced: true)
 
     if Preference.bool(for: .blackOutMonitor) {
       blackOutOtherMonitors()
@@ -1411,6 +1412,7 @@ class MainWindowController: PlayerWindowController {
     videoViewConstraints.values.forEach { $0.constant = 0 }
     videoView.needsLayout = true
     videoView.layoutSubtreeIfNeeded()
+    videoView.videoLayer.draw(forced: true)
 
     if Preference.bool(for: .pauseWhenLeavingFullScreen) && player.info.state == .playing {
       player.pause()

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1877,6 +1877,11 @@ class PlayerCore: NSObject {
     syncUI(.playButton)
     mpv.setFlag(MPVOption.PlaybackControl.pause, true, level: .verbose)
 
+    // Must force drawing to cover the case where this player was previously used to play a video
+    // and is now playing an audio file without an album cover and without using music mode.
+    // See issue #5403.
+    mainWindow.videoView.videoLayer.draw(forced: true)
+
     // Get video size and set the initial window size
     let width = mpv.getInt(MPVProperty.width)
     let height = mpv.getInt(MPVProperty.height)
@@ -2047,7 +2052,6 @@ class PlayerCore: NSObject {
   func playbackRestarted() {
     log("Playback restarted")
     reloadSavedIINAfilters()
-    mainWindow.videoView.videoLayer.draw(forced: true)
 
     if RemoteCommandController.useSystemMediaControl {
       NowPlayingInfoManager.updateInfo()

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -540,6 +540,11 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
     NotificationCenter.default.post(name: .iinaMainWindowChanged, object: true)
   }
   
+  func windowDidChangeOcclusionState(_ notification: Notification) {
+    // Must force drawing for audio files that have album cover art.
+    videoView.videoLayer.draw(forced: true)
+  }
+
   func windowDidResignMain(_ notification: Notification) {
     NotificationCenter.default.post(name: .iinaMainWindowChanged, object: false)
   }


### PR DESCRIPTION
This commit will:
- Move the call to force drawing from `playbackRestarted` to `fileLoaded` in `PlayerCore`
- Add a `windowDidChangeOcclusionState` method to `PlayerWindowController` that forces drawing
- Add calls to force drawing in `windowDidEnterFullScreen` and `windowDidExitFullScreen` in `MainWindowController`

This corrects the performance problem when repeatedly seeking. And restores calls to force drawing removed in commit 0107e9d.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5403.

---

**Description:**
