### PR TITLE
Workaround for imprecise Double values for speed provided by mpv (fixes #5472)

### DIFF
--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -344,17 +344,13 @@ extension Double {
   /// a comma to signify the decimal):
   /// ```
   /// let num: Double = 12.34
-  /// let badStr = "Value is \(num)"          // badStr will *always* be "Value is 12.34"
-  /// let goodStr = "Value is \(num.string)"  // goodStr will be "Value is 12,34"
+  /// let badStr = "Value is \(num)"                                // badStr will *always* be "Value is 12.34"
+  /// let goodStr = "Value is \(num.groupedStringUpTo6Decimals)"  // goodStr will be "Value is 12,34"
   /// ```
   ///
-  /// Currently the output string is limited to 15 digits after the decimal. This should be more than
-  /// enough for any imaginable use right now, but the limit can and should be increased in the future if
-  /// needed. (It's not clear what the maximum allowed value for `NumberFormatter.maximumFractionDigits`
-  /// actually is. An attempt to set it equal to `NSIntegerMax` seemed to result in it being silently set to
-  /// `6` instead.)
-  var string: String {
-    return fmtDecimalMaxFractionDigits15.string(from: self as NSNumber) ?? "NaN"
+  /// Currently the output string is limited to 6 digits after the decimal. This matches the precision used by mpv's APIs.
+  var groupedStringUpTo6Decimals: String {
+    return fmtDecimalGroupingMaxFractionDigits6.string(from: self as NSNumber) ?? "NaN"
   }
 }
 
@@ -379,13 +375,16 @@ fileprivate let fmtDecimalMaxFractionDigits2: NumberFormatter = {
   return fmt
 }()
 
-fileprivate let fmtDecimalMaxFractionDigits15: NumberFormatter = {
+/// Formatter for `Double`.
+/// - Displays up to 6 digits after the decimal before rounding.
+/// - Omits trailing zeroes.
+/// - Uses grouping separator (e.g. comma) for large numbers.
+fileprivate let fmtDecimalGroupingMaxFractionDigits6: NumberFormatter = {
   let fmt = NumberFormatter()
   fmt.numberStyle = .decimal
   fmt.usesGroupingSeparator = true
-  fmt.maximumSignificantDigits = 25
   fmt.minimumFractionDigits = 0
-  fmt.maximumFractionDigits = 15
+  fmt.maximumFractionDigits = 6
   fmt.usesSignificantDigits = false
   return fmt
 }()

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -489,7 +489,7 @@ class MenuController: NSObject, NSMenuDelegate {
     let loopMode = player.getLoopMode()
     fileLoop.state = loopMode == .file ? .on : .off
     playlistLoop.state = loopMode == .playlist ? .on : .off
-    let speed = player.info.playSpeed.string
+    let speed = player.info.playSpeed.groupedStringUpTo6Decimals
     speedIndicator.title = String(format: NSLocalizedString("menu.speed", comment: "Speed:"), speed)
   }
 
@@ -954,7 +954,7 @@ class MenuController: NSObject, NSMenuDelegate {
       case "speed_up",
         "speed_down":
         // Title format expects arg type: String
-        valObj = abs(value).string
+        valObj = abs(value).groupedStringUpTo6Decimals
       default:
         // Title format expects numeric arg
         valObj = abs(value)

--- a/iina/OSDMessage.swift
+++ b/iina/OSDMessage.swift
@@ -154,7 +154,7 @@ enum OSDMessage {
 
     case .speed(let value):
       return (
-        String(format: NSLocalizedString("osd.speed", comment: "Speed: %@x"), value.string),
+        String(format: NSLocalizedString("osd.speed", comment: "Speed: %@x"), value.groupedStringUpTo6Decimals),
         .normal
       )
 

--- a/iina/QuickSettingViewController.swift
+++ b/iina/QuickSettingViewController.swift
@@ -228,11 +228,10 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
     switchHorizontalLine2.layer?.opacity = 0.5
 
     // Localize decimal format of numbers
-    speedSlider0_25xLabel.stringValue = "\(0.25.string)x"
-    // Unclear if these need to be localized. Better to be safe?
-    speedSlider1xLabel.stringValue = "\(1.string)x"
-    speedSlider4xLabel.stringValue = "\(4.string)x"
-    speedSlider16xLabel.stringValue = "\(16.string)x"
+    speedSlider0_25xLabel.stringValue = "\(0.25.groupedStringUpTo6Decimals)x"
+    speedSlider1xLabel.stringValue = "1x"
+    speedSlider4xLabel.stringValue = "4x"
+    speedSlider16xLabel.stringValue = "16x"
 
     customSpeedTextField.formatter = speedFormatter
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5472.

---

**Description:**

 - Rename Double's `string` property to `groupedStringUpTo6Decimals`.
 - Reduce its `maximumFractionDigits` from 15 to 6, to match standard mpv precision, and to avoid issues caused by small floating point imprecision
 - Remove its use of `maximumSignificantDigits`, which the Apple docs state as unnecessary when `usesSignificantDigits==false`.