### PR TITLE
Fix fails to add videos files to playlist, #5487

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1942,7 +1942,7 @@ class PlayerCore: NSObject {
   func fileEnded(dueToStopCommand: Bool) {
     // if receive end-file when loading file, might be error
     // wait for idle
-    if info.state == .starting {
+    if info.state == .loading {
       if !dueToStopCommand {
         receivedEndFileWhileLoading = true
       }


### PR DESCRIPTION
This commit will change the player state check in `PlayerCore.fileEnded` from checking if the state is `starting` to checking if the state is `loading` in order to properly match the behavior of the old code in 1.3.5 that was checking the `fileLoading` flag.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5487.

---

**Description:**
