### PR TITLE
Add CFBundleDocumentTypes for folder, volume (fixes #5488)

### DIFF
--- a/iina/Info.plist
+++ b/iina/Info.plist
@@ -5,6 +5,18 @@
 	<key>CFBundleDocumentTypes</key>
 	<array>
 		<dict>
+			<key>CFBundleTypeName</key>
+			<string>Folder</string>
+			<key>CFBundleTypeRole</key>
+			<string>Viewer</string>
+			<key>LSHandlerRank</key>
+			<string>Default</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>public.folder</string>
+			</array>
+		</dict>
+		<dict>
 			<key>CFBundleTypeExtensions</key>
 			<array>
 				<string>mkv</string>


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5488.

---

**Description:**

- Copied entries from VLC's `Info.plist`.
- Tested & confirmed that after the app is built with these entries, the `Open with` context menu lists IINA as an option.