### PR TITLE
Make left/rightArrowLabel listen to mpv speed

### DIFF
--- a/iina/Base.lproj/MainWindowController.xib
+++ b/iina/Base.lproj/MainWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23504" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23727" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23727"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -534,8 +534,8 @@
             </subviews>
             <constraints>
                 <constraint firstItem="QTI-wi-oyB" firstAttribute="centerY" secondItem="Xts-Pc-T8d" secondAttribute="centerY" id="HgA-Mc-Bhf"/>
-                <constraint firstItem="QTI-wi-oyB" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Xts-Pc-T8d" secondAttribute="leading" id="NqC-Xk-Iqd"/>
-                <constraint firstAttribute="trailing" secondItem="QTI-wi-oyB" secondAttribute="trailing" constant="8" id="eQW-Mv-flr"/>
+                <constraint firstItem="QTI-wi-oyB" firstAttribute="leading" secondItem="Xts-Pc-T8d" secondAttribute="leading" id="NqC-Xk-Iqd"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="QTI-wi-oyB" secondAttribute="trailing" id="eQW-Mv-flr"/>
                 <constraint firstAttribute="height" constant="24" id="sLY-0Y-Hql"/>
                 <constraint firstAttribute="width" constant="26" id="zCh-hV-cEH"/>
             </constraints>

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2715,8 +2715,6 @@ class MainWindowController: PlayerWindowController {
     super.updatePlayButtonState(paused: paused)
     if paused {
       speedValueIndex = AppData.availableSpeedValues.count / 2
-      leftArrowLabel.isHidden = true
-      rightArrowLabel.isHidden = true
     }
   }
 
@@ -2759,8 +2757,6 @@ class MainWindowController: PlayerWindowController {
     if player.info.state == .paused {
       // speed is already reset by playerCore
       speedValueIndex = AppData.availableSpeedValues.count / 2
-      leftArrowLabel.isHidden = true
-      rightArrowLabel.isHidden = true
       // set speed to 0 if is fastforwarding
       if isFastforwarding {
         player.setSpeed(1)
@@ -2853,18 +2849,6 @@ class MainWindowController: PlayerWindowController {
       isFastforwarding = true
       let speedValue = AppData.availableSpeedValues[speedValueIndex]
       player.setSpeed(speedValue)
-      if speedValueIndex == 5 {
-        leftArrowLabel.isHidden = true
-        rightArrowLabel.isHidden = true
-      } else if speedValueIndex < 5 {
-        leftArrowLabel.isHidden = false
-        rightArrowLabel.isHidden = true
-        leftArrowLabel.stringValue = String(format: "%.2fx", speedValue)
-      } else if speedValueIndex > 5 {
-        leftArrowLabel.isHidden = true
-        rightArrowLabel.isHidden = false
-        rightArrowLabel.stringValue = String(format: "%.0fx", speedValue)
-      }
       // if is paused
       if player.info.state == .paused {
         player.resume()
@@ -2876,6 +2860,24 @@ class MainWindowController: PlayerWindowController {
     case .seek:
       player.seek(relativeSecond: left ? -10 : 10, option: .relative)
 
+    }
+  }
+
+  func updateSpeedLabel(speed: Double) {
+    if (speed == 1) {
+      leftArrowLabel.isHidden = true
+      rightArrowLabel.isHidden = true
+    } else if speed < 1 {
+      leftArrowLabel.isHidden = false
+      rightArrowLabel.isHidden = true
+      leftArrowLabel.stringValue = String(format: "%.2fx", speed)
+    } else if speed > 1 {
+      leftArrowLabel.isHidden = true
+      rightArrowLabel.isHidden = false
+      let fmt = NumberFormatter()
+      fmt.numberStyle = .decimal
+      fmt.maximumSignificantDigits = 3
+      rightArrowLabel.stringValue = fmt.string(for: speed)! + "x"
     }
   }
 

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -2144,6 +2144,7 @@ class PlayerCore: NSObject {
     guard info.state.active else { return }
     info.playSpeed = speed
     sendOSD(.speed(speed))
+    mainWindow.updateSpeedLabel(speed: speed)
     needReloadQuickSettingsView()
     NowPlayingInfoManager.shared.updateInfo()
   }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4052.

---

**Description:**
Currently the left/rightArrowLabel is only updated when clicking on the fast/slowfoward button, making it not always indicating the current playback speed and might cause confusion to users (see #4052). This PR makes it updates the labels when the playback speed changes. Other minor changes:
- Adjust the constraint of the rightArrowLabel to show more digits
- Make the rightArrowLabel always shows 3 significant digits
- Don't reset the labels on clicking play/pause button