### PR TITLE
Add customObjectInstantitationMethod to .typos.toml

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -22,6 +22,8 @@ extend-ignore-re = [
 
 [default.extend-identifiers]
 "caf" = "caf"
+# Xcode uses this property in XIBs.
+"customObjectInstantitationMethod" = "customObjectInstantitationMethod"
 "iy" = "iy"
 "reloadSavedIINAfilters" = "reloadSavedIINAfilters"
 "ScreenshootOSDView" = "ScreenshootOSDView"


### PR DESCRIPTION
This commit will add `customObjectInstantitationMethod` to the `default.extend-identifiers` section of .typos.toml.

The spelling check is complaining that "instantiation" is miss-spelled in the property name `customObjectInstantitationMethod` that appears in multiple XIBs on the second line. As Xcode is adding this property this typo can not be corrected and has to be ignored.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
