### PR TITLE
Fix closing mini window doesn't stop audio, #5505

### DIFF
--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -171,7 +171,8 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
       player.overrideAutoSwitchToMusicMode = false
       player.switchBackFromMiniPlayer(automatically: true, showMainWindow: false)
     }
-    player.mainWindow.close()
+    player.stop()
+    player.events.emit(.windowWillClose)
   }
 
   // MARK: - Window delegate: Size


### PR DESCRIPTION
This commit will change `MiniPlayerWindowController.windowWillClose` to call `player.stop` and emit a `windowWillClose` event instead of calling `player.mainWindow.close`.

With the change to open the mini player window directly the main window is not guaranteed to be open, in which case close is a no-op and does not result in `MainWindowController.windowWillClose` being called which the mini player relied upon to stop playback.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5505.

---

**Description:**
