### PR TITLE
playback: change the behavior of prev media button, fix #4611

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2861,7 +2861,7 @@ class MainWindowController: PlayerWindowController {
       }
 
     case .playlist:
-      player.mpv.command(left ? .playlistPrev : .playlistNext, checkError: false)
+      player.navigateInPlaylist(nextMedia: !left)
 
     case .seek:
       player.seek(relativeSecond: left ? -10 : 10, option: .relative)

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1431,7 +1431,11 @@ class PlayerCore: NSObject {
   }
 
   func navigateInPlaylist(nextMedia: Bool) {
-    mpv.command(nextMedia ? .playlistNext : .playlistPrev, checkError: false)
+    if nextMedia == false && (info.playlist.first?.isPlaying) ?? false {
+      seek(absoluteSecond: 0)
+    } else {
+      mpv.command(nextMedia ? .playlistNext : .playlistPrev, checkError: false)
+    }
   }
 
   @discardableResult


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4611.

---

**Description:**
Restart from the beginning of the track when trying to navigate to the previous track in the playlist when there's no previous track.

