### PR TITLE
Handle show playlist/chapter panel menu item for mini player

### DIFF
--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -478,11 +478,10 @@ class MenuController: NSObject, NSMenuDelegate {
 
   private func updatePlaybackMenu() {
     let player = PlayerCore.active
-    let isDisplayingPlaylist = player.mainWindow.sideBarStatus == .playlist &&
-          player.mainWindow.playlistView.currentTab == .playlist
+    let playlistPanelVisible = player.isInMiniPlayer ? player.miniPlayer.isPlaylistVisible : player.mainWindow.sideBarStatus == .playlist
+    let isDisplayingPlaylist = playlistPanelVisible && player.mainWindow.playlistView.currentTab == .playlist
     playlistPanel?.title = isDisplayingPlaylist ? Constants.String.hidePlaylistPanel : Constants.String.playlistPanel
-    let isDisplayingChapters = player.mainWindow.sideBarStatus == .playlist &&
-          player.mainWindow.playlistView.currentTab == .chapters
+    let isDisplayingChapters = playlistPanelVisible && player.mainWindow.playlistView.currentTab == .chapters
     chapterPanel?.title = isDisplayingChapters ? Constants.String.hideChaptersPanel : Constants.String.chaptersPanel
     pause.title = player.info.state == .paused ? Constants.String.resume : Constants.String.pause
     abLoop.state = player.isABLoopActive ? .on : .off

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -64,6 +64,10 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     }
   }()
 
+  var playlistView: PlaylistViewController {
+    return player.mainWindow.playlistView
+  }
+
   override var mouseActionDisabledViews: [NSView?] {[backgroundView, playlistWrapperView] as [NSView?]}
 
   // MARK: - Initialization
@@ -325,6 +329,17 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
 
   // MARK: - IBActions
 
+  func showPlaylistAction(_ tab: PlaylistViewController.TabViewType) {
+    if !isPlaylistVisible {
+      playlistView.pleaseSwitchToTab(tab)
+      togglePlaylist(self)
+    } else if playlistView.currentTab == tab {
+      togglePlaylist(self)
+    } else {
+      playlistView.pleaseSwitchToTab(tab)
+    }
+  }
+
   @IBAction func togglePlaylist(_ sender: Any) {
     guard let window = window else { return }
     if isPlaylistVisible {
@@ -334,7 +349,7 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     } else {
       // show
       isPlaylistVisible = true
-      player.mainWindow.playlistView.reloadData(playlist: true, chapters: true)
+      playlistView.reloadData(playlist: true, chapters: true)
 
       var newFrame = window.frame
       newFrame.origin.y -= DefaultPlaylistHeight

--- a/iina/MiniPlayerWindowMenuActions.swift
+++ b/iina/MiniPlayerWindowMenuActions.swift
@@ -14,9 +14,16 @@ extension MiniPlayerWindowController {
     setWindowFloatingOnTop(!isOntop)
   }
 
-
   @objc func menuSwitchToMiniPlayer(_ sender: NSMenuItem) {
     player.switchBackFromMiniPlayer()
+  }
+
+  @objc func menuShowPlaylistPanel(_ sender: NSMenuItem) {
+    showPlaylistAction(.playlist)
+  }
+
+  @objc func menuShowChaptersPanel(_ sender: NSMenuItem) {
+    showPlaylistAction(.chapters)
   }
 
 }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5412.

---

**Description:**
Handle `menuShowPlaylistPanel` and `menuShowChaptersPanel` for menu actions for the mini player.

P.S. We should really separate `playlistView` from the main window, which requires a pretty large refactor. Maybe consider doing it in 1.5.0?