### PR TITLE
Separate the tab views of the quick setting view

### DIFF
--- a/iina/Base.lproj/QuickSettingViewController.xib
+++ b/iina/Base.lproj/QuickSettingViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23504" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23727" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23504"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23727"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -23,6 +23,7 @@
                 <outlet property="audioEqSlider8" destination="JaQ-EH-K1U" id="NZP-1Y-Q4q"/>
                 <outlet property="audioEqSlider9" destination="gbd-xf-hGS" id="yjy-wE-LJd"/>
                 <outlet property="audioTabBtn" destination="3Fk-ey-FhK" id="I1P-Dg-gtv"/>
+                <outlet property="audioTabScrollView" destination="wXn-sV-AmG" id="hwa-q0-ZFH"/>
                 <outlet property="audioTableView" destination="FLg-2m-Zaq" id="rId-Io-Y2B"/>
                 <outlet property="brightnessSlider" destination="eFW-a3-kWx" id="BTl-mg-ShV"/>
                 <outlet property="buttonTopConstraint" destination="qd3-0i-qbr" id="uh3-P6-1jm"/>
@@ -76,24 +77,26 @@
                 <outlet property="subTextColorWell" destination="9mo-uL-hfC" id="HEi-c0-WG6"/>
                 <outlet property="subTextFontBtn" destination="qGz-rB-dsV" id="Xkg-P1-vDv"/>
                 <outlet property="subTextSizePopUp" destination="xtF-tn-m9W" id="62h-S6-9gV"/>
+                <outlet property="subtitlesTabScrollView" destination="3kA-IY-poi" id="bPE-kn-tig"/>
                 <outlet property="switchHorizontalLine" destination="PyM-xa-vx9" id="LX2-Xa-lH4"/>
                 <outlet property="switchHorizontalLine2" destination="qYi-uQ-6qo" id="doE-zM-QU3"/>
                 <outlet property="tabView" destination="udA-m2-eJb" id="zL4-73-AVP"/>
                 <outlet property="videoTabBtn" destination="Ma8-6g-tVw" id="d0g-Fi-gzz"/>
+                <outlet property="videoTabScrollView" destination="SHU-hX-9MT" id="2Ju-pD-rhR"/>
                 <outlet property="videoTableView" destination="rsV-qL-l7b" id="A8k-AU-noQ"/>
                 <outlet property="view" destination="Hz6-mo-xeY" id="0bl-1N-x8E"/>
             </connections>
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <customView misplaced="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY" customClass="QuickSettingView" customModule="IINA" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="0.0" width="360" height="912"/>
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Hz6-mo-xeY" customClass="QuickSettingView" customModule="IINA" customModuleProvider="target">
+            <rect key="frame" x="0.0" y="0.0" width="360" height="267"/>
             <subviews>
                 <stackView distribution="fillEqually" orientation="horizontal" alignment="centerY" horizontalStackHuggingPriority="200" verticalStackHuggingPriority="250" horizontalHuggingPriority="200" detachesHiddenViews="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dNi-Ib-2vd" userLabel="TabButtons Stack View">
-                    <rect key="frame" x="20" y="864" width="337" height="48"/>
+                    <rect key="frame" x="20" y="219" width="320" height="48"/>
                     <subviews>
                         <button imageHugsTitle="YES" horizontalHuggingPriority="252" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Ma8-6g-tVw" userLabel="VideoTab Button">
-                            <rect key="frame" x="0.0" y="0.0" width="107" height="48"/>
+                            <rect key="frame" x="0.0" y="0.0" width="100" height="48"/>
                             <buttonCell key="cell" type="square" title="VIDEO" bezelStyle="shadowlessSquare" image="tab_video" imagePosition="leading" alignment="center" imageScaling="proportionallyDown" inset="2" id="lQt-I0-jHO">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="systemBold"/>
@@ -103,7 +106,7 @@
                             </connections>
                         </button>
                         <button tag="1" imageHugsTitle="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3Fk-ey-FhK" userLabel="AudioTab Button">
-                            <rect key="frame" x="115" y="0.0" width="107" height="48"/>
+                            <rect key="frame" x="108" y="0.0" width="99" height="48"/>
                             <buttonCell key="cell" type="square" title="AUDIO" bezelStyle="shadowlessSquare" image="tab_audio" imagePosition="leading" alignment="center" imageScaling="proportionallyDown" inset="2" id="cpm-5o-a2c">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="systemBold"/>
@@ -113,7 +116,7 @@
                             </connections>
                         </button>
                         <button tag="2" imageHugsTitle="YES" horizontalHuggingPriority="253" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="rH3-pU-mFc" userLabel="SubtitlesTab Button">
-                            <rect key="frame" x="230" y="0.0" width="107" height="48"/>
+                            <rect key="frame" x="215" y="0.0" width="105" height="48"/>
                             <buttonCell key="cell" type="square" title="SUBTITLES" bezelStyle="shadowlessSquare" image="tab_sub" imagePosition="leading" alignment="center" imageScaling="proportionallyDown" inset="2" id="NxO-to-jcI">
                                 <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                                 <font key="font" metaFont="systemBold"/>
@@ -144,2379 +147,28 @@
                     </customSpacing>
                 </stackView>
                 <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="L78-cf-BxB" userLabel="BelowTabButtons Horizontal Line">
-                    <rect key="frame" x="0.0" y="861" width="377" height="5"/>
+                    <rect key="frame" x="0.0" y="216" width="360" height="5"/>
                 </box>
                 <tabView drawsBackground="NO" type="noTabsNoBorder" translatesAutoresizingMaskIntoConstraints="NO" id="udA-m2-eJb" userLabel="AllTabs Tab View">
-                    <rect key="frame" x="0.0" y="0.0" width="377" height="863"/>
+                    <rect key="frame" x="0.0" y="0.0" width="360" height="218"/>
                     <font key="font" metaFont="system"/>
                     <tabViewItems>
                         <tabViewItem label="Video" identifier="1" id="CYP-el-A6A" userLabel="VideoTab Tab View Item">
                             <view key="view" id="NRI-ba-KMd" userLabel="VideoTab View">
-                                <rect key="frame" x="0.0" y="0.0" width="367" height="863"/>
+                                <rect key="frame" x="0.0" y="0.0" width="360" height="218"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                <subviews>
-                                    <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="SHU-hX-9MT" userLabel="VideoTab Scroll View">
-                                        <rect key="frame" x="0.0" y="0.0" width="367" height="863"/>
-                                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="8Es-YX-dNf" userLabel="VideoTab Clip View">
-                                            <rect key="frame" x="0.0" y="0.0" width="367" height="863"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                            <subviews>
-                                                <view translatesAutoresizingMaskIntoConstraints="NO" id="ZGz-La-n9c" userLabel="VideoTab Flipped CONTENT VIEW" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="107" width="367" height="756"/>
-                                                    <subviews>
-                                                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="seu-WU-cTV" userLabel="HORIZONTAL-INSETS">
-                                                            <rect key="frame" x="20" y="736" width="327" height="0.0"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="height" id="4UC-le-Tmg"/>
-                                                            </constraints>
-                                                        </customView>
-                                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ng5-FC-tts" userLabel="Video track Label">
-                                                            <rect key="frame" x="18" y="720" width="331" height="16"/>
-                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Video track:" id="VzC-tM-KT7">
-                                                                <font key="font" metaFont="systemBold"/>
-                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                            </textFieldCell>
-                                                        </textField>
-                                                        <scrollView focusRingType="none" borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ykw-rb-M9D" userLabel="VideoTrackTable Scroll View">
-                                                            <rect key="frame" x="0.0" y="637" width="367" height="75"/>
-                                                            <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="jek-w4-LTf" userLabel="VideoTrackTable Clip View">
-                                                                <rect key="frame" x="0.0" y="0.0" width="367" height="75"/>
-                                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                <subviews>
-                                                                    <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="rsV-qL-l7b" userLabel="VideoTrackTable Table View">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="367" height="75"/>
-                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                        <size key="intercellSpacing" width="3" height="2"/>
-                                                                        <color key="backgroundColor" white="1" alpha="0.082057643580000006" colorSpace="deviceWhite"/>
-                                                                        <tableViewGridLines key="gridStyleMask" horizontal="YES"/>
-                                                                        <color key="gridColor" red="1" green="1" blue="1" alpha="0.10000000000000001" colorSpace="calibratedRGB"/>
-                                                                        <tableColumns>
-                                                                            <tableColumn identifier="IsChosen" editable="NO" width="16" minWidth="16" maxWidth="16" id="PPM-Xv-dec">
-                                                                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="right">
-                                                                                    <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                    <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
-                                                                                </tableHeaderCell>
-                                                                                <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" refusesFirstResponder="YES" alignment="right" title="0" id="z4R-2L-mKS">
-                                                                                    <font key="font" metaFont="system"/>
-                                                                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                                </textFieldCell>
-                                                                                <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                                                                <prototypeCellViews>
-                                                                                    <tableCellView id="99i-8I-ANv">
-                                                                                        <rect key="frame" x="1" y="1" width="21" height="17"/>
-                                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                                        <subviews>
-                                                                                            <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="kfS-xI-KPe">
-                                                                                                <rect key="frame" x="0.0" y="0.0" width="21" height="17"/>
-                                                                                                <constraints>
-                                                                                                    <constraint firstAttribute="height" constant="17" id="tAH-cB-Po2"/>
-                                                                                                </constraints>
-                                                                                                <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="dlX-H5-BCo">
-                                                                                                    <font key="font" metaFont="system"/>
-                                                                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                                                </textFieldCell>
-                                                                                                <connections>
-                                                                                                    <binding destination="99i-8I-ANv" name="value" keyPath="objectValue" id="dU5-kW-VVa"/>
-                                                                                                </connections>
-                                                                                            </textField>
-                                                                                        </subviews>
-                                                                                        <constraints>
-                                                                                            <constraint firstItem="kfS-xI-KPe" firstAttribute="leading" secondItem="99i-8I-ANv" secondAttribute="leading" constant="2" id="R3c-qW-JBz"/>
-                                                                                            <constraint firstItem="kfS-xI-KPe" firstAttribute="centerX" secondItem="99i-8I-ANv" secondAttribute="centerX" id="hfL-Lc-0J5"/>
-                                                                                            <constraint firstItem="kfS-xI-KPe" firstAttribute="centerY" secondItem="99i-8I-ANv" secondAttribute="centerY" id="m0P-If-qLe"/>
-                                                                                        </constraints>
-                                                                                        <connections>
-                                                                                            <outlet property="textField" destination="kfS-xI-KPe" id="bhC-fw-C4F"/>
-                                                                                        </connections>
-                                                                                    </tableCellView>
-                                                                                </prototypeCellViews>
-                                                                            </tableColumn>
-                                                                            <tableColumn identifier="TrackId" width="33" minWidth="33" maxWidth="100" id="Rm0-nB-ZDI">
-                                                                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="right">
-                                                                                    <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                                                                </tableHeaderCell>
-                                                                                <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" refusesFirstResponder="YES" alignment="left" title="Text Cell" id="9ss-EF-bby">
-                                                                                    <font key="font" metaFont="system"/>
-                                                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                                </textFieldCell>
-                                                                                <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                                                                <prototypeCellViews>
-                                                                                    <tableCellView id="EOK-X6-h3U">
-                                                                                        <rect key="frame" x="25" y="1" width="33" height="17"/>
-                                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                                        <subviews>
-                                                                                            <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="s0D-BR-Bfy">
-                                                                                                <rect key="frame" x="0.0" y="0.0" width="33" height="17"/>
-                                                                                                <constraints>
-                                                                                                    <constraint firstAttribute="height" constant="17" id="wbc-c0-LPM"/>
-                                                                                                </constraints>
-                                                                                                <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="right" title="Table View Cell" id="Pf6-Fd-0mO">
-                                                                                                    <font key="font" metaFont="systemBold"/>
-                                                                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                                                </textFieldCell>
-                                                                                                <connections>
-                                                                                                    <binding destination="EOK-X6-h3U" name="value" keyPath="objectValue" id="JPW-KP-pJN"/>
-                                                                                                </connections>
-                                                                                            </textField>
-                                                                                        </subviews>
-                                                                                        <constraints>
-                                                                                            <constraint firstItem="s0D-BR-Bfy" firstAttribute="centerY" secondItem="EOK-X6-h3U" secondAttribute="centerY" id="Dar-xn-ZWQ"/>
-                                                                                            <constraint firstItem="s0D-BR-Bfy" firstAttribute="centerX" secondItem="EOK-X6-h3U" secondAttribute="centerX" id="EJ9-Zw-Nzl"/>
-                                                                                            <constraint firstItem="s0D-BR-Bfy" firstAttribute="leading" secondItem="EOK-X6-h3U" secondAttribute="leading" constant="2" id="aQ1-Zg-h8j"/>
-                                                                                        </constraints>
-                                                                                        <connections>
-                                                                                            <outlet property="textField" destination="s0D-BR-Bfy" id="Gdk-1b-JTF"/>
-                                                                                        </connections>
-                                                                                    </tableCellView>
-                                                                                </prototypeCellViews>
-                                                                            </tableColumn>
-                                                                            <tableColumn identifier="TrackName" editable="NO" width="292" minWidth="100" maxWidth="10000" id="DgA-Ly-Gb8">
-                                                                                <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                                                                    <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                    <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                                                                </tableHeaderCell>
-                                                                                <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" refusesFirstResponder="YES" allowsUndo="NO" alignment="left" title="Text Cell" id="qpa-hD-ImC">
-                                                                                    <font key="font" metaFont="system"/>
-                                                                                    <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                                </textFieldCell>
-                                                                                <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                                                                <prototypeCellViews>
-                                                                                    <tableCellView id="QLv-Qp-hCf">
-                                                                                        <rect key="frame" x="61" y="1" width="296" height="17"/>
-                                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                                        <subviews>
-                                                                                            <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="r2o-di-dN5">
-                                                                                                <rect key="frame" x="0.0" y="0.0" width="296" height="17"/>
-                                                                                                <constraints>
-                                                                                                    <constraint firstAttribute="height" constant="17" id="Ai3-GM-1Yw"/>
-                                                                                                </constraints>
-                                                                                                <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="jWy-C5-Xu9">
-                                                                                                    <font key="font" metaFont="system"/>
-                                                                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                                                </textFieldCell>
-                                                                                                <connections>
-                                                                                                    <binding destination="QLv-Qp-hCf" name="value" keyPath="objectValue" id="RoD-Zm-RdC"/>
-                                                                                                </connections>
-                                                                                            </textField>
-                                                                                        </subviews>
-                                                                                        <constraints>
-                                                                                            <constraint firstItem="r2o-di-dN5" firstAttribute="leading" secondItem="QLv-Qp-hCf" secondAttribute="leading" constant="2" id="Lhx-nh-pQ4"/>
-                                                                                            <constraint firstItem="r2o-di-dN5" firstAttribute="centerX" secondItem="QLv-Qp-hCf" secondAttribute="centerX" id="ZHJ-3g-zVB"/>
-                                                                                            <constraint firstItem="r2o-di-dN5" firstAttribute="centerY" secondItem="QLv-Qp-hCf" secondAttribute="centerY" id="c5v-ES-heI"/>
-                                                                                        </constraints>
-                                                                                        <connections>
-                                                                                            <outlet property="textField" destination="r2o-di-dN5" id="wA6-wm-GAV"/>
-                                                                                        </connections>
-                                                                                    </tableCellView>
-                                                                                </prototypeCellViews>
-                                                                            </tableColumn>
-                                                                        </tableColumns>
-                                                                    </tableView>
-                                                                </subviews>
-                                                            </clipView>
-                                                            <constraints>
-                                                                <constraint firstAttribute="height" constant="75" id="QlN-U3-ekO"/>
-                                                            </constraints>
-                                                            <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="XXI-Cy-jma">
-                                                                <rect key="frame" x="0.0" y="59" width="56" height="16"/>
-                                                                <autoresizingMask key="autoresizingMask"/>
-                                                            </scroller>
-                                                            <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="wog-uC-A3q">
-                                                                <rect key="frame" x="-16" y="0.0" width="16" height="0.0"/>
-                                                                <autoresizingMask key="autoresizingMask"/>
-                                                            </scroller>
-                                                        </scrollView>
-                                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CUa-0e-DwY" userLabel="Aspect ratio Label">
-                                                            <rect key="frame" x="18" y="601" width="331" height="16"/>
-                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Aspect ratio:" id="YgL-iV-bca">
-                                                                <font key="font" metaFont="systemBold"/>
-                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                            </textFieldCell>
-                                                        </textField>
-                                                        <segmentedControl horizontalHuggingPriority="100" verticalHuggingPriority="750" horizontalCompressionResistancePriority="500" translatesAutoresizingMaskIntoConstraints="NO" id="Ljl-w6-gIf" userLabel="AspectRatio Segmented Control">
-                                                            <rect key="frame" x="18" y="570" width="253" height="24"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="240" id="43J-t3-UhR"/>
-                                                            </constraints>
-                                                            <segmentedCell key="cell" refusesFirstResponder="YES" borderStyle="border" alignment="left" segmentDistribution="fillProportionally" style="rounded" trackingMode="selectOne" id="cMu-YF-riv">
-                                                                <font key="font" metaFont="system"/>
-                                                                <segments>
-                                                                    <segment label="Default" selected="YES"/>
-                                                                    <segment label="4:3" tag="1"/>
-                                                                    <segment label="16:9" tag="2"/>
-                                                                    <segment label="16:10" tag="3"/>
-                                                                    <segment label="21:9" tag="4"/>
-                                                                    <segment label="5:4"/>
-                                                                </segments>
-                                                            </segmentedCell>
-                                                            <connections>
-                                                                <action selector="aspectChangedAction:" target="-2" id="U7C-TJ-2UJ"/>
-                                                            </connections>
-                                                        </segmentedControl>
-                                                        <textField identifier="customAspectRatio" focusRingType="none" horizontalHuggingPriority="500" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XAI-y0-tcy" userLabel="CustomAspectRatio Text Field">
-                                                            <rect key="frame" x="277" y="572" width="70" height="21"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="900" constant="30" id="JnW-kS-XvK"/>
-                                                            </constraints>
-                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="jR7-Mt-N0T" customClass="RoundedTextFieldCell" customModule="IINA" customModuleProvider="target">
-                                                                <font key="font" metaFont="system"/>
-                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                            </textFieldCell>
-                                                            <connections>
-                                                                <action selector="customAspectEditFinishedAction:" target="-2" id="8DL-tk-4rJ"/>
-                                                            </connections>
-                                                        </textField>
-                                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oAm-jJ-3kE" userLabel="CropLabel Text Field">
-                                                            <rect key="frame" x="18" y="535" width="331" height="16"/>
-                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Crop:" id="m9e-IB-IDJ">
-                                                                <font key="font" metaFont="systemBold"/>
-                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                            </textFieldCell>
-                                                        </textField>
-                                                        <segmentedControl horizontalHuggingPriority="100" verticalHuggingPriority="750" horizontalCompressionResistancePriority="500" translatesAutoresizingMaskIntoConstraints="NO" id="sPT-jd-T7a" userLabel="CropChooser Segmented Control">
-                                                            <rect key="frame" x="18" y="504" width="331" height="24"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="230" id="tTp-B3-gF5"/>
-                                                            </constraints>
-                                                            <segmentedCell key="cell" refusesFirstResponder="YES" borderStyle="border" alignment="left" segmentDistribution="fillProportionally" style="rounded" trackingMode="selectOne" id="iuN-rN-jT7" userLabel="CropChooser Segmented Cell">
-                                                                <font key="font" metaFont="system"/>
-                                                                <segments>
-                                                                    <segment label="None"/>
-                                                                    <segment label="4:3" selected="YES" tag="1"/>
-                                                                    <segment label="16:9" tag="2"/>
-                                                                    <segment label="16:10" tag="3"/>
-                                                                    <segment label="21:9" tag="4"/>
-                                                                    <segment label="5:4"/>
-                                                                    <segment label="Custom…"/>
-                                                                </segments>
-                                                            </segmentedCell>
-                                                            <connections>
-                                                                <action selector="cropChangedAction:" target="-2" id="94g-N6-rTB"/>
-                                                            </connections>
-                                                        </segmentedControl>
-                                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7vv-En-VYY" userLabel="RotationLabel Text Field">
-                                                            <rect key="frame" x="18" y="469" width="331" height="16"/>
-                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Rotation:" id="to3-rc-Agv">
-                                                                <font key="font" metaFont="systemBold"/>
-                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                            </textFieldCell>
-                                                        </textField>
-                                                        <segmentedControl verticalHuggingPriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="bza-SA-tXE" userLabel="Rotation Segmented Control">
-                                                            <rect key="frame" x="18" y="438" width="171" height="24"/>
-                                                            <segmentedCell key="cell" refusesFirstResponder="YES" borderStyle="border" alignment="left" segmentDistribution="fillEqually" style="rounded" trackingMode="selectOne" id="z1L-0N-dfK">
-                                                                <font key="font" metaFont="system"/>
-                                                                <segments>
-                                                                    <segment label="0°" selected="YES"/>
-                                                                    <segment label="90°" tag="1"/>
-                                                                    <segment label="180°" tag="2"/>
-                                                                    <segment label="270°" tag="3"/>
-                                                                </segments>
-                                                            </segmentedCell>
-                                                            <connections>
-                                                                <action selector="rotationChangedAction:" target="-2" id="aL1-XS-nLe"/>
-                                                            </connections>
-                                                        </segmentedControl>
-                                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="d4r-sL-0Vo" userLabel="SpeedLabel Text Field">
-                                                            <rect key="frame" x="18" y="403" width="307" height="16"/>
-                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Speed:" id="1KQ-oZ-A2x">
-                                                                <font key="font" metaFont="systemBold"/>
-                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                            </textFieldCell>
-                                                        </textField>
-                                                        <button translatesAutoresizingMaskIntoConstraints="NO" id="705-dt-Zwl" userLabel="SpeedReset Button">
-                                                            <rect key="frame" x="331" y="400" width="16" height="21"/>
-                                                            <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRefreshFreestandingTemplate" imagePosition="only" alignment="center" controlSize="small" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="e2B-Ie-9hS">
-                                                                <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                <font key="font" metaFont="message" size="11"/>
-                                                            </buttonCell>
-                                                            <constraints>
-                                                                <constraint firstAttribute="height" constant="16" id="EC5-Kq-oB4"/>
-                                                                <constraint firstAttribute="width" constant="16" id="Gst-Sh-NwE"/>
-                                                            </constraints>
-                                                            <connections>
-                                                                <action selector="resetSpeedAction:" target="-2" id="2Ms-5F-wpA"/>
-                                                            </connections>
-                                                        </button>
-                                                        <customView autoresizesSubviews="NO" horizontalHuggingPriority="200" horizontalCompressionResistancePriority="700" translatesAutoresizingMaskIntoConstraints="NO" id="5v4-Te-950" userLabel="SpeedSlider Container View">
-                                                            <rect key="frame" x="19" y="357" width="328" height="42"/>
-                                                            <subviews>
-                                                                <slider horizontalHuggingPriority="1" verticalHuggingPriority="700" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="700" translatesAutoresizingMaskIntoConstraints="NO" id="UWh-M9-5Nw" userLabel="SpeedSlider Horizontal Tick Slider">
-                                                                    <rect key="frame" x="-1" y="10" width="234" height="20"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="width" constant="230" id="oce-0K-3Eq"/>
-                                                                    </constraints>
-                                                                    <sliderCell key="cell" controlSize="small" continuous="YES" refusesFirstResponder="YES" alignment="left" maxValue="24" doubleValue="8" tickMarkPosition="below" numberOfTickMarks="25" sliderType="linear" id="qxp-Lt-D6o"/>
-                                                                    <connections>
-                                                                        <action selector="speedChangedAction:" target="-2" id="asr-iq-ZNJ"/>
-                                                                    </connections>
-                                                                </slider>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="100" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3EN-WD-QNI" userLabel="SpeedSliderIndicator Text Field">
-                                                                    <rect key="frame" x="72" y="29" width="19" height="13"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="1x" usesSingleLineMode="YES" id="ldQ-YL-IEp">
-                                                                        <font key="font" metaFont="system" size="10"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nhb-Co-xbZ" userLabel="0.25xLabel Text Field">
-                                                                    <rect key="frame" x="-1" y="0.0" width="29" height="11"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="0.25x" id="Ew1-N1-0Pi">
-                                                                        <font key="font" metaFont="label" size="9"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wBg-Dk-cUX" userLabel="1xLabel Text Field">
-                                                                    <rect key="frame" x="71" y="0.0" width="18" height="11"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="1x" id="B0I-bX-HZS">
-                                                                        <font key="font" metaFont="label" size="9"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Njq-za-TIf" userLabel="4xLabel Text Field">
-                                                                    <rect key="frame" x="145" y="0.0" width="19" height="11"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="4x" id="PLX-gY-e0h">
-                                                                        <font key="font" metaFont="label" size="9"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mjX-Jf-925" userLabel="16xLabel Text Field">
-                                                                    <rect key="frame" x="213" y="0.0" width="20" height="11"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="16x" id="p63-Nx-yJZ">
-                                                                        <font key="font" metaFont="label" size="9"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="100" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sIs-a1-rGR" userLabel="SpeedEdit Text Field">
-                                                                    <rect key="frame" x="239" y="9" width="78" height="22"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" title="1" usesSingleLineMode="YES" bezelStyle="round" id="Mav-NA-RfN" userLabel="SpeedEdit Text Field Cell" customClass="RoundedTextFieldCell" customModule="IINA" customModuleProvider="target">
-                                                                        <font key="font" metaFont="system"/>
-                                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                    <connections>
-                                                                        <action selector="customSpeedEditFinishedAction:" target="-2" id="f1u-Mu-w4S"/>
-                                                                    </connections>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="999" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ftl-yD-3Pp">
-                                                                    <rect key="frame" x="315" y="12" width="15" height="16"/>
-                                                                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="x" id="dD9-6c-nPz">
-                                                                        <font key="font" metaFont="system"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                            </subviews>
-                                                            <constraints>
-                                                                <constraint firstItem="Njq-za-TIf" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="wBg-Dk-cUX" secondAttribute="leading" id="0og-bi-e6K"/>
-                                                                <constraint firstItem="Njq-za-TIf" firstAttribute="firstBaseline" secondItem="Nhb-Co-xbZ" secondAttribute="firstBaseline" id="3b5-3Q-r9W"/>
-                                                                <constraint firstItem="sIs-a1-rGR" firstAttribute="leading" secondItem="UWh-M9-5Nw" secondAttribute="trailing" constant="8" id="45f-oW-eLi"/>
-                                                                <constraint firstItem="3EN-WD-QNI" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="UWh-M9-5Nw" secondAttribute="trailing" id="5HH-wM-xVs"/>
-                                                                <constraint firstItem="wBg-Dk-cUX" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Nhb-Co-xbZ" secondAttribute="trailing" id="85g-vN-0eC"/>
-                                                                <constraint firstAttribute="trailing" secondItem="ftl-yD-3Pp" secondAttribute="trailing" id="96C-Yr-KHl"/>
-                                                                <constraint firstItem="mjX-Jf-925" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Njq-za-TIf" secondAttribute="trailing" id="Aep-cH-5hZ"/>
-                                                                <constraint firstItem="UWh-M9-5Nw" firstAttribute="top" secondItem="3EN-WD-QNI" secondAttribute="bottom" constant="1" id="Ew9-hh-DuD"/>
-                                                                <constraint firstItem="Njq-za-TIf" firstAttribute="centerX" secondItem="UWh-M9-5Nw" secondAttribute="trailing" multiplier="0.667" id="H0i-c4-qHi"/>
-                                                                <constraint firstItem="sIs-a1-rGR" firstAttribute="trailing" secondItem="ftl-yD-3Pp" secondAttribute="leading" id="NH7-04-aU7"/>
-                                                                <constraint firstItem="3EN-WD-QNI" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="UWh-M9-5Nw" secondAttribute="leading" id="VCK-Xl-WI5"/>
-                                                                <constraint firstItem="ftl-yD-3Pp" firstAttribute="firstBaseline" secondItem="sIs-a1-rGR" secondAttribute="firstBaseline" id="ZAk-oK-iEc"/>
-                                                                <constraint firstItem="mjX-Jf-925" firstAttribute="trailing" secondItem="UWh-M9-5Nw" secondAttribute="trailing" id="a9v-VN-b9b"/>
-                                                                <constraint firstItem="UWh-M9-5Nw" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="1" id="b9h-cf-WWr"/>
-                                                                <constraint firstItem="Nhb-Co-xbZ" firstAttribute="leading" secondItem="UWh-M9-5Nw" secondAttribute="leading" id="bpH-bS-WjS"/>
-                                                                <constraint firstItem="3EN-WD-QNI" firstAttribute="top" secondItem="5v4-Te-950" secondAttribute="top" id="cOT-x8-ZcW"/>
-                                                                <constraint firstItem="wBg-Dk-cUX" firstAttribute="centerX" secondItem="UWh-M9-5Nw" secondAttribute="leading" multiplier="0.3333" constant="80" id="hlk-KQ-DJ7"/>
-                                                                <constraint firstItem="wBg-Dk-cUX" firstAttribute="firstBaseline" secondItem="Nhb-Co-xbZ" secondAttribute="firstBaseline" id="ime-8Z-RkU"/>
-                                                                <constraint firstAttribute="bottom" secondItem="Nhb-Co-xbZ" secondAttribute="bottom" id="iwc-ox-8MG"/>
-                                                                <constraint firstItem="mjX-Jf-925" firstAttribute="firstBaseline" secondItem="Nhb-Co-xbZ" secondAttribute="firstBaseline" id="pcC-I5-fWK"/>
-                                                                <constraint firstItem="3EN-WD-QNI" firstAttribute="centerX" secondItem="UWh-M9-5Nw" secondAttribute="leading" priority="800" constant="80" id="qTf-o6-Mef"/>
-                                                                <constraint firstItem="Nhb-Co-xbZ" firstAttribute="top" secondItem="UWh-M9-5Nw" secondAttribute="bottom" constant="1" id="vt5-Yi-wDm"/>
-                                                                <constraint firstItem="sIs-a1-rGR" firstAttribute="centerY" secondItem="UWh-M9-5Nw" secondAttribute="centerY" id="xKa-An-0CC"/>
-                                                            </constraints>
-                                                        </customView>
-                                                        <box autoresizesSubviews="NO" boxType="custom" cornerRadius="6" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="2ye-g4-fz5" userLabel="Switches Box">
-                                                            <rect key="frame" x="20" y="207" width="327" height="130"/>
-                                                            <view key="contentView" id="bBc-PP-gHz" userLabel="Switches Box View">
-                                                                <rect key="frame" x="1" y="1" width="325" height="128"/>
-                                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                <subviews>
-                                                                    <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="PyM-xa-vx9" userLabel="Horizontal Line 1">
-                                                                        <rect key="frame" x="12" y="83" width="301" height="5"/>
-                                                                    </box>
-                                                                    <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="qYi-uQ-6qo" userLabel="Horizontal Line 2">
-                                                                        <rect key="frame" x="12" y="40" width="301" height="5"/>
-                                                                    </box>
-                                                                    <switch horizontalHuggingPriority="750" verticalHuggingPriority="750" baseWritingDirection="leftToRight" alignment="left" translatesAutoresizingMaskIntoConstraints="NO" id="UKk-rD-n2A">
-                                                                        <rect key="frame" x="265" y="51" width="42" height="25"/>
-                                                                        <connections>
-                                                                            <action selector="deinterlaceAction:" target="-2" id="Wks-al-3dq"/>
-                                                                        </connections>
-                                                                    </switch>
-                                                                    <switch horizontalHuggingPriority="750" verticalHuggingPriority="750" baseWritingDirection="leftToRight" alignment="left" translatesAutoresizingMaskIntoConstraints="NO" id="TNg-iM-cVP">
-                                                                        <rect key="frame" x="265" y="8" width="42" height="25"/>
-                                                                        <connections>
-                                                                            <action selector="hdrAction:" target="-2" id="caQ-5H-pX4"/>
-                                                                        </connections>
-                                                                    </switch>
-                                                                    <switch horizontalHuggingPriority="750" verticalHuggingPriority="750" baseWritingDirection="leftToRight" alignment="left" translatesAutoresizingMaskIntoConstraints="NO" id="AbD-ap-nO5">
-                                                                        <rect key="frame" x="265" y="94" width="42" height="25"/>
-                                                                        <connections>
-                                                                            <action selector="hardwareDecodingAction:" target="-2" id="Fv6-2y-odN"/>
-                                                                        </connections>
-                                                                    </switch>
-                                                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OvF-ci-44R">
-                                                                        <rect key="frame" x="18" y="101" width="124" height="16"/>
-                                                                        <textFieldCell key="cell" lineBreakMode="clipping" title="Hardware Decoding" id="rw1-Qb-0RV">
-                                                                            <font key="font" usesAppearanceFont="YES"/>
-                                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                        </textFieldCell>
-                                                                    </textField>
-                                                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xJo-hi-ale">
-                                                                        <rect key="frame" x="18" y="15" width="32" height="16"/>
-                                                                        <textFieldCell key="cell" lineBreakMode="clipping" title="HDR" id="UW4-by-XRS">
-                                                                            <font key="font" usesAppearanceFont="YES"/>
-                                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                        </textFieldCell>
-                                                                    </textField>
-                                                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="m39-41-Kwj">
-                                                                        <rect key="frame" x="18" y="58" width="73" height="16"/>
-                                                                        <textFieldCell key="cell" lineBreakMode="clipping" title="Deinterlace" id="eqd-nF-8ff">
-                                                                            <font key="font" usesAppearanceFont="YES"/>
-                                                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                        </textFieldCell>
-                                                                    </textField>
-                                                                </subviews>
-                                                                <constraints>
-                                                                    <constraint firstItem="AbD-ap-nO5" firstAttribute="top" secondItem="bBc-PP-gHz" secondAttribute="top" constant="10" id="5cF-CC-AbB"/>
-                                                                    <constraint firstItem="qYi-uQ-6qo" firstAttribute="top" secondItem="UKk-rD-n2A" secondAttribute="bottom" constant="10" id="6VJ-Ah-h6m"/>
-                                                                    <constraint firstItem="TNg-iM-cVP" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="xJo-hi-ale" secondAttribute="trailing" id="AFb-Zd-1Kk"/>
-                                                                    <constraint firstItem="OvF-ci-44R" firstAttribute="firstBaseline" secondItem="AbD-ap-nO5" secondAttribute="firstBaseline" id="C5V-KG-rtA"/>
-                                                                    <constraint firstItem="xJo-hi-ale" firstAttribute="firstBaseline" secondItem="TNg-iM-cVP" secondAttribute="firstBaseline" id="FgR-gq-g9W"/>
-                                                                    <constraint firstItem="OvF-ci-44R" firstAttribute="leading" secondItem="bBc-PP-gHz" secondAttribute="leading" constant="20" symbolic="YES" id="HQZ-2y-rKx"/>
-                                                                    <constraint firstItem="AbD-ap-nO5" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="OvF-ci-44R" secondAttribute="trailing" id="JmL-a7-GPB"/>
-                                                                    <constraint firstAttribute="trailing" secondItem="UKk-rD-n2A" secondAttribute="trailing" constant="20" symbolic="YES" id="SGe-oO-XfD"/>
-                                                                    <constraint firstItem="qYi-uQ-6qo" firstAttribute="trailing" secondItem="PyM-xa-vx9" secondAttribute="trailing" id="W6Y-bH-eCi"/>
-                                                                    <constraint firstAttribute="bottom" secondItem="TNg-iM-cVP" secondAttribute="bottom" constant="10" id="XFf-u8-uTi"/>
-                                                                    <constraint firstAttribute="trailing" secondItem="PyM-xa-vx9" secondAttribute="trailing" constant="12" id="Zny-ol-SPy"/>
-                                                                    <constraint firstItem="PyM-xa-vx9" firstAttribute="top" secondItem="AbD-ap-nO5" secondAttribute="bottom" constant="10" id="aZI-9n-idy"/>
-                                                                    <constraint firstItem="PyM-xa-vx9" firstAttribute="leading" secondItem="bBc-PP-gHz" secondAttribute="leading" constant="12" id="cAs-bS-FEB"/>
-                                                                    <constraint firstItem="TNg-iM-cVP" firstAttribute="top" secondItem="qYi-uQ-6qo" secondAttribute="bottom" constant="10" id="eVy-VT-STY"/>
-                                                                    <constraint firstItem="UKk-rD-n2A" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="m39-41-Kwj" secondAttribute="trailing" id="faP-iu-15E"/>
-                                                                    <constraint firstItem="xJo-hi-ale" firstAttribute="leading" secondItem="bBc-PP-gHz" secondAttribute="leading" constant="20" symbolic="YES" id="hah-hi-Vnt"/>
-                                                                    <constraint firstItem="m39-41-Kwj" firstAttribute="leading" secondItem="bBc-PP-gHz" secondAttribute="leading" constant="20" symbolic="YES" id="l2S-aw-jeb"/>
-                                                                    <constraint firstAttribute="trailing" secondItem="AbD-ap-nO5" secondAttribute="trailing" constant="20" symbolic="YES" id="q7m-cn-c9D"/>
-                                                                    <constraint firstItem="m39-41-Kwj" firstAttribute="firstBaseline" secondItem="UKk-rD-n2A" secondAttribute="firstBaseline" id="qP2-ce-a9h"/>
-                                                                    <constraint firstItem="qYi-uQ-6qo" firstAttribute="leading" secondItem="PyM-xa-vx9" secondAttribute="leading" id="tkm-Ze-qkw"/>
-                                                                    <constraint firstAttribute="trailing" secondItem="TNg-iM-cVP" secondAttribute="trailing" constant="20" symbolic="YES" id="ugo-Rb-i01"/>
-                                                                    <constraint firstItem="UKk-rD-n2A" firstAttribute="top" secondItem="PyM-xa-vx9" secondAttribute="bottom" constant="10" id="w2S-IA-KK8"/>
-                                                                </constraints>
-                                                            </view>
-                                                            <constraints>
-                                                                <constraint firstAttribute="height" constant="130" id="mMk-SO-lBd"/>
-                                                            </constraints>
-                                                            <color key="borderColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
-                                                            <color key="fillColor" red="0.99999600649999998" green="1" blue="1" alpha="0.10000000000000001" colorSpace="custom" customColorSpace="sRGB"/>
-                                                        </box>
-                                                        <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="7PK-hh-Xx5">
-                                                            <rect key="frame" x="0.0" y="184" width="367" height="5"/>
-                                                        </box>
-                                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QqK-iZ-rFX" userLabel="EqualizerLabel Text Field">
-                                                            <rect key="frame" x="18" y="150" width="331" height="16"/>
-                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Equalizer:" id="zcD-Tg-7Oi">
-                                                                <font key="font" metaFont="systemBold"/>
-                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                            </textFieldCell>
-                                                        </textField>
-                                                        <stackView distribution="equalCentering" orientation="vertical" alignment="leading" spacing="11" horizontalStackHuggingPriority="1000" verticalStackHuggingPriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="9Ua-jA-xuA" userLabel="EqualizerLabels Vertical Stack View">
-                                                            <rect key="frame" x="20" y="20" width="55" height="110"/>
-                                                            <subviews>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Kzg-Uw-tpM">
-                                                                    <rect key="frame" x="-2" y="97" width="59" height="13"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Brightness:" id="cdR-uY-riN">
-                                                                        <font key="font" metaFont="message" size="11"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zeE-QB-5WQ">
-                                                                    <rect key="frame" x="-2" y="73" width="59" height="13"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Contrast:" id="eDl-Si-LSa">
-                                                                        <font key="font" metaFont="message" size="11"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="inU-m8-46Z">
-                                                                    <rect key="frame" x="-2" y="48" width="59" height="14"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Saturation:" id="Rky-lo-Buu">
-                                                                        <font key="font" metaFont="message" size="11"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NFp-1S-x9x">
-                                                                    <rect key="frame" x="-2" y="24" width="59" height="13"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Gamma:" id="r6x-z0-oFC">
-                                                                        <font key="font" metaFont="message" size="11"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BdF-A5-VPG">
-                                                                    <rect key="frame" x="-2" y="0.0" width="59" height="13"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Hue:" id="eLh-fu-pMj">
-                                                                        <font key="font" metaFont="message" size="11"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                            </subviews>
-                                                            <constraints>
-                                                                <constraint firstItem="BdF-A5-VPG" firstAttribute="bottom" secondItem="Kzg-Uw-tpM" secondAttribute="top" constant="110" id="0cF-1Q-5Et"/>
-                                                                <constraint firstItem="inU-m8-46Z" firstAttribute="height" secondItem="Kzg-Uw-tpM" secondAttribute="height" id="B8c-8a-Bmv"/>
-                                                                <constraint firstItem="NFp-1S-x9x" firstAttribute="height" secondItem="Kzg-Uw-tpM" secondAttribute="height" id="aRf-Mh-zKA"/>
-                                                                <constraint firstItem="BdF-A5-VPG" firstAttribute="height" secondItem="Kzg-Uw-tpM" secondAttribute="height" id="ecB-OH-83m"/>
-                                                                <constraint firstItem="zeE-QB-5WQ" firstAttribute="height" secondItem="Kzg-Uw-tpM" secondAttribute="height" id="myf-5F-a3g"/>
-                                                            </constraints>
-                                                            <visibilityPriorities>
-                                                                <integer value="1000"/>
-                                                                <integer value="1000"/>
-                                                                <integer value="1000"/>
-                                                                <integer value="1000"/>
-                                                                <integer value="1000"/>
-                                                            </visibilityPriorities>
-                                                            <customSpacing>
-                                                                <real value="3.4028234663852886e+38"/>
-                                                                <real value="3.4028234663852886e+38"/>
-                                                                <real value="3.4028234663852886e+38"/>
-                                                                <real value="3.4028234663852886e+38"/>
-                                                                <real value="3.4028234663852886e+38"/>
-                                                            </customSpacing>
-                                                        </stackView>
-                                                        <stackView distribution="equalCentering" orientation="vertical" alignment="leading" spacing="11" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="pam-gJ-b3R" userLabel="EqualizerSliders Vertical Stack View">
-                                                            <rect key="frame" x="83" y="20" width="241" height="110"/>
-                                                            <subviews>
-                                                                <slider identifier="brightnessSlider" horizontalHuggingPriority="800" verticalHuggingPriority="750" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="eFW-a3-kWx" userLabel="Brightness Slider">
-                                                                    <rect key="frame" x="-2" y="95" width="238" height="17"/>
-                                                                    <sliderCell key="cell" controlSize="small" continuous="YES" refusesFirstResponder="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="7Km-3j-0F1"/>
-                                                                    <accessibility identifier="brightnessLabel"/>
-                                                                    <connections>
-                                                                        <action selector="equalizerSliderAction:" target="-2" id="D6V-VG-FTQ"/>
-                                                                    </connections>
-                                                                </slider>
-                                                                <slider identifier="contrastSlider" horizontalHuggingPriority="800" verticalHuggingPriority="750" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="mTb-L6-55O" userLabel="Contrast Slider">
-                                                                    <rect key="frame" x="-2" y="71" width="238" height="17"/>
-                                                                    <sliderCell key="cell" controlSize="small" continuous="YES" refusesFirstResponder="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="hgz-bN-WeD"/>
-                                                                    <connections>
-                                                                        <action selector="equalizerSliderAction:" target="-2" id="Nvx-FI-qAc"/>
-                                                                    </connections>
-                                                                </slider>
-                                                                <slider identifier="saturationSlider" horizontalHuggingPriority="800" verticalHuggingPriority="750" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="VlS-Jo-4C0" userLabel="Saturation Slider">
-                                                                    <rect key="frame" x="-2" y="46" width="238" height="18"/>
-                                                                    <sliderCell key="cell" controlSize="small" continuous="YES" refusesFirstResponder="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="XWl-TS-6CD"/>
-                                                                    <connections>
-                                                                        <action selector="equalizerSliderAction:" target="-2" id="lqV-jM-722"/>
-                                                                    </connections>
-                                                                </slider>
-                                                                <slider identifier="gammaSlider" horizontalHuggingPriority="100" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fLl-8b-pj0" userLabel="Gamma Slider">
-                                                                    <rect key="frame" x="-2" y="22" width="245" height="17"/>
-                                                                    <sliderCell key="cell" controlSize="small" continuous="YES" refusesFirstResponder="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="4De-8a-gIx"/>
-                                                                    <connections>
-                                                                        <action selector="equalizerSliderAction:" target="-2" id="eBS-E6-XBk"/>
-                                                                    </connections>
-                                                                </slider>
-                                                                <slider identifier="hueSlider" horizontalHuggingPriority="100" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mKB-Mu-l5Y" userLabel="Hue Slider">
-                                                                    <rect key="frame" x="-2" y="-2" width="245" height="17"/>
-                                                                    <sliderCell key="cell" controlSize="small" continuous="YES" refusesFirstResponder="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="Bwq-Om-Y6s"/>
-                                                                    <connections>
-                                                                        <action selector="equalizerSliderAction:" target="-2" id="Lkh-f1-UR2"/>
-                                                                    </connections>
-                                                                </slider>
-                                                            </subviews>
-                                                            <constraints>
-                                                                <constraint firstItem="fLl-8b-pj0" firstAttribute="height" secondItem="eFW-a3-kWx" secondAttribute="height" id="Boz-5a-gkt"/>
-                                                                <constraint firstItem="mKB-Mu-l5Y" firstAttribute="height" secondItem="eFW-a3-kWx" secondAttribute="height" id="IMb-Uf-aiY"/>
-                                                                <constraint firstItem="mTb-L6-55O" firstAttribute="height" secondItem="eFW-a3-kWx" secondAttribute="height" id="PYB-dj-5Ou"/>
-                                                                <constraint firstItem="VlS-Jo-4C0" firstAttribute="height" secondItem="eFW-a3-kWx" secondAttribute="height" id="qJM-QY-tdM"/>
-                                                            </constraints>
-                                                            <visibilityPriorities>
-                                                                <integer value="1000"/>
-                                                                <integer value="1000"/>
-                                                                <integer value="1000"/>
-                                                                <integer value="1000"/>
-                                                                <integer value="1000"/>
-                                                            </visibilityPriorities>
-                                                            <customSpacing>
-                                                                <real value="3.4028234663852886e+38"/>
-                                                                <real value="3.4028234663852886e+38"/>
-                                                                <real value="3.4028234663852886e+38"/>
-                                                                <real value="3.4028234663852886e+38"/>
-                                                                <real value="3.4028234663852886e+38"/>
-                                                            </customSpacing>
-                                                        </stackView>
-                                                        <stackView distribution="equalCentering" orientation="vertical" alignment="leading" spacing="11" horizontalStackHuggingPriority="1000" verticalStackHuggingPriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="iAC-lz-PuL" userLabel="EqualizerResetButtons Vertical Stack View">
-                                                            <rect key="frame" x="332" y="20" width="15" height="110"/>
-                                                            <subviews>
-                                                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cjG-f1-Mkg" userLabel="Brightness Square Button">
-                                                                    <rect key="frame" x="0.0" y="94" width="15" height="19"/>
-                                                                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRefreshFreestandingTemplate" imagePosition="overlaps" alignment="center" refusesFirstResponder="YES" inset="2" id="63a-cd-eXa">
-                                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                        <font key="font" metaFont="system"/>
-                                                                    </buttonCell>
-                                                                    <connections>
-                                                                        <action selector="resetEqualizerBtnAction:" target="-2" id="pnK-gu-1Jd"/>
-                                                                    </connections>
-                                                                </button>
-                                                                <button tag="1" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KVl-YU-9O3" userLabel="Contrast Square Button">
-                                                                    <rect key="frame" x="0.0" y="70" width="15" height="19"/>
-                                                                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRefreshFreestandingTemplate" imagePosition="overlaps" alignment="center" refusesFirstResponder="YES" inset="2" id="NIq-6H-Orr">
-                                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                        <font key="font" metaFont="system"/>
-                                                                    </buttonCell>
-                                                                    <connections>
-                                                                        <action selector="resetEqualizerBtnAction:" target="-2" id="fkB-MT-0WI"/>
-                                                                    </connections>
-                                                                </button>
-                                                                <button tag="2" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lgg-zH-OLr" userLabel="Saturation Square Button">
-                                                                    <rect key="frame" x="0.0" y="45" width="15" height="20"/>
-                                                                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRefreshFreestandingTemplate" imagePosition="overlaps" alignment="center" refusesFirstResponder="YES" inset="2" id="D5D-O8-MdN">
-                                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                        <font key="font" metaFont="system"/>
-                                                                    </buttonCell>
-                                                                    <connections>
-                                                                        <action selector="resetEqualizerBtnAction:" target="-2" id="C3s-y1-9aO"/>
-                                                                    </connections>
-                                                                </button>
-                                                                <button tag="3" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fGZ-vI-EP8" userLabel="Gamma Square Button">
-                                                                    <rect key="frame" x="0.0" y="21" width="15" height="19"/>
-                                                                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRefreshFreestandingTemplate" imagePosition="overlaps" alignment="center" refusesFirstResponder="YES" inset="2" id="7sd-9d-D6H">
-                                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                        <font key="font" metaFont="system"/>
-                                                                    </buttonCell>
-                                                                    <connections>
-                                                                        <action selector="resetEqualizerBtnAction:" target="-2" id="HTf-KH-SVv"/>
-                                                                    </connections>
-                                                                </button>
-                                                                <button tag="4" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="W7J-wR-UH3" userLabel="Hue Square Button">
-                                                                    <rect key="frame" x="0.0" y="-3" width="15" height="19"/>
-                                                                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRefreshFreestandingTemplate" imagePosition="overlaps" alignment="center" refusesFirstResponder="YES" inset="2" id="Mrx-t0-wfm">
-                                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                        <font key="font" metaFont="system"/>
-                                                                    </buttonCell>
-                                                                    <connections>
-                                                                        <action selector="resetEqualizerBtnAction:" target="-2" id="z43-kY-r5n"/>
-                                                                    </connections>
-                                                                </button>
-                                                            </subviews>
-                                                            <constraints>
-                                                                <constraint firstItem="KVl-YU-9O3" firstAttribute="height" secondItem="cjG-f1-Mkg" secondAttribute="height" id="3Dj-Pa-cqs"/>
-                                                                <constraint firstItem="W7J-wR-UH3" firstAttribute="width" secondItem="cjG-f1-Mkg" secondAttribute="width" id="G6i-E8-li2"/>
-                                                                <constraint firstItem="cjG-f1-Mkg" firstAttribute="width" secondItem="iAC-lz-PuL" secondAttribute="width" id="QQR-g4-ove"/>
-                                                                <constraint firstItem="lgg-zH-OLr" firstAttribute="width" secondItem="cjG-f1-Mkg" secondAttribute="width" id="Rzt-nR-RLP"/>
-                                                                <constraint firstItem="fGZ-vI-EP8" firstAttribute="height" secondItem="cjG-f1-Mkg" secondAttribute="height" id="UAQ-aO-pfl"/>
-                                                                <constraint firstItem="fGZ-vI-EP8" firstAttribute="width" secondItem="cjG-f1-Mkg" secondAttribute="width" id="Zbs-eB-FlT"/>
-                                                                <constraint firstItem="W7J-wR-UH3" firstAttribute="height" secondItem="cjG-f1-Mkg" secondAttribute="height" id="bKm-mB-ZYz"/>
-                                                                <constraint firstItem="KVl-YU-9O3" firstAttribute="width" secondItem="cjG-f1-Mkg" secondAttribute="width" id="lff-hV-QFG"/>
-                                                                <constraint firstItem="lgg-zH-OLr" firstAttribute="height" secondItem="cjG-f1-Mkg" secondAttribute="height" id="yCh-nD-xHV"/>
-                                                            </constraints>
-                                                            <visibilityPriorities>
-                                                                <integer value="1000"/>
-                                                                <integer value="1000"/>
-                                                                <integer value="1000"/>
-                                                                <integer value="1000"/>
-                                                                <integer value="1000"/>
-                                                            </visibilityPriorities>
-                                                            <customSpacing>
-                                                                <real value="3.4028234663852886e+38"/>
-                                                                <real value="3.4028234663852886e+38"/>
-                                                                <real value="3.4028234663852886e+38"/>
-                                                                <real value="3.4028234663852886e+38"/>
-                                                                <real value="3.4028234663852886e+38"/>
-                                                            </customSpacing>
-                                                        </stackView>
-                                                    </subviews>
-                                                    <constraints>
-                                                        <constraint firstItem="5v4-Te-950" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" constant="-1" id="0re-Ss-vgh"/>
-                                                        <constraint firstItem="CUa-0e-DwY" firstAttribute="top" secondItem="ykw-rb-M9D" secondAttribute="bottom" constant="20" id="18w-9C-Htc"/>
-                                                        <constraint firstItem="iAC-lz-PuL" firstAttribute="leading" secondItem="pam-gJ-b3R" secondAttribute="trailing" constant="8" id="29l-xI-5MV"/>
-                                                        <constraint firstItem="d4r-sL-0Vo" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="2jO-JJ-N1O"/>
-                                                        <constraint firstItem="sPT-jd-T7a" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="2ul-1b-OX5"/>
-                                                        <constraint firstItem="2ye-g4-fz5" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="44Q-AK-wMR"/>
-                                                        <constraint firstItem="Kzg-Uw-tpM" firstAttribute="top" secondItem="QqK-iZ-rFX" secondAttribute="bottom" constant="20" id="9DE-4W-Fjh"/>
-                                                        <constraint firstItem="Ng5-FC-tts" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="ATc-Y8-5g4"/>
-                                                        <constraint firstItem="5v4-Te-950" firstAttribute="top" secondItem="d4r-sL-0Vo" secondAttribute="bottom" constant="4" id="BQk-0k-lKI"/>
-                                                        <constraint firstItem="CUa-0e-DwY" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="Bds-Tt-2To"/>
-                                                        <constraint firstItem="Ng5-FC-tts" firstAttribute="top" secondItem="seu-WU-cTV" secondAttribute="bottom" id="Bee-nq-Jqn"/>
-                                                        <constraint firstItem="2ye-g4-fz5" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="CAc-p7-CMr"/>
-                                                        <constraint firstAttribute="trailing" secondItem="7PK-hh-Xx5" secondAttribute="trailing" id="CS1-Ac-ZtH"/>
-                                                        <constraint firstItem="oAm-jJ-3kE" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="EfX-U0-EIF"/>
-                                                        <constraint firstItem="705-dt-Zwl" firstAttribute="centerY" secondItem="d4r-sL-0Vo" secondAttribute="centerY" id="F4m-Zy-HTN"/>
-                                                        <constraint firstItem="7vv-En-VYY" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="HEy-h1-lqH"/>
-                                                        <constraint firstItem="seu-WU-cTV" firstAttribute="leading" secondItem="ZGz-La-n9c" secondAttribute="leading" constant="20" id="HfL-vM-J77"/>
-                                                        <constraint firstAttribute="trailing" secondItem="ykw-rb-M9D" secondAttribute="trailing" id="IBg-Q4-5QO"/>
-                                                        <constraint firstItem="QqK-iZ-rFX" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="JJs-e3-UKh"/>
-                                                        <constraint firstItem="Ljl-w6-gIf" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="L7x-Q3-ibY"/>
-                                                        <constraint firstItem="pam-gJ-b3R" firstAttribute="leading" secondItem="9Ua-jA-xuA" secondAttribute="trailing" constant="8" id="LuL-bM-125"/>
-                                                        <constraint firstItem="9Ua-jA-xuA" firstAttribute="bottom" secondItem="pam-gJ-b3R" secondAttribute="bottom" id="M47-JF-xr3"/>
-                                                        <constraint firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" constant="20" id="MdM-i9-hvu"/>
-                                                        <constraint firstItem="iAC-lz-PuL" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="N9R-AO-t8I"/>
-                                                        <constraint firstItem="sPT-jd-T7a" firstAttribute="top" secondItem="oAm-jJ-3kE" secondAttribute="bottom" constant="8" id="Qtq-cO-WY6"/>
-                                                        <constraint firstItem="7vv-En-VYY" firstAttribute="top" secondItem="sPT-jd-T7a" secondAttribute="bottom" constant="20" id="R1L-b4-S0z"/>
-                                                        <constraint firstItem="705-dt-Zwl" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="RsZ-BB-OpQ"/>
-                                                        <constraint firstItem="Ng5-FC-tts" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="S29-9J-zbt"/>
-                                                        <constraint firstItem="bza-SA-tXE" firstAttribute="top" secondItem="7vv-En-VYY" secondAttribute="bottom" constant="8" id="TaT-kr-h6n"/>
-                                                        <constraint firstItem="Ljl-w6-gIf" firstAttribute="top" secondItem="CUa-0e-DwY" secondAttribute="bottom" constant="8" id="VQG-QL-MrS"/>
-                                                        <constraint firstItem="iAC-lz-PuL" firstAttribute="top" secondItem="pam-gJ-b3R" secondAttribute="top" id="WDy-ol-Zpc"/>
-                                                        <constraint firstItem="7PK-hh-Xx5" firstAttribute="top" secondItem="2ye-g4-fz5" secondAttribute="bottom" constant="20" id="WHx-2i-Qb8"/>
-                                                        <constraint firstItem="sPT-jd-T7a" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="WhF-R9-ItL"/>
-                                                        <constraint firstItem="705-dt-Zwl" firstAttribute="leading" secondItem="d4r-sL-0Vo" secondAttribute="trailing" constant="8" id="aI1-cp-e3U"/>
-                                                        <constraint firstItem="seu-WU-cTV" firstAttribute="top" secondItem="ZGz-La-n9c" secondAttribute="top" constant="20" id="aal-Nb-2Z5"/>
-                                                        <constraint firstItem="QqK-iZ-rFX" firstAttribute="top" secondItem="7PK-hh-Xx5" secondAttribute="bottom" constant="20" id="agN-ia-1uy"/>
-                                                        <constraint firstAttribute="bottom" secondItem="BdF-A5-VPG" secondAttribute="bottom" constant="20" id="arL-JQ-GVl"/>
-                                                        <constraint firstItem="2ye-g4-fz5" firstAttribute="top" secondItem="5v4-Te-950" secondAttribute="bottom" constant="20" id="csu-lc-eNH"/>
-                                                        <constraint firstItem="9Ua-jA-xuA" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="czg-lU-OMG"/>
-                                                        <constraint firstItem="9Ua-jA-xuA" firstAttribute="top" secondItem="pam-gJ-b3R" secondAttribute="top" id="dTe-2U-dda"/>
-                                                        <constraint firstItem="7vv-En-VYY" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="dkC-Ih-pd9"/>
-                                                        <constraint firstItem="XAI-y0-tcy" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="eDi-7P-BEj"/>
-                                                        <constraint firstItem="5v4-Te-950" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="eeP-VU-TPP"/>
-                                                        <constraint firstItem="bza-SA-tXE" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="fDz-nh-c5C"/>
-                                                        <constraint firstItem="iAC-lz-PuL" firstAttribute="bottom" secondItem="pam-gJ-b3R" secondAttribute="bottom" id="keh-UM-dNZ"/>
-                                                        <constraint firstItem="XAI-y0-tcy" firstAttribute="leading" secondItem="Ljl-w6-gIf" secondAttribute="trailing" constant="8" id="kgN-Qb-S24"/>
-                                                        <constraint firstItem="Ng5-FC-tts" firstAttribute="bottom" secondItem="ykw-rb-M9D" secondAttribute="top" constant="-8" id="lB5-5K-ADf"/>
-                                                        <constraint firstItem="QqK-iZ-rFX" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="raN-KU-S8w"/>
-                                                        <constraint firstItem="XAI-y0-tcy" firstAttribute="firstBaseline" secondItem="Ljl-w6-gIf" secondAttribute="firstBaseline" id="sgV-3o-i04"/>
-                                                        <constraint firstItem="d4r-sL-0Vo" firstAttribute="top" secondItem="bza-SA-tXE" secondAttribute="bottom" constant="20" id="srR-fD-fdH"/>
-                                                        <constraint firstItem="oAm-jJ-3kE" firstAttribute="top" secondItem="Ljl-w6-gIf" secondAttribute="bottom" constant="20" id="t9T-NG-qVR"/>
-                                                        <constraint firstItem="ykw-rb-M9D" firstAttribute="leading" secondItem="ZGz-La-n9c" secondAttribute="leading" id="vVO-4e-Lao"/>
-                                                        <constraint firstItem="oAm-jJ-3kE" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="xkj-ic-q9D"/>
-                                                        <constraint firstItem="7PK-hh-Xx5" firstAttribute="leading" secondItem="ZGz-La-n9c" secondAttribute="leading" id="y5p-Be-83s"/>
-                                                        <constraint firstItem="CUa-0e-DwY" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="yE8-pS-Zgy"/>
-                                                    </constraints>
-                                                </view>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstItem="ZGz-La-n9c" firstAttribute="leading" secondItem="8Es-YX-dNf" secondAttribute="leading" id="GY8-wi-aRg"/>
-                                                <constraint firstItem="ZGz-La-n9c" firstAttribute="top" secondItem="8Es-YX-dNf" secondAttribute="top" id="QX6-9q-Dx8"/>
-                                                <constraint firstAttribute="trailing" secondItem="ZGz-La-n9c" secondAttribute="trailing" id="d7r-rT-3ad"/>
-                                            </constraints>
-                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                        </clipView>
-                                        <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="tk3-fh-4Dl">
-                                            <rect key="frame" x="-100" y="-100" width="360" height="16"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                        </scroller>
-                                        <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" doubleValue="1" horizontal="NO" id="Vtu-Wx-ydk">
-                                            <rect key="frame" x="345" y="0.0" width="15" height="738"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                        </scroller>
-                                    </scrollView>
-                                </subviews>
-                                <constraints>
-                                    <constraint firstAttribute="bottom" secondItem="SHU-hX-9MT" secondAttribute="bottom" id="1MH-ay-Jwy"/>
-                                    <constraint firstItem="SHU-hX-9MT" firstAttribute="leading" secondItem="NRI-ba-KMd" secondAttribute="leading" id="6sl-nB-kPa"/>
-                                    <constraint firstAttribute="trailing" secondItem="SHU-hX-9MT" secondAttribute="trailing" id="cfV-LC-bmO"/>
-                                    <constraint firstItem="SHU-hX-9MT" firstAttribute="top" secondItem="NRI-ba-KMd" secondAttribute="top" id="qz1-oZ-Sxp"/>
-                                </constraints>
                             </view>
                         </tabViewItem>
                         <tabViewItem label="Audio" identifier="2" id="bzk-c2-LH5" userLabel="AudioTab Tab View Item">
                             <view key="view" id="Dxl-wa-zgc" userLabel="AudioTab View">
                                 <rect key="frame" x="0.0" y="0.0" width="360" height="863"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                <subviews>
-                                    <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="wXn-sV-AmG" userLabel="AudioTab Scroll View">
-                                        <rect key="frame" x="0.0" y="0.0" width="360" height="863"/>
-                                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="oVx-Sp-Lhl" userLabel="AudioTab Clip View">
-                                            <rect key="frame" x="0.0" y="0.0" width="360" height="863"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                            <subviews>
-                                                <customView translatesAutoresizingMaskIntoConstraints="NO" id="NZU-RD-Dm3" userLabel="AudioTab Flipped View" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="327" width="360" height="536"/>
-                                                    <subviews>
-                                                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="my2-5o-bNb" userLabel="AudioTab CONTENT VIEW">
-                                                            <rect key="frame" x="0.0" y="0.0" width="360" height="536"/>
-                                                            <subviews>
-                                                                <customView translatesAutoresizingMaskIntoConstraints="NO" id="TA9-9G-tIE" userLabel="PANEL EDGE INSETS">
-                                                                    <rect key="frame" x="20" y="516" width="320" height="0.0"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" id="jt3-qe-0KY"/>
-                                                                    </constraints>
-                                                                </customView>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="E4v-kh-61H">
-                                                                    <rect key="frame" x="18" y="500" width="324" height="16"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Audio track:" id="x39-62-7KC">
-                                                                        <font key="font" metaFont="systemBold"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qal-0X-4kS" userLabel="AudioTrackTable Scroll View">
-                                                                    <rect key="frame" x="0.0" y="417" width="360" height="75"/>
-                                                                    <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="vgF-KN-yHf" userLabel="AudioTrackTable Clip View">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="360" height="60"/>
-                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                        <subviews>
-                                                                            <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="FLg-2m-Zaq" userLabel="AudioTrackTable Table View">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="371" height="60"/>
-                                                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                                <size key="intercellSpacing" width="3" height="2"/>
-                                                                                <color key="backgroundColor" white="1" alpha="0.080000000000000002" colorSpace="deviceWhite"/>
-                                                                                <tableViewGridLines key="gridStyleMask" horizontal="YES"/>
-                                                                                <color key="gridColor" red="1" green="1" blue="1" alpha="0.10000000000000001" colorSpace="calibratedRGB"/>
-                                                                                <tableColumns>
-                                                                                    <tableColumn identifier="IsChosen" editable="NO" width="16" minWidth="16" maxWidth="16" id="ZIu-kj-B9n">
-                                                                                        <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="right">
-                                                                                            <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                            <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
-                                                                                        </tableHeaderCell>
-                                                                                        <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" refusesFirstResponder="YES" allowsUndo="NO" alignment="right" title="0" id="L0u-GY-T4V">
-                                                                                            <font key="font" metaFont="system"/>
-                                                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                                        </textFieldCell>
-                                                                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                                                                        <prototypeCellViews>
-                                                                                            <tableCellView id="YPg-3T-gYm">
-                                                                                                <rect key="frame" x="1" y="1" width="21" height="17"/>
-                                                                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                                                <subviews>
-                                                                                                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="JVk-Od-tIT">
-                                                                                                        <rect key="frame" x="0.0" y="0.0" width="21" height="17"/>
-                                                                                                        <constraints>
-                                                                                                            <constraint firstAttribute="height" constant="17" id="vjY-8T-n1G"/>
-                                                                                                        </constraints>
-                                                                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="vDh-JM-5Wz">
-                                                                                                            <font key="font" metaFont="system"/>
-                                                                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                                                        </textFieldCell>
-                                                                                                        <connections>
-                                                                                                            <binding destination="YPg-3T-gYm" name="value" keyPath="objectValue" id="JAF-yk-Dy6"/>
-                                                                                                        </connections>
-                                                                                                    </textField>
-                                                                                                </subviews>
-                                                                                                <constraints>
-                                                                                                    <constraint firstItem="JVk-Od-tIT" firstAttribute="leading" secondItem="YPg-3T-gYm" secondAttribute="leading" constant="2" id="2Bt-id-0Kx"/>
-                                                                                                    <constraint firstItem="JVk-Od-tIT" firstAttribute="centerY" secondItem="YPg-3T-gYm" secondAttribute="centerY" id="3bg-HG-oBA"/>
-                                                                                                    <constraint firstItem="JVk-Od-tIT" firstAttribute="centerX" secondItem="YPg-3T-gYm" secondAttribute="centerX" id="4dW-UY-Zkt"/>
-                                                                                                </constraints>
-                                                                                                <connections>
-                                                                                                    <outlet property="textField" destination="JVk-Od-tIT" id="T58-nt-RWg"/>
-                                                                                                </connections>
-                                                                                            </tableCellView>
-                                                                                        </prototypeCellViews>
-                                                                                    </tableColumn>
-                                                                                    <tableColumn identifier="TrackId" width="33" minWidth="33" maxWidth="100" id="EYV-gb-3Pa">
-                                                                                        <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="right">
-                                                                                            <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                                                                        </tableHeaderCell>
-                                                                                        <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" refusesFirstResponder="YES" alignment="left" title="Text Cell" id="N1f-X9-gS0">
-                                                                                            <font key="font" metaFont="system"/>
-                                                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                            <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                                        </textFieldCell>
-                                                                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                                                                        <prototypeCellViews>
-                                                                                            <tableCellView id="UuQ-IW-yZg">
-                                                                                                <rect key="frame" x="25" y="1" width="33" height="17"/>
-                                                                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                                                <subviews>
-                                                                                                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="MSR-2Q-pOS">
-                                                                                                        <rect key="frame" x="0.0" y="0.0" width="33" height="17"/>
-                                                                                                        <constraints>
-                                                                                                            <constraint firstAttribute="height" constant="17" id="s2f-ef-WYF"/>
-                                                                                                        </constraints>
-                                                                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="right" title="Table View Cell" id="KyY-Ui-vAx">
-                                                                                                            <font key="font" metaFont="systemBold"/>
-                                                                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                                                        </textFieldCell>
-                                                                                                        <connections>
-                                                                                                            <binding destination="UuQ-IW-yZg" name="value" keyPath="objectValue" id="xK8-Oh-aYl"/>
-                                                                                                        </connections>
-                                                                                                    </textField>
-                                                                                                </subviews>
-                                                                                                <constraints>
-                                                                                                    <constraint firstItem="MSR-2Q-pOS" firstAttribute="centerX" secondItem="UuQ-IW-yZg" secondAttribute="centerX" id="258-KD-r05"/>
-                                                                                                    <constraint firstItem="MSR-2Q-pOS" firstAttribute="leading" secondItem="UuQ-IW-yZg" secondAttribute="leading" constant="2" id="XLG-lN-23V"/>
-                                                                                                    <constraint firstItem="MSR-2Q-pOS" firstAttribute="centerY" secondItem="UuQ-IW-yZg" secondAttribute="centerY" id="ZNm-DN-1ac"/>
-                                                                                                </constraints>
-                                                                                                <connections>
-                                                                                                    <outlet property="textField" destination="MSR-2Q-pOS" id="saV-nP-ICX"/>
-                                                                                                </connections>
-                                                                                            </tableCellView>
-                                                                                        </prototypeCellViews>
-                                                                                    </tableColumn>
-                                                                                    <tableColumn identifier="TrackName" editable="NO" width="304" minWidth="100" maxWidth="3.4028234663852886e+38" id="cKa-XV-ATZ">
-                                                                                        <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                                                                            <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                                                                        </tableHeaderCell>
-                                                                                        <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" refusesFirstResponder="YES" allowsUndo="NO" alignment="left" title="Text Cell" id="GXH-iA-cJP">
-                                                                                            <font key="font" metaFont="system"/>
-                                                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                                        </textFieldCell>
-                                                                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                                                                        <prototypeCellViews>
-                                                                                            <tableCellView id="zgo-9v-dTl">
-                                                                                                <rect key="frame" x="61" y="1" width="308" height="17"/>
-                                                                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                                                <subviews>
-                                                                                                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="6YE-jM-I4J">
-                                                                                                        <rect key="frame" x="0.0" y="1" width="308" height="16"/>
-                                                                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="Spe-xo-cXu">
-                                                                                                            <font key="font" metaFont="system"/>
-                                                                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                                                        </textFieldCell>
-                                                                                                        <connections>
-                                                                                                            <binding destination="zgo-9v-dTl" name="value" keyPath="objectValue" id="elh-SX-Hoc"/>
-                                                                                                        </connections>
-                                                                                                    </textField>
-                                                                                                </subviews>
-                                                                                                <constraints>
-                                                                                                    <constraint firstItem="6YE-jM-I4J" firstAttribute="centerY" secondItem="zgo-9v-dTl" secondAttribute="centerY" id="6zV-9M-5AW"/>
-                                                                                                    <constraint firstItem="6YE-jM-I4J" firstAttribute="centerX" secondItem="zgo-9v-dTl" secondAttribute="centerX" id="IZA-BZ-Luh"/>
-                                                                                                    <constraint firstItem="6YE-jM-I4J" firstAttribute="leading" secondItem="zgo-9v-dTl" secondAttribute="leading" constant="2" id="o4O-fu-f2N"/>
-                                                                                                </constraints>
-                                                                                                <connections>
-                                                                                                    <outlet property="textField" destination="6YE-jM-I4J" id="c8V-Nb-jHJ"/>
-                                                                                                </connections>
-                                                                                            </tableCellView>
-                                                                                        </prototypeCellViews>
-                                                                                    </tableColumn>
-                                                                                </tableColumns>
-                                                                            </tableView>
-                                                                        </subviews>
-                                                                    </clipView>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="75" id="sBV-Kf-cvi"/>
-                                                                    </constraints>
-                                                                    <scroller key="horizontalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="Pal-8c-4eQ">
-                                                                        <rect key="frame" x="0.0" y="60" width="360" height="15"/>
-                                                                        <autoresizingMask key="autoresizingMask"/>
-                                                                    </scroller>
-                                                                    <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="uet-8b-szq">
-                                                                        <rect key="frame" x="-16" y="0.0" width="16" height="0.0"/>
-                                                                        <autoresizingMask key="autoresizingMask"/>
-                                                                    </scroller>
-                                                                </scrollView>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kvu-fg-olx">
-                                                                    <rect key="frame" x="18" y="381" width="324" height="16"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="External audio:" id="Lnu-kz-cql">
-                                                                        <font key="font" metaFont="systemBold"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="XdF-fV-DCz">
-                                                                    <rect key="frame" x="13" y="344" width="334" height="32"/>
-                                                                    <buttonCell key="cell" type="push" title="Load External Audio Track…" bezelStyle="rounded" alignment="center" refusesFirstResponder="YES" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="8Ax-5X-osl">
-                                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                        <font key="font" metaFont="system"/>
-                                                                    </buttonCell>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="305" id="J6K-sf-QKi"/>
-                                                                    </constraints>
-                                                                    <connections>
-                                                                        <action selector="loadExternalAudioAction:" target="-2" id="Qlt-LO-puw"/>
-                                                                    </connections>
-                                                                </button>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZPW-fz-5Oi">
-                                                                    <rect key="frame" x="18" y="315" width="324" height="16"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Audio delay:" id="AKs-VQ-fKF">
-                                                                        <font key="font" metaFont="systemBold"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <customView autoresizesSubviews="NO" horizontalHuggingPriority="200" horizontalCompressionResistancePriority="700" translatesAutoresizingMaskIntoConstraints="NO" id="j85-rj-toQ" userLabel="AudioDelaySlider Container View">
-                                                                    <rect key="frame" x="19" y="264" width="321" height="47"/>
-                                                                    <subviews>
-                                                                        <slider horizontalHuggingPriority="1" verticalHuggingPriority="700" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="700" translatesAutoresizingMaskIntoConstraints="NO" id="gJr-l6-WQ2" userLabel="AudioDelaySlider Horizontal Tick Slider">
-                                                                            <rect key="frame" x="-1" y="10" width="245" height="25"/>
-                                                                            <sliderCell key="cell" controlSize="small" continuous="YES" refusesFirstResponder="YES" state="on" alignment="left" minValue="-5" maxValue="5" tickMarkPosition="below" numberOfTickMarks="21" sliderType="linear" id="Xty-CC-H0Z"/>
-                                                                            <connections>
-                                                                                <action selector="audioDelayChangedAction:" target="-2" id="Rqw-fj-519"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="giU-Mo-tN9" userLabel="AudioDelaySliderIndicator Text Field">
-                                                                            <rect key="frame" x="109" y="34" width="24" height="13"/>
-                                                                            <constraints>
-                                                                                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="20" id="F50-i5-7bi"/>
-                                                                            </constraints>
-                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="0s" usesSingleLineMode="YES" id="udN-rq-omw">
-                                                                                <font key="font" metaFont="system" size="10"/>
-                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tGk-m1-Vjc" userLabel="-5s Text Field">
-                                                                            <rect key="frame" x="-1" y="0.0" width="20" height="11"/>
-                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="-5s" id="YCG-xK-eAs" userLabel="-5s">
-                                                                                <font key="font" metaFont="label" size="9"/>
-                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3GW-C1-d0g" userLabel="0s Text Field">
-                                                                            <rect key="frame" x="112" y="0.0" width="19" height="11"/>
-                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="0s" id="kan-bp-QDi">
-                                                                                <font key="font" metaFont="label" size="9"/>
-                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MPz-pR-Ys8" userLabel="+5s Text Field">
-                                                                            <rect key="frame" x="223" y="0.0" width="21" height="11"/>
-                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="+5s" id="Kt8-Kg-i2O">
-                                                                                <font key="font" metaFont="label" size="9"/>
-                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Qiz-tS-aWT" userLabel="CustomAudioDelay Text Field">
-                                                                            <rect key="frame" x="250" y="12" width="60" height="21"/>
-                                                                            <constraints>
-                                                                                <constraint firstAttribute="width" constant="60" id="gRx-xy-Pqs"/>
-                                                                            </constraints>
-                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" title="1" drawsBackground="YES" usesSingleLineMode="YES" id="EHa-PR-jHw" userLabel="CustomAudioDelay Text Field Cell" customClass="RoundedTextFieldCell" customModule="IINA" customModuleProvider="target">
-                                                                                <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="C53-E5-t2Z"/>
-                                                                                <font key="font" metaFont="system"/>
-                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                            <connections>
-                                                                                <action selector="customAudioDelayEditFinishedAction:" target="-2" id="wbu-lF-nTa"/>
-                                                                            </connections>
-                                                                        </textField>
-                                                                        <textField focusRingType="none" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ImH-jg-Agp" userLabel="s">
-                                                                            <rect key="frame" x="308" y="15" width="15" height="16"/>
-                                                                            <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="s" id="1VY-EN-1mi">
-                                                                                <font key="font" metaFont="system"/>
-                                                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                            </textFieldCell>
-                                                                        </textField>
-                                                                    </subviews>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="trailing" secondItem="ImH-jg-Agp" secondAttribute="trailing" id="0Hm-Fa-s2l"/>
-                                                                        <constraint firstItem="Qiz-tS-aWT" firstAttribute="height" relation="lessThanOrEqual" secondItem="gJr-l6-WQ2" secondAttribute="height" id="4pT-hs-YkF"/>
-                                                                        <constraint firstItem="3GW-C1-d0g" firstAttribute="firstBaseline" secondItem="tGk-m1-Vjc" secondAttribute="firstBaseline" id="5Yt-IM-92q"/>
-                                                                        <constraint firstItem="giU-Mo-tN9" firstAttribute="centerX" secondItem="gJr-l6-WQ2" secondAttribute="leading" priority="800" constant="120" id="5oB-ve-G3c"/>
-                                                                        <constraint firstItem="Qiz-tS-aWT" firstAttribute="centerY" secondItem="gJr-l6-WQ2" secondAttribute="centerY" id="EuL-BL-hNW"/>
-                                                                        <constraint firstItem="MPz-pR-Ys8" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="3GW-C1-d0g" secondAttribute="trailing" id="HXO-hx-eYN"/>
-                                                                        <constraint firstItem="tGk-m1-Vjc" firstAttribute="top" secondItem="gJr-l6-WQ2" secondAttribute="bottom" constant="1" id="JOa-Yf-S4K"/>
-                                                                        <constraint firstItem="3GW-C1-d0g" firstAttribute="centerX" secondItem="gJr-l6-WQ2" secondAttribute="centerX" id="LAh-D4-yaM"/>
-                                                                        <constraint firstItem="3GW-C1-d0g" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="tGk-m1-Vjc" secondAttribute="trailing" id="LFA-0J-hOe"/>
-                                                                        <constraint firstAttribute="bottom" secondItem="tGk-m1-Vjc" secondAttribute="bottom" id="LP9-eY-HFx"/>
-                                                                        <constraint firstItem="MPz-pR-Ys8" firstAttribute="trailing" secondItem="gJr-l6-WQ2" secondAttribute="trailing" id="OxL-FZ-Jgq"/>
-                                                                        <constraint firstItem="tGk-m1-Vjc" firstAttribute="leading" secondItem="gJr-l6-WQ2" secondAttribute="leading" id="T4d-XW-ILF"/>
-                                                                        <constraint firstItem="gJr-l6-WQ2" firstAttribute="top" secondItem="giU-Mo-tN9" secondAttribute="bottom" constant="1" id="VBE-Mf-Tzb"/>
-                                                                        <constraint firstItem="MPz-pR-Ys8" firstAttribute="firstBaseline" secondItem="tGk-m1-Vjc" secondAttribute="firstBaseline" id="gIk-ck-vZB"/>
-                                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="300" id="gtm-1I-YqP"/>
-                                                                        <constraint firstItem="Qiz-tS-aWT" firstAttribute="trailing" secondItem="ImH-jg-Agp" secondAttribute="leading" id="nCE-1H-uD9"/>
-                                                                        <constraint firstItem="Qiz-tS-aWT" firstAttribute="leading" secondItem="gJr-l6-WQ2" secondAttribute="trailing" constant="8" id="uSJ-g9-Azy"/>
-                                                                        <constraint firstItem="ImH-jg-Agp" firstAttribute="firstBaseline" secondItem="Qiz-tS-aWT" secondAttribute="firstBaseline" id="vOx-Zo-ayO"/>
-                                                                        <constraint firstItem="giU-Mo-tN9" firstAttribute="top" secondItem="j85-rj-toQ" secondAttribute="top" id="vc3-E4-DgR"/>
-                                                                        <constraint firstItem="giU-Mo-tN9" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="gJr-l6-WQ2" secondAttribute="leading" id="wwv-IQ-GEx"/>
-                                                                    </constraints>
-                                                                </customView>
-                                                                <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="KKr-0Y-831">
-                                                                    <rect key="frame" x="0.0" y="241" width="360" height="5"/>
-                                                                </box>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IHl-Ks-v7I" userLabel="Equalizer Label">
-                                                                    <rect key="frame" x="18" y="207" width="69" height="16"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Equalizer:" id="iS4-Zr-9Ig">
-                                                                        <font key="font" metaFont="systemBold"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <box title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="OLt-cd-X9q">
-                                                                    <rect key="frame" x="17" y="8" width="326" height="161"/>
-                                                                    <view key="contentView" id="CL6-Wk-vXc">
-                                                                        <rect key="frame" x="4" y="5" width="318" height="153"/>
-                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                    </view>
-                                                                </box>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="1000" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jUH-hL-3U3" userLabel="+12 dB Text Field">
-                                                                    <rect key="frame" x="293" y="141" width="41" height="14"/>
-                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="+12 dB" id="4BZ-H1-GEU">
-                                                                        <font key="font" metaFont="smallSystem"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="izd-aj-gqV" userLabel="0 dB Text Field">
-                                                                    <rect key="frame" x="305" y="90" width="29" height="14"/>
-                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="0 dB" id="lBn-YS-jL7">
-                                                                        <font key="font" metaFont="smallSystem"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Wkv-a4-uiD" userLabel="-12 dB Text Field">
-                                                                    <rect key="frame" x="295" y="39" width="39" height="14"/>
-                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="-12 dB" id="Lpw-ws-Ezh">
-                                                                        <font key="font" metaFont="smallSystem"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EDx-YH-ofM">
-                                                                    <rect key="frame" x="33" y="20" width="19" height="11"/>
-                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="32" id="HBF-J7-Tie">
-                                                                        <font key="font" metaFont="label" size="9"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dKk-CE-yY0">
-                                                                    <rect key="frame" x="60" y="20" width="20" height="11"/>
-                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="64" id="4PG-5R-5G0">
-                                                                        <font key="font" metaFont="label" size="9"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gfz-yF-41J">
-                                                                    <rect key="frame" x="84" y="20" width="24" height="11"/>
-                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="125" id="1cq-dc-JfM">
-                                                                        <font key="font" metaFont="label" size="9"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1he-Ll-CYl">
-                                                                    <rect key="frame" x="109" y="20" width="26" height="11"/>
-                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="250" id="ekh-gc-2qo">
-                                                                        <font key="font" metaFont="label" size="9"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="j15-F0-7GR">
-                                                                    <rect key="frame" x="135" y="20" width="26" height="11"/>
-                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="500" id="tHa-vN-OlI">
-                                                                        <font key="font" metaFont="label" size="9"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wvc-3m-7dA">
-                                                                    <rect key="frame" x="166" y="20" width="18" height="11"/>
-                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="1k" id="Rtc-Eg-J2u">
-                                                                        <font key="font" metaFont="label" size="9"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cnq-7d-eC4">
-                                                                    <rect key="frame" x="192" y="20" width="19" height="11"/>
-                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="2k" id="j9w-YU-EcC">
-                                                                        <font key="font" metaFont="label" size="9"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uUe-VB-wyv">
-                                                                    <rect key="frame" x="218" y="20" width="20" height="11"/>
-                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="4k" id="i0j-2a-vKD">
-                                                                        <font key="font" metaFont="label" size="9"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eOZ-KM-xLa">
-                                                                    <rect key="frame" x="244" y="20" width="19" height="11"/>
-                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="8k" id="e4X-H4-VxS">
-                                                                        <font key="font" metaFont="label" size="9"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aOD-Qz-oE3">
-                                                                    <rect key="frame" x="268" y="20" width="24" height="11"/>
-                                                                    <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="16k" id="era-AG-bSl">
-                                                                        <font key="font" metaFont="label" size="9"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="ArR-4S-Gps">
-                                                                    <rect key="frame" x="36" y="146" width="251" height="5"/>
-                                                                </box>
-                                                                <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="S1M-YW-ac8">
-                                                                    <rect key="frame" x="36" y="43" width="251" height="5"/>
-                                                                </box>
-                                                                <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="ANI-DE-0LU">
-                                                                    <rect key="frame" x="36" y="120" width="251" height="5"/>
-                                                                </box>
-                                                                <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="W8L-56-yE9">
-                                                                    <rect key="frame" x="36" y="95" width="251" height="5"/>
-                                                                </box>
-                                                                <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="1jP-b9-gGi">
-                                                                    <rect key="frame" x="36" y="69" width="251" height="5"/>
-                                                                </box>
-                                                                <stackView distribution="equalSpacing" orientation="horizontal" alignment="top" spacing="13" horizontalStackHuggingPriority="1000" verticalStackHuggingPriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="xtT-Or-HjR" userLabel="AudioEQSliders HStack">
-                                                                    <rect key="frame" x="36" y="39" width="251" height="116"/>
-                                                                    <subviews>
-                                                                        <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" translatesAutoresizingMaskIntoConstraints="NO" id="pHR-ym-VeQ">
-                                                                            <rect key="frame" x="-2" y="-2" width="17" height="120"/>
-                                                                            <sliderCell key="cell" controlSize="mini" refusesFirstResponder="YES" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" sliderType="linear" id="Twm-2U-8ou"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="ywO-zh-sWU"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="Qhv-oC-xzP">
-                                                                            <rect key="frame" x="24" y="-2" width="18" height="120"/>
-                                                                            <sliderCell key="cell" controlSize="mini" refusesFirstResponder="YES" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" sliderType="linear" id="SCy-Om-bV6"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="xQb-Li-0pw"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" tag="2" translatesAutoresizingMaskIntoConstraints="NO" id="iDT-gu-k7t">
-                                                                            <rect key="frame" x="51" y="-2" width="17" height="120"/>
-                                                                            <sliderCell key="cell" controlSize="mini" refusesFirstResponder="YES" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" sliderType="linear" id="a7E-4j-6g2"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="bCl-L6-1iR"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" tag="3" translatesAutoresizingMaskIntoConstraints="NO" id="O2w-VO-03F">
-                                                                            <rect key="frame" x="77" y="-2" width="18" height="120"/>
-                                                                            <sliderCell key="cell" controlSize="mini" refusesFirstResponder="YES" state="on" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" sliderType="linear" id="TbE-dB-ORk"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="15r-Ui-dhW"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" tag="4" translatesAutoresizingMaskIntoConstraints="NO" id="npn-V6-hjZ">
-                                                                            <rect key="frame" x="104" y="-2" width="17" height="120"/>
-                                                                            <sliderCell key="cell" controlSize="mini" refusesFirstResponder="YES" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" sliderType="linear" id="4Ra-VR-yOK"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="sWe-Hb-axh"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" tag="5" translatesAutoresizingMaskIntoConstraints="NO" id="TKd-tg-Xtc">
-                                                                            <rect key="frame" x="130" y="-2" width="17" height="120"/>
-                                                                            <sliderCell key="cell" controlSize="mini" refusesFirstResponder="YES" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" sliderType="linear" id="xV9-OM-MHq"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="bVX-Tj-pgM"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" tag="6" translatesAutoresizingMaskIntoConstraints="NO" id="nNf-gg-4tL">
-                                                                            <rect key="frame" x="156" y="-2" width="18" height="120"/>
-                                                                            <sliderCell key="cell" controlSize="mini" refusesFirstResponder="YES" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" sliderType="linear" id="TNb-Es-VsX"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="p1d-eK-UB3"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" tag="7" translatesAutoresizingMaskIntoConstraints="NO" id="JaQ-EH-K1U">
-                                                                            <rect key="frame" x="183" y="-2" width="17" height="120"/>
-                                                                            <sliderCell key="cell" controlSize="mini" refusesFirstResponder="YES" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" sliderType="linear" id="P8O-pY-Nby"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="oxX-UX-l6i"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" tag="8" translatesAutoresizingMaskIntoConstraints="NO" id="gbd-xf-hGS">
-                                                                            <rect key="frame" x="209" y="-2" width="18" height="120"/>
-                                                                            <sliderCell key="cell" controlSize="mini" refusesFirstResponder="YES" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" sliderType="linear" id="GEq-jW-WUw"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="pkI-fs-ZCs"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                        <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" tag="9" translatesAutoresizingMaskIntoConstraints="NO" id="w04-h5-qaz">
-                                                                            <rect key="frame" x="236" y="-2" width="17" height="120"/>
-                                                                            <sliderCell key="cell" controlSize="mini" refusesFirstResponder="YES" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" sliderType="linear" id="5FD-oT-GpE"/>
-                                                                            <connections>
-                                                                                <action selector="audioEqSliderAction:" target="-2" id="I08-gI-z8e"/>
-                                                                            </connections>
-                                                                        </slider>
-                                                                    </subviews>
-                                                                    <constraints>
-                                                                        <constraint firstItem="Qhv-oC-xzP" firstAttribute="width" secondItem="pHR-ym-VeQ" secondAttribute="width" id="8NF-D9-ur6"/>
-                                                                        <constraint firstItem="iDT-gu-k7t" firstAttribute="width" secondItem="pHR-ym-VeQ" secondAttribute="width" id="Hhg-eV-Uuj"/>
-                                                                        <constraint firstItem="O2w-VO-03F" firstAttribute="width" secondItem="pHR-ym-VeQ" secondAttribute="width" id="P1Q-Vw-1Bj"/>
-                                                                        <constraint firstItem="w04-h5-qaz" firstAttribute="width" secondItem="pHR-ym-VeQ" secondAttribute="width" id="QV9-LY-UR9"/>
-                                                                        <constraint firstItem="TKd-tg-Xtc" firstAttribute="width" secondItem="pHR-ym-VeQ" secondAttribute="width" id="XGa-3f-NGX"/>
-                                                                        <constraint firstItem="npn-V6-hjZ" firstAttribute="width" secondItem="pHR-ym-VeQ" secondAttribute="width" id="b6u-Pz-OHZ"/>
-                                                                        <constraint firstItem="nNf-gg-4tL" firstAttribute="width" secondItem="pHR-ym-VeQ" secondAttribute="width" id="bsR-FZ-TcX"/>
-                                                                        <constraint firstAttribute="height" constant="116" id="nDW-aS-hPT"/>
-                                                                        <constraint firstItem="gbd-xf-hGS" firstAttribute="width" secondItem="pHR-ym-VeQ" secondAttribute="width" id="zSM-iB-jXD"/>
-                                                                        <constraint firstItem="JaQ-EH-K1U" firstAttribute="width" secondItem="pHR-ym-VeQ" secondAttribute="width" id="zqG-dT-mKp"/>
-                                                                    </constraints>
-                                                                    <visibilityPriorities>
-                                                                        <integer value="1000"/>
-                                                                        <integer value="1000"/>
-                                                                        <integer value="1000"/>
-                                                                        <integer value="1000"/>
-                                                                        <integer value="1000"/>
-                                                                        <integer value="1000"/>
-                                                                        <integer value="1000"/>
-                                                                        <integer value="1000"/>
-                                                                        <integer value="1000"/>
-                                                                        <integer value="1000"/>
-                                                                    </visibilityPriorities>
-                                                                    <customSpacing>
-                                                                        <real value="3.4028234663852886e+38"/>
-                                                                        <real value="3.4028234663852886e+38"/>
-                                                                        <real value="3.4028234663852886e+38"/>
-                                                                        <real value="3.4028234663852886e+38"/>
-                                                                        <real value="3.4028234663852886e+38"/>
-                                                                        <real value="3.4028234663852886e+38"/>
-                                                                        <real value="3.4028234663852886e+38"/>
-                                                                        <real value="3.4028234663852886e+38"/>
-                                                                        <real value="3.4028234663852886e+38"/>
-                                                                        <real value="3.4028234663852886e+38"/>
-                                                                    </customSpacing>
-                                                                </stackView>
-                                                                <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="u9C-Fk-Aag">
-                                                                    <rect key="frame" x="17" y="175" width="241" height="25"/>
-                                                                    <popUpButtonCell key="cell" type="push" title="Save the current EQ as a preset…" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" tag="-3" imageScaling="proportionallyDown" inset="2" autoenablesItems="NO" altersStateOfSelectedItem="NO" selectedItem="sE0-LN-T8i" id="WKa-AJ-OEZ">
-                                                                        <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                                                                        <font key="font" metaFont="message"/>
-                                                                        <menu key="menu" autoenablesItems="NO" id="7k5-w9-dRQ">
-                                                                            <items>
-                                                                                <menuItem title="Save the current EQ as a preset…" tag="-3" id="sE0-LN-T8i">
-                                                                                    <modifierMask key="keyEquivalentModifierMask"/>
-                                                                                </menuItem>
-                                                                                <menuItem title="Rename the current EQ preset…" tag="-2" id="2tD-0L-UUs">
-                                                                                    <modifierMask key="keyEquivalentModifierMask"/>
-                                                                                </menuItem>
-                                                                                <menuItem title="Remove the current EQ preset" tag="-1" id="dvI-Rj-7qF">
-                                                                                    <modifierMask key="keyEquivalentModifierMask"/>
-                                                                                </menuItem>
-                                                                                <menuItem isSeparatorItem="YES" tag="-1000" id="o0F-oJ-6GY"/>
-                                                                                <menuItem title="Manual" tag="1000" id="LPh-nJ-GjN">
-                                                                                    <modifierMask key="keyEquivalentModifierMask"/>
-                                                                                </menuItem>
-                                                                                <menuItem isSeparatorItem="YES" tag="-1000" id="wBP-97-nRB"/>
-                                                                            </items>
-                                                                        </menu>
-                                                                    </popUpButtonCell>
-                                                                    <connections>
-                                                                        <action selector="eqPopUpButtonAction:" target="-2" id="xZN-vl-ZAe"/>
-                                                                    </connections>
-                                                                </popUpButton>
-                                                            </subviews>
-                                                            <constraints>
-                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="u9C-Fk-Aag" secondAttribute="trailing" id="0EN-5k-aN1"/>
-                                                                <constraint firstItem="gbd-xf-hGS" firstAttribute="centerX" secondItem="eOZ-KM-xLa" secondAttribute="centerX" id="0eU-JU-3Np"/>
-                                                                <constraint firstItem="izd-aj-gqV" firstAttribute="trailing" secondItem="TA9-9G-tIE" secondAttribute="trailing" priority="900" constant="-8" id="1xH-vk-y7P"/>
-                                                                <constraint firstItem="EDx-YH-ofM" firstAttribute="top" secondItem="pHR-ym-VeQ" secondAttribute="bottom" constant="8" id="3GI-bd-VUa"/>
-                                                                <constraint firstItem="OLt-cd-X9q" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" constant="20" id="3jA-3U-EyF"/>
-                                                                <constraint firstItem="xtT-Or-HjR" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" constant="36" id="5mj-ks-OY2"/>
-                                                                <constraint firstItem="dKk-CE-yY0" firstAttribute="centerX" secondItem="Qhv-oC-xzP" secondAttribute="centerX" constant="1" id="6U0-bD-UHn"/>
-                                                                <constraint firstItem="xtT-Or-HjR" firstAttribute="trailing" secondItem="1jP-b9-gGi" secondAttribute="trailing" id="7KT-qB-NbC"/>
-                                                                <constraint firstItem="XdF-fV-DCz" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="TA9-9G-tIE" secondAttribute="trailing" id="8OK-le-NFN"/>
-                                                                <constraint firstItem="TA9-9G-tIE" firstAttribute="leading" secondItem="E4v-kh-61H" secondAttribute="leading" id="9So-jf-b5w"/>
-                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="E4v-kh-61H" secondAttribute="trailing" id="9ol-Ih-xQV"/>
-                                                                <constraint firstItem="EDx-YH-ofM" firstAttribute="leading" secondItem="TA9-9G-tIE" secondAttribute="leading" constant="15" id="AXq-h3-TVD"/>
-                                                                <constraint firstItem="KKr-0Y-831" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" id="Be6-hz-QAY"/>
-                                                                <constraint firstItem="j85-rj-toQ" firstAttribute="top" secondItem="ZPW-fz-5Oi" secondAttribute="bottom" constant="4" id="Cv3-B2-U9b"/>
-                                                                <constraint firstItem="W8L-56-yE9" firstAttribute="top" secondItem="ANI-DE-0LU" secondAttribute="bottom" constant="24" id="Cx5-Cs-3tw"/>
-                                                                <constraint firstAttribute="bottom" secondItem="OLt-cd-X9q" secondAttribute="bottom" constant="12" id="DuU-Xa-KxH"/>
-                                                                <constraint firstItem="wvc-3m-7dA" firstAttribute="top" secondItem="EDx-YH-ofM" secondAttribute="top" id="Ebj-KB-Fia"/>
-                                                                <constraint firstItem="IHl-Ks-v7I" firstAttribute="leading" secondItem="TA9-9G-tIE" secondAttribute="leading" id="FcZ-qn-ZcQ"/>
-                                                                <constraint firstItem="1he-Ll-CYl" firstAttribute="top" secondItem="EDx-YH-ofM" secondAttribute="top" id="G46-BJ-iVG"/>
-                                                                <constraint firstItem="OLt-cd-X9q" firstAttribute="top" secondItem="u9C-Fk-Aag" secondAttribute="bottom" constant="12" id="Gkx-KC-N8G"/>
-                                                                <constraint firstItem="izd-aj-gqV" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="xtT-Or-HjR" secondAttribute="trailing" constant="8" symbolic="YES" id="HaA-55-Hxi"/>
-                                                                <constraint firstAttribute="trailing" secondItem="KKr-0Y-831" secondAttribute="trailing" id="HbW-t2-Z43"/>
-                                                                <constraint firstItem="cnq-7d-eC4" firstAttribute="top" secondItem="EDx-YH-ofM" secondAttribute="top" id="Hrv-XD-CMS"/>
-                                                                <constraint firstItem="xtT-Or-HjR" firstAttribute="trailing" secondItem="ANI-DE-0LU" secondAttribute="trailing" id="KHn-q4-CcN"/>
-                                                                <constraint firstItem="xtT-Or-HjR" firstAttribute="trailing" secondItem="ArR-4S-Gps" secondAttribute="trailing" id="KYz-NQ-5Sx"/>
-                                                                <constraint firstItem="j15-F0-7GR" firstAttribute="centerX" secondItem="npn-V6-hjZ" secondAttribute="centerX" id="Km4-rZ-GeG"/>
-                                                                <constraint firstItem="ArR-4S-Gps" firstAttribute="leading" secondItem="xtT-Or-HjR" secondAttribute="leading" id="L7D-aW-dXh"/>
-                                                                <constraint firstItem="uUe-VB-wyv" firstAttribute="top" secondItem="EDx-YH-ofM" secondAttribute="top" id="La7-D2-OgL"/>
-                                                                <constraint firstItem="1jP-b9-gGi" firstAttribute="leading" secondItem="xtT-Or-HjR" secondAttribute="leading" id="M4U-5L-YBe"/>
-                                                                <constraint firstItem="Wkv-a4-uiD" firstAttribute="bottom" secondItem="xtT-Or-HjR" secondAttribute="bottom" id="MaV-fd-img"/>
-                                                                <constraint firstItem="gfz-yF-41J" firstAttribute="top" secondItem="EDx-YH-ofM" secondAttribute="top" id="Mwa-bq-dus"/>
-                                                                <constraint firstItem="kvu-fg-olx" firstAttribute="trailing" secondItem="TA9-9G-tIE" secondAttribute="trailing" id="OAI-WO-gae"/>
-                                                                <constraint firstItem="S1M-YW-ac8" firstAttribute="top" secondItem="Wkv-a4-uiD" secondAttribute="bottom" constant="-7" id="OrC-6T-y1a"/>
-                                                                <constraint firstAttribute="bottom" secondItem="EDx-YH-ofM" secondAttribute="bottom" constant="20" id="Ovj-hj-4mO"/>
-                                                                <constraint firstItem="ANI-DE-0LU" firstAttribute="top" secondItem="ArR-4S-Gps" secondAttribute="bottom" constant="25" id="PLv-Fr-gGS"/>
-                                                                <constraint firstItem="Qal-0X-4kS" firstAttribute="top" secondItem="E4v-kh-61H" secondAttribute="bottom" constant="8" id="PfL-cK-sd5"/>
-                                                                <constraint firstItem="IHl-Ks-v7I" firstAttribute="top" secondItem="KKr-0Y-831" secondAttribute="bottom" constant="20" id="Q61-jq-LnT"/>
-                                                                <constraint firstItem="1he-Ll-CYl" firstAttribute="centerX" secondItem="O2w-VO-03F" secondAttribute="centerX" id="R4m-Vs-AK3"/>
-                                                                <constraint firstItem="cnq-7d-eC4" firstAttribute="centerX" secondItem="nNf-gg-4tL" secondAttribute="centerX" id="Rge-iX-npw"/>
-                                                                <constraint firstItem="j15-F0-7GR" firstAttribute="top" secondItem="EDx-YH-ofM" secondAttribute="top" id="RvX-Nr-Tiv"/>
-                                                                <constraint firstItem="j85-rj-toQ" firstAttribute="trailing" secondItem="TA9-9G-tIE" secondAttribute="trailing" id="S7O-V6-BBj"/>
-                                                                <constraint firstItem="Qal-0X-4kS" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" id="SwW-S7-LX2"/>
-                                                                <constraint firstItem="jUH-hL-3U3" firstAttribute="top" secondItem="ArR-4S-Gps" secondAttribute="bottom" constant="-7" id="TTJ-hH-udD"/>
-                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="IHl-Ks-v7I" secondAttribute="trailing" id="Xkb-2S-Po9"/>
-                                                                <constraint firstItem="KKr-0Y-831" firstAttribute="top" secondItem="j85-rj-toQ" secondAttribute="bottom" constant="20" id="YFM-EH-jIy"/>
-                                                                <constraint firstItem="u9C-Fk-Aag" firstAttribute="leading" secondItem="IHl-Ks-v7I" secondAttribute="leading" id="ZFp-mr-6fU"/>
-                                                                <constraint firstItem="TA9-9G-tIE" firstAttribute="top" secondItem="my2-5o-bNb" secondAttribute="top" constant="20" id="aLW-0J-VPR"/>
-                                                                <constraint firstItem="Wkv-a4-uiD" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="xtT-Or-HjR" secondAttribute="trailing" constant="8" symbolic="YES" id="ajo-XO-YDd"/>
-                                                                <constraint firstItem="TA9-9G-tIE" firstAttribute="leading" secondItem="ZPW-fz-5Oi" secondAttribute="leading" id="alo-ld-qH9"/>
-                                                                <constraint firstItem="xtT-Or-HjR" firstAttribute="trailing" secondItem="S1M-YW-ac8" secondAttribute="trailing" id="b2z-Fx-bbY"/>
-                                                                <constraint firstItem="ImH-jg-Agp" firstAttribute="trailing" secondItem="TA9-9G-tIE" secondAttribute="trailing" id="bO7-1x-a1O"/>
-                                                                <constraint firstItem="Wkv-a4-uiD" firstAttribute="trailing" secondItem="TA9-9G-tIE" secondAttribute="trailing" priority="900" constant="-8" id="dYP-Us-6bj"/>
-                                                                <constraint firstItem="dKk-CE-yY0" firstAttribute="top" secondItem="EDx-YH-ofM" secondAttribute="top" id="dw4-5m-LIU"/>
-                                                                <constraint firstItem="ZPW-fz-5Oi" firstAttribute="trailing" secondItem="TA9-9G-tIE" secondAttribute="trailing" id="e0g-tm-BF8"/>
-                                                                <constraint firstAttribute="trailing" secondItem="OLt-cd-X9q" secondAttribute="trailing" constant="20" id="eEI-bd-PJn"/>
-                                                                <constraint firstItem="jUH-hL-3U3" firstAttribute="trailing" secondItem="TA9-9G-tIE" secondAttribute="trailing" priority="900" constant="-8" id="f4B-e4-9IW"/>
-                                                                <constraint firstItem="eOZ-KM-xLa" firstAttribute="top" secondItem="EDx-YH-ofM" secondAttribute="top" id="fUd-pm-IiH"/>
-                                                                <constraint firstItem="xtT-Or-HjR" firstAttribute="trailing" secondItem="W8L-56-yE9" secondAttribute="trailing" id="g7m-yN-bs2"/>
-                                                                <constraint firstItem="aOD-Qz-oE3" firstAttribute="top" secondItem="EDx-YH-ofM" secondAttribute="top" id="gOd-gW-hDD"/>
-                                                                <constraint firstItem="XdF-fV-DCz" firstAttribute="top" secondItem="kvu-fg-olx" secondAttribute="bottom" constant="10" id="gud-hM-Hf0"/>
-                                                                <constraint firstItem="TA9-9G-tIE" firstAttribute="leading" secondItem="XdF-fV-DCz" secondAttribute="leading" id="hKL-gp-ucV"/>
-                                                                <constraint firstItem="uUe-VB-wyv" firstAttribute="centerX" secondItem="JaQ-EH-K1U" secondAttribute="centerX" id="iT9-ha-L66"/>
-                                                                <constraint firstItem="jUH-hL-3U3" firstAttribute="leading" secondItem="xtT-Or-HjR" secondAttribute="trailing" constant="8" id="iZZ-Of-qr8"/>
-                                                                <constraint firstItem="EDx-YH-ofM" firstAttribute="centerX" secondItem="pHR-ym-VeQ" secondAttribute="centerX" id="idL-dD-1e3"/>
-                                                                <constraint firstItem="W8L-56-yE9" firstAttribute="leading" secondItem="xtT-Or-HjR" secondAttribute="leading" id="lAk-iT-TBS"/>
-                                                                <constraint firstAttribute="trailing" secondItem="Qal-0X-4kS" secondAttribute="trailing" id="lda-T8-U6J"/>
-                                                                <constraint firstAttribute="trailing" secondItem="TA9-9G-tIE" secondAttribute="trailing" constant="20" id="nPX-nn-l3H"/>
-                                                                <constraint firstItem="izd-aj-gqV" firstAttribute="centerY" secondItem="xtT-Or-HjR" secondAttribute="centerY" id="nqS-iu-yym"/>
-                                                                <constraint firstItem="xtT-Or-HjR" firstAttribute="top" secondItem="u9C-Fk-Aag" secondAttribute="bottom" constant="24" id="oeh-GA-5gh"/>
-                                                                <constraint firstItem="ZPW-fz-5Oi" firstAttribute="top" secondItem="XdF-fV-DCz" secondAttribute="bottom" constant="20" id="pbW-gp-age"/>
-                                                                <constraint firstItem="1jP-b9-gGi" firstAttribute="top" secondItem="W8L-56-yE9" secondAttribute="bottom" constant="25" id="qUd-A0-ymw"/>
-                                                                <constraint firstItem="jUH-hL-3U3" firstAttribute="top" secondItem="xtT-Or-HjR" secondAttribute="top" id="rir-xy-gWG"/>
-                                                                <constraint firstItem="ANI-DE-0LU" firstAttribute="leading" secondItem="xtT-Or-HjR" secondAttribute="leading" id="tLi-9T-WbG"/>
-                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ZPW-fz-5Oi" secondAttribute="trailing" id="tRW-zx-YUE"/>
-                                                                <constraint firstItem="w04-h5-qaz" firstAttribute="centerX" secondItem="aOD-Qz-oE3" secondAttribute="centerX" id="u1s-K3-1TR"/>
-                                                                <constraint firstItem="S1M-YW-ac8" firstAttribute="leading" secondItem="xtT-Or-HjR" secondAttribute="leading" id="uYh-dN-68c"/>
-                                                                <constraint firstItem="j85-rj-toQ" firstAttribute="leading" secondItem="TA9-9G-tIE" secondAttribute="leading" constant="-1" id="vYG-N7-4eH"/>
-                                                                <constraint firstItem="wvc-3m-7dA" firstAttribute="centerX" secondItem="TKd-tg-Xtc" secondAttribute="centerX" id="vsl-Na-7AB"/>
-                                                                <constraint firstItem="E4v-kh-61H" firstAttribute="trailing" secondItem="TA9-9G-tIE" secondAttribute="trailing" id="vxi-gU-jaJ"/>
-                                                                <constraint firstItem="kvu-fg-olx" firstAttribute="top" secondItem="Qal-0X-4kS" secondAttribute="bottom" constant="20" id="wOv-GA-HuD"/>
-                                                                <constraint firstItem="u9C-Fk-Aag" firstAttribute="top" secondItem="IHl-Ks-v7I" secondAttribute="bottom" constant="8" symbolic="YES" id="xMS-fe-cqp"/>
-                                                                <constraint firstItem="kvu-fg-olx" firstAttribute="leading" secondItem="TA9-9G-tIE" secondAttribute="leading" id="xkY-DB-G0z"/>
-                                                                <constraint firstItem="gfz-yF-41J" firstAttribute="centerX" secondItem="iDT-gu-k7t" secondAttribute="centerX" id="xnf-hN-6Hv"/>
-                                                                <constraint firstItem="TA9-9G-tIE" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" constant="20" id="y32-7d-2YS"/>
-                                                                <constraint firstItem="gJr-l6-WQ2" firstAttribute="leading" secondItem="TA9-9G-tIE" secondAttribute="leading" id="zda-HN-bk0"/>
-                                                                <constraint firstItem="TA9-9G-tIE" firstAttribute="top" secondItem="E4v-kh-61H" secondAttribute="top" id="zoG-7o-Hig"/>
-                                                            </constraints>
-                                                        </customView>
-                                                    </subviews>
-                                                    <constraints>
-                                                        <constraint firstItem="my2-5o-bNb" firstAttribute="top" secondItem="NZU-RD-Dm3" secondAttribute="top" id="IWt-bk-0fS"/>
-                                                        <constraint firstItem="my2-5o-bNb" firstAttribute="leading" secondItem="NZU-RD-Dm3" secondAttribute="leading" id="pxh-2E-RNE"/>
-                                                        <constraint firstAttribute="trailing" secondItem="my2-5o-bNb" secondAttribute="trailing" id="uM8-H5-QwQ"/>
-                                                        <constraint firstAttribute="bottom" secondItem="my2-5o-bNb" secondAttribute="bottom" id="zoi-sm-jxY"/>
-                                                    </constraints>
-                                                </customView>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstItem="NZU-RD-Dm3" firstAttribute="leading" secondItem="oVx-Sp-Lhl" secondAttribute="leading" id="FiN-fI-rgF"/>
-                                                <constraint firstAttribute="trailing" secondItem="NZU-RD-Dm3" secondAttribute="trailing" id="KAz-hn-L3D"/>
-                                                <constraint firstItem="NZU-RD-Dm3" firstAttribute="top" secondItem="oVx-Sp-Lhl" secondAttribute="top" id="xiA-4o-mvi"/>
-                                            </constraints>
-                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                        </clipView>
-                                        <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="klo-Db-oQE" userLabel="AudioTab Horizontal Scroller">
-                                            <rect key="frame" x="-100" y="-100" width="360" height="15"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                        </scroller>
-                                        <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="17z-n6-rH9" userLabel="AudioTab Vertical Scroller">
-                                            <rect key="frame" x="360" y="0.0" width="15" height="738"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                        </scroller>
-                                    </scrollView>
-                                </subviews>
-                                <constraints>
-                                    <constraint firstAttribute="trailing" secondItem="wXn-sV-AmG" secondAttribute="trailing" id="0QE-XK-d8S"/>
-                                    <constraint firstItem="wXn-sV-AmG" firstAttribute="top" secondItem="Dxl-wa-zgc" secondAttribute="top" id="0zm-BX-gew"/>
-                                    <constraint firstAttribute="bottom" secondItem="wXn-sV-AmG" secondAttribute="bottom" id="LcL-SJ-WPN"/>
-                                    <constraint firstItem="wXn-sV-AmG" firstAttribute="leading" secondItem="Dxl-wa-zgc" secondAttribute="leading" id="gtG-kK-1SM"/>
-                                </constraints>
                             </view>
                         </tabViewItem>
                         <tabViewItem label="Subtitle" identifier="" id="jND-MZ-sKB" userLabel="SubtitlesTab Tab View Item">
                             <view key="view" id="MrM-2b-7ob" userLabel="SubtitlesTab View">
                                 <rect key="frame" x="0.0" y="0.0" width="377" height="863"/>
                                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                <subviews>
-                                    <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="3kA-IY-poi" userLabel="SubtitlesTab Scroll View">
-                                        <rect key="frame" x="0.0" y="0.0" width="377" height="863"/>
-                                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="epy-wp-Ja5" userLabel="SubtitlesTab Clip View">
-                                            <rect key="frame" x="0.0" y="0.0" width="362" height="863"/>
-                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                            <subviews>
-                                                <customView translatesAutoresizingMaskIntoConstraints="NO" id="pm4-x9-WJ5" userLabel="SubtitlesTab Flipped CONTENT VIEW" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
-                                                    <rect key="frame" x="0.0" y="-5" width="362" height="868"/>
-                                                    <subviews>
-                                                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="PJb-5N-8QM" userLabel="PANEL EDGE INSETS">
-                                                            <rect key="frame" x="20" y="868" width="322" height="0.0"/>
-                                                            <constraints>
-                                                                <constraint firstAttribute="height" id="jai-Pg-hCw"/>
-                                                            </constraints>
-                                                        </customView>
-                                                        <customView translatesAutoresizingMaskIntoConstraints="NO" id="Wuf-PX-OYd" userLabel="SubBasicSection Container View">
-                                                            <rect key="frame" x="0.0" y="0.0" width="362" height="868"/>
-                                                            <subviews>
-                                                                <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Fq-4o-8Hh" userLabel="SubTable Scroll View">
-                                                                    <rect key="frame" x="0.0" y="745" width="362" height="75"/>
-                                                                    <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="dJV-R0-O3M" userLabel="SubTable Clip View">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="362" height="75"/>
-                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                        <subviews>
-                                                                            <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="2vU-hm-gGB" userLabel="SubTable Table View">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="362" height="75"/>
-                                                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                                <size key="intercellSpacing" width="3" height="2"/>
-                                                                                <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.080000000000000002" colorSpace="calibratedRGB"/>
-                                                                                <tableViewGridLines key="gridStyleMask" horizontal="YES"/>
-                                                                                <color key="gridColor" red="1" green="1" blue="1" alpha="0.10000000000000001" colorSpace="calibratedRGB"/>
-                                                                                <tableColumns>
-                                                                                    <tableColumn identifier="IsChosen" width="16" minWidth="16" maxWidth="16" id="vbW-xz-mKZ">
-                                                                                        <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="right">
-                                                                                            <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                            <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
-                                                                                        </tableHeaderCell>
-                                                                                        <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" refusesFirstResponder="YES" allowsUndo="NO" alignment="right" title="0" id="CAr-N0-j64">
-                                                                                            <font key="font" metaFont="system"/>
-                                                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                                        </textFieldCell>
-                                                                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                                                                        <prototypeCellViews>
-                                                                                            <tableCellView id="0Gi-L0-dSi">
-                                                                                                <rect key="frame" x="1" y="1" width="21" height="17"/>
-                                                                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                                                <subviews>
-                                                                                                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="7Ky-LN-z9K">
-                                                                                                        <rect key="frame" x="0.0" y="0.0" width="21" height="17"/>
-                                                                                                        <constraints>
-                                                                                                            <constraint firstAttribute="height" constant="17" id="ANA-U2-c96"/>
-                                                                                                        </constraints>
-                                                                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="Jvb-cP-PSf">
-                                                                                                            <font key="font" metaFont="system"/>
-                                                                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                                                        </textFieldCell>
-                                                                                                        <connections>
-                                                                                                            <binding destination="0Gi-L0-dSi" name="value" keyPath="objectValue" id="SHY-wA-1bI"/>
-                                                                                                        </connections>
-                                                                                                    </textField>
-                                                                                                </subviews>
-                                                                                                <constraints>
-                                                                                                    <constraint firstItem="7Ky-LN-z9K" firstAttribute="centerY" secondItem="0Gi-L0-dSi" secondAttribute="centerY" id="KJ7-CB-ONK"/>
-                                                                                                    <constraint firstItem="7Ky-LN-z9K" firstAttribute="centerX" secondItem="0Gi-L0-dSi" secondAttribute="centerX" id="Q6E-Hs-h57"/>
-                                                                                                    <constraint firstItem="7Ky-LN-z9K" firstAttribute="leading" secondItem="0Gi-L0-dSi" secondAttribute="leading" constant="2" id="dH0-ya-hZR"/>
-                                                                                                </constraints>
-                                                                                                <connections>
-                                                                                                    <outlet property="textField" destination="7Ky-LN-z9K" id="dZy-6W-J6f"/>
-                                                                                                </connections>
-                                                                                            </tableCellView>
-                                                                                        </prototypeCellViews>
-                                                                                    </tableColumn>
-                                                                                    <tableColumn identifier="TrackId" width="33" minWidth="33" maxWidth="100" id="q3e-dd-aXM">
-                                                                                        <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="right">
-                                                                                            <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                                                                        </tableHeaderCell>
-                                                                                        <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" refusesFirstResponder="YES" alignment="left" title="Text Cell" id="EUu-Vz-tXf">
-                                                                                            <font key="font" metaFont="system"/>
-                                                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                            <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                                        </textFieldCell>
-                                                                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                                                                        <prototypeCellViews>
-                                                                                            <tableCellView id="tbH-U7-ooT">
-                                                                                                <rect key="frame" x="25" y="1" width="33" height="17"/>
-                                                                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                                                <subviews>
-                                                                                                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Ydk-iU-8pQ">
-                                                                                                        <rect key="frame" x="0.0" y="0.0" width="33" height="17"/>
-                                                                                                        <constraints>
-                                                                                                            <constraint firstAttribute="height" constant="17" id="hAr-TV-jh1"/>
-                                                                                                        </constraints>
-                                                                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="right" title="Table View Cell" id="Mbq-Qm-2xb">
-                                                                                                            <font key="font" metaFont="systemBold"/>
-                                                                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                                                        </textFieldCell>
-                                                                                                        <connections>
-                                                                                                            <binding destination="tbH-U7-ooT" name="value" keyPath="objectValue" id="v9L-V1-LQl"/>
-                                                                                                        </connections>
-                                                                                                    </textField>
-                                                                                                </subviews>
-                                                                                                <constraints>
-                                                                                                    <constraint firstItem="Ydk-iU-8pQ" firstAttribute="centerX" secondItem="tbH-U7-ooT" secondAttribute="centerX" id="2In-Gw-XMG"/>
-                                                                                                    <constraint firstItem="Ydk-iU-8pQ" firstAttribute="centerY" secondItem="tbH-U7-ooT" secondAttribute="centerY" id="5I6-JL-iuh"/>
-                                                                                                    <constraint firstItem="Ydk-iU-8pQ" firstAttribute="leading" secondItem="tbH-U7-ooT" secondAttribute="leading" constant="2" id="YGU-lg-3bg"/>
-                                                                                                </constraints>
-                                                                                                <connections>
-                                                                                                    <outlet property="textField" destination="Ydk-iU-8pQ" id="WBI-LA-u5S"/>
-                                                                                                </connections>
-                                                                                            </tableCellView>
-                                                                                        </prototypeCellViews>
-                                                                                    </tableColumn>
-                                                                                    <tableColumn identifier="TrackName" width="282" minWidth="100" maxWidth="3.4028234663852886e+38" id="jxP-dI-qjH">
-                                                                                        <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                                                                            <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                                                                        </tableHeaderCell>
-                                                                                        <textFieldCell key="dataCell" lineBreakMode="truncatingMiddle" selectable="YES" refusesFirstResponder="YES" allowsUndo="NO" alignment="left" title="Text Cell" id="Ml5-Kc-QjI">
-                                                                                            <font key="font" metaFont="system"/>
-                                                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                                        </textFieldCell>
-                                                                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                                                                        <prototypeCellViews>
-                                                                                            <tableCellView id="Uvf-Ds-mrn">
-                                                                                                <rect key="frame" x="61" y="1" width="286" height="17"/>
-                                                                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                                                <subviews>
-                                                                                                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="E2W-Vb-Tgt">
-                                                                                                        <rect key="frame" x="0.0" y="0.0" width="286" height="17"/>
-                                                                                                        <constraints>
-                                                                                                            <constraint firstAttribute="height" constant="17" id="Z7t-1Z-ziR"/>
-                                                                                                        </constraints>
-                                                                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="Qpg-8B-Eks">
-                                                                                                            <font key="font" metaFont="system"/>
-                                                                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                                                        </textFieldCell>
-                                                                                                        <connections>
-                                                                                                            <binding destination="Uvf-Ds-mrn" name="value" keyPath="objectValue" id="eER-Qt-JMe"/>
-                                                                                                        </connections>
-                                                                                                    </textField>
-                                                                                                </subviews>
-                                                                                                <constraints>
-                                                                                                    <constraint firstItem="E2W-Vb-Tgt" firstAttribute="centerX" secondItem="Uvf-Ds-mrn" secondAttribute="centerX" id="CjW-1W-Ghg"/>
-                                                                                                    <constraint firstItem="E2W-Vb-Tgt" firstAttribute="leading" secondItem="Uvf-Ds-mrn" secondAttribute="leading" constant="2" id="i83-Js-1Hh"/>
-                                                                                                    <constraint firstItem="E2W-Vb-Tgt" firstAttribute="centerY" secondItem="Uvf-Ds-mrn" secondAttribute="centerY" id="wCF-Cd-UF3"/>
-                                                                                                </constraints>
-                                                                                                <connections>
-                                                                                                    <outlet property="textField" destination="E2W-Vb-Tgt" id="0MJ-5K-pni"/>
-                                                                                                </connections>
-                                                                                            </tableCellView>
-                                                                                        </prototypeCellViews>
-                                                                                    </tableColumn>
-                                                                                </tableColumns>
-                                                                            </tableView>
-                                                                        </subviews>
-                                                                    </clipView>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="75" id="lC0-Wa-BTh"/>
-                                                                    </constraints>
-                                                                    <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="T7q-K8-765" userLabel="SubTable Horizontal Scroller">
-                                                                        <rect key="frame" x="0.0" y="56" width="360" height="16"/>
-                                                                        <autoresizingMask key="autoresizingMask"/>
-                                                                    </scroller>
-                                                                    <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="j0M-29-ecd" userLabel="SubTable Vertical Scroller">
-                                                                        <rect key="frame" x="-16" y="0.0" width="16" height="0.0"/>
-                                                                        <autoresizingMask key="autoresizingMask"/>
-                                                                    </scroller>
-                                                                </scrollView>
-                                                                <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LMp-7Y-Rxg" userLabel="SecondarySub Scroll View">
-                                                                    <rect key="frame" x="0.0" y="622" width="362" height="75"/>
-                                                                    <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="EKn-MX-Fao" userLabel="SecondarySub Clip View">
-                                                                        <rect key="frame" x="0.0" y="0.0" width="362" height="75"/>
-                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                        <subviews>
-                                                                            <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="Jve-qX-Agy" userLabel="SecondarySub Table View">
-                                                                                <rect key="frame" x="0.0" y="0.0" width="362" height="75"/>
-                                                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                                <size key="intercellSpacing" width="3" height="2"/>
-                                                                                <color key="backgroundColor" white="1" alpha="0.080000000000000002" colorSpace="deviceWhite"/>
-                                                                                <tableViewGridLines key="gridStyleMask" horizontal="YES"/>
-                                                                                <color key="gridColor" red="1" green="1" blue="1" alpha="0.10000000000000001" colorSpace="calibratedRGB"/>
-                                                                                <tableColumns>
-                                                                                    <tableColumn identifier="IsChosen" width="16" minWidth="16" maxWidth="16" id="2lj-8m-Jqb">
-                                                                                        <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="right">
-                                                                                            <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                            <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
-                                                                                        </tableHeaderCell>
-                                                                                        <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" refusesFirstResponder="YES" allowsUndo="NO" alignment="right" title="0" id="0ju-Sf-fcb">
-                                                                                            <font key="font" metaFont="system"/>
-                                                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                                        </textFieldCell>
-                                                                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                                                                        <prototypeCellViews>
-                                                                                            <tableCellView id="OdH-WH-l2U">
-                                                                                                <rect key="frame" x="1" y="1" width="21" height="17"/>
-                                                                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                                                <subviews>
-                                                                                                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="615-Ps-9YF">
-                                                                                                        <rect key="frame" x="0.0" y="0.0" width="21" height="17"/>
-                                                                                                        <constraints>
-                                                                                                            <constraint firstAttribute="height" constant="17" id="qtL-Np-vkj"/>
-                                                                                                        </constraints>
-                                                                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="f23-sU-Thx">
-                                                                                                            <font key="font" metaFont="system"/>
-                                                                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                                                        </textFieldCell>
-                                                                                                        <connections>
-                                                                                                            <binding destination="OdH-WH-l2U" name="value" keyPath="objectValue" id="Hxt-qf-TUc"/>
-                                                                                                        </connections>
-                                                                                                    </textField>
-                                                                                                </subviews>
-                                                                                                <constraints>
-                                                                                                    <constraint firstItem="615-Ps-9YF" firstAttribute="centerX" secondItem="OdH-WH-l2U" secondAttribute="centerX" id="GOp-6I-AcY"/>
-                                                                                                    <constraint firstItem="615-Ps-9YF" firstAttribute="leading" secondItem="OdH-WH-l2U" secondAttribute="leading" constant="2" id="gvC-jA-iBO"/>
-                                                                                                    <constraint firstItem="615-Ps-9YF" firstAttribute="centerY" secondItem="OdH-WH-l2U" secondAttribute="centerY" id="viA-Z1-ctw"/>
-                                                                                                </constraints>
-                                                                                                <connections>
-                                                                                                    <outlet property="textField" destination="615-Ps-9YF" id="nhJ-wW-r7t"/>
-                                                                                                </connections>
-                                                                                            </tableCellView>
-                                                                                        </prototypeCellViews>
-                                                                                    </tableColumn>
-                                                                                    <tableColumn identifier="TrackId" width="33" minWidth="33" maxWidth="100" id="91Y-DK-bjV">
-                                                                                        <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="right">
-                                                                                            <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                                                                        </tableHeaderCell>
-                                                                                        <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" refusesFirstResponder="YES" alignment="left" title="Text Cell" id="CI9-tC-NBv">
-                                                                                            <font key="font" metaFont="system"/>
-                                                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                            <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                                        </textFieldCell>
-                                                                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                                                                        <prototypeCellViews>
-                                                                                            <tableCellView id="7bA-1U-4oy">
-                                                                                                <rect key="frame" x="25" y="1" width="33" height="17"/>
-                                                                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                                                <subviews>
-                                                                                                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="CCb-vZ-l96">
-                                                                                                        <rect key="frame" x="0.0" y="0.0" width="33" height="17"/>
-                                                                                                        <constraints>
-                                                                                                            <constraint firstAttribute="height" constant="17" id="plc-pR-j5l"/>
-                                                                                                        </constraints>
-                                                                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="right" title="Table View Cell" id="YOu-ft-k7r">
-                                                                                                            <font key="font" metaFont="systemBold"/>
-                                                                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                                                        </textFieldCell>
-                                                                                                        <connections>
-                                                                                                            <binding destination="7bA-1U-4oy" name="value" keyPath="objectValue" id="Gpz-IX-2Y6"/>
-                                                                                                        </connections>
-                                                                                                    </textField>
-                                                                                                </subviews>
-                                                                                                <constraints>
-                                                                                                    <constraint firstItem="CCb-vZ-l96" firstAttribute="leading" secondItem="7bA-1U-4oy" secondAttribute="leading" constant="2" id="9FN-Mp-PWo"/>
-                                                                                                    <constraint firstItem="CCb-vZ-l96" firstAttribute="centerX" secondItem="7bA-1U-4oy" secondAttribute="centerX" id="FtS-zV-DsW"/>
-                                                                                                    <constraint firstItem="CCb-vZ-l96" firstAttribute="centerY" secondItem="7bA-1U-4oy" secondAttribute="centerY" id="ZUx-Ce-XBD"/>
-                                                                                                </constraints>
-                                                                                                <connections>
-                                                                                                    <outlet property="textField" destination="CCb-vZ-l96" id="BKB-n2-rPJ"/>
-                                                                                                </connections>
-                                                                                            </tableCellView>
-                                                                                        </prototypeCellViews>
-                                                                                    </tableColumn>
-                                                                                    <tableColumn identifier="TrackName" width="282" minWidth="40" maxWidth="3.4028234663852886e+38" id="jc0-mX-0JS">
-                                                                                        <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
-                                                                                            <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                            <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
-                                                                                        </tableHeaderCell>
-                                                                                        <textFieldCell key="dataCell" lineBreakMode="truncatingMiddle" selectable="YES" refusesFirstResponder="YES" allowsUndo="NO" alignment="left" title="Text Cell" id="Zmu-ck-pua">
-                                                                                            <font key="font" metaFont="system"/>
-                                                                                            <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
-                                                                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                                        </textFieldCell>
-                                                                                        <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
-                                                                                        <prototypeCellViews>
-                                                                                            <tableCellView id="pG0-Y6-Qgh">
-                                                                                                <rect key="frame" x="61" y="1" width="286" height="17"/>
-                                                                                                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                                                <subviews>
-                                                                                                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="ig9-1H-Wpa">
-                                                                                                        <rect key="frame" x="0.0" y="0.0" width="286" height="17"/>
-                                                                                                        <constraints>
-                                                                                                            <constraint firstAttribute="height" constant="17" id="mlg-vW-akC"/>
-                                                                                                        </constraints>
-                                                                                                        <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="51L-l6-3vz">
-                                                                                                            <font key="font" metaFont="system"/>
-                                                                                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                                                        </textFieldCell>
-                                                                                                        <connections>
-                                                                                                            <binding destination="pG0-Y6-Qgh" name="value" keyPath="objectValue" id="E98-T1-joW"/>
-                                                                                                        </connections>
-                                                                                                    </textField>
-                                                                                                </subviews>
-                                                                                                <constraints>
-                                                                                                    <constraint firstItem="ig9-1H-Wpa" firstAttribute="centerX" secondItem="pG0-Y6-Qgh" secondAttribute="centerX" id="0uX-1k-wPF"/>
-                                                                                                    <constraint firstItem="ig9-1H-Wpa" firstAttribute="centerY" secondItem="pG0-Y6-Qgh" secondAttribute="centerY" id="9ij-Pw-V2f"/>
-                                                                                                    <constraint firstItem="ig9-1H-Wpa" firstAttribute="leading" secondItem="pG0-Y6-Qgh" secondAttribute="leading" constant="2" id="eic-9d-9Mi"/>
-                                                                                                </constraints>
-                                                                                                <connections>
-                                                                                                    <outlet property="textField" destination="ig9-1H-Wpa" id="GcF-vc-iAf"/>
-                                                                                                </connections>
-                                                                                            </tableCellView>
-                                                                                        </prototypeCellViews>
-                                                                                    </tableColumn>
-                                                                                </tableColumns>
-                                                                            </tableView>
-                                                                        </subviews>
-                                                                    </clipView>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="75" id="h9T-Pz-NPG"/>
-                                                                    </constraints>
-                                                                    <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="ZW0-tb-txz" userLabel="SecondarySub Horizontal Scroller">
-                                                                        <rect key="frame" x="0.0" y="56" width="360" height="16"/>
-                                                                        <autoresizingMask key="autoresizingMask"/>
-                                                                    </scroller>
-                                                                    <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="YIS-JA-mpZ" userLabel="SecondarySub Vertical Scroller">
-                                                                        <rect key="frame" x="-16" y="0.0" width="16" height="0.0"/>
-                                                                        <autoresizingMask key="autoresizingMask"/>
-                                                                    </scroller>
-                                                                </scrollView>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mYH-DV-e4F" userLabel="Subtitle">
-                                                                    <rect key="frame" x="18" y="832" width="60" height="16"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Subtitle:" id="eXZ-HN-qL4">
-                                                                        <font key="font" metaFont="systemBold"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3xe-mv-ORw" userLabel="Secondary subtitle">
-                                                                    <rect key="frame" x="18" y="709" width="131" height="16"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Secondary subtitle:" id="bKb-pW-HnS">
-                                                                        <font key="font" metaFont="systemBold"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="M2U-rq-X2L" userLabel="External subtitles">
-                                                                    <rect key="frame" x="18" y="586" width="326" height="16"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="External subtitles:" id="RA1-fF-OrB">
-                                                                        <font key="font" metaFont="systemBold"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="zQu-u6-goi" userLabel="Load Subtitle and Disclosure Triangle">
-                                                                    <rect key="frame" x="17" y="556" width="128" height="24"/>
-                                                                    <segmentedCell key="cell" refusesFirstResponder="YES" borderStyle="border" alignment="left" style="rounded" trackingMode="momentary" id="AB5-UZ-euc">
-                                                                        <font key="font" metaFont="system"/>
-                                                                        <segments>
-                                                                            <segment label="Load Subtitle…"/>
-                                                                            <segment image="triangle-down" tag="1">
-                                                                                <nil key="label"/>
-                                                                            </segment>
-                                                                        </segments>
-                                                                    </segmentedCell>
-                                                                    <connections>
-                                                                        <action selector="loadExternalSubAction:" target="-2" id="6k4-nh-xFo"/>
-                                                                    </connections>
-                                                                </segmentedControl>
-                                                                <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YIE-pv-gCK" userLabel="Search Online Segmented Control">
-                                                                    <rect key="frame" x="147" y="556" width="111" height="24"/>
-                                                                    <segmentedCell key="cell" refusesFirstResponder="YES" borderStyle="border" alignment="left" style="rounded" trackingMode="momentary" id="Rbb-wh-cLc">
-                                                                        <font key="font" metaFont="system"/>
-                                                                        <segments>
-                                                                            <segment label="Search Online…"/>
-                                                                        </segments>
-                                                                    </segmentedCell>
-                                                                    <connections>
-                                                                        <action selector="searchOnlineAction:" target="-2" id="z9B-mh-JoN"/>
-                                                                    </connections>
-                                                                </segmentedControl>
-                                                                <box title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="0ir-bk-Itm">
-                                                                    <rect key="frame" x="17" y="358" width="328" height="182"/>
-                                                                    <view key="contentView" id="SbY-uL-YKR">
-                                                                        <rect key="frame" x="4" y="5" width="320" height="174"/>
-                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                    </view>
-                                                                </box>
-                                                                <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dXz-x4-sm5" userLabel="SubDelay Horizontal Tick Bottom Slider">
-                                                                    <rect key="frame" x="30" y="440" width="233" height="20"/>
-                                                                    <sliderCell key="cell" controlSize="small" continuous="YES" refusesFirstResponder="YES" state="on" alignment="left" minValue="-5" maxValue="5" tickMarkPosition="below" numberOfTickMarks="21" sliderType="linear" id="h1D-gP-Dst"/>
-                                                                    <connections>
-                                                                        <action selector="subDelayChangedAction:" target="-2" id="rzg-cd-v6B"/>
-                                                                    </connections>
-                                                                </slider>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VdJ-nq-zaM" userLabel="SubDelaySliderIndicator">
-                                                                    <rect key="frame" x="140" y="459" width="24" height="13"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="20" id="OZJ-QN-MzG"/>
-                                                                    </constraints>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="0s" usesSingleLineMode="YES" id="upM-Lz-YwK">
-                                                                        <font key="font" metaFont="system" size="10"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cOv-Yl-KdH">
-                                                                    <rect key="frame" x="30" y="476" width="98" height="16"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Subtitle delay:" id="Wkz-wW-sOM">
-                                                                        <font key="font" metaFont="systemBold"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VbE-TV-lb5">
-                                                                    <rect key="frame" x="30" y="430" width="20" height="11"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="-5s" id="uCX-EC-jXM">
-                                                                        <font key="font" metaFont="label" size="9"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="r77-VA-Z1b">
-                                                                    <rect key="frame" x="242" y="430" width="21" height="11"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="+5s" id="xfX-wr-DTJ">
-                                                                        <font key="font" metaFont="label" size="9"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eOz-bB-vzM" userLabel="CustomDelayEdit Text Field">
-                                                                    <rect key="frame" x="269" y="440" width="50" height="21"/>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="width" constant="50" id="ptd-kK-aWm"/>
-                                                                    </constraints>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" title="0" drawsBackground="YES" usesSingleLineMode="YES" id="bZu-Wx-06O" customClass="RoundedTextFieldCell" customModule="IINA" customModuleProvider="target">
-                                                                        <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="HxX-is-3eO"/>
-                                                                        <font key="font" metaFont="system"/>
-                                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                    <connections>
-                                                                        <action selector="customSubDelayEditFinishedAction:" target="-2" id="oMk-9O-MYn"/>
-                                                                    </connections>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4U2-kT-76O">
-                                                                    <rect key="frame" x="317" y="443" width="15" height="16"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="s" id="bsT-FB-GhF">
-                                                                        <font key="font" metaFont="system"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kzp-GR-Sy4">
-                                                                    <rect key="frame" x="139" y="430" width="15" height="11"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="0s" id="LEZ-fv-buL">
-                                                                        <font key="font" metaFont="label" size="9"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <switch horizontalHuggingPriority="750" verticalHuggingPriority="750" baseWritingDirection="leftToRight" alignment="left" translatesAutoresizingMaskIntoConstraints="NO" id="9f0-0q-rg2">
-                                                                    <rect key="frame" x="302" y="827" width="42" height="25"/>
-                                                                    <connections>
-                                                                        <action selector="hideSubAction:" target="-2" id="I9P-h7-1Vv"/>
-                                                                    </connections>
-                                                                </switch>
-                                                                <switch horizontalHuggingPriority="750" verticalHuggingPriority="750" baseWritingDirection="leftToRight" alignment="left" translatesAutoresizingMaskIntoConstraints="NO" id="Ji9-kR-VBA">
-                                                                    <rect key="frame" x="302" y="704" width="42" height="25"/>
-                                                                    <connections>
-                                                                        <action selector="hideSecSubAction:" target="-2" id="QOg-07-Szj"/>
-                                                                    </connections>
-                                                                </switch>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9xm-5m-Q7G">
-                                                                    <rect key="frame" x="18" y="326" width="44" height="16"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Scale:" id="Wbx-Ti-qiS">
-                                                                        <font key="font" metaFont="systemBold"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <button translatesAutoresizingMaskIntoConstraints="NO" id="8ZC-Wx-nt7">
-                                                                    <rect key="frame" x="326" y="318" width="16" height="21"/>
-                                                                    <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRefreshFreestandingTemplate" imagePosition="only" alignment="center" controlSize="small" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="ojj-5V-n3t">
-                                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                        <font key="font" metaFont="message" size="11"/>
-                                                                    </buttonCell>
-                                                                    <constraints>
-                                                                        <constraint firstAttribute="height" constant="16" id="GIz-PJ-9SR"/>
-                                                                        <constraint firstAttribute="width" constant="16" id="HE1-PU-O12"/>
-                                                                    </constraints>
-                                                                    <connections>
-                                                                        <action selector="subScaleReset:" target="-2" id="wfC-aE-U04"/>
-                                                                    </connections>
-                                                                </button>
-                                                                <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="B8f-KH-BaO">
-                                                                    <rect key="frame" x="18" y="292" width="326" height="28"/>
-                                                                    <sliderCell key="cell" continuous="YES" refusesFirstResponder="YES" alignment="left" minValue="-5" maxValue="5" tickMarkPosition="above" sliderType="linear" id="Qpw-NH-Unh"/>
-                                                                    <connections>
-                                                                        <action selector="subScaleSliderAction:" target="-2" id="zEB-hd-cz8"/>
-                                                                    </connections>
-                                                                </slider>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OEX-Gn-xCa">
-                                                                    <rect key="frame" x="30" y="402" width="61" height="16"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Position:" id="t03-36-Zge">
-                                                                        <font key="font" metaFont="systemBold"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ipr-WR-eax">
-                                                                    <rect key="frame" x="18" y="270" width="73" height="16"/>
-                                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Text Style:" id="ZBd-13-lA1">
-                                                                        <font key="font" metaFont="systemBold"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="uSx-qN-Wxd">
-                                                                    <rect key="frame" x="30" y="506" width="302" height="21"/>
-                                                                    <segmentedCell key="cell" controlSize="small" borderStyle="border" alignment="left" segmentDistribution="fillEqually" style="rounded" trackingMode="selectOne" id="88M-pi-2Hc">
-                                                                        <font key="font" metaFont="smallSystem"/>
-                                                                        <segments>
-                                                                            <segment label="Primary Subtitles" selected="YES"/>
-                                                                            <segment label="Secondary Subtitles" tag="1"/>
-                                                                        </segments>
-                                                                    </segmentedCell>
-                                                                    <connections>
-                                                                        <action selector="subSegmentedControlAction:" target="-2" id="G3a-hY-Qcj"/>
-                                                                    </connections>
-                                                                </segmentedControl>
-                                                                <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lzW-d6-Asr">
-                                                                    <rect key="frame" x="30" y="368" width="302" height="28"/>
-                                                                    <sliderCell key="cell" continuous="YES" refusesFirstResponder="YES" alignment="left" maxValue="100" tickMarkPosition="above" sliderType="linear" id="fZU-F1-3pO"/>
-                                                                    <connections>
-                                                                        <action selector="subPosSliderAction:" target="-2" id="Top-XW-i2A"/>
-                                                                    </connections>
-                                                                </slider>
-                                                                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lkf-Yn-nsR" userLabel="Subtitle style options disclaimer">
-                                                                    <rect key="frame" x="18" y="43" width="326" height="28"/>
-                                                                    <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Subtitle style options may break ASS rendering, and some of them will be disabled depending on subtitle type." id="wBD-pZ-Bvu">
-                                                                        <font key="font" metaFont="message" size="11"/>
-                                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                    </textFieldCell>
-                                                                </textField>
-                                                                <box title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="7LX-zh-k2A">
-                                                                    <rect key="frame" x="17" y="80" width="328" height="180"/>
-                                                                    <view key="contentView" id="Af7-Zt-hXH">
-                                                                        <rect key="frame" x="4" y="5" width="320" height="172"/>
-                                                                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                                                                        <subviews>
-                                                                            <colorWell wellStyle="minimal" translatesAutoresizingMaskIntoConstraints="NO" id="9mo-uL-hfC" customClass="RoundedColorWell" customModule="IINA" customModuleProvider="target">
-                                                                                <rect key="frame" x="49" y="119" width="29" height="25"/>
-                                                                                <constraints>
-                                                                                    <constraint firstAttribute="height" constant="21" id="Rgf-Cu-gr0"/>
-                                                                                    <constraint firstAttribute="width" constant="21" id="tlC-zK-dZi"/>
-                                                                                </constraints>
-                                                                                <color key="color" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
-                                                                                <connections>
-                                                                                    <action selector="subTextColorAction:" target="-2" id="K9J-nN-LTp"/>
-                                                                                </connections>
-                                                                            </colorWell>
-                                                                            <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xtF-tn-m9W" userLabel="Text font size">
-                                                                                <rect key="frame" x="124" y="119" width="78" height="22"/>
-                                                                                <popUpButtonCell key="cell" type="push" title="55" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" refusesFirstResponder="YES" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="mep-aa-rk7" id="qha-uU-Cos" userLabel="Cell">
-                                                                                    <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                                                                                    <font key="font" metaFont="message" size="11"/>
-                                                                                    <menu key="menu" id="NDG-BT-qrU">
-                                                                                        <items>
-                                                                                            <menuItem title="30" id="JeH-nY-dU8"/>
-                                                                                            <menuItem title="35" id="zcb-7y-OVG"/>
-                                                                                            <menuItem title="40" id="Sp8-cj-Zrx"/>
-                                                                                            <menuItem title="45" id="OVn-Oj-YAr"/>
-                                                                                            <menuItem title="50" id="YTM-1c-Gl0"/>
-                                                                                            <menuItem title="55" state="on" id="mep-aa-rk7"/>
-                                                                                            <menuItem title="60" id="CFK-kH-8hR"/>
-                                                                                            <menuItem title="65" id="n2O-ot-Bir"/>
-                                                                                            <menuItem title="70" id="AmU-VN-wGN"/>
-                                                                                        </items>
-                                                                                    </menu>
-                                                                                </popUpButtonCell>
-                                                                                <constraints>
-                                                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="70" id="d7u-5q-vDg"/>
-                                                                                </constraints>
-                                                                                <connections>
-                                                                                    <action selector="subTextSizeAction:" target="-2" id="Z3b-cC-c1V"/>
-                                                                                </connections>
-                                                                            </popUpButton>
-                                                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jj7-9J-PmG">
-                                                                                <rect key="frame" x="10" y="12" width="36" height="14"/>
-                                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Color:" id="6LO-6y-IsA">
-                                                                                    <font key="font" metaFont="message" size="11"/>
-                                                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                                </textFieldCell>
-                                                                            </textField>
-                                                                            <textField focusRingType="none" horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vLY-cB-GEf">
-                                                                                <rect key="frame" x="83" y="124" width="39" height="14"/>
-                                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Size:" id="s9l-Hb-SCk">
-                                                                                    <font key="font" metaFont="message" size="11"/>
-                                                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                                </textFieldCell>
-                                                                            </textField>
-                                                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xdm-hT-rQs">
-                                                                                <rect key="frame" x="10" y="90" width="51" height="14"/>
-                                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="BORDER" id="GlZ-YU-dNm">
-                                                                                    <font key="font" metaFont="smallSystemBold"/>
-                                                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                                </textFieldCell>
-                                                                            </textField>
-                                                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BcK-R6-e8c">
-                                                                                <rect key="frame" x="10" y="68" width="36" height="14"/>
-                                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Color:" id="ANn-CR-JOV">
-                                                                                    <font key="font" metaFont="message" size="11"/>
-                                                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                                </textFieldCell>
-                                                                            </textField>
-                                                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kaq-YT-MxI">
-                                                                                <rect key="frame" x="10" y="124" width="36" height="14"/>
-                                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Color:" id="3kI-6i-ujt">
-                                                                                    <font key="font" metaFont="message" size="11"/>
-                                                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                                </textFieldCell>
-                                                                            </textField>
-                                                                            <textField focusRingType="none" horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7Lw-84-lts">
-                                                                                <rect key="frame" x="83" y="68" width="39" height="14"/>
-                                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Width:" id="22j-ra-GAY">
-                                                                                    <font key="font" metaFont="message" size="11"/>
-                                                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                                </textFieldCell>
-                                                                            </textField>
-                                                                            <colorWell wellStyle="minimal" translatesAutoresizingMaskIntoConstraints="NO" id="U2e-zB-Kue" customClass="RoundedColorWell" customModule="IINA" customModuleProvider="target">
-                                                                                <rect key="frame" x="49" y="63" width="29" height="25"/>
-                                                                                <constraints>
-                                                                                    <constraint firstAttribute="height" constant="21" id="OaA-1O-DoB"/>
-                                                                                    <constraint firstAttribute="width" constant="21" id="kwW-fi-4RZ"/>
-                                                                                </constraints>
-                                                                                <color key="color" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
-                                                                                <connections>
-                                                                                    <action selector="subTextBorderColorAction:" target="-2" id="ACh-s2-ew1"/>
-                                                                                </connections>
-                                                                            </colorWell>
-                                                                            <colorWell wellStyle="minimal" translatesAutoresizingMaskIntoConstraints="NO" id="Ure-tT-JEy" customClass="RoundedColorWell" customModule="IINA" customModuleProvider="target">
-                                                                                <rect key="frame" x="49" y="7" width="29" height="25"/>
-                                                                                <constraints>
-                                                                                    <constraint firstAttribute="height" constant="21" id="Ivi-Q0-PSs"/>
-                                                                                    <constraint firstAttribute="width" constant="21" id="qQW-fy-gq5"/>
-                                                                                </constraints>
-                                                                                <color key="color" red="1" green="1" blue="1" alpha="0.0" colorSpace="calibratedRGB"/>
-                                                                                <connections>
-                                                                                    <action selector="subTextBgColorAction:" target="-2" id="hoQ-1z-12N"/>
-                                                                                </connections>
-                                                                            </colorWell>
-                                                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WJ6-Fb-q7a">
-                                                                                <rect key="frame" x="10" y="34" width="86" height="14"/>
-                                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="BACKGROUND" id="uqb-mz-A22">
-                                                                                    <font key="font" metaFont="smallSystemBold"/>
-                                                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                                </textFieldCell>
-                                                                            </textField>
-                                                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jTT-rB-qLu">
-                                                                                <rect key="frame" x="10" y="146" width="300" height="14"/>
-                                                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="FONT" id="g6B-DC-lJ0">
-                                                                                    <font key="font" metaFont="smallSystemBold"/>
-                                                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                                                                </textFieldCell>
-                                                                            </textField>
-                                                                            <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bkX-rt-2bg" userLabel="Text Border Width">
-                                                                                <rect key="frame" x="124" y="63" width="78" height="22"/>
-                                                                                <popUpButtonCell key="cell" type="push" title="3" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" refusesFirstResponder="YES" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="h6k-DT-fv5" id="xGc-Oh-HJO">
-                                                                                    <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
-                                                                                    <font key="font" metaFont="message" size="11"/>
-                                                                                    <menu key="menu" id="LnU-HE-pGc">
-                                                                                        <items>
-                                                                                            <menuItem title="0" id="3eG-mV-UGW"/>
-                                                                                            <menuItem title="0.25" id="DdO-VX-HCz"/>
-                                                                                            <menuItem title="0.5" id="avJ-cW-Iws"/>
-                                                                                            <menuItem title="1" id="nvA-Ae-4XS"/>
-                                                                                            <menuItem title="1.5" id="JbG-Ur-b55"/>
-                                                                                            <menuItem title="2" id="bxa-ha-AXL"/>
-                                                                                            <menuItem title="2.5" id="nPr-QJ-Ty3"/>
-                                                                                            <menuItem title="3" state="on" id="h6k-DT-fv5"/>
-                                                                                            <menuItem title="4" id="ssK-tS-ogL"/>
-                                                                                            <menuItem title="5" id="7su-au-nwq"/>
-                                                                                        </items>
-                                                                                    </menu>
-                                                                                </popUpButtonCell>
-                                                                                <constraints>
-                                                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="70" id="Udn-GZ-bGb"/>
-                                                                                </constraints>
-                                                                                <connections>
-                                                                                    <action selector="subTextBorderWidthAction:" target="-2" id="qyR-r0-5LO"/>
-                                                                                </connections>
-                                                                            </popUpButton>
-                                                                            <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qGz-rB-dsV">
-                                                                                <rect key="frame" x="204" y="116" width="76" height="27"/>
-                                                                                <buttonCell key="cell" type="push" title="Font..." bezelStyle="rounded" alignment="center" controlSize="small" refusesFirstResponder="YES" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ghy-e7-7Of">
-                                                                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
-                                                                                    <font key="font" metaFont="message" size="11"/>
-                                                                                </buttonCell>
-                                                                                <constraints>
-                                                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="64" id="0zp-I9-Wwd"/>
-                                                                                </constraints>
-                                                                                <connections>
-                                                                                    <action selector="subFontAction:" target="-2" id="suw-pH-n9w"/>
-                                                                                </connections>
-                                                                            </button>
-                                                                        </subviews>
-                                                                        <constraints>
-                                                                            <constraint firstItem="qGz-rB-dsV" firstAttribute="firstBaseline" secondItem="xtF-tn-m9W" secondAttribute="firstBaseline" id="3Eq-V6-soB"/>
-                                                                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="qGz-rB-dsV" secondAttribute="trailing" constant="12" id="4A1-C0-lIc"/>
-                                                                            <constraint firstItem="jTT-rB-qLu" firstAttribute="leading" secondItem="Af7-Zt-hXH" secondAttribute="leading" constant="12" id="5O5-mn-fCE"/>
-                                                                            <constraint firstItem="U2e-zB-Kue" firstAttribute="leading" secondItem="BcK-R6-e8c" secondAttribute="trailing" constant="8" id="65d-js-nhu"/>
-                                                                            <constraint firstAttribute="bottom" secondItem="jj7-9J-PmG" secondAttribute="bottom" constant="12" id="6fH-Jn-ujf"/>
-                                                                            <constraint firstItem="vLY-cB-GEf" firstAttribute="leading" secondItem="9mo-uL-hfC" secondAttribute="trailing" constant="12" id="8Vf-dn-rZf"/>
-                                                                            <constraint firstItem="bkX-rt-2bg" firstAttribute="leading" secondItem="7Lw-84-lts" secondAttribute="trailing" constant="8" id="939-fu-npK"/>
-                                                                            <constraint firstItem="kaq-YT-MxI" firstAttribute="top" secondItem="jTT-rB-qLu" secondAttribute="bottom" constant="8" id="9pC-xj-1nZ"/>
-                                                                            <constraint firstItem="BcK-R6-e8c" firstAttribute="top" secondItem="xdm-hT-rQs" secondAttribute="bottom" constant="8" id="EIw-94-ed6"/>
-                                                                            <constraint firstItem="WJ6-Fb-q7a" firstAttribute="leading" secondItem="Af7-Zt-hXH" secondAttribute="leading" constant="12" id="F57-GW-5X8"/>
-                                                                            <constraint firstItem="xtF-tn-m9W" firstAttribute="firstBaseline" secondItem="vLY-cB-GEf" secondAttribute="firstBaseline" id="G5p-Ab-r3M"/>
-                                                                            <constraint firstItem="Ure-tT-JEy" firstAttribute="leading" secondItem="jj7-9J-PmG" secondAttribute="trailing" constant="8" id="GlA-sc-4aV"/>
-                                                                            <constraint firstItem="7Lw-84-lts" firstAttribute="centerY" secondItem="U2e-zB-Kue" secondAttribute="centerY" id="Htc-Fd-Cm1"/>
-                                                                            <constraint firstItem="9mo-uL-hfC" firstAttribute="centerY" secondItem="kaq-YT-MxI" secondAttribute="centerY" id="KEN-mY-ULr"/>
-                                                                            <constraint firstAttribute="trailing" secondItem="jTT-rB-qLu" secondAttribute="trailing" constant="12" id="N5f-vc-50s"/>
-                                                                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="xdm-hT-rQs" secondAttribute="trailing" constant="20" symbolic="YES" id="OX2-t3-H3Q"/>
-                                                                            <constraint firstItem="WJ6-Fb-q7a" firstAttribute="top" secondItem="BcK-R6-e8c" secondAttribute="bottom" constant="20" id="OYB-fW-sD1"/>
-                                                                            <constraint firstItem="9mo-uL-hfC" firstAttribute="leading" secondItem="kaq-YT-MxI" secondAttribute="trailing" constant="8" id="THb-yf-myj"/>
-                                                                            <constraint firstItem="jTT-rB-qLu" firstAttribute="top" secondItem="Af7-Zt-hXH" secondAttribute="top" constant="12" id="Ve8-74-C39"/>
-                                                                            <constraint firstItem="xtF-tn-m9W" firstAttribute="leading" secondItem="vLY-cB-GEf" secondAttribute="trailing" constant="8" id="WhN-1A-O6Z"/>
-                                                                            <constraint firstItem="vLY-cB-GEf" firstAttribute="width" secondItem="7Lw-84-lts" secondAttribute="width" id="Yf7-sF-HSW"/>
-                                                                            <constraint firstItem="U2e-zB-Kue" firstAttribute="centerY" secondItem="BcK-R6-e8c" secondAttribute="centerY" id="i61-Ap-Dx2"/>
-                                                                            <constraint firstItem="xdm-hT-rQs" firstAttribute="top" secondItem="kaq-YT-MxI" secondAttribute="bottom" constant="20" id="iXN-xa-vik"/>
-                                                                            <constraint firstItem="kaq-YT-MxI" firstAttribute="leading" secondItem="Af7-Zt-hXH" secondAttribute="leading" constant="12" id="inC-da-nUo"/>
-                                                                            <constraint firstItem="qGz-rB-dsV" firstAttribute="leading" secondItem="xtF-tn-m9W" secondAttribute="trailing" constant="12" id="ivi-6P-L50"/>
-                                                                            <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="WJ6-Fb-q7a" secondAttribute="trailing" constant="20" symbolic="YES" id="jPg-xe-u7t"/>
-                                                                            <constraint firstItem="bkX-rt-2bg" firstAttribute="firstBaseline" secondItem="7Lw-84-lts" secondAttribute="firstBaseline" id="kFG-eO-qrQ"/>
-                                                                            <constraint firstItem="jj7-9J-PmG" firstAttribute="leading" secondItem="Af7-Zt-hXH" secondAttribute="leading" constant="12" id="pRY-0Z-2pR"/>
-                                                                            <constraint firstItem="7Lw-84-lts" firstAttribute="leading" secondItem="U2e-zB-Kue" secondAttribute="trailing" constant="12" id="sCn-ZY-OEP"/>
-                                                                            <constraint firstItem="Ure-tT-JEy" firstAttribute="centerY" secondItem="jj7-9J-PmG" secondAttribute="centerY" id="t82-Me-2bY"/>
-                                                                            <constraint firstItem="vLY-cB-GEf" firstAttribute="centerY" secondItem="9mo-uL-hfC" secondAttribute="centerY" id="tvm-SS-Tc1"/>
-                                                                            <constraint firstItem="BcK-R6-e8c" firstAttribute="leading" secondItem="Af7-Zt-hXH" secondAttribute="leading" constant="12" id="yHH-zJ-4LP"/>
-                                                                            <constraint firstItem="xdm-hT-rQs" firstAttribute="leading" secondItem="Af7-Zt-hXH" secondAttribute="leading" constant="12" id="yJg-Uq-KhW"/>
-                                                                            <constraint firstItem="jj7-9J-PmG" firstAttribute="top" secondItem="WJ6-Fb-q7a" secondAttribute="bottom" constant="8" id="yM7-UH-dD5"/>
-                                                                        </constraints>
-                                                                    </view>
-                                                                </box>
-                                                            </subviews>
-                                                            <constraints>
-                                                                <constraint firstAttribute="trailing" secondItem="LMp-7Y-Rxg" secondAttribute="trailing" id="0Gl-lc-Bm7"/>
-                                                                <constraint firstAttribute="trailing" secondItem="1Fq-4o-8Hh" secondAttribute="trailing" id="1hL-1o-nGN"/>
-                                                                <constraint firstItem="cOv-Yl-KdH" firstAttribute="top" secondItem="uSx-qN-Wxd" secondAttribute="bottom" constant="16" id="1pU-WQ-8au"/>
-                                                                <constraint firstItem="0ir-bk-Itm" firstAttribute="top" secondItem="uSx-qN-Wxd" secondAttribute="top" constant="-12" id="1sw-Bc-baf"/>
-                                                                <constraint firstItem="zQu-u6-goi" firstAttribute="top" secondItem="M2U-rq-X2L" secondAttribute="bottom" constant="8" id="26L-W9-3iG"/>
-                                                                <constraint firstItem="lzW-d6-Asr" firstAttribute="top" secondItem="OEX-Gn-xCa" secondAttribute="bottom" constant="8" symbolic="YES" id="2wF-65-uMD"/>
-                                                                <constraint firstItem="kzp-GR-Sy4" firstAttribute="centerX" secondItem="dXz-x4-sm5" secondAttribute="centerX" id="33J-Xb-Xbh"/>
-                                                                <constraint firstAttribute="trailing" secondItem="uSx-qN-Wxd" secondAttribute="trailing" constant="32" id="4N2-mY-Uir"/>
-                                                                <constraint firstItem="9f0-0q-rg2" firstAttribute="centerY" secondItem="mYH-DV-e4F" secondAttribute="centerY" id="6px-Sx-9dj"/>
-                                                                <constraint firstItem="VdJ-nq-zaM" firstAttribute="centerX" secondItem="dXz-x4-sm5" secondAttribute="leading" priority="800" constant="120" id="7t1-v0-J55"/>
-                                                                <constraint firstItem="r77-VA-Z1b" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="kzp-GR-Sy4" secondAttribute="trailing" id="8Vz-fK-wJu"/>
-                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="cOv-Yl-KdH" secondAttribute="trailing" symbolic="YES" id="9Qi-Yg-Fnx"/>
-                                                                <constraint firstItem="uSx-qN-Wxd" firstAttribute="top" secondItem="zQu-u6-goi" secondAttribute="bottom" constant="32" id="9aD-1Y-69c"/>
-                                                                <constraint firstItem="kzp-GR-Sy4" firstAttribute="top" secondItem="dXz-x4-sm5" secondAttribute="bottom" constant="1" id="9mp-6s-MHB"/>
-                                                                <constraint firstItem="eOz-bB-vzM" firstAttribute="firstBaseline" secondItem="4U2-kT-76O" secondAttribute="firstBaseline" id="A37-KG-QaU"/>
-                                                                <constraint firstItem="VdJ-nq-zaM" firstAttribute="top" secondItem="cOv-Yl-KdH" secondAttribute="bottom" constant="4" id="Axq-IW-PvK"/>
-                                                                <constraint firstItem="VdJ-nq-zaM" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="dXz-x4-sm5" secondAttribute="leading" id="CCu-4g-OKS"/>
-                                                                <constraint firstItem="7LX-zh-k2A" firstAttribute="top" secondItem="ipr-WR-eax" secondAttribute="bottom" constant="12" id="Czl-Ke-76C"/>
-                                                                <constraint firstItem="YIE-pv-gCK" firstAttribute="leading" secondItem="zQu-u6-goi" secondAttribute="trailing" constant="8" id="DPc-T2-84N"/>
-                                                                <constraint firstItem="8ZC-Wx-nt7" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="9xm-5m-Q7G" secondAttribute="trailing" constant="8" symbolic="YES" id="EJV-9A-iSr"/>
-                                                                <constraint firstItem="dXz-x4-sm5" firstAttribute="top" secondItem="VdJ-nq-zaM" secondAttribute="bottom" constant="1" id="Fdp-D4-VPU"/>
-                                                                <constraint firstItem="ipr-WR-eax" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="20" symbolic="YES" id="GJa-kl-cZG"/>
-                                                                <constraint firstItem="3xe-mv-ORw" firstAttribute="top" secondItem="1Fq-4o-8Hh" secondAttribute="bottom" constant="20" id="I4y-iB-fWM"/>
-                                                                <constraint firstItem="9xm-5m-Q7G" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="20" symbolic="YES" id="Ion-Pe-Xk3"/>
-                                                                <constraint firstItem="mYH-DV-e4F" firstAttribute="top" secondItem="Wuf-PX-OYd" secondAttribute="top" constant="20" id="Izb-ki-XeU"/>
-                                                                <constraint firstItem="Lkf-Yn-nsR" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="20" symbolic="YES" id="J5o-SU-epm"/>
-                                                                <constraint firstItem="Lkf-Yn-nsR" firstAttribute="top" secondItem="7LX-zh-k2A" secondAttribute="bottom" constant="13" id="KLz-m8-d8U"/>
-                                                                <constraint firstItem="Ji9-kR-VBA" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="3xe-mv-ORw" secondAttribute="trailing" constant="8" id="L0n-h9-nNd"/>
-                                                                <constraint firstItem="7LX-zh-k2A" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="20" symbolic="YES" id="LGI-fp-Ys5"/>
-                                                                <constraint firstItem="eOz-bB-vzM" firstAttribute="leading" secondItem="dXz-x4-sm5" secondAttribute="trailing" constant="8" id="LTf-pu-8fz"/>
-                                                                <constraint firstItem="Ji9-kR-VBA" firstAttribute="centerY" secondItem="3xe-mv-ORw" secondAttribute="centerY" id="MFX-GK-WcM"/>
-                                                                <constraint firstItem="lzW-d6-Asr" firstAttribute="leading" secondItem="OEX-Gn-xCa" secondAttribute="leading" id="Mia-2d-0Te"/>
-                                                                <constraint firstItem="LMp-7Y-Rxg" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" id="O1s-aJ-7eK"/>
-                                                                <constraint firstItem="8ZC-Wx-nt7" firstAttribute="firstBaseline" secondItem="9xm-5m-Q7G" secondAttribute="firstBaseline" id="OXd-wT-lGK"/>
-                                                                <constraint firstAttribute="bottom" secondItem="Lkf-Yn-nsR" secondAttribute="bottom" constant="43" id="P51-zb-a92"/>
-                                                                <constraint firstAttribute="trailing" secondItem="Lkf-Yn-nsR" secondAttribute="trailing" constant="20" symbolic="YES" id="PUa-CC-Z0Q"/>
-                                                                <constraint firstItem="VbE-TV-lb5" firstAttribute="leading" secondItem="dXz-x4-sm5" secondAttribute="leading" id="Q0F-ty-AhB"/>
-                                                                <constraint firstItem="0ir-bk-Itm" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="20" symbolic="YES" id="QwI-HD-6Sz"/>
-                                                                <constraint firstItem="B8f-KH-BaO" firstAttribute="top" secondItem="9xm-5m-Q7G" secondAttribute="bottom" constant="8" symbolic="YES" id="W1h-j5-1KT"/>
-                                                                <constraint firstItem="lzW-d6-Asr" firstAttribute="bottom" secondItem="0ir-bk-Itm" secondAttribute="bottom" constant="-12" id="X0h-W2-tPJ"/>
-                                                                <constraint firstItem="cOv-Yl-KdH" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="32" id="XVY-2L-hRa"/>
-                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ipr-WR-eax" secondAttribute="trailing" constant="20" symbolic="YES" id="Xqi-cr-Zcr"/>
-                                                                <constraint firstItem="M2U-rq-X2L" firstAttribute="top" secondItem="LMp-7Y-Rxg" secondAttribute="bottom" constant="20" id="Y58-bK-q43"/>
-                                                                <constraint firstItem="kzp-GR-Sy4" firstAttribute="firstBaseline" secondItem="VbE-TV-lb5" secondAttribute="firstBaseline" id="ZeT-rD-nRd"/>
-                                                                <constraint firstItem="uSx-qN-Wxd" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="32" id="bnw-GB-lTA"/>
-                                                                <constraint firstItem="ipr-WR-eax" firstAttribute="top" secondItem="B8f-KH-BaO" secondAttribute="bottom" constant="12" id="c2C-0A-9vr"/>
-                                                                <constraint firstAttribute="trailing" secondItem="4U2-kT-76O" secondAttribute="trailing" constant="32" id="cG1-zO-3Hw"/>
-                                                                <constraint firstItem="1Fq-4o-8Hh" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" id="eCR-6x-gEL"/>
-                                                                <constraint firstItem="r77-VA-Z1b" firstAttribute="firstBaseline" secondItem="VbE-TV-lb5" secondAttribute="firstBaseline" id="fRc-yO-K49"/>
-                                                                <constraint firstAttribute="trailing" secondItem="8ZC-Wx-nt7" secondAttribute="trailing" constant="20" symbolic="YES" id="fXL-dK-K3k"/>
-                                                                <constraint firstItem="OEX-Gn-xCa" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="32" id="fYl-bc-V56"/>
-                                                                <constraint firstItem="9f0-0q-rg2" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="mYH-DV-e4F" secondAttribute="trailing" constant="8" id="hl1-vl-yic"/>
-                                                                <constraint firstItem="1Fq-4o-8Hh" firstAttribute="top" secondItem="mYH-DV-e4F" secondAttribute="bottom" constant="12" id="hl3-X4-nod"/>
-                                                                <constraint firstItem="OEX-Gn-xCa" firstAttribute="top" secondItem="VbE-TV-lb5" secondAttribute="bottom" constant="12" id="hmb-st-dnt"/>
-                                                                <constraint firstItem="r77-VA-Z1b" firstAttribute="trailing" secondItem="dXz-x4-sm5" secondAttribute="trailing" id="kSN-80-IMR"/>
-                                                                <constraint firstItem="lzW-d6-Asr" firstAttribute="centerX" secondItem="Wuf-PX-OYd" secondAttribute="centerX" id="lDd-s9-Jfa"/>
-                                                                <constraint firstItem="YIE-pv-gCK" firstAttribute="centerY" secondItem="zQu-u6-goi" secondAttribute="centerY" id="lUf-kQ-zMz"/>
-                                                                <constraint firstItem="kzp-GR-Sy4" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="VbE-TV-lb5" secondAttribute="trailing" id="llG-p4-ckS"/>
-                                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="OEX-Gn-xCa" secondAttribute="trailing" constant="32" id="qdd-SN-rDl"/>
-                                                                <constraint firstItem="eOz-bB-vzM" firstAttribute="centerY" secondItem="dXz-x4-sm5" secondAttribute="centerY" id="rgl-9k-oY7"/>
-                                                                <constraint firstItem="4U2-kT-76O" firstAttribute="leading" secondItem="eOz-bB-vzM" secondAttribute="trailing" id="rnJ-T0-g1e"/>
-                                                                <constraint firstAttribute="trailing" secondItem="0ir-bk-Itm" secondAttribute="trailing" constant="20" symbolic="YES" id="uGz-Yc-xe7"/>
-                                                                <constraint firstItem="9xm-5m-Q7G" firstAttribute="top" secondItem="lzW-d6-Asr" secondAttribute="bottom" constant="32" id="ubO-C0-vLx"/>
-                                                                <constraint firstItem="LMp-7Y-Rxg" firstAttribute="top" secondItem="3xe-mv-ORw" secondAttribute="bottom" constant="12" id="uj7-Lc-oLk"/>
-                                                                <constraint firstAttribute="trailing" secondItem="7LX-zh-k2A" secondAttribute="trailing" constant="20" symbolic="YES" id="wd8-Lc-k23"/>
-                                                                <constraint firstItem="dXz-x4-sm5" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="32" id="ydW-mS-48Z"/>
-                                                            </constraints>
-                                                        </customView>
-                                                    </subviews>
-                                                    <constraints>
-                                                        <constraint firstItem="zQu-u6-goi" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="1jU-tm-xfg"/>
-                                                        <constraint firstItem="Wuf-PX-OYd" firstAttribute="top" secondItem="pm4-x9-WJ5" secondAttribute="top" id="Asb-va-Eiv"/>
-                                                        <constraint firstItem="PJb-5N-8QM" firstAttribute="leading" secondItem="pm4-x9-WJ5" secondAttribute="leading" constant="20" id="BQV-10-Aft"/>
-                                                        <constraint firstItem="9f0-0q-rg2" firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="E3K-iB-zmF"/>
-                                                        <constraint firstItem="3xe-mv-ORw" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="EM8-9Q-Yhw"/>
-                                                        <constraint firstItem="M2U-rq-X2L" firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="H2R-H8-0CG"/>
-                                                        <constraint firstItem="Wuf-PX-OYd" firstAttribute="leading" secondItem="pm4-x9-WJ5" secondAttribute="leading" id="Hee-mM-GuU"/>
-                                                        <constraint firstItem="B8f-KH-BaO" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="KiN-OM-Cn5"/>
-                                                        <constraint firstAttribute="trailing" secondItem="Wuf-PX-OYd" secondAttribute="trailing" id="NTd-uf-my8"/>
-                                                        <constraint firstItem="Ji9-kR-VBA" firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="RAY-i7-3Pp"/>
-                                                        <constraint firstItem="YIE-pv-gCK" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="SXw-h1-5CU"/>
-                                                        <constraint firstItem="mYH-DV-e4F" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="aMT-hN-hi6"/>
-                                                        <constraint firstItem="M2U-rq-X2L" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="cph-Mm-h9J"/>
-                                                        <constraint firstAttribute="bottom" secondItem="Wuf-PX-OYd" secondAttribute="bottom" id="loV-NP-OEC"/>
-                                                        <constraint firstItem="PJb-5N-8QM" firstAttribute="top" secondItem="pm4-x9-WJ5" secondAttribute="top" id="m2Z-kA-64n"/>
-                                                        <constraint firstItem="B8f-KH-BaO" firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="pHd-ob-TjH"/>
-                                                        <constraint firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" constant="20" id="wXW-Nt-gpv"/>
-                                                    </constraints>
-                                                </customView>
-                                            </subviews>
-                                            <constraints>
-                                                <constraint firstItem="pm4-x9-WJ5" firstAttribute="top" secondItem="epy-wp-Ja5" secondAttribute="top" id="1bs-mX-gdk"/>
-                                                <constraint firstAttribute="trailing" secondItem="pm4-x9-WJ5" secondAttribute="trailing" id="HgD-xH-Xz0"/>
-                                                <constraint firstItem="pm4-x9-WJ5" firstAttribute="leading" secondItem="epy-wp-Ja5" secondAttribute="leading" id="kbf-OJ-lKt"/>
-                                            </constraints>
-                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                        </clipView>
-                                        <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="jEt-nA-sGO">
-                                            <rect key="frame" x="-100" y="-100" width="360" height="16"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                        </scroller>
-                                        <scroller key="verticalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="3ZS-ug-kkq">
-                                            <rect key="frame" x="362" y="0.0" width="15" height="863"/>
-                                            <autoresizingMask key="autoresizingMask"/>
-                                        </scroller>
-                                    </scrollView>
-                                </subviews>
-                                <constraints>
-                                    <constraint firstAttribute="trailing" secondItem="3kA-IY-poi" secondAttribute="trailing" id="Bdn-AG-ch2"/>
-                                    <constraint firstItem="3kA-IY-poi" firstAttribute="top" secondItem="MrM-2b-7ob" secondAttribute="top" id="PN9-XJ-p1Z"/>
-                                    <constraint firstAttribute="bottom" secondItem="3kA-IY-poi" secondAttribute="bottom" id="V1r-MX-Hap"/>
-                                    <constraint firstItem="3kA-IY-poi" firstAttribute="leading" secondItem="MrM-2b-7ob" secondAttribute="leading" id="dzt-V6-YeS"/>
-                                </constraints>
                             </view>
                         </tabViewItem>
                     </tabViewItems>
@@ -2535,7 +187,7 @@
                 <constraint firstItem="L78-cf-BxB" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="tzm-Ub-xUS"/>
                 <constraint firstAttribute="width" priority="900" constant="360" id="wbT-t0-p1J"/>
             </constraints>
-            <point key="canvasLocation" x="101" y="441"/>
+            <point key="canvasLocation" x="329" y="-1185"/>
         </customView>
         <customObject id="15X-3x-QZ1" customClass="NSFontManager"/>
         <viewController id="KVt-CA-hSE" userLabel="Popover View Controller"/>
@@ -2545,6 +197,2339 @@
             </connections>
         </popover>
         <userDefaultsController representsSharedInstance="YES" id="CE5-Ex-Oo6"/>
+        <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="SHU-hX-9MT" userLabel="VideoTab Scroll View">
+            <rect key="frame" x="0.0" y="0.0" width="367" height="756"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+            <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="8Es-YX-dNf" userLabel="VideoTab Clip View">
+                <rect key="frame" x="0.0" y="0.0" width="367" height="756"/>
+                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                <subviews>
+                    <view translatesAutoresizingMaskIntoConstraints="NO" id="ZGz-La-n9c" userLabel="VideoTab Flipped CONTENT VIEW" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
+                        <rect key="frame" x="0.0" y="0.0" width="367" height="756"/>
+                        <subviews>
+                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="seu-WU-cTV" userLabel="HORIZONTAL-INSETS">
+                                <rect key="frame" x="20" y="736" width="327" height="0.0"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" id="4UC-le-Tmg"/>
+                                </constraints>
+                            </customView>
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ng5-FC-tts" userLabel="Video track Label">
+                                <rect key="frame" x="18" y="720" width="331" height="16"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Video track:" id="VzC-tM-KT7">
+                                    <font key="font" metaFont="systemBold"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <scrollView focusRingType="none" borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ykw-rb-M9D" userLabel="VideoTrackTable Scroll View">
+                                <rect key="frame" x="0.0" y="637" width="367" height="75"/>
+                                <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="jek-w4-LTf" userLabel="VideoTrackTable Clip View">
+                                    <rect key="frame" x="0.0" y="0.0" width="367" height="75"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="rsV-qL-l7b" userLabel="VideoTrackTable Table View">
+                                            <rect key="frame" x="0.0" y="0.0" width="367" height="75"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <size key="intercellSpacing" width="3" height="2"/>
+                                            <color key="backgroundColor" white="1" alpha="0.082057643580000006" colorSpace="deviceWhite"/>
+                                            <tableViewGridLines key="gridStyleMask" horizontal="YES"/>
+                                            <color key="gridColor" red="1" green="1" blue="1" alpha="0.10000000000000001" colorSpace="calibratedRGB"/>
+                                            <tableColumns>
+                                                <tableColumn identifier="IsChosen" editable="NO" width="16" minWidth="16" maxWidth="16" id="PPM-Xv-dec">
+                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="right">
+                                                        <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                    </tableHeaderCell>
+                                                    <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" refusesFirstResponder="YES" alignment="right" title="0" id="z4R-2L-mKS">
+                                                        <font key="font" metaFont="system"/>
+                                                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                    <prototypeCellViews>
+                                                        <tableCellView id="99i-8I-ANv">
+                                                            <rect key="frame" x="1" y="1" width="21" height="17"/>
+                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                            <subviews>
+                                                                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="kfS-xI-KPe">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="21" height="17"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="height" constant="17" id="tAH-cB-Po2"/>
+                                                                    </constraints>
+                                                                    <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="dlX-H5-BCo">
+                                                                        <font key="font" metaFont="system"/>
+                                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                    <connections>
+                                                                        <binding destination="99i-8I-ANv" name="value" keyPath="objectValue" id="dU5-kW-VVa"/>
+                                                                    </connections>
+                                                                </textField>
+                                                            </subviews>
+                                                            <constraints>
+                                                                <constraint firstItem="kfS-xI-KPe" firstAttribute="leading" secondItem="99i-8I-ANv" secondAttribute="leading" constant="2" id="R3c-qW-JBz"/>
+                                                                <constraint firstItem="kfS-xI-KPe" firstAttribute="centerX" secondItem="99i-8I-ANv" secondAttribute="centerX" id="hfL-Lc-0J5"/>
+                                                                <constraint firstItem="kfS-xI-KPe" firstAttribute="centerY" secondItem="99i-8I-ANv" secondAttribute="centerY" id="m0P-If-qLe"/>
+                                                            </constraints>
+                                                            <connections>
+                                                                <outlet property="textField" destination="kfS-xI-KPe" id="bhC-fw-C4F"/>
+                                                            </connections>
+                                                        </tableCellView>
+                                                    </prototypeCellViews>
+                                                </tableColumn>
+                                                <tableColumn identifier="TrackId" width="33" minWidth="33" maxWidth="100" id="Rm0-nB-ZDI">
+                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="right">
+                                                        <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                                    </tableHeaderCell>
+                                                    <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" refusesFirstResponder="YES" alignment="left" title="Text Cell" id="9ss-EF-bby">
+                                                        <font key="font" metaFont="system"/>
+                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                    <prototypeCellViews>
+                                                        <tableCellView id="EOK-X6-h3U">
+                                                            <rect key="frame" x="25" y="1" width="33" height="17"/>
+                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                            <subviews>
+                                                                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="s0D-BR-Bfy">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="33" height="17"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="height" constant="17" id="wbc-c0-LPM"/>
+                                                                    </constraints>
+                                                                    <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="right" title="Table View Cell" id="Pf6-Fd-0mO">
+                                                                        <font key="font" metaFont="systemBold"/>
+                                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                    <connections>
+                                                                        <binding destination="EOK-X6-h3U" name="value" keyPath="objectValue" id="JPW-KP-pJN"/>
+                                                                    </connections>
+                                                                </textField>
+                                                            </subviews>
+                                                            <constraints>
+                                                                <constraint firstItem="s0D-BR-Bfy" firstAttribute="centerY" secondItem="EOK-X6-h3U" secondAttribute="centerY" id="Dar-xn-ZWQ"/>
+                                                                <constraint firstItem="s0D-BR-Bfy" firstAttribute="centerX" secondItem="EOK-X6-h3U" secondAttribute="centerX" id="EJ9-Zw-Nzl"/>
+                                                                <constraint firstItem="s0D-BR-Bfy" firstAttribute="leading" secondItem="EOK-X6-h3U" secondAttribute="leading" constant="2" id="aQ1-Zg-h8j"/>
+                                                            </constraints>
+                                                            <connections>
+                                                                <outlet property="textField" destination="s0D-BR-Bfy" id="Gdk-1b-JTF"/>
+                                                            </connections>
+                                                        </tableCellView>
+                                                    </prototypeCellViews>
+                                                </tableColumn>
+                                                <tableColumn identifier="TrackName" editable="NO" width="292" minWidth="100" maxWidth="10000" id="DgA-Ly-Gb8">
+                                                    <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                        <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                                    </tableHeaderCell>
+                                                    <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" refusesFirstResponder="YES" allowsUndo="NO" alignment="left" title="Text Cell" id="qpa-hD-ImC">
+                                                        <font key="font" metaFont="system"/>
+                                                        <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                    <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                    <prototypeCellViews>
+                                                        <tableCellView id="QLv-Qp-hCf">
+                                                            <rect key="frame" x="61" y="1" width="296" height="17"/>
+                                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                            <subviews>
+                                                                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="r2o-di-dN5">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="296" height="17"/>
+                                                                    <constraints>
+                                                                        <constraint firstAttribute="height" constant="17" id="Ai3-GM-1Yw"/>
+                                                                    </constraints>
+                                                                    <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="jWy-C5-Xu9">
+                                                                        <font key="font" metaFont="system"/>
+                                                                        <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                    </textFieldCell>
+                                                                    <connections>
+                                                                        <binding destination="QLv-Qp-hCf" name="value" keyPath="objectValue" id="RoD-Zm-RdC"/>
+                                                                    </connections>
+                                                                </textField>
+                                                            </subviews>
+                                                            <constraints>
+                                                                <constraint firstItem="r2o-di-dN5" firstAttribute="leading" secondItem="QLv-Qp-hCf" secondAttribute="leading" constant="2" id="Lhx-nh-pQ4"/>
+                                                                <constraint firstItem="r2o-di-dN5" firstAttribute="centerX" secondItem="QLv-Qp-hCf" secondAttribute="centerX" id="ZHJ-3g-zVB"/>
+                                                                <constraint firstItem="r2o-di-dN5" firstAttribute="centerY" secondItem="QLv-Qp-hCf" secondAttribute="centerY" id="c5v-ES-heI"/>
+                                                            </constraints>
+                                                            <connections>
+                                                                <outlet property="textField" destination="r2o-di-dN5" id="wA6-wm-GAV"/>
+                                                            </connections>
+                                                        </tableCellView>
+                                                    </prototypeCellViews>
+                                                </tableColumn>
+                                            </tableColumns>
+                                        </tableView>
+                                    </subviews>
+                                </clipView>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="75" id="QlN-U3-ekO"/>
+                                </constraints>
+                                <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="XXI-Cy-jma">
+                                    <rect key="frame" x="0.0" y="59" width="56" height="16"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
+                                <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="wog-uC-A3q">
+                                    <rect key="frame" x="-16" y="0.0" width="16" height="0.0"/>
+                                    <autoresizingMask key="autoresizingMask"/>
+                                </scroller>
+                            </scrollView>
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="CUa-0e-DwY" userLabel="Aspect ratio Label">
+                                <rect key="frame" x="18" y="601" width="331" height="16"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Aspect ratio:" id="YgL-iV-bca">
+                                    <font key="font" metaFont="systemBold"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <segmentedControl horizontalHuggingPriority="100" verticalHuggingPriority="750" horizontalCompressionResistancePriority="500" translatesAutoresizingMaskIntoConstraints="NO" id="Ljl-w6-gIf" userLabel="AspectRatio Segmented Control">
+                                <rect key="frame" x="18" y="570" width="253" height="24"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="240" id="43J-t3-UhR"/>
+                                </constraints>
+                                <segmentedCell key="cell" refusesFirstResponder="YES" borderStyle="border" alignment="left" segmentDistribution="fillProportionally" style="rounded" trackingMode="selectOne" id="cMu-YF-riv">
+                                    <font key="font" metaFont="system"/>
+                                    <segments>
+                                        <segment label="Default" selected="YES"/>
+                                        <segment label="4:3" tag="1"/>
+                                        <segment label="16:9" tag="2"/>
+                                        <segment label="16:10" tag="3"/>
+                                        <segment label="21:9" tag="4"/>
+                                        <segment label="5:4"/>
+                                    </segments>
+                                </segmentedCell>
+                                <connections>
+                                    <action selector="aspectChangedAction:" target="-2" id="U7C-TJ-2UJ"/>
+                                </connections>
+                            </segmentedControl>
+                            <textField identifier="customAspectRatio" focusRingType="none" horizontalHuggingPriority="500" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="XAI-y0-tcy" userLabel="CustomAspectRatio Text Field">
+                                <rect key="frame" x="277" y="572" width="70" height="21"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" priority="900" constant="30" id="JnW-kS-XvK"/>
+                                </constraints>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" usesSingleLineMode="YES" id="jR7-Mt-N0T" customClass="RoundedTextFieldCell" customModule="IINA" customModuleProvider="target">
+                                    <font key="font" metaFont="system"/>
+                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                                <connections>
+                                    <action selector="customAspectEditFinishedAction:" target="-2" id="8DL-tk-4rJ"/>
+                                </connections>
+                            </textField>
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="oAm-jJ-3kE" userLabel="CropLabel Text Field">
+                                <rect key="frame" x="18" y="535" width="331" height="16"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Crop:" id="m9e-IB-IDJ">
+                                    <font key="font" metaFont="systemBold"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <segmentedControl horizontalHuggingPriority="100" verticalHuggingPriority="750" horizontalCompressionResistancePriority="500" translatesAutoresizingMaskIntoConstraints="NO" id="sPT-jd-T7a" userLabel="CropChooser Segmented Control">
+                                <rect key="frame" x="18" y="504" width="331" height="24"/>
+                                <constraints>
+                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="230" id="tTp-B3-gF5"/>
+                                </constraints>
+                                <segmentedCell key="cell" refusesFirstResponder="YES" borderStyle="border" alignment="left" segmentDistribution="fillProportionally" style="rounded" trackingMode="selectOne" id="iuN-rN-jT7" userLabel="CropChooser Segmented Cell">
+                                    <font key="font" metaFont="system"/>
+                                    <segments>
+                                        <segment label="None"/>
+                                        <segment label="4:3" selected="YES" tag="1"/>
+                                        <segment label="16:9" tag="2"/>
+                                        <segment label="16:10" tag="3"/>
+                                        <segment label="21:9" tag="4"/>
+                                        <segment label="5:4"/>
+                                        <segment label="Custom…"/>
+                                    </segments>
+                                </segmentedCell>
+                                <connections>
+                                    <action selector="cropChangedAction:" target="-2" id="94g-N6-rTB"/>
+                                </connections>
+                            </segmentedControl>
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7vv-En-VYY" userLabel="RotationLabel Text Field">
+                                <rect key="frame" x="18" y="469" width="331" height="16"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Rotation:" id="to3-rc-Agv">
+                                    <font key="font" metaFont="systemBold"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <segmentedControl verticalHuggingPriority="751" translatesAutoresizingMaskIntoConstraints="NO" id="bza-SA-tXE" userLabel="Rotation Segmented Control">
+                                <rect key="frame" x="18" y="438" width="171" height="24"/>
+                                <segmentedCell key="cell" refusesFirstResponder="YES" borderStyle="border" alignment="left" segmentDistribution="fillEqually" style="rounded" trackingMode="selectOne" id="z1L-0N-dfK">
+                                    <font key="font" metaFont="system"/>
+                                    <segments>
+                                        <segment label="0°" selected="YES"/>
+                                        <segment label="90°" tag="1"/>
+                                        <segment label="180°" tag="2"/>
+                                        <segment label="270°" tag="3"/>
+                                    </segments>
+                                </segmentedCell>
+                                <connections>
+                                    <action selector="rotationChangedAction:" target="-2" id="aL1-XS-nLe"/>
+                                </connections>
+                            </segmentedControl>
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="d4r-sL-0Vo" userLabel="SpeedLabel Text Field">
+                                <rect key="frame" x="18" y="403" width="307" height="16"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Speed:" id="1KQ-oZ-A2x">
+                                    <font key="font" metaFont="systemBold"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <button translatesAutoresizingMaskIntoConstraints="NO" id="705-dt-Zwl" userLabel="SpeedReset Button">
+                                <rect key="frame" x="331" y="400" width="16" height="21"/>
+                                <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRefreshFreestandingTemplate" imagePosition="only" alignment="center" controlSize="small" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="e2B-Ie-9hS">
+                                    <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                    <font key="font" metaFont="message" size="11"/>
+                                </buttonCell>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="16" id="EC5-Kq-oB4"/>
+                                    <constraint firstAttribute="width" constant="16" id="Gst-Sh-NwE"/>
+                                </constraints>
+                                <connections>
+                                    <action selector="resetSpeedAction:" target="-2" id="2Ms-5F-wpA"/>
+                                </connections>
+                            </button>
+                            <customView autoresizesSubviews="NO" horizontalHuggingPriority="200" horizontalCompressionResistancePriority="700" translatesAutoresizingMaskIntoConstraints="NO" id="5v4-Te-950" userLabel="SpeedSlider Container View">
+                                <rect key="frame" x="19" y="357" width="328" height="42"/>
+                                <subviews>
+                                    <slider horizontalHuggingPriority="1" verticalHuggingPriority="700" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="700" translatesAutoresizingMaskIntoConstraints="NO" id="UWh-M9-5Nw" userLabel="SpeedSlider Horizontal Tick Slider">
+                                        <rect key="frame" x="-1" y="10" width="234" height="20"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="230" id="oce-0K-3Eq"/>
+                                        </constraints>
+                                        <sliderCell key="cell" controlSize="small" continuous="YES" refusesFirstResponder="YES" alignment="left" maxValue="24" doubleValue="8" tickMarkPosition="below" numberOfTickMarks="25" sliderType="linear" id="qxp-Lt-D6o"/>
+                                        <connections>
+                                            <action selector="speedChangedAction:" target="-2" id="asr-iq-ZNJ"/>
+                                        </connections>
+                                    </slider>
+                                    <textField focusRingType="none" horizontalHuggingPriority="100" verticalHuggingPriority="750" horizontalCompressionResistancePriority="1000" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3EN-WD-QNI" userLabel="SpeedSliderIndicator Text Field">
+                                        <rect key="frame" x="72" y="29" width="19" height="13"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="1x" usesSingleLineMode="YES" id="ldQ-YL-IEp">
+                                            <font key="font" metaFont="system" size="10"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Nhb-Co-xbZ" userLabel="0.25xLabel Text Field">
+                                        <rect key="frame" x="-1" y="0.0" width="29" height="11"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="0.25x" id="Ew1-N1-0Pi">
+                                            <font key="font" metaFont="label" size="9"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wBg-Dk-cUX" userLabel="1xLabel Text Field">
+                                        <rect key="frame" x="71" y="0.0" width="18" height="11"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="1x" id="B0I-bX-HZS">
+                                            <font key="font" metaFont="label" size="9"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Njq-za-TIf" userLabel="4xLabel Text Field">
+                                        <rect key="frame" x="145" y="0.0" width="19" height="11"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="4x" id="PLX-gY-e0h">
+                                            <font key="font" metaFont="label" size="9"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mjX-Jf-925" userLabel="16xLabel Text Field">
+                                        <rect key="frame" x="213" y="0.0" width="20" height="11"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="16x" id="p63-Nx-yJZ">
+                                            <font key="font" metaFont="label" size="9"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="100" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="sIs-a1-rGR" userLabel="SpeedEdit Text Field">
+                                        <rect key="frame" x="239" y="9" width="78" height="22"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" title="1" usesSingleLineMode="YES" bezelStyle="round" id="Mav-NA-RfN" userLabel="SpeedEdit Text Field Cell" customClass="RoundedTextFieldCell" customModule="IINA" customModuleProvider="target">
+                                            <font key="font" metaFont="system"/>
+                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                        <connections>
+                                            <action selector="customSpeedEditFinishedAction:" target="-2" id="f1u-Mu-w4S"/>
+                                        </connections>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="999" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ftl-yD-3Pp">
+                                        <rect key="frame" x="315" y="12" width="15" height="16"/>
+                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="center" title="x" id="dD9-6c-nPz">
+                                            <font key="font" metaFont="system"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="Njq-za-TIf" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="wBg-Dk-cUX" secondAttribute="leading" id="0og-bi-e6K"/>
+                                    <constraint firstItem="Njq-za-TIf" firstAttribute="firstBaseline" secondItem="Nhb-Co-xbZ" secondAttribute="firstBaseline" id="3b5-3Q-r9W"/>
+                                    <constraint firstItem="sIs-a1-rGR" firstAttribute="leading" secondItem="UWh-M9-5Nw" secondAttribute="trailing" constant="8" id="45f-oW-eLi"/>
+                                    <constraint firstItem="3EN-WD-QNI" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="UWh-M9-5Nw" secondAttribute="trailing" id="5HH-wM-xVs"/>
+                                    <constraint firstItem="wBg-Dk-cUX" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Nhb-Co-xbZ" secondAttribute="trailing" id="85g-vN-0eC"/>
+                                    <constraint firstAttribute="trailing" secondItem="ftl-yD-3Pp" secondAttribute="trailing" id="96C-Yr-KHl"/>
+                                    <constraint firstItem="mjX-Jf-925" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="Njq-za-TIf" secondAttribute="trailing" id="Aep-cH-5hZ"/>
+                                    <constraint firstItem="UWh-M9-5Nw" firstAttribute="top" secondItem="3EN-WD-QNI" secondAttribute="bottom" constant="1" id="Ew9-hh-DuD"/>
+                                    <constraint firstItem="Njq-za-TIf" firstAttribute="centerX" secondItem="UWh-M9-5Nw" secondAttribute="trailing" multiplier="0.667" id="H0i-c4-qHi"/>
+                                    <constraint firstItem="sIs-a1-rGR" firstAttribute="trailing" secondItem="ftl-yD-3Pp" secondAttribute="leading" id="NH7-04-aU7"/>
+                                    <constraint firstItem="3EN-WD-QNI" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="UWh-M9-5Nw" secondAttribute="leading" id="VCK-Xl-WI5"/>
+                                    <constraint firstItem="ftl-yD-3Pp" firstAttribute="firstBaseline" secondItem="sIs-a1-rGR" secondAttribute="firstBaseline" id="ZAk-oK-iEc"/>
+                                    <constraint firstItem="mjX-Jf-925" firstAttribute="trailing" secondItem="UWh-M9-5Nw" secondAttribute="trailing" id="a9v-VN-b9b"/>
+                                    <constraint firstItem="UWh-M9-5Nw" firstAttribute="leading" secondItem="5v4-Te-950" secondAttribute="leading" constant="1" id="b9h-cf-WWr"/>
+                                    <constraint firstItem="Nhb-Co-xbZ" firstAttribute="leading" secondItem="UWh-M9-5Nw" secondAttribute="leading" id="bpH-bS-WjS"/>
+                                    <constraint firstItem="3EN-WD-QNI" firstAttribute="top" secondItem="5v4-Te-950" secondAttribute="top" id="cOT-x8-ZcW"/>
+                                    <constraint firstItem="wBg-Dk-cUX" firstAttribute="centerX" secondItem="UWh-M9-5Nw" secondAttribute="leading" multiplier="0.3333" constant="80" id="hlk-KQ-DJ7"/>
+                                    <constraint firstItem="wBg-Dk-cUX" firstAttribute="firstBaseline" secondItem="Nhb-Co-xbZ" secondAttribute="firstBaseline" id="ime-8Z-RkU"/>
+                                    <constraint firstAttribute="bottom" secondItem="Nhb-Co-xbZ" secondAttribute="bottom" id="iwc-ox-8MG"/>
+                                    <constraint firstItem="mjX-Jf-925" firstAttribute="firstBaseline" secondItem="Nhb-Co-xbZ" secondAttribute="firstBaseline" id="pcC-I5-fWK"/>
+                                    <constraint firstItem="3EN-WD-QNI" firstAttribute="centerX" secondItem="UWh-M9-5Nw" secondAttribute="leading" priority="800" constant="80" id="qTf-o6-Mef"/>
+                                    <constraint firstItem="Nhb-Co-xbZ" firstAttribute="top" secondItem="UWh-M9-5Nw" secondAttribute="bottom" constant="1" id="vt5-Yi-wDm"/>
+                                    <constraint firstItem="sIs-a1-rGR" firstAttribute="centerY" secondItem="UWh-M9-5Nw" secondAttribute="centerY" id="xKa-An-0CC"/>
+                                </constraints>
+                            </customView>
+                            <box autoresizesSubviews="NO" boxType="custom" cornerRadius="6" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="2ye-g4-fz5" userLabel="Switches Box">
+                                <rect key="frame" x="20" y="207" width="327" height="130"/>
+                                <view key="contentView" id="bBc-PP-gHz" userLabel="Switches Box View">
+                                    <rect key="frame" x="1" y="1" width="325" height="128"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                    <subviews>
+                                        <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="PyM-xa-vx9" userLabel="Horizontal Line 1">
+                                            <rect key="frame" x="12" y="83" width="301" height="5"/>
+                                        </box>
+                                        <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="qYi-uQ-6qo" userLabel="Horizontal Line 2">
+                                            <rect key="frame" x="12" y="40" width="301" height="5"/>
+                                        </box>
+                                        <switch horizontalHuggingPriority="750" verticalHuggingPriority="750" baseWritingDirection="leftToRight" alignment="left" translatesAutoresizingMaskIntoConstraints="NO" id="UKk-rD-n2A">
+                                            <rect key="frame" x="265" y="51" width="42" height="25"/>
+                                            <connections>
+                                                <action selector="deinterlaceAction:" target="-2" id="Wks-al-3dq"/>
+                                            </connections>
+                                        </switch>
+                                        <switch horizontalHuggingPriority="750" verticalHuggingPriority="750" baseWritingDirection="leftToRight" alignment="left" translatesAutoresizingMaskIntoConstraints="NO" id="TNg-iM-cVP">
+                                            <rect key="frame" x="265" y="8" width="42" height="25"/>
+                                            <connections>
+                                                <action selector="hdrAction:" target="-2" id="caQ-5H-pX4"/>
+                                            </connections>
+                                        </switch>
+                                        <switch horizontalHuggingPriority="750" verticalHuggingPriority="750" baseWritingDirection="leftToRight" alignment="left" translatesAutoresizingMaskIntoConstraints="NO" id="AbD-ap-nO5">
+                                            <rect key="frame" x="265" y="94" width="42" height="25"/>
+                                            <connections>
+                                                <action selector="hardwareDecodingAction:" target="-2" id="Fv6-2y-odN"/>
+                                            </connections>
+                                        </switch>
+                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="OvF-ci-44R">
+                                            <rect key="frame" x="18" y="101" width="124" height="16"/>
+                                            <textFieldCell key="cell" lineBreakMode="clipping" title="Hardware Decoding" id="rw1-Qb-0RV">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xJo-hi-ale">
+                                            <rect key="frame" x="18" y="15" width="32" height="16"/>
+                                            <textFieldCell key="cell" lineBreakMode="clipping" title="HDR" id="UW4-by-XRS">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="m39-41-Kwj">
+                                            <rect key="frame" x="18" y="58" width="73" height="16"/>
+                                            <textFieldCell key="cell" lineBreakMode="clipping" title="Deinterlace" id="eqd-nF-8ff">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                    </subviews>
+                                    <constraints>
+                                        <constraint firstItem="AbD-ap-nO5" firstAttribute="top" secondItem="bBc-PP-gHz" secondAttribute="top" constant="10" id="5cF-CC-AbB"/>
+                                        <constraint firstItem="qYi-uQ-6qo" firstAttribute="top" secondItem="UKk-rD-n2A" secondAttribute="bottom" constant="10" id="6VJ-Ah-h6m"/>
+                                        <constraint firstItem="TNg-iM-cVP" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="xJo-hi-ale" secondAttribute="trailing" id="AFb-Zd-1Kk"/>
+                                        <constraint firstItem="OvF-ci-44R" firstAttribute="firstBaseline" secondItem="AbD-ap-nO5" secondAttribute="firstBaseline" id="C5V-KG-rtA"/>
+                                        <constraint firstItem="xJo-hi-ale" firstAttribute="firstBaseline" secondItem="TNg-iM-cVP" secondAttribute="firstBaseline" id="FgR-gq-g9W"/>
+                                        <constraint firstItem="OvF-ci-44R" firstAttribute="leading" secondItem="bBc-PP-gHz" secondAttribute="leading" constant="20" symbolic="YES" id="HQZ-2y-rKx"/>
+                                        <constraint firstItem="AbD-ap-nO5" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="OvF-ci-44R" secondAttribute="trailing" id="JmL-a7-GPB"/>
+                                        <constraint firstAttribute="trailing" secondItem="UKk-rD-n2A" secondAttribute="trailing" constant="20" symbolic="YES" id="SGe-oO-XfD"/>
+                                        <constraint firstItem="qYi-uQ-6qo" firstAttribute="trailing" secondItem="PyM-xa-vx9" secondAttribute="trailing" id="W6Y-bH-eCi"/>
+                                        <constraint firstAttribute="bottom" secondItem="TNg-iM-cVP" secondAttribute="bottom" constant="10" id="XFf-u8-uTi"/>
+                                        <constraint firstAttribute="trailing" secondItem="PyM-xa-vx9" secondAttribute="trailing" constant="12" id="Zny-ol-SPy"/>
+                                        <constraint firstItem="PyM-xa-vx9" firstAttribute="top" secondItem="AbD-ap-nO5" secondAttribute="bottom" constant="10" id="aZI-9n-idy"/>
+                                        <constraint firstItem="PyM-xa-vx9" firstAttribute="leading" secondItem="bBc-PP-gHz" secondAttribute="leading" constant="12" id="cAs-bS-FEB"/>
+                                        <constraint firstItem="TNg-iM-cVP" firstAttribute="top" secondItem="qYi-uQ-6qo" secondAttribute="bottom" constant="10" id="eVy-VT-STY"/>
+                                        <constraint firstItem="UKk-rD-n2A" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="m39-41-Kwj" secondAttribute="trailing" id="faP-iu-15E"/>
+                                        <constraint firstItem="xJo-hi-ale" firstAttribute="leading" secondItem="bBc-PP-gHz" secondAttribute="leading" constant="20" symbolic="YES" id="hah-hi-Vnt"/>
+                                        <constraint firstItem="m39-41-Kwj" firstAttribute="leading" secondItem="bBc-PP-gHz" secondAttribute="leading" constant="20" symbolic="YES" id="l2S-aw-jeb"/>
+                                        <constraint firstAttribute="trailing" secondItem="AbD-ap-nO5" secondAttribute="trailing" constant="20" symbolic="YES" id="q7m-cn-c9D"/>
+                                        <constraint firstItem="m39-41-Kwj" firstAttribute="firstBaseline" secondItem="UKk-rD-n2A" secondAttribute="firstBaseline" id="qP2-ce-a9h"/>
+                                        <constraint firstItem="qYi-uQ-6qo" firstAttribute="leading" secondItem="PyM-xa-vx9" secondAttribute="leading" id="tkm-Ze-qkw"/>
+                                        <constraint firstAttribute="trailing" secondItem="TNg-iM-cVP" secondAttribute="trailing" constant="20" symbolic="YES" id="ugo-Rb-i01"/>
+                                        <constraint firstItem="UKk-rD-n2A" firstAttribute="top" secondItem="PyM-xa-vx9" secondAttribute="bottom" constant="10" id="w2S-IA-KK8"/>
+                                    </constraints>
+                                </view>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="130" id="mMk-SO-lBd"/>
+                                </constraints>
+                                <color key="borderColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                <color key="fillColor" red="0.99999600649999998" green="1" blue="1" alpha="0.10000000000000001" colorSpace="custom" customColorSpace="sRGB"/>
+                            </box>
+                            <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="7PK-hh-Xx5">
+                                <rect key="frame" x="0.0" y="184" width="367" height="5"/>
+                            </box>
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QqK-iZ-rFX" userLabel="EqualizerLabel Text Field">
+                                <rect key="frame" x="18" y="150" width="331" height="16"/>
+                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Equalizer:" id="zcD-Tg-7Oi">
+                                    <font key="font" metaFont="systemBold"/>
+                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                </textFieldCell>
+                            </textField>
+                            <stackView distribution="equalCentering" orientation="vertical" alignment="leading" spacing="11" horizontalStackHuggingPriority="1000" verticalStackHuggingPriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="9Ua-jA-xuA" userLabel="EqualizerLabels Vertical Stack View">
+                                <rect key="frame" x="20" y="20" width="55" height="110"/>
+                                <subviews>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Kzg-Uw-tpM">
+                                        <rect key="frame" x="-2" y="97" width="59" height="13"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Brightness:" id="cdR-uY-riN">
+                                            <font key="font" metaFont="message" size="11"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zeE-QB-5WQ">
+                                        <rect key="frame" x="-2" y="73" width="59" height="13"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Contrast:" id="eDl-Si-LSa">
+                                            <font key="font" metaFont="message" size="11"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="inU-m8-46Z">
+                                        <rect key="frame" x="-2" y="48" width="59" height="14"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Saturation:" id="Rky-lo-Buu">
+                                            <font key="font" metaFont="message" size="11"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NFp-1S-x9x">
+                                        <rect key="frame" x="-2" y="24" width="59" height="13"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Gamma:" id="r6x-z0-oFC">
+                                            <font key="font" metaFont="message" size="11"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BdF-A5-VPG">
+                                        <rect key="frame" x="-2" y="0.0" width="59" height="13"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Hue:" id="eLh-fu-pMj">
+                                            <font key="font" metaFont="message" size="11"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="BdF-A5-VPG" firstAttribute="bottom" secondItem="Kzg-Uw-tpM" secondAttribute="top" constant="110" id="0cF-1Q-5Et"/>
+                                    <constraint firstItem="inU-m8-46Z" firstAttribute="height" secondItem="Kzg-Uw-tpM" secondAttribute="height" id="B8c-8a-Bmv"/>
+                                    <constraint firstItem="NFp-1S-x9x" firstAttribute="height" secondItem="Kzg-Uw-tpM" secondAttribute="height" id="aRf-Mh-zKA"/>
+                                    <constraint firstItem="BdF-A5-VPG" firstAttribute="height" secondItem="Kzg-Uw-tpM" secondAttribute="height" id="ecB-OH-83m"/>
+                                    <constraint firstItem="zeE-QB-5WQ" firstAttribute="height" secondItem="Kzg-Uw-tpM" secondAttribute="height" id="myf-5F-a3g"/>
+                                </constraints>
+                                <visibilityPriorities>
+                                    <integer value="1000"/>
+                                    <integer value="1000"/>
+                                    <integer value="1000"/>
+                                    <integer value="1000"/>
+                                    <integer value="1000"/>
+                                </visibilityPriorities>
+                                <customSpacing>
+                                    <real value="3.4028234663852886e+38"/>
+                                    <real value="3.4028234663852886e+38"/>
+                                    <real value="3.4028234663852886e+38"/>
+                                    <real value="3.4028234663852886e+38"/>
+                                    <real value="3.4028234663852886e+38"/>
+                                </customSpacing>
+                            </stackView>
+                            <stackView distribution="equalCentering" orientation="vertical" alignment="leading" spacing="11" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="pam-gJ-b3R" userLabel="EqualizerSliders Vertical Stack View">
+                                <rect key="frame" x="83" y="20" width="241" height="110"/>
+                                <subviews>
+                                    <slider identifier="brightnessSlider" horizontalHuggingPriority="800" verticalHuggingPriority="750" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="eFW-a3-kWx" userLabel="Brightness Slider">
+                                        <rect key="frame" x="-2" y="95" width="238" height="17"/>
+                                        <sliderCell key="cell" controlSize="small" continuous="YES" refusesFirstResponder="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="7Km-3j-0F1"/>
+                                        <accessibility identifier="brightnessLabel"/>
+                                        <connections>
+                                            <action selector="equalizerSliderAction:" target="-2" id="D6V-VG-FTQ"/>
+                                        </connections>
+                                    </slider>
+                                    <slider identifier="contrastSlider" horizontalHuggingPriority="800" verticalHuggingPriority="750" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="mTb-L6-55O" userLabel="Contrast Slider">
+                                        <rect key="frame" x="-2" y="71" width="238" height="17"/>
+                                        <sliderCell key="cell" controlSize="small" continuous="YES" refusesFirstResponder="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="hgz-bN-WeD"/>
+                                        <connections>
+                                            <action selector="equalizerSliderAction:" target="-2" id="Nvx-FI-qAc"/>
+                                        </connections>
+                                    </slider>
+                                    <slider identifier="saturationSlider" horizontalHuggingPriority="800" verticalHuggingPriority="750" horizontalCompressionResistancePriority="100" translatesAutoresizingMaskIntoConstraints="NO" id="VlS-Jo-4C0" userLabel="Saturation Slider">
+                                        <rect key="frame" x="-2" y="46" width="238" height="18"/>
+                                        <sliderCell key="cell" controlSize="small" continuous="YES" refusesFirstResponder="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="XWl-TS-6CD"/>
+                                        <connections>
+                                            <action selector="equalizerSliderAction:" target="-2" id="lqV-jM-722"/>
+                                        </connections>
+                                    </slider>
+                                    <slider identifier="gammaSlider" horizontalHuggingPriority="100" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fLl-8b-pj0" userLabel="Gamma Slider">
+                                        <rect key="frame" x="-2" y="22" width="245" height="17"/>
+                                        <sliderCell key="cell" controlSize="small" continuous="YES" refusesFirstResponder="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="4De-8a-gIx"/>
+                                        <connections>
+                                            <action selector="equalizerSliderAction:" target="-2" id="eBS-E6-XBk"/>
+                                        </connections>
+                                    </slider>
+                                    <slider identifier="hueSlider" horizontalHuggingPriority="100" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="mKB-Mu-l5Y" userLabel="Hue Slider">
+                                        <rect key="frame" x="-2" y="-2" width="245" height="17"/>
+                                        <sliderCell key="cell" controlSize="small" continuous="YES" refusesFirstResponder="YES" state="on" alignment="left" minValue="-100" maxValue="100" tickMarkPosition="above" sliderType="linear" id="Bwq-Om-Y6s"/>
+                                        <connections>
+                                            <action selector="equalizerSliderAction:" target="-2" id="Lkh-f1-UR2"/>
+                                        </connections>
+                                    </slider>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="fLl-8b-pj0" firstAttribute="height" secondItem="eFW-a3-kWx" secondAttribute="height" id="Boz-5a-gkt"/>
+                                    <constraint firstItem="mKB-Mu-l5Y" firstAttribute="height" secondItem="eFW-a3-kWx" secondAttribute="height" id="IMb-Uf-aiY"/>
+                                    <constraint firstItem="mTb-L6-55O" firstAttribute="height" secondItem="eFW-a3-kWx" secondAttribute="height" id="PYB-dj-5Ou"/>
+                                    <constraint firstItem="VlS-Jo-4C0" firstAttribute="height" secondItem="eFW-a3-kWx" secondAttribute="height" id="qJM-QY-tdM"/>
+                                </constraints>
+                                <visibilityPriorities>
+                                    <integer value="1000"/>
+                                    <integer value="1000"/>
+                                    <integer value="1000"/>
+                                    <integer value="1000"/>
+                                    <integer value="1000"/>
+                                </visibilityPriorities>
+                                <customSpacing>
+                                    <real value="3.4028234663852886e+38"/>
+                                    <real value="3.4028234663852886e+38"/>
+                                    <real value="3.4028234663852886e+38"/>
+                                    <real value="3.4028234663852886e+38"/>
+                                    <real value="3.4028234663852886e+38"/>
+                                </customSpacing>
+                            </stackView>
+                            <stackView distribution="equalCentering" orientation="vertical" alignment="leading" spacing="11" horizontalStackHuggingPriority="1000" verticalStackHuggingPriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="iAC-lz-PuL" userLabel="EqualizerResetButtons Vertical Stack View">
+                                <rect key="frame" x="332" y="20" width="15" height="110"/>
+                                <subviews>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="cjG-f1-Mkg" userLabel="Brightness Square Button">
+                                        <rect key="frame" x="0.0" y="94" width="15" height="19"/>
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRefreshFreestandingTemplate" imagePosition="overlaps" alignment="center" refusesFirstResponder="YES" inset="2" id="63a-cd-eXa">
+                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <action selector="resetEqualizerBtnAction:" target="-2" id="pnK-gu-1Jd"/>
+                                        </connections>
+                                    </button>
+                                    <button tag="1" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="KVl-YU-9O3" userLabel="Contrast Square Button">
+                                        <rect key="frame" x="0.0" y="70" width="15" height="19"/>
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRefreshFreestandingTemplate" imagePosition="overlaps" alignment="center" refusesFirstResponder="YES" inset="2" id="NIq-6H-Orr">
+                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <action selector="resetEqualizerBtnAction:" target="-2" id="fkB-MT-0WI"/>
+                                        </connections>
+                                    </button>
+                                    <button tag="2" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lgg-zH-OLr" userLabel="Saturation Square Button">
+                                        <rect key="frame" x="0.0" y="45" width="15" height="20"/>
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRefreshFreestandingTemplate" imagePosition="overlaps" alignment="center" refusesFirstResponder="YES" inset="2" id="D5D-O8-MdN">
+                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <action selector="resetEqualizerBtnAction:" target="-2" id="C3s-y1-9aO"/>
+                                        </connections>
+                                    </button>
+                                    <button tag="3" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="fGZ-vI-EP8" userLabel="Gamma Square Button">
+                                        <rect key="frame" x="0.0" y="21" width="15" height="19"/>
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRefreshFreestandingTemplate" imagePosition="overlaps" alignment="center" refusesFirstResponder="YES" inset="2" id="7sd-9d-D6H">
+                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <action selector="resetEqualizerBtnAction:" target="-2" id="HTf-KH-SVv"/>
+                                        </connections>
+                                    </button>
+                                    <button tag="4" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="W7J-wR-UH3" userLabel="Hue Square Button">
+                                        <rect key="frame" x="0.0" y="-3" width="15" height="19"/>
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRefreshFreestandingTemplate" imagePosition="overlaps" alignment="center" refusesFirstResponder="YES" inset="2" id="Mrx-t0-wfm">
+                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <connections>
+                                            <action selector="resetEqualizerBtnAction:" target="-2" id="z43-kY-r5n"/>
+                                        </connections>
+                                    </button>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstItem="KVl-YU-9O3" firstAttribute="height" secondItem="cjG-f1-Mkg" secondAttribute="height" id="3Dj-Pa-cqs"/>
+                                    <constraint firstItem="W7J-wR-UH3" firstAttribute="width" secondItem="cjG-f1-Mkg" secondAttribute="width" id="G6i-E8-li2"/>
+                                    <constraint firstItem="cjG-f1-Mkg" firstAttribute="width" secondItem="iAC-lz-PuL" secondAttribute="width" id="QQR-g4-ove"/>
+                                    <constraint firstItem="lgg-zH-OLr" firstAttribute="width" secondItem="cjG-f1-Mkg" secondAttribute="width" id="Rzt-nR-RLP"/>
+                                    <constraint firstItem="fGZ-vI-EP8" firstAttribute="height" secondItem="cjG-f1-Mkg" secondAttribute="height" id="UAQ-aO-pfl"/>
+                                    <constraint firstItem="fGZ-vI-EP8" firstAttribute="width" secondItem="cjG-f1-Mkg" secondAttribute="width" id="Zbs-eB-FlT"/>
+                                    <constraint firstItem="W7J-wR-UH3" firstAttribute="height" secondItem="cjG-f1-Mkg" secondAttribute="height" id="bKm-mB-ZYz"/>
+                                    <constraint firstItem="KVl-YU-9O3" firstAttribute="width" secondItem="cjG-f1-Mkg" secondAttribute="width" id="lff-hV-QFG"/>
+                                    <constraint firstItem="lgg-zH-OLr" firstAttribute="height" secondItem="cjG-f1-Mkg" secondAttribute="height" id="yCh-nD-xHV"/>
+                                </constraints>
+                                <visibilityPriorities>
+                                    <integer value="1000"/>
+                                    <integer value="1000"/>
+                                    <integer value="1000"/>
+                                    <integer value="1000"/>
+                                    <integer value="1000"/>
+                                </visibilityPriorities>
+                                <customSpacing>
+                                    <real value="3.4028234663852886e+38"/>
+                                    <real value="3.4028234663852886e+38"/>
+                                    <real value="3.4028234663852886e+38"/>
+                                    <real value="3.4028234663852886e+38"/>
+                                    <real value="3.4028234663852886e+38"/>
+                                </customSpacing>
+                            </stackView>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="5v4-Te-950" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" constant="-1" id="0re-Ss-vgh"/>
+                            <constraint firstItem="CUa-0e-DwY" firstAttribute="top" secondItem="ykw-rb-M9D" secondAttribute="bottom" constant="20" id="18w-9C-Htc"/>
+                            <constraint firstItem="iAC-lz-PuL" firstAttribute="leading" secondItem="pam-gJ-b3R" secondAttribute="trailing" constant="8" id="29l-xI-5MV"/>
+                            <constraint firstItem="d4r-sL-0Vo" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="2jO-JJ-N1O"/>
+                            <constraint firstItem="sPT-jd-T7a" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="2ul-1b-OX5"/>
+                            <constraint firstItem="2ye-g4-fz5" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="44Q-AK-wMR"/>
+                            <constraint firstItem="Kzg-Uw-tpM" firstAttribute="top" secondItem="QqK-iZ-rFX" secondAttribute="bottom" constant="20" id="9DE-4W-Fjh"/>
+                            <constraint firstItem="Ng5-FC-tts" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="ATc-Y8-5g4"/>
+                            <constraint firstItem="5v4-Te-950" firstAttribute="top" secondItem="d4r-sL-0Vo" secondAttribute="bottom" constant="4" id="BQk-0k-lKI"/>
+                            <constraint firstItem="CUa-0e-DwY" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="Bds-Tt-2To"/>
+                            <constraint firstItem="Ng5-FC-tts" firstAttribute="top" secondItem="seu-WU-cTV" secondAttribute="bottom" id="Bee-nq-Jqn"/>
+                            <constraint firstItem="2ye-g4-fz5" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="CAc-p7-CMr"/>
+                            <constraint firstAttribute="trailing" secondItem="7PK-hh-Xx5" secondAttribute="trailing" id="CS1-Ac-ZtH"/>
+                            <constraint firstItem="oAm-jJ-3kE" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="EfX-U0-EIF"/>
+                            <constraint firstItem="705-dt-Zwl" firstAttribute="centerY" secondItem="d4r-sL-0Vo" secondAttribute="centerY" id="F4m-Zy-HTN"/>
+                            <constraint firstItem="7vv-En-VYY" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="HEy-h1-lqH"/>
+                            <constraint firstItem="seu-WU-cTV" firstAttribute="leading" secondItem="ZGz-La-n9c" secondAttribute="leading" constant="20" id="HfL-vM-J77"/>
+                            <constraint firstAttribute="trailing" secondItem="ykw-rb-M9D" secondAttribute="trailing" id="IBg-Q4-5QO"/>
+                            <constraint firstItem="QqK-iZ-rFX" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="JJs-e3-UKh"/>
+                            <constraint firstItem="Ljl-w6-gIf" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="L7x-Q3-ibY"/>
+                            <constraint firstItem="pam-gJ-b3R" firstAttribute="leading" secondItem="9Ua-jA-xuA" secondAttribute="trailing" constant="8" id="LuL-bM-125"/>
+                            <constraint firstItem="9Ua-jA-xuA" firstAttribute="bottom" secondItem="pam-gJ-b3R" secondAttribute="bottom" id="M47-JF-xr3"/>
+                            <constraint firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" constant="20" id="MdM-i9-hvu"/>
+                            <constraint firstItem="iAC-lz-PuL" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="N9R-AO-t8I"/>
+                            <constraint firstItem="sPT-jd-T7a" firstAttribute="top" secondItem="oAm-jJ-3kE" secondAttribute="bottom" constant="8" id="Qtq-cO-WY6"/>
+                            <constraint firstItem="7vv-En-VYY" firstAttribute="top" secondItem="sPT-jd-T7a" secondAttribute="bottom" constant="20" id="R1L-b4-S0z"/>
+                            <constraint firstItem="705-dt-Zwl" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="RsZ-BB-OpQ"/>
+                            <constraint firstItem="Ng5-FC-tts" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="S29-9J-zbt"/>
+                            <constraint firstItem="bza-SA-tXE" firstAttribute="top" secondItem="7vv-En-VYY" secondAttribute="bottom" constant="8" id="TaT-kr-h6n"/>
+                            <constraint firstItem="Ljl-w6-gIf" firstAttribute="top" secondItem="CUa-0e-DwY" secondAttribute="bottom" constant="8" id="VQG-QL-MrS"/>
+                            <constraint firstItem="iAC-lz-PuL" firstAttribute="top" secondItem="pam-gJ-b3R" secondAttribute="top" id="WDy-ol-Zpc"/>
+                            <constraint firstItem="7PK-hh-Xx5" firstAttribute="top" secondItem="2ye-g4-fz5" secondAttribute="bottom" constant="20" id="WHx-2i-Qb8"/>
+                            <constraint firstItem="sPT-jd-T7a" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="WhF-R9-ItL"/>
+                            <constraint firstItem="705-dt-Zwl" firstAttribute="leading" secondItem="d4r-sL-0Vo" secondAttribute="trailing" constant="8" id="aI1-cp-e3U"/>
+                            <constraint firstItem="seu-WU-cTV" firstAttribute="top" secondItem="ZGz-La-n9c" secondAttribute="top" constant="20" id="aal-Nb-2Z5"/>
+                            <constraint firstItem="QqK-iZ-rFX" firstAttribute="top" secondItem="7PK-hh-Xx5" secondAttribute="bottom" constant="20" id="agN-ia-1uy"/>
+                            <constraint firstAttribute="bottom" secondItem="BdF-A5-VPG" secondAttribute="bottom" constant="20" id="arL-JQ-GVl"/>
+                            <constraint firstItem="2ye-g4-fz5" firstAttribute="top" secondItem="5v4-Te-950" secondAttribute="bottom" constant="20" id="csu-lc-eNH"/>
+                            <constraint firstItem="9Ua-jA-xuA" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="czg-lU-OMG"/>
+                            <constraint firstItem="9Ua-jA-xuA" firstAttribute="top" secondItem="pam-gJ-b3R" secondAttribute="top" id="dTe-2U-dda"/>
+                            <constraint firstItem="7vv-En-VYY" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="dkC-Ih-pd9"/>
+                            <constraint firstItem="XAI-y0-tcy" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="eDi-7P-BEj"/>
+                            <constraint firstItem="5v4-Te-950" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="eeP-VU-TPP"/>
+                            <constraint firstItem="bza-SA-tXE" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="fDz-nh-c5C"/>
+                            <constraint firstItem="iAC-lz-PuL" firstAttribute="bottom" secondItem="pam-gJ-b3R" secondAttribute="bottom" id="keh-UM-dNZ"/>
+                            <constraint firstItem="XAI-y0-tcy" firstAttribute="leading" secondItem="Ljl-w6-gIf" secondAttribute="trailing" constant="8" id="kgN-Qb-S24"/>
+                            <constraint firstItem="Ng5-FC-tts" firstAttribute="bottom" secondItem="ykw-rb-M9D" secondAttribute="top" constant="-8" id="lB5-5K-ADf"/>
+                            <constraint firstItem="QqK-iZ-rFX" firstAttribute="leading" secondItem="seu-WU-cTV" secondAttribute="leading" id="raN-KU-S8w"/>
+                            <constraint firstItem="XAI-y0-tcy" firstAttribute="firstBaseline" secondItem="Ljl-w6-gIf" secondAttribute="firstBaseline" id="sgV-3o-i04"/>
+                            <constraint firstItem="d4r-sL-0Vo" firstAttribute="top" secondItem="bza-SA-tXE" secondAttribute="bottom" constant="20" id="srR-fD-fdH"/>
+                            <constraint firstItem="oAm-jJ-3kE" firstAttribute="top" secondItem="Ljl-w6-gIf" secondAttribute="bottom" constant="20" id="t9T-NG-qVR"/>
+                            <constraint firstItem="ykw-rb-M9D" firstAttribute="leading" secondItem="ZGz-La-n9c" secondAttribute="leading" id="vVO-4e-Lao"/>
+                            <constraint firstItem="oAm-jJ-3kE" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="xkj-ic-q9D"/>
+                            <constraint firstItem="7PK-hh-Xx5" firstAttribute="leading" secondItem="ZGz-La-n9c" secondAttribute="leading" id="y5p-Be-83s"/>
+                            <constraint firstItem="CUa-0e-DwY" firstAttribute="trailing" secondItem="seu-WU-cTV" secondAttribute="trailing" id="yE8-pS-Zgy"/>
+                        </constraints>
+                    </view>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="ZGz-La-n9c" firstAttribute="leading" secondItem="8Es-YX-dNf" secondAttribute="leading" id="GY8-wi-aRg"/>
+                    <constraint firstItem="ZGz-La-n9c" firstAttribute="top" secondItem="8Es-YX-dNf" secondAttribute="top" id="QX6-9q-Dx8"/>
+                    <constraint firstAttribute="trailing" secondItem="ZGz-La-n9c" secondAttribute="trailing" id="d7r-rT-3ad"/>
+                </constraints>
+                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+            </clipView>
+            <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="tk3-fh-4Dl">
+                <rect key="frame" x="-100" y="-100" width="360" height="16"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </scroller>
+            <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="Vtu-Wx-ydk">
+                <rect key="frame" x="352" y="0.0" width="15" height="751"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </scroller>
+            <point key="canvasLocation" x="-94.5" y="-570"/>
+        </scrollView>
+        <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="wXn-sV-AmG" userLabel="AudioTab Scroll View">
+            <rect key="frame" x="0.0" y="0.0" width="360" height="536"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+            <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="oVx-Sp-Lhl" userLabel="AudioTab Clip View">
+                <rect key="frame" x="0.0" y="0.0" width="360" height="536"/>
+                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                <subviews>
+                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="NZU-RD-Dm3" userLabel="AudioTab Flipped View" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
+                        <rect key="frame" x="0.0" y="0.0" width="360" height="536"/>
+                        <subviews>
+                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="my2-5o-bNb" userLabel="AudioTab CONTENT VIEW">
+                                <rect key="frame" x="0.0" y="0.0" width="360" height="536"/>
+                                <subviews>
+                                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="TA9-9G-tIE" userLabel="PANEL EDGE INSETS">
+                                        <rect key="frame" x="20" y="516" width="320" height="0.0"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" id="jt3-qe-0KY"/>
+                                        </constraints>
+                                    </customView>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="E4v-kh-61H">
+                                        <rect key="frame" x="18" y="500" width="324" height="16"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Audio track:" id="x39-62-7KC">
+                                            <font key="font" metaFont="systemBold"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Qal-0X-4kS" userLabel="AudioTrackTable Scroll View">
+                                        <rect key="frame" x="0.0" y="417" width="360" height="75"/>
+                                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="vgF-KN-yHf" userLabel="AudioTrackTable Clip View">
+                                            <rect key="frame" x="0.0" y="0.0" width="360" height="75"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <subviews>
+                                                <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnReordering="NO" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="FLg-2m-Zaq" userLabel="AudioTrackTable Table View">
+                                                    <rect key="frame" x="0.0" y="0.0" width="360" height="75"/>
+                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                    <size key="intercellSpacing" width="3" height="2"/>
+                                                    <color key="backgroundColor" white="1" alpha="0.080000000000000002" colorSpace="deviceWhite"/>
+                                                    <tableViewGridLines key="gridStyleMask" horizontal="YES"/>
+                                                    <color key="gridColor" red="1" green="1" blue="1" alpha="0.10000000000000001" colorSpace="calibratedRGB"/>
+                                                    <tableColumns>
+                                                        <tableColumn identifier="IsChosen" editable="NO" width="16" minWidth="16" maxWidth="16" id="ZIu-kj-B9n">
+                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="right">
+                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                            </tableHeaderCell>
+                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" refusesFirstResponder="YES" allowsUndo="NO" alignment="right" title="0" id="L0u-GY-T4V">
+                                                                <font key="font" metaFont="system"/>
+                                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                            <prototypeCellViews>
+                                                                <tableCellView id="YPg-3T-gYm">
+                                                                    <rect key="frame" x="1" y="1" width="21" height="17"/>
+                                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                    <subviews>
+                                                                        <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="JVk-Od-tIT">
+                                                                            <rect key="frame" x="0.0" y="0.0" width="21" height="17"/>
+                                                                            <constraints>
+                                                                                <constraint firstAttribute="height" constant="17" id="vjY-8T-n1G"/>
+                                                                            </constraints>
+                                                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="vDh-JM-5Wz">
+                                                                                <font key="font" metaFont="system"/>
+                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                            </textFieldCell>
+                                                                            <connections>
+                                                                                <binding destination="YPg-3T-gYm" name="value" keyPath="objectValue" id="JAF-yk-Dy6"/>
+                                                                            </connections>
+                                                                        </textField>
+                                                                    </subviews>
+                                                                    <constraints>
+                                                                        <constraint firstItem="JVk-Od-tIT" firstAttribute="leading" secondItem="YPg-3T-gYm" secondAttribute="leading" constant="2" id="2Bt-id-0Kx"/>
+                                                                        <constraint firstItem="JVk-Od-tIT" firstAttribute="centerY" secondItem="YPg-3T-gYm" secondAttribute="centerY" id="3bg-HG-oBA"/>
+                                                                        <constraint firstItem="JVk-Od-tIT" firstAttribute="centerX" secondItem="YPg-3T-gYm" secondAttribute="centerX" id="4dW-UY-Zkt"/>
+                                                                    </constraints>
+                                                                    <connections>
+                                                                        <outlet property="textField" destination="JVk-Od-tIT" id="T58-nt-RWg"/>
+                                                                    </connections>
+                                                                </tableCellView>
+                                                            </prototypeCellViews>
+                                                        </tableColumn>
+                                                        <tableColumn identifier="TrackId" width="33" minWidth="33" maxWidth="100" id="EYV-gb-3Pa">
+                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="right">
+                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                                            </tableHeaderCell>
+                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" refusesFirstResponder="YES" alignment="left" title="Text Cell" id="N1f-X9-gS0">
+                                                                <font key="font" metaFont="system"/>
+                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                            <prototypeCellViews>
+                                                                <tableCellView id="UuQ-IW-yZg">
+                                                                    <rect key="frame" x="25" y="1" width="33" height="17"/>
+                                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                    <subviews>
+                                                                        <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="MSR-2Q-pOS">
+                                                                            <rect key="frame" x="0.0" y="0.0" width="33" height="17"/>
+                                                                            <constraints>
+                                                                                <constraint firstAttribute="height" constant="17" id="s2f-ef-WYF"/>
+                                                                            </constraints>
+                                                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="right" title="Table View Cell" id="KyY-Ui-vAx">
+                                                                                <font key="font" metaFont="systemBold"/>
+                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                            </textFieldCell>
+                                                                            <connections>
+                                                                                <binding destination="UuQ-IW-yZg" name="value" keyPath="objectValue" id="xK8-Oh-aYl"/>
+                                                                            </connections>
+                                                                        </textField>
+                                                                    </subviews>
+                                                                    <constraints>
+                                                                        <constraint firstItem="MSR-2Q-pOS" firstAttribute="centerX" secondItem="UuQ-IW-yZg" secondAttribute="centerX" id="258-KD-r05"/>
+                                                                        <constraint firstItem="MSR-2Q-pOS" firstAttribute="leading" secondItem="UuQ-IW-yZg" secondAttribute="leading" constant="2" id="XLG-lN-23V"/>
+                                                                        <constraint firstItem="MSR-2Q-pOS" firstAttribute="centerY" secondItem="UuQ-IW-yZg" secondAttribute="centerY" id="ZNm-DN-1ac"/>
+                                                                    </constraints>
+                                                                    <connections>
+                                                                        <outlet property="textField" destination="MSR-2Q-pOS" id="saV-nP-ICX"/>
+                                                                    </connections>
+                                                                </tableCellView>
+                                                            </prototypeCellViews>
+                                                        </tableColumn>
+                                                        <tableColumn identifier="TrackName" editable="NO" width="292" minWidth="100" maxWidth="3.4028234663852886e+38" id="cKa-XV-ATZ">
+                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                                            </tableHeaderCell>
+                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" refusesFirstResponder="YES" allowsUndo="NO" alignment="left" title="Text Cell" id="GXH-iA-cJP">
+                                                                <font key="font" metaFont="system"/>
+                                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                            <prototypeCellViews>
+                                                                <tableCellView id="zgo-9v-dTl">
+                                                                    <rect key="frame" x="61" y="1" width="296" height="17"/>
+                                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                    <subviews>
+                                                                        <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="6YE-jM-I4J">
+                                                                            <rect key="frame" x="0.0" y="1" width="296" height="16"/>
+                                                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="Spe-xo-cXu">
+                                                                                <font key="font" metaFont="system"/>
+                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                            </textFieldCell>
+                                                                            <connections>
+                                                                                <binding destination="zgo-9v-dTl" name="value" keyPath="objectValue" id="elh-SX-Hoc"/>
+                                                                            </connections>
+                                                                        </textField>
+                                                                    </subviews>
+                                                                    <constraints>
+                                                                        <constraint firstItem="6YE-jM-I4J" firstAttribute="centerY" secondItem="zgo-9v-dTl" secondAttribute="centerY" id="6zV-9M-5AW"/>
+                                                                        <constraint firstItem="6YE-jM-I4J" firstAttribute="centerX" secondItem="zgo-9v-dTl" secondAttribute="centerX" id="IZA-BZ-Luh"/>
+                                                                        <constraint firstItem="6YE-jM-I4J" firstAttribute="leading" secondItem="zgo-9v-dTl" secondAttribute="leading" constant="2" id="o4O-fu-f2N"/>
+                                                                    </constraints>
+                                                                    <connections>
+                                                                        <outlet property="textField" destination="6YE-jM-I4J" id="c8V-Nb-jHJ"/>
+                                                                    </connections>
+                                                                </tableCellView>
+                                                            </prototypeCellViews>
+                                                        </tableColumn>
+                                                    </tableColumns>
+                                                </tableView>
+                                            </subviews>
+                                        </clipView>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="75" id="sBV-Kf-cvi"/>
+                                        </constraints>
+                                        <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="Pal-8c-4eQ">
+                                            <rect key="frame" x="0.0" y="60" width="360" height="15"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </scroller>
+                                        <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="uet-8b-szq">
+                                            <rect key="frame" x="-16" y="0.0" width="16" height="0.0"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </scroller>
+                                    </scrollView>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kvu-fg-olx">
+                                        <rect key="frame" x="18" y="381" width="324" height="16"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="External audio:" id="Lnu-kz-cql">
+                                            <font key="font" metaFont="systemBold"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="XdF-fV-DCz">
+                                        <rect key="frame" x="13" y="344" width="334" height="32"/>
+                                        <buttonCell key="cell" type="push" title="Load External Audio Track…" bezelStyle="rounded" alignment="center" refusesFirstResponder="YES" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="8Ax-5X-osl">
+                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="system"/>
+                                        </buttonCell>
+                                        <constraints>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="305" id="J6K-sf-QKi"/>
+                                        </constraints>
+                                        <connections>
+                                            <action selector="loadExternalAudioAction:" target="-2" id="Qlt-LO-puw"/>
+                                        </connections>
+                                    </button>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ZPW-fz-5Oi">
+                                        <rect key="frame" x="18" y="315" width="324" height="16"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Audio delay:" id="AKs-VQ-fKF">
+                                            <font key="font" metaFont="systemBold"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <customView autoresizesSubviews="NO" horizontalHuggingPriority="200" horizontalCompressionResistancePriority="700" translatesAutoresizingMaskIntoConstraints="NO" id="j85-rj-toQ" userLabel="AudioDelaySlider Container View">
+                                        <rect key="frame" x="19" y="264" width="321" height="47"/>
+                                        <subviews>
+                                            <slider horizontalHuggingPriority="1" verticalHuggingPriority="700" horizontalCompressionResistancePriority="1" verticalCompressionResistancePriority="700" translatesAutoresizingMaskIntoConstraints="NO" id="gJr-l6-WQ2" userLabel="AudioDelaySlider Horizontal Tick Slider">
+                                                <rect key="frame" x="-1" y="10" width="245" height="25"/>
+                                                <sliderCell key="cell" controlSize="small" continuous="YES" refusesFirstResponder="YES" state="on" alignment="left" minValue="-5" maxValue="5" tickMarkPosition="below" numberOfTickMarks="21" sliderType="linear" id="Xty-CC-H0Z"/>
+                                                <connections>
+                                                    <action selector="audioDelayChangedAction:" target="-2" id="Rqw-fj-519"/>
+                                                </connections>
+                                            </slider>
+                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="giU-Mo-tN9" userLabel="AudioDelaySliderIndicator Text Field">
+                                                <rect key="frame" x="109" y="34" width="24" height="13"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="20" id="F50-i5-7bi"/>
+                                                </constraints>
+                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="0s" usesSingleLineMode="YES" id="udN-rq-omw">
+                                                    <font key="font" metaFont="system" size="10"/>
+                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                </textFieldCell>
+                                            </textField>
+                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="tGk-m1-Vjc" userLabel="-5s Text Field">
+                                                <rect key="frame" x="-1" y="0.0" width="20" height="11"/>
+                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="-5s" id="YCG-xK-eAs" userLabel="-5s">
+                                                    <font key="font" metaFont="label" size="9"/>
+                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                </textFieldCell>
+                                            </textField>
+                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3GW-C1-d0g" userLabel="0s Text Field">
+                                                <rect key="frame" x="112" y="0.0" width="19" height="11"/>
+                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="0s" id="kan-bp-QDi">
+                                                    <font key="font" metaFont="label" size="9"/>
+                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                </textFieldCell>
+                                            </textField>
+                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="MPz-pR-Ys8" userLabel="+5s Text Field">
+                                                <rect key="frame" x="223" y="0.0" width="21" height="11"/>
+                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="+5s" id="Kt8-Kg-i2O">
+                                                    <font key="font" metaFont="label" size="9"/>
+                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                </textFieldCell>
+                                            </textField>
+                                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Qiz-tS-aWT" userLabel="CustomAudioDelay Text Field">
+                                                <rect key="frame" x="250" y="12" width="60" height="21"/>
+                                                <constraints>
+                                                    <constraint firstAttribute="width" constant="60" id="gRx-xy-Pqs"/>
+                                                </constraints>
+                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" title="1" drawsBackground="YES" usesSingleLineMode="YES" id="EHa-PR-jHw" userLabel="CustomAudioDelay Text Field Cell" customClass="RoundedTextFieldCell" customModule="IINA" customModuleProvider="target">
+                                                    <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="C53-E5-t2Z"/>
+                                                    <font key="font" metaFont="system"/>
+                                                    <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                </textFieldCell>
+                                                <connections>
+                                                    <action selector="customAudioDelayEditFinishedAction:" target="-2" id="wbu-lF-nTa"/>
+                                                </connections>
+                                            </textField>
+                                            <textField focusRingType="none" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ImH-jg-Agp" userLabel="s">
+                                                <rect key="frame" x="308" y="15" width="15" height="16"/>
+                                                <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="s" id="1VY-EN-1mi">
+                                                    <font key="font" metaFont="system"/>
+                                                    <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                    <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                </textFieldCell>
+                                            </textField>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstAttribute="trailing" secondItem="ImH-jg-Agp" secondAttribute="trailing" id="0Hm-Fa-s2l"/>
+                                            <constraint firstItem="Qiz-tS-aWT" firstAttribute="height" relation="lessThanOrEqual" secondItem="gJr-l6-WQ2" secondAttribute="height" id="4pT-hs-YkF"/>
+                                            <constraint firstItem="3GW-C1-d0g" firstAttribute="firstBaseline" secondItem="tGk-m1-Vjc" secondAttribute="firstBaseline" id="5Yt-IM-92q"/>
+                                            <constraint firstItem="giU-Mo-tN9" firstAttribute="centerX" secondItem="gJr-l6-WQ2" secondAttribute="leading" priority="800" constant="120" id="5oB-ve-G3c"/>
+                                            <constraint firstItem="Qiz-tS-aWT" firstAttribute="centerY" secondItem="gJr-l6-WQ2" secondAttribute="centerY" id="EuL-BL-hNW"/>
+                                            <constraint firstItem="MPz-pR-Ys8" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="3GW-C1-d0g" secondAttribute="trailing" id="HXO-hx-eYN"/>
+                                            <constraint firstItem="tGk-m1-Vjc" firstAttribute="top" secondItem="gJr-l6-WQ2" secondAttribute="bottom" constant="1" id="JOa-Yf-S4K"/>
+                                            <constraint firstItem="3GW-C1-d0g" firstAttribute="centerX" secondItem="gJr-l6-WQ2" secondAttribute="centerX" id="LAh-D4-yaM"/>
+                                            <constraint firstItem="3GW-C1-d0g" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="tGk-m1-Vjc" secondAttribute="trailing" id="LFA-0J-hOe"/>
+                                            <constraint firstAttribute="bottom" secondItem="tGk-m1-Vjc" secondAttribute="bottom" id="LP9-eY-HFx"/>
+                                            <constraint firstItem="MPz-pR-Ys8" firstAttribute="trailing" secondItem="gJr-l6-WQ2" secondAttribute="trailing" id="OxL-FZ-Jgq"/>
+                                            <constraint firstItem="tGk-m1-Vjc" firstAttribute="leading" secondItem="gJr-l6-WQ2" secondAttribute="leading" id="T4d-XW-ILF"/>
+                                            <constraint firstItem="gJr-l6-WQ2" firstAttribute="top" secondItem="giU-Mo-tN9" secondAttribute="bottom" constant="1" id="VBE-Mf-Tzb"/>
+                                            <constraint firstItem="MPz-pR-Ys8" firstAttribute="firstBaseline" secondItem="tGk-m1-Vjc" secondAttribute="firstBaseline" id="gIk-ck-vZB"/>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="300" id="gtm-1I-YqP"/>
+                                            <constraint firstItem="Qiz-tS-aWT" firstAttribute="trailing" secondItem="ImH-jg-Agp" secondAttribute="leading" id="nCE-1H-uD9"/>
+                                            <constraint firstItem="Qiz-tS-aWT" firstAttribute="leading" secondItem="gJr-l6-WQ2" secondAttribute="trailing" constant="8" id="uSJ-g9-Azy"/>
+                                            <constraint firstItem="ImH-jg-Agp" firstAttribute="firstBaseline" secondItem="Qiz-tS-aWT" secondAttribute="firstBaseline" id="vOx-Zo-ayO"/>
+                                            <constraint firstItem="giU-Mo-tN9" firstAttribute="top" secondItem="j85-rj-toQ" secondAttribute="top" id="vc3-E4-DgR"/>
+                                            <constraint firstItem="giU-Mo-tN9" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="gJr-l6-WQ2" secondAttribute="leading" id="wwv-IQ-GEx"/>
+                                        </constraints>
+                                    </customView>
+                                    <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="KKr-0Y-831">
+                                        <rect key="frame" x="0.0" y="241" width="360" height="5"/>
+                                    </box>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="IHl-Ks-v7I" userLabel="Equalizer Label">
+                                        <rect key="frame" x="18" y="207" width="69" height="16"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Equalizer:" id="iS4-Zr-9Ig">
+                                            <font key="font" metaFont="systemBold"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <box title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="OLt-cd-X9q">
+                                        <rect key="frame" x="17" y="8" width="326" height="161"/>
+                                        <view key="contentView" id="CL6-Wk-vXc">
+                                            <rect key="frame" x="4" y="5" width="318" height="153"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                        </view>
+                                    </box>
+                                    <textField focusRingType="none" horizontalHuggingPriority="1000" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jUH-hL-3U3" userLabel="+12 dB Text Field">
+                                        <rect key="frame" x="293" y="141" width="41" height="14"/>
+                                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="+12 dB" id="4BZ-H1-GEU">
+                                            <font key="font" metaFont="smallSystem"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="izd-aj-gqV" userLabel="0 dB Text Field">
+                                        <rect key="frame" x="305" y="90" width="29" height="14"/>
+                                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="0 dB" id="lBn-YS-jL7">
+                                            <font key="font" metaFont="smallSystem"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Wkv-a4-uiD" userLabel="-12 dB Text Field">
+                                        <rect key="frame" x="295" y="39" width="39" height="14"/>
+                                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="-12 dB" id="Lpw-ws-Ezh">
+                                            <font key="font" metaFont="smallSystem"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="EDx-YH-ofM">
+                                        <rect key="frame" x="33" y="20" width="19" height="11"/>
+                                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="32" id="HBF-J7-Tie">
+                                            <font key="font" metaFont="label" size="9"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dKk-CE-yY0">
+                                        <rect key="frame" x="60" y="20" width="20" height="11"/>
+                                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="64" id="4PG-5R-5G0">
+                                            <font key="font" metaFont="label" size="9"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="gfz-yF-41J">
+                                        <rect key="frame" x="84" y="20" width="24" height="11"/>
+                                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="125" id="1cq-dc-JfM">
+                                            <font key="font" metaFont="label" size="9"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="1he-Ll-CYl">
+                                        <rect key="frame" x="109" y="20" width="26" height="11"/>
+                                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="250" id="ekh-gc-2qo">
+                                            <font key="font" metaFont="label" size="9"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="j15-F0-7GR">
+                                        <rect key="frame" x="135" y="20" width="26" height="11"/>
+                                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="500" id="tHa-vN-OlI">
+                                            <font key="font" metaFont="label" size="9"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="wvc-3m-7dA">
+                                        <rect key="frame" x="166" y="20" width="18" height="11"/>
+                                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="1k" id="Rtc-Eg-J2u">
+                                            <font key="font" metaFont="label" size="9"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cnq-7d-eC4">
+                                        <rect key="frame" x="192" y="20" width="19" height="11"/>
+                                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="2k" id="j9w-YU-EcC">
+                                            <font key="font" metaFont="label" size="9"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="uUe-VB-wyv">
+                                        <rect key="frame" x="218" y="20" width="20" height="11"/>
+                                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="4k" id="i0j-2a-vKD">
+                                            <font key="font" metaFont="label" size="9"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eOZ-KM-xLa">
+                                        <rect key="frame" x="244" y="20" width="19" height="11"/>
+                                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="8k" id="e4X-H4-VxS">
+                                            <font key="font" metaFont="label" size="9"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="aOD-Qz-oE3">
+                                        <rect key="frame" x="268" y="20" width="24" height="11"/>
+                                        <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="16k" id="era-AG-bSl">
+                                            <font key="font" metaFont="label" size="9"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="ArR-4S-Gps">
+                                        <rect key="frame" x="36" y="146" width="251" height="5"/>
+                                    </box>
+                                    <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="S1M-YW-ac8">
+                                        <rect key="frame" x="36" y="43" width="251" height="5"/>
+                                    </box>
+                                    <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="ANI-DE-0LU">
+                                        <rect key="frame" x="36" y="120" width="251" height="5"/>
+                                    </box>
+                                    <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="W8L-56-yE9">
+                                        <rect key="frame" x="36" y="95" width="251" height="5"/>
+                                    </box>
+                                    <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="1jP-b9-gGi">
+                                        <rect key="frame" x="36" y="69" width="251" height="5"/>
+                                    </box>
+                                    <stackView distribution="equalSpacing" orientation="horizontal" alignment="top" spacing="13" horizontalStackHuggingPriority="1000" verticalStackHuggingPriority="1000" translatesAutoresizingMaskIntoConstraints="NO" id="xtT-Or-HjR" userLabel="AudioEQSliders HStack">
+                                        <rect key="frame" x="36" y="39" width="251" height="116"/>
+                                        <subviews>
+                                            <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" translatesAutoresizingMaskIntoConstraints="NO" id="pHR-ym-VeQ">
+                                                <rect key="frame" x="-2" y="-2" width="17" height="120"/>
+                                                <sliderCell key="cell" controlSize="mini" refusesFirstResponder="YES" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" sliderType="linear" id="Twm-2U-8ou"/>
+                                                <connections>
+                                                    <action selector="audioEqSliderAction:" target="-2" id="ywO-zh-sWU"/>
+                                                </connections>
+                                            </slider>
+                                            <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" tag="1" translatesAutoresizingMaskIntoConstraints="NO" id="Qhv-oC-xzP">
+                                                <rect key="frame" x="24" y="-2" width="18" height="120"/>
+                                                <sliderCell key="cell" controlSize="mini" refusesFirstResponder="YES" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" sliderType="linear" id="SCy-Om-bV6"/>
+                                                <connections>
+                                                    <action selector="audioEqSliderAction:" target="-2" id="xQb-Li-0pw"/>
+                                                </connections>
+                                            </slider>
+                                            <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" tag="2" translatesAutoresizingMaskIntoConstraints="NO" id="iDT-gu-k7t">
+                                                <rect key="frame" x="51" y="-2" width="17" height="120"/>
+                                                <sliderCell key="cell" controlSize="mini" refusesFirstResponder="YES" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" sliderType="linear" id="a7E-4j-6g2"/>
+                                                <connections>
+                                                    <action selector="audioEqSliderAction:" target="-2" id="bCl-L6-1iR"/>
+                                                </connections>
+                                            </slider>
+                                            <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" tag="3" translatesAutoresizingMaskIntoConstraints="NO" id="O2w-VO-03F">
+                                                <rect key="frame" x="77" y="-2" width="18" height="120"/>
+                                                <sliderCell key="cell" controlSize="mini" refusesFirstResponder="YES" state="on" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" sliderType="linear" id="TbE-dB-ORk"/>
+                                                <connections>
+                                                    <action selector="audioEqSliderAction:" target="-2" id="15r-Ui-dhW"/>
+                                                </connections>
+                                            </slider>
+                                            <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" tag="4" translatesAutoresizingMaskIntoConstraints="NO" id="npn-V6-hjZ">
+                                                <rect key="frame" x="104" y="-2" width="17" height="120"/>
+                                                <sliderCell key="cell" controlSize="mini" refusesFirstResponder="YES" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" sliderType="linear" id="4Ra-VR-yOK"/>
+                                                <connections>
+                                                    <action selector="audioEqSliderAction:" target="-2" id="sWe-Hb-axh"/>
+                                                </connections>
+                                            </slider>
+                                            <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" tag="5" translatesAutoresizingMaskIntoConstraints="NO" id="TKd-tg-Xtc">
+                                                <rect key="frame" x="130" y="-2" width="17" height="120"/>
+                                                <sliderCell key="cell" controlSize="mini" refusesFirstResponder="YES" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" sliderType="linear" id="xV9-OM-MHq"/>
+                                                <connections>
+                                                    <action selector="audioEqSliderAction:" target="-2" id="bVX-Tj-pgM"/>
+                                                </connections>
+                                            </slider>
+                                            <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" tag="6" translatesAutoresizingMaskIntoConstraints="NO" id="nNf-gg-4tL">
+                                                <rect key="frame" x="156" y="-2" width="18" height="120"/>
+                                                <sliderCell key="cell" controlSize="mini" refusesFirstResponder="YES" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" sliderType="linear" id="TNb-Es-VsX"/>
+                                                <connections>
+                                                    <action selector="audioEqSliderAction:" target="-2" id="p1d-eK-UB3"/>
+                                                </connections>
+                                            </slider>
+                                            <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" tag="7" translatesAutoresizingMaskIntoConstraints="NO" id="JaQ-EH-K1U">
+                                                <rect key="frame" x="183" y="-2" width="17" height="120"/>
+                                                <sliderCell key="cell" controlSize="mini" refusesFirstResponder="YES" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" sliderType="linear" id="P8O-pY-Nby"/>
+                                                <connections>
+                                                    <action selector="audioEqSliderAction:" target="-2" id="oxX-UX-l6i"/>
+                                                </connections>
+                                            </slider>
+                                            <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" tag="8" translatesAutoresizingMaskIntoConstraints="NO" id="gbd-xf-hGS">
+                                                <rect key="frame" x="209" y="-2" width="18" height="120"/>
+                                                <sliderCell key="cell" controlSize="mini" refusesFirstResponder="YES" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" sliderType="linear" id="GEq-jW-WUw"/>
+                                                <connections>
+                                                    <action selector="audioEqSliderAction:" target="-2" id="pkI-fs-ZCs"/>
+                                                </connections>
+                                            </slider>
+                                            <slider horizontalHuggingPriority="750" verticalCompressionResistancePriority="500" tag="9" translatesAutoresizingMaskIntoConstraints="NO" id="w04-h5-qaz">
+                                                <rect key="frame" x="236" y="-2" width="17" height="120"/>
+                                                <sliderCell key="cell" controlSize="mini" refusesFirstResponder="YES" alignment="left" minValue="-12" maxValue="12" tickMarkPosition="left" sliderType="linear" id="5FD-oT-GpE"/>
+                                                <connections>
+                                                    <action selector="audioEqSliderAction:" target="-2" id="I08-gI-z8e"/>
+                                                </connections>
+                                            </slider>
+                                        </subviews>
+                                        <constraints>
+                                            <constraint firstItem="Qhv-oC-xzP" firstAttribute="width" secondItem="pHR-ym-VeQ" secondAttribute="width" id="8NF-D9-ur6"/>
+                                            <constraint firstItem="iDT-gu-k7t" firstAttribute="width" secondItem="pHR-ym-VeQ" secondAttribute="width" id="Hhg-eV-Uuj"/>
+                                            <constraint firstItem="O2w-VO-03F" firstAttribute="width" secondItem="pHR-ym-VeQ" secondAttribute="width" id="P1Q-Vw-1Bj"/>
+                                            <constraint firstItem="w04-h5-qaz" firstAttribute="width" secondItem="pHR-ym-VeQ" secondAttribute="width" id="QV9-LY-UR9"/>
+                                            <constraint firstItem="TKd-tg-Xtc" firstAttribute="width" secondItem="pHR-ym-VeQ" secondAttribute="width" id="XGa-3f-NGX"/>
+                                            <constraint firstItem="npn-V6-hjZ" firstAttribute="width" secondItem="pHR-ym-VeQ" secondAttribute="width" id="b6u-Pz-OHZ"/>
+                                            <constraint firstItem="nNf-gg-4tL" firstAttribute="width" secondItem="pHR-ym-VeQ" secondAttribute="width" id="bsR-FZ-TcX"/>
+                                            <constraint firstAttribute="height" constant="116" id="nDW-aS-hPT"/>
+                                            <constraint firstItem="gbd-xf-hGS" firstAttribute="width" secondItem="pHR-ym-VeQ" secondAttribute="width" id="zSM-iB-jXD"/>
+                                            <constraint firstItem="JaQ-EH-K1U" firstAttribute="width" secondItem="pHR-ym-VeQ" secondAttribute="width" id="zqG-dT-mKp"/>
+                                        </constraints>
+                                        <visibilityPriorities>
+                                            <integer value="1000"/>
+                                            <integer value="1000"/>
+                                            <integer value="1000"/>
+                                            <integer value="1000"/>
+                                            <integer value="1000"/>
+                                            <integer value="1000"/>
+                                            <integer value="1000"/>
+                                            <integer value="1000"/>
+                                            <integer value="1000"/>
+                                            <integer value="1000"/>
+                                        </visibilityPriorities>
+                                        <customSpacing>
+                                            <real value="3.4028234663852886e+38"/>
+                                            <real value="3.4028234663852886e+38"/>
+                                            <real value="3.4028234663852886e+38"/>
+                                            <real value="3.4028234663852886e+38"/>
+                                            <real value="3.4028234663852886e+38"/>
+                                            <real value="3.4028234663852886e+38"/>
+                                            <real value="3.4028234663852886e+38"/>
+                                            <real value="3.4028234663852886e+38"/>
+                                            <real value="3.4028234663852886e+38"/>
+                                            <real value="3.4028234663852886e+38"/>
+                                        </customSpacing>
+                                    </stackView>
+                                    <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="u9C-Fk-Aag">
+                                        <rect key="frame" x="17" y="175" width="241" height="25"/>
+                                        <popUpButtonCell key="cell" type="push" title="Save the current EQ as a preset…" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" borderStyle="borderAndBezel" tag="-3" imageScaling="proportionallyDown" inset="2" autoenablesItems="NO" altersStateOfSelectedItem="NO" selectedItem="sE0-LN-T8i" id="WKa-AJ-OEZ">
+                                            <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="message"/>
+                                            <menu key="menu" autoenablesItems="NO" id="7k5-w9-dRQ">
+                                                <items>
+                                                    <menuItem title="Save the current EQ as a preset…" tag="-3" id="sE0-LN-T8i">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                    </menuItem>
+                                                    <menuItem title="Rename the current EQ preset…" tag="-2" id="2tD-0L-UUs">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                    </menuItem>
+                                                    <menuItem title="Remove the current EQ preset" tag="-1" id="dvI-Rj-7qF">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" tag="-1000" id="o0F-oJ-6GY"/>
+                                                    <menuItem title="Manual" tag="1000" id="LPh-nJ-GjN">
+                                                        <modifierMask key="keyEquivalentModifierMask"/>
+                                                    </menuItem>
+                                                    <menuItem isSeparatorItem="YES" tag="-1000" id="wBP-97-nRB"/>
+                                                </items>
+                                            </menu>
+                                        </popUpButtonCell>
+                                        <connections>
+                                            <action selector="eqPopUpButtonAction:" target="-2" id="xZN-vl-ZAe"/>
+                                        </connections>
+                                    </popUpButton>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="u9C-Fk-Aag" secondAttribute="trailing" id="0EN-5k-aN1"/>
+                                    <constraint firstItem="gbd-xf-hGS" firstAttribute="centerX" secondItem="eOZ-KM-xLa" secondAttribute="centerX" id="0eU-JU-3Np"/>
+                                    <constraint firstItem="izd-aj-gqV" firstAttribute="trailing" secondItem="TA9-9G-tIE" secondAttribute="trailing" priority="900" constant="-8" id="1xH-vk-y7P"/>
+                                    <constraint firstItem="EDx-YH-ofM" firstAttribute="top" secondItem="pHR-ym-VeQ" secondAttribute="bottom" constant="8" id="3GI-bd-VUa"/>
+                                    <constraint firstItem="OLt-cd-X9q" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" constant="20" id="3jA-3U-EyF"/>
+                                    <constraint firstItem="xtT-Or-HjR" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" constant="36" id="5mj-ks-OY2"/>
+                                    <constraint firstItem="dKk-CE-yY0" firstAttribute="centerX" secondItem="Qhv-oC-xzP" secondAttribute="centerX" constant="1" id="6U0-bD-UHn"/>
+                                    <constraint firstItem="xtT-Or-HjR" firstAttribute="trailing" secondItem="1jP-b9-gGi" secondAttribute="trailing" id="7KT-qB-NbC"/>
+                                    <constraint firstItem="XdF-fV-DCz" firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="TA9-9G-tIE" secondAttribute="trailing" id="8OK-le-NFN"/>
+                                    <constraint firstItem="TA9-9G-tIE" firstAttribute="leading" secondItem="E4v-kh-61H" secondAttribute="leading" id="9So-jf-b5w"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="E4v-kh-61H" secondAttribute="trailing" id="9ol-Ih-xQV"/>
+                                    <constraint firstItem="EDx-YH-ofM" firstAttribute="leading" secondItem="TA9-9G-tIE" secondAttribute="leading" constant="15" id="AXq-h3-TVD"/>
+                                    <constraint firstItem="KKr-0Y-831" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" id="Be6-hz-QAY"/>
+                                    <constraint firstItem="j85-rj-toQ" firstAttribute="top" secondItem="ZPW-fz-5Oi" secondAttribute="bottom" constant="4" id="Cv3-B2-U9b"/>
+                                    <constraint firstItem="W8L-56-yE9" firstAttribute="top" secondItem="ANI-DE-0LU" secondAttribute="bottom" constant="24" id="Cx5-Cs-3tw"/>
+                                    <constraint firstAttribute="bottom" secondItem="OLt-cd-X9q" secondAttribute="bottom" constant="12" id="DuU-Xa-KxH"/>
+                                    <constraint firstItem="wvc-3m-7dA" firstAttribute="top" secondItem="EDx-YH-ofM" secondAttribute="top" id="Ebj-KB-Fia"/>
+                                    <constraint firstItem="IHl-Ks-v7I" firstAttribute="leading" secondItem="TA9-9G-tIE" secondAttribute="leading" id="FcZ-qn-ZcQ"/>
+                                    <constraint firstItem="1he-Ll-CYl" firstAttribute="top" secondItem="EDx-YH-ofM" secondAttribute="top" id="G46-BJ-iVG"/>
+                                    <constraint firstItem="OLt-cd-X9q" firstAttribute="top" secondItem="u9C-Fk-Aag" secondAttribute="bottom" constant="12" id="Gkx-KC-N8G"/>
+                                    <constraint firstItem="izd-aj-gqV" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="xtT-Or-HjR" secondAttribute="trailing" constant="8" symbolic="YES" id="HaA-55-Hxi"/>
+                                    <constraint firstAttribute="trailing" secondItem="KKr-0Y-831" secondAttribute="trailing" id="HbW-t2-Z43"/>
+                                    <constraint firstItem="cnq-7d-eC4" firstAttribute="top" secondItem="EDx-YH-ofM" secondAttribute="top" id="Hrv-XD-CMS"/>
+                                    <constraint firstItem="xtT-Or-HjR" firstAttribute="trailing" secondItem="ANI-DE-0LU" secondAttribute="trailing" id="KHn-q4-CcN"/>
+                                    <constraint firstItem="xtT-Or-HjR" firstAttribute="trailing" secondItem="ArR-4S-Gps" secondAttribute="trailing" id="KYz-NQ-5Sx"/>
+                                    <constraint firstItem="j15-F0-7GR" firstAttribute="centerX" secondItem="npn-V6-hjZ" secondAttribute="centerX" id="Km4-rZ-GeG"/>
+                                    <constraint firstItem="ArR-4S-Gps" firstAttribute="leading" secondItem="xtT-Or-HjR" secondAttribute="leading" id="L7D-aW-dXh"/>
+                                    <constraint firstItem="uUe-VB-wyv" firstAttribute="top" secondItem="EDx-YH-ofM" secondAttribute="top" id="La7-D2-OgL"/>
+                                    <constraint firstItem="1jP-b9-gGi" firstAttribute="leading" secondItem="xtT-Or-HjR" secondAttribute="leading" id="M4U-5L-YBe"/>
+                                    <constraint firstItem="Wkv-a4-uiD" firstAttribute="bottom" secondItem="xtT-Or-HjR" secondAttribute="bottom" id="MaV-fd-img"/>
+                                    <constraint firstItem="gfz-yF-41J" firstAttribute="top" secondItem="EDx-YH-ofM" secondAttribute="top" id="Mwa-bq-dus"/>
+                                    <constraint firstItem="kvu-fg-olx" firstAttribute="trailing" secondItem="TA9-9G-tIE" secondAttribute="trailing" id="OAI-WO-gae"/>
+                                    <constraint firstItem="S1M-YW-ac8" firstAttribute="top" secondItem="Wkv-a4-uiD" secondAttribute="bottom" constant="-7" id="OrC-6T-y1a"/>
+                                    <constraint firstAttribute="bottom" secondItem="EDx-YH-ofM" secondAttribute="bottom" constant="20" id="Ovj-hj-4mO"/>
+                                    <constraint firstItem="ANI-DE-0LU" firstAttribute="top" secondItem="ArR-4S-Gps" secondAttribute="bottom" constant="25" id="PLv-Fr-gGS"/>
+                                    <constraint firstItem="Qal-0X-4kS" firstAttribute="top" secondItem="E4v-kh-61H" secondAttribute="bottom" constant="8" id="PfL-cK-sd5"/>
+                                    <constraint firstItem="IHl-Ks-v7I" firstAttribute="top" secondItem="KKr-0Y-831" secondAttribute="bottom" constant="20" id="Q61-jq-LnT"/>
+                                    <constraint firstItem="1he-Ll-CYl" firstAttribute="centerX" secondItem="O2w-VO-03F" secondAttribute="centerX" id="R4m-Vs-AK3"/>
+                                    <constraint firstItem="cnq-7d-eC4" firstAttribute="centerX" secondItem="nNf-gg-4tL" secondAttribute="centerX" id="Rge-iX-npw"/>
+                                    <constraint firstItem="j15-F0-7GR" firstAttribute="top" secondItem="EDx-YH-ofM" secondAttribute="top" id="RvX-Nr-Tiv"/>
+                                    <constraint firstItem="j85-rj-toQ" firstAttribute="trailing" secondItem="TA9-9G-tIE" secondAttribute="trailing" id="S7O-V6-BBj"/>
+                                    <constraint firstItem="Qal-0X-4kS" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" id="SwW-S7-LX2"/>
+                                    <constraint firstItem="jUH-hL-3U3" firstAttribute="top" secondItem="ArR-4S-Gps" secondAttribute="bottom" constant="-7" id="TTJ-hH-udD"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="IHl-Ks-v7I" secondAttribute="trailing" id="Xkb-2S-Po9"/>
+                                    <constraint firstItem="KKr-0Y-831" firstAttribute="top" secondItem="j85-rj-toQ" secondAttribute="bottom" constant="20" id="YFM-EH-jIy"/>
+                                    <constraint firstItem="u9C-Fk-Aag" firstAttribute="leading" secondItem="IHl-Ks-v7I" secondAttribute="leading" id="ZFp-mr-6fU"/>
+                                    <constraint firstItem="TA9-9G-tIE" firstAttribute="top" secondItem="my2-5o-bNb" secondAttribute="top" constant="20" id="aLW-0J-VPR"/>
+                                    <constraint firstItem="Wkv-a4-uiD" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="xtT-Or-HjR" secondAttribute="trailing" constant="8" symbolic="YES" id="ajo-XO-YDd"/>
+                                    <constraint firstItem="TA9-9G-tIE" firstAttribute="leading" secondItem="ZPW-fz-5Oi" secondAttribute="leading" id="alo-ld-qH9"/>
+                                    <constraint firstItem="xtT-Or-HjR" firstAttribute="trailing" secondItem="S1M-YW-ac8" secondAttribute="trailing" id="b2z-Fx-bbY"/>
+                                    <constraint firstItem="ImH-jg-Agp" firstAttribute="trailing" secondItem="TA9-9G-tIE" secondAttribute="trailing" id="bO7-1x-a1O"/>
+                                    <constraint firstItem="Wkv-a4-uiD" firstAttribute="trailing" secondItem="TA9-9G-tIE" secondAttribute="trailing" priority="900" constant="-8" id="dYP-Us-6bj"/>
+                                    <constraint firstItem="dKk-CE-yY0" firstAttribute="top" secondItem="EDx-YH-ofM" secondAttribute="top" id="dw4-5m-LIU"/>
+                                    <constraint firstItem="ZPW-fz-5Oi" firstAttribute="trailing" secondItem="TA9-9G-tIE" secondAttribute="trailing" id="e0g-tm-BF8"/>
+                                    <constraint firstAttribute="trailing" secondItem="OLt-cd-X9q" secondAttribute="trailing" constant="20" id="eEI-bd-PJn"/>
+                                    <constraint firstItem="jUH-hL-3U3" firstAttribute="trailing" secondItem="TA9-9G-tIE" secondAttribute="trailing" priority="900" constant="-8" id="f4B-e4-9IW"/>
+                                    <constraint firstItem="eOZ-KM-xLa" firstAttribute="top" secondItem="EDx-YH-ofM" secondAttribute="top" id="fUd-pm-IiH"/>
+                                    <constraint firstItem="xtT-Or-HjR" firstAttribute="trailing" secondItem="W8L-56-yE9" secondAttribute="trailing" id="g7m-yN-bs2"/>
+                                    <constraint firstItem="aOD-Qz-oE3" firstAttribute="top" secondItem="EDx-YH-ofM" secondAttribute="top" id="gOd-gW-hDD"/>
+                                    <constraint firstItem="XdF-fV-DCz" firstAttribute="top" secondItem="kvu-fg-olx" secondAttribute="bottom" constant="10" id="gud-hM-Hf0"/>
+                                    <constraint firstItem="TA9-9G-tIE" firstAttribute="leading" secondItem="XdF-fV-DCz" secondAttribute="leading" id="hKL-gp-ucV"/>
+                                    <constraint firstItem="uUe-VB-wyv" firstAttribute="centerX" secondItem="JaQ-EH-K1U" secondAttribute="centerX" id="iT9-ha-L66"/>
+                                    <constraint firstItem="jUH-hL-3U3" firstAttribute="leading" secondItem="xtT-Or-HjR" secondAttribute="trailing" constant="8" id="iZZ-Of-qr8"/>
+                                    <constraint firstItem="EDx-YH-ofM" firstAttribute="centerX" secondItem="pHR-ym-VeQ" secondAttribute="centerX" id="idL-dD-1e3"/>
+                                    <constraint firstItem="W8L-56-yE9" firstAttribute="leading" secondItem="xtT-Or-HjR" secondAttribute="leading" id="lAk-iT-TBS"/>
+                                    <constraint firstAttribute="trailing" secondItem="Qal-0X-4kS" secondAttribute="trailing" id="lda-T8-U6J"/>
+                                    <constraint firstAttribute="trailing" secondItem="TA9-9G-tIE" secondAttribute="trailing" constant="20" id="nPX-nn-l3H"/>
+                                    <constraint firstItem="izd-aj-gqV" firstAttribute="centerY" secondItem="xtT-Or-HjR" secondAttribute="centerY" id="nqS-iu-yym"/>
+                                    <constraint firstItem="xtT-Or-HjR" firstAttribute="top" secondItem="u9C-Fk-Aag" secondAttribute="bottom" constant="24" id="oeh-GA-5gh"/>
+                                    <constraint firstItem="ZPW-fz-5Oi" firstAttribute="top" secondItem="XdF-fV-DCz" secondAttribute="bottom" constant="20" id="pbW-gp-age"/>
+                                    <constraint firstItem="1jP-b9-gGi" firstAttribute="top" secondItem="W8L-56-yE9" secondAttribute="bottom" constant="25" id="qUd-A0-ymw"/>
+                                    <constraint firstItem="jUH-hL-3U3" firstAttribute="top" secondItem="xtT-Or-HjR" secondAttribute="top" id="rir-xy-gWG"/>
+                                    <constraint firstItem="ANI-DE-0LU" firstAttribute="leading" secondItem="xtT-Or-HjR" secondAttribute="leading" id="tLi-9T-WbG"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ZPW-fz-5Oi" secondAttribute="trailing" id="tRW-zx-YUE"/>
+                                    <constraint firstItem="w04-h5-qaz" firstAttribute="centerX" secondItem="aOD-Qz-oE3" secondAttribute="centerX" id="u1s-K3-1TR"/>
+                                    <constraint firstItem="S1M-YW-ac8" firstAttribute="leading" secondItem="xtT-Or-HjR" secondAttribute="leading" id="uYh-dN-68c"/>
+                                    <constraint firstItem="j85-rj-toQ" firstAttribute="leading" secondItem="TA9-9G-tIE" secondAttribute="leading" constant="-1" id="vYG-N7-4eH"/>
+                                    <constraint firstItem="wvc-3m-7dA" firstAttribute="centerX" secondItem="TKd-tg-Xtc" secondAttribute="centerX" id="vsl-Na-7AB"/>
+                                    <constraint firstItem="E4v-kh-61H" firstAttribute="trailing" secondItem="TA9-9G-tIE" secondAttribute="trailing" id="vxi-gU-jaJ"/>
+                                    <constraint firstItem="kvu-fg-olx" firstAttribute="top" secondItem="Qal-0X-4kS" secondAttribute="bottom" constant="20" id="wOv-GA-HuD"/>
+                                    <constraint firstItem="u9C-Fk-Aag" firstAttribute="top" secondItem="IHl-Ks-v7I" secondAttribute="bottom" constant="8" symbolic="YES" id="xMS-fe-cqp"/>
+                                    <constraint firstItem="kvu-fg-olx" firstAttribute="leading" secondItem="TA9-9G-tIE" secondAttribute="leading" id="xkY-DB-G0z"/>
+                                    <constraint firstItem="gfz-yF-41J" firstAttribute="centerX" secondItem="iDT-gu-k7t" secondAttribute="centerX" id="xnf-hN-6Hv"/>
+                                    <constraint firstItem="TA9-9G-tIE" firstAttribute="leading" secondItem="my2-5o-bNb" secondAttribute="leading" constant="20" id="y32-7d-2YS"/>
+                                    <constraint firstItem="gJr-l6-WQ2" firstAttribute="leading" secondItem="TA9-9G-tIE" secondAttribute="leading" id="zda-HN-bk0"/>
+                                    <constraint firstItem="TA9-9G-tIE" firstAttribute="top" secondItem="E4v-kh-61H" secondAttribute="top" id="zoG-7o-Hig"/>
+                                </constraints>
+                            </customView>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="my2-5o-bNb" firstAttribute="top" secondItem="NZU-RD-Dm3" secondAttribute="top" id="IWt-bk-0fS"/>
+                            <constraint firstItem="my2-5o-bNb" firstAttribute="leading" secondItem="NZU-RD-Dm3" secondAttribute="leading" id="pxh-2E-RNE"/>
+                            <constraint firstAttribute="trailing" secondItem="my2-5o-bNb" secondAttribute="trailing" id="uM8-H5-QwQ"/>
+                            <constraint firstAttribute="bottom" secondItem="my2-5o-bNb" secondAttribute="bottom" id="zoi-sm-jxY"/>
+                        </constraints>
+                    </customView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="NZU-RD-Dm3" firstAttribute="leading" secondItem="oVx-Sp-Lhl" secondAttribute="leading" id="FiN-fI-rgF"/>
+                    <constraint firstAttribute="trailing" secondItem="NZU-RD-Dm3" secondAttribute="trailing" id="KAz-hn-L3D"/>
+                    <constraint firstItem="NZU-RD-Dm3" firstAttribute="top" secondItem="oVx-Sp-Lhl" secondAttribute="top" id="xiA-4o-mvi"/>
+                </constraints>
+                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+            </clipView>
+            <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="klo-Db-oQE" userLabel="AudioTab Horizontal Scroller">
+                <rect key="frame" x="-100" y="-100" width="360" height="15"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </scroller>
+            <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="17z-n6-rH9" userLabel="AudioTab Vertical Scroller">
+                <rect key="frame" x="360" y="0.0" width="15" height="535"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </scroller>
+            <point key="canvasLocation" x="329" y="-680"/>
+        </scrollView>
+        <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="10" horizontalPageScroll="10" verticalLineScroll="10" verticalPageScroll="10" hasHorizontalScroller="NO" usesPredominantAxisScrolling="NO" id="3kA-IY-poi" userLabel="SubtitlesTab Scroll View">
+            <rect key="frame" x="0.0" y="0.0" width="362" height="868"/>
+            <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
+            <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="epy-wp-Ja5" userLabel="SubtitlesTab Clip View">
+                <rect key="frame" x="0.0" y="0.0" width="362" height="868"/>
+                <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                <subviews>
+                    <customView translatesAutoresizingMaskIntoConstraints="NO" id="pm4-x9-WJ5" userLabel="SubtitlesTab Flipped CONTENT VIEW" customClass="FlippedView" customModule="IINA" customModuleProvider="target">
+                        <rect key="frame" x="0.0" y="0.0" width="362" height="868"/>
+                        <subviews>
+                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="PJb-5N-8QM" userLabel="PANEL EDGE INSETS">
+                                <rect key="frame" x="20" y="868" width="322" height="0.0"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" id="jai-Pg-hCw"/>
+                                </constraints>
+                            </customView>
+                            <customView translatesAutoresizingMaskIntoConstraints="NO" id="Wuf-PX-OYd" userLabel="SubBasicSection Container View">
+                                <rect key="frame" x="0.0" y="0.0" width="362" height="868"/>
+                                <subviews>
+                                    <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="1Fq-4o-8Hh" userLabel="SubTable Scroll View">
+                                        <rect key="frame" x="0.0" y="745" width="362" height="75"/>
+                                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="dJV-R0-O3M" userLabel="SubTable Clip View">
+                                            <rect key="frame" x="0.0" y="0.0" width="362" height="75"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <subviews>
+                                                <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="2vU-hm-gGB" userLabel="SubTable Table View">
+                                                    <rect key="frame" x="0.0" y="0.0" width="362" height="75"/>
+                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                    <size key="intercellSpacing" width="3" height="2"/>
+                                                    <color key="backgroundColor" red="1" green="1" blue="1" alpha="0.080000000000000002" colorSpace="calibratedRGB"/>
+                                                    <tableViewGridLines key="gridStyleMask" horizontal="YES"/>
+                                                    <color key="gridColor" red="1" green="1" blue="1" alpha="0.10000000000000001" colorSpace="calibratedRGB"/>
+                                                    <tableColumns>
+                                                        <tableColumn identifier="IsChosen" width="16" minWidth="16" maxWidth="16" id="vbW-xz-mKZ">
+                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="right">
+                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                            </tableHeaderCell>
+                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" refusesFirstResponder="YES" allowsUndo="NO" alignment="right" title="0" id="CAr-N0-j64">
+                                                                <font key="font" metaFont="system"/>
+                                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                            <prototypeCellViews>
+                                                                <tableCellView id="0Gi-L0-dSi">
+                                                                    <rect key="frame" x="1" y="1" width="21" height="17"/>
+                                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                    <subviews>
+                                                                        <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="7Ky-LN-z9K">
+                                                                            <rect key="frame" x="0.0" y="0.0" width="21" height="17"/>
+                                                                            <constraints>
+                                                                                <constraint firstAttribute="height" constant="17" id="ANA-U2-c96"/>
+                                                                            </constraints>
+                                                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="Jvb-cP-PSf">
+                                                                                <font key="font" metaFont="system"/>
+                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                            </textFieldCell>
+                                                                            <connections>
+                                                                                <binding destination="0Gi-L0-dSi" name="value" keyPath="objectValue" id="SHY-wA-1bI"/>
+                                                                            </connections>
+                                                                        </textField>
+                                                                    </subviews>
+                                                                    <constraints>
+                                                                        <constraint firstItem="7Ky-LN-z9K" firstAttribute="centerY" secondItem="0Gi-L0-dSi" secondAttribute="centerY" id="KJ7-CB-ONK"/>
+                                                                        <constraint firstItem="7Ky-LN-z9K" firstAttribute="centerX" secondItem="0Gi-L0-dSi" secondAttribute="centerX" id="Q6E-Hs-h57"/>
+                                                                        <constraint firstItem="7Ky-LN-z9K" firstAttribute="leading" secondItem="0Gi-L0-dSi" secondAttribute="leading" constant="2" id="dH0-ya-hZR"/>
+                                                                    </constraints>
+                                                                    <connections>
+                                                                        <outlet property="textField" destination="7Ky-LN-z9K" id="dZy-6W-J6f"/>
+                                                                    </connections>
+                                                                </tableCellView>
+                                                            </prototypeCellViews>
+                                                        </tableColumn>
+                                                        <tableColumn identifier="TrackId" width="33" minWidth="33" maxWidth="100" id="q3e-dd-aXM">
+                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="right">
+                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                                            </tableHeaderCell>
+                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" refusesFirstResponder="YES" alignment="left" title="Text Cell" id="EUu-Vz-tXf">
+                                                                <font key="font" metaFont="system"/>
+                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                            <prototypeCellViews>
+                                                                <tableCellView id="tbH-U7-ooT">
+                                                                    <rect key="frame" x="25" y="1" width="33" height="17"/>
+                                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                    <subviews>
+                                                                        <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Ydk-iU-8pQ">
+                                                                            <rect key="frame" x="0.0" y="0.0" width="33" height="17"/>
+                                                                            <constraints>
+                                                                                <constraint firstAttribute="height" constant="17" id="hAr-TV-jh1"/>
+                                                                            </constraints>
+                                                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="right" title="Table View Cell" id="Mbq-Qm-2xb">
+                                                                                <font key="font" metaFont="systemBold"/>
+                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                            </textFieldCell>
+                                                                            <connections>
+                                                                                <binding destination="tbH-U7-ooT" name="value" keyPath="objectValue" id="v9L-V1-LQl"/>
+                                                                            </connections>
+                                                                        </textField>
+                                                                    </subviews>
+                                                                    <constraints>
+                                                                        <constraint firstItem="Ydk-iU-8pQ" firstAttribute="centerX" secondItem="tbH-U7-ooT" secondAttribute="centerX" id="2In-Gw-XMG"/>
+                                                                        <constraint firstItem="Ydk-iU-8pQ" firstAttribute="centerY" secondItem="tbH-U7-ooT" secondAttribute="centerY" id="5I6-JL-iuh"/>
+                                                                        <constraint firstItem="Ydk-iU-8pQ" firstAttribute="leading" secondItem="tbH-U7-ooT" secondAttribute="leading" constant="2" id="YGU-lg-3bg"/>
+                                                                    </constraints>
+                                                                    <connections>
+                                                                        <outlet property="textField" destination="Ydk-iU-8pQ" id="WBI-LA-u5S"/>
+                                                                    </connections>
+                                                                </tableCellView>
+                                                            </prototypeCellViews>
+                                                        </tableColumn>
+                                                        <tableColumn identifier="TrackName" width="282" minWidth="100" maxWidth="3.4028234663852886e+38" id="jxP-dI-qjH">
+                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                                            </tableHeaderCell>
+                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingMiddle" selectable="YES" refusesFirstResponder="YES" allowsUndo="NO" alignment="left" title="Text Cell" id="Ml5-Kc-QjI">
+                                                                <font key="font" metaFont="system"/>
+                                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                            <prototypeCellViews>
+                                                                <tableCellView id="Uvf-Ds-mrn">
+                                                                    <rect key="frame" x="61" y="1" width="286" height="17"/>
+                                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                    <subviews>
+                                                                        <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="E2W-Vb-Tgt">
+                                                                            <rect key="frame" x="0.0" y="0.0" width="286" height="17"/>
+                                                                            <constraints>
+                                                                                <constraint firstAttribute="height" constant="17" id="Z7t-1Z-ziR"/>
+                                                                            </constraints>
+                                                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="Qpg-8B-Eks">
+                                                                                <font key="font" metaFont="system"/>
+                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                            </textFieldCell>
+                                                                            <connections>
+                                                                                <binding destination="Uvf-Ds-mrn" name="value" keyPath="objectValue" id="eER-Qt-JMe"/>
+                                                                            </connections>
+                                                                        </textField>
+                                                                    </subviews>
+                                                                    <constraints>
+                                                                        <constraint firstItem="E2W-Vb-Tgt" firstAttribute="centerX" secondItem="Uvf-Ds-mrn" secondAttribute="centerX" id="CjW-1W-Ghg"/>
+                                                                        <constraint firstItem="E2W-Vb-Tgt" firstAttribute="leading" secondItem="Uvf-Ds-mrn" secondAttribute="leading" constant="2" id="i83-Js-1Hh"/>
+                                                                        <constraint firstItem="E2W-Vb-Tgt" firstAttribute="centerY" secondItem="Uvf-Ds-mrn" secondAttribute="centerY" id="wCF-Cd-UF3"/>
+                                                                    </constraints>
+                                                                    <connections>
+                                                                        <outlet property="textField" destination="E2W-Vb-Tgt" id="0MJ-5K-pni"/>
+                                                                    </connections>
+                                                                </tableCellView>
+                                                            </prototypeCellViews>
+                                                        </tableColumn>
+                                                    </tableColumns>
+                                                </tableView>
+                                            </subviews>
+                                        </clipView>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="75" id="lC0-Wa-BTh"/>
+                                        </constraints>
+                                        <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="T7q-K8-765" userLabel="SubTable Horizontal Scroller">
+                                            <rect key="frame" x="0.0" y="56" width="360" height="16"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </scroller>
+                                        <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="j0M-29-ecd" userLabel="SubTable Vertical Scroller">
+                                            <rect key="frame" x="-16" y="0.0" width="16" height="0.0"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </scroller>
+                                    </scrollView>
+                                    <scrollView borderType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="LMp-7Y-Rxg" userLabel="SecondarySub Scroll View">
+                                        <rect key="frame" x="0.0" y="622" width="362" height="75"/>
+                                        <clipView key="contentView" drawsBackground="NO" copiesOnScroll="NO" id="EKn-MX-Fao" userLabel="SecondarySub Clip View">
+                                            <rect key="frame" x="0.0" y="0.0" width="362" height="75"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <subviews>
+                                                <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" tableStyle="fullWidth" columnResizing="NO" multipleSelection="NO" autosaveColumns="NO" rowSizeStyle="automatic" viewBased="YES" id="Jve-qX-Agy" userLabel="SecondarySub Table View">
+                                                    <rect key="frame" x="0.0" y="0.0" width="362" height="75"/>
+                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                    <size key="intercellSpacing" width="3" height="2"/>
+                                                    <color key="backgroundColor" white="1" alpha="0.080000000000000002" colorSpace="deviceWhite"/>
+                                                    <tableViewGridLines key="gridStyleMask" horizontal="YES"/>
+                                                    <color key="gridColor" red="1" green="1" blue="1" alpha="0.10000000000000001" colorSpace="calibratedRGB"/>
+                                                    <tableColumns>
+                                                        <tableColumn identifier="IsChosen" width="16" minWidth="16" maxWidth="16" id="2lj-8m-Jqb">
+                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="right">
+                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
+                                                            </tableHeaderCell>
+                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" refusesFirstResponder="YES" allowsUndo="NO" alignment="right" title="0" id="0ju-Sf-fcb">
+                                                                <font key="font" metaFont="system"/>
+                                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                            <prototypeCellViews>
+                                                                <tableCellView id="OdH-WH-l2U">
+                                                                    <rect key="frame" x="1" y="1" width="21" height="17"/>
+                                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                    <subviews>
+                                                                        <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="615-Ps-9YF">
+                                                                            <rect key="frame" x="0.0" y="0.0" width="21" height="17"/>
+                                                                            <constraints>
+                                                                                <constraint firstAttribute="height" constant="17" id="qtL-Np-vkj"/>
+                                                                            </constraints>
+                                                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="f23-sU-Thx">
+                                                                                <font key="font" metaFont="system"/>
+                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                            </textFieldCell>
+                                                                            <connections>
+                                                                                <binding destination="OdH-WH-l2U" name="value" keyPath="objectValue" id="Hxt-qf-TUc"/>
+                                                                            </connections>
+                                                                        </textField>
+                                                                    </subviews>
+                                                                    <constraints>
+                                                                        <constraint firstItem="615-Ps-9YF" firstAttribute="centerX" secondItem="OdH-WH-l2U" secondAttribute="centerX" id="GOp-6I-AcY"/>
+                                                                        <constraint firstItem="615-Ps-9YF" firstAttribute="leading" secondItem="OdH-WH-l2U" secondAttribute="leading" constant="2" id="gvC-jA-iBO"/>
+                                                                        <constraint firstItem="615-Ps-9YF" firstAttribute="centerY" secondItem="OdH-WH-l2U" secondAttribute="centerY" id="viA-Z1-ctw"/>
+                                                                    </constraints>
+                                                                    <connections>
+                                                                        <outlet property="textField" destination="615-Ps-9YF" id="nhJ-wW-r7t"/>
+                                                                    </connections>
+                                                                </tableCellView>
+                                                            </prototypeCellViews>
+                                                        </tableColumn>
+                                                        <tableColumn identifier="TrackId" width="33" minWidth="33" maxWidth="100" id="91Y-DK-bjV">
+                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="right">
+                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                                            </tableHeaderCell>
+                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingTail" selectable="YES" editable="YES" refusesFirstResponder="YES" alignment="left" title="Text Cell" id="CI9-tC-NBv">
+                                                                <font key="font" metaFont="system"/>
+                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                            <prototypeCellViews>
+                                                                <tableCellView id="7bA-1U-4oy">
+                                                                    <rect key="frame" x="25" y="1" width="33" height="17"/>
+                                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                    <subviews>
+                                                                        <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="CCb-vZ-l96">
+                                                                            <rect key="frame" x="0.0" y="0.0" width="33" height="17"/>
+                                                                            <constraints>
+                                                                                <constraint firstAttribute="height" constant="17" id="plc-pR-j5l"/>
+                                                                            </constraints>
+                                                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" alignment="right" title="Table View Cell" id="YOu-ft-k7r">
+                                                                                <font key="font" metaFont="systemBold"/>
+                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                            </textFieldCell>
+                                                                            <connections>
+                                                                                <binding destination="7bA-1U-4oy" name="value" keyPath="objectValue" id="Gpz-IX-2Y6"/>
+                                                                            </connections>
+                                                                        </textField>
+                                                                    </subviews>
+                                                                    <constraints>
+                                                                        <constraint firstItem="CCb-vZ-l96" firstAttribute="leading" secondItem="7bA-1U-4oy" secondAttribute="leading" constant="2" id="9FN-Mp-PWo"/>
+                                                                        <constraint firstItem="CCb-vZ-l96" firstAttribute="centerX" secondItem="7bA-1U-4oy" secondAttribute="centerX" id="FtS-zV-DsW"/>
+                                                                        <constraint firstItem="CCb-vZ-l96" firstAttribute="centerY" secondItem="7bA-1U-4oy" secondAttribute="centerY" id="ZUx-Ce-XBD"/>
+                                                                    </constraints>
+                                                                    <connections>
+                                                                        <outlet property="textField" destination="CCb-vZ-l96" id="BKB-n2-rPJ"/>
+                                                                    </connections>
+                                                                </tableCellView>
+                                                            </prototypeCellViews>
+                                                        </tableColumn>
+                                                        <tableColumn identifier="TrackName" width="282" minWidth="40" maxWidth="3.4028234663852886e+38" id="jc0-mX-0JS">
+                                                            <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" alignment="left">
+                                                                <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="calibratedWhite"/>
+                                                            </tableHeaderCell>
+                                                            <textFieldCell key="dataCell" lineBreakMode="truncatingMiddle" selectable="YES" refusesFirstResponder="YES" allowsUndo="NO" alignment="left" title="Text Cell" id="Zmu-ck-pua">
+                                                                <font key="font" metaFont="system"/>
+                                                                <color key="textColor" name="textColor" catalog="System" colorSpace="catalog"/>
+                                                                <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                                            </textFieldCell>
+                                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                                            <prototypeCellViews>
+                                                                <tableCellView id="pG0-Y6-Qgh">
+                                                                    <rect key="frame" x="61" y="1" width="286" height="17"/>
+                                                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                                                    <subviews>
+                                                                        <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="ig9-1H-Wpa">
+                                                                            <rect key="frame" x="0.0" y="0.0" width="286" height="17"/>
+                                                                            <constraints>
+                                                                                <constraint firstAttribute="height" constant="17" id="mlg-vW-akC"/>
+                                                                            </constraints>
+                                                                            <textFieldCell key="cell" lineBreakMode="truncatingTail" sendsActionOnEndEditing="YES" title="Table View Cell" id="51L-l6-3vz">
+                                                                                <font key="font" metaFont="system"/>
+                                                                                <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                                            </textFieldCell>
+                                                                            <connections>
+                                                                                <binding destination="pG0-Y6-Qgh" name="value" keyPath="objectValue" id="E98-T1-joW"/>
+                                                                            </connections>
+                                                                        </textField>
+                                                                    </subviews>
+                                                                    <constraints>
+                                                                        <constraint firstItem="ig9-1H-Wpa" firstAttribute="centerX" secondItem="pG0-Y6-Qgh" secondAttribute="centerX" id="0uX-1k-wPF"/>
+                                                                        <constraint firstItem="ig9-1H-Wpa" firstAttribute="centerY" secondItem="pG0-Y6-Qgh" secondAttribute="centerY" id="9ij-Pw-V2f"/>
+                                                                        <constraint firstItem="ig9-1H-Wpa" firstAttribute="leading" secondItem="pG0-Y6-Qgh" secondAttribute="leading" constant="2" id="eic-9d-9Mi"/>
+                                                                    </constraints>
+                                                                    <connections>
+                                                                        <outlet property="textField" destination="ig9-1H-Wpa" id="GcF-vc-iAf"/>
+                                                                    </connections>
+                                                                </tableCellView>
+                                                            </prototypeCellViews>
+                                                        </tableColumn>
+                                                    </tableColumns>
+                                                </tableView>
+                                            </subviews>
+                                        </clipView>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="75" id="h9T-Pz-NPG"/>
+                                        </constraints>
+                                        <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="ZW0-tb-txz" userLabel="SecondarySub Horizontal Scroller">
+                                            <rect key="frame" x="0.0" y="56" width="360" height="16"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </scroller>
+                                        <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="YIS-JA-mpZ" userLabel="SecondarySub Vertical Scroller">
+                                            <rect key="frame" x="-16" y="0.0" width="16" height="0.0"/>
+                                            <autoresizingMask key="autoresizingMask"/>
+                                        </scroller>
+                                    </scrollView>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mYH-DV-e4F" userLabel="Subtitle">
+                                        <rect key="frame" x="18" y="832" width="60" height="16"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Subtitle:" id="eXZ-HN-qL4">
+                                            <font key="font" metaFont="systemBold"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="3xe-mv-ORw" userLabel="Secondary subtitle">
+                                        <rect key="frame" x="18" y="709" width="131" height="16"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Secondary subtitle:" id="bKb-pW-HnS">
+                                            <font key="font" metaFont="systemBold"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="M2U-rq-X2L" userLabel="External subtitles">
+                                        <rect key="frame" x="18" y="586" width="326" height="16"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="External subtitles:" id="RA1-fF-OrB">
+                                            <font key="font" metaFont="systemBold"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="zQu-u6-goi" userLabel="Load Subtitle and Disclosure Triangle">
+                                        <rect key="frame" x="17" y="556" width="128" height="24"/>
+                                        <segmentedCell key="cell" refusesFirstResponder="YES" borderStyle="border" alignment="left" style="rounded" trackingMode="momentary" id="AB5-UZ-euc">
+                                            <font key="font" metaFont="system"/>
+                                            <segments>
+                                                <segment label="Load Subtitle…"/>
+                                                <segment image="triangle-down" tag="1">
+                                                    <nil key="label"/>
+                                                </segment>
+                                            </segments>
+                                        </segmentedCell>
+                                        <connections>
+                                            <action selector="loadExternalSubAction:" target="-2" id="6k4-nh-xFo"/>
+                                        </connections>
+                                    </segmentedControl>
+                                    <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="YIE-pv-gCK" userLabel="Search Online Segmented Control">
+                                        <rect key="frame" x="147" y="556" width="111" height="24"/>
+                                        <segmentedCell key="cell" refusesFirstResponder="YES" borderStyle="border" alignment="left" style="rounded" trackingMode="momentary" id="Rbb-wh-cLc">
+                                            <font key="font" metaFont="system"/>
+                                            <segments>
+                                                <segment label="Search Online…"/>
+                                            </segments>
+                                        </segmentedCell>
+                                        <connections>
+                                            <action selector="searchOnlineAction:" target="-2" id="z9B-mh-JoN"/>
+                                        </connections>
+                                    </segmentedControl>
+                                    <box title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="0ir-bk-Itm">
+                                        <rect key="frame" x="17" y="358" width="328" height="182"/>
+                                        <view key="contentView" id="SbY-uL-YKR">
+                                            <rect key="frame" x="4" y="5" width="320" height="174"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                        </view>
+                                    </box>
+                                    <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="dXz-x4-sm5" userLabel="SubDelay Horizontal Tick Bottom Slider">
+                                        <rect key="frame" x="30" y="440" width="233" height="20"/>
+                                        <sliderCell key="cell" controlSize="small" continuous="YES" refusesFirstResponder="YES" state="on" alignment="left" minValue="-5" maxValue="5" tickMarkPosition="below" numberOfTickMarks="21" sliderType="linear" id="h1D-gP-Dst"/>
+                                        <connections>
+                                            <action selector="subDelayChangedAction:" target="-2" id="rzg-cd-v6B"/>
+                                        </connections>
+                                    </slider>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VdJ-nq-zaM" userLabel="SubDelaySliderIndicator">
+                                        <rect key="frame" x="140" y="459" width="24" height="13"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="20" id="OZJ-QN-MzG"/>
+                                        </constraints>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="center" title="0s" usesSingleLineMode="YES" id="upM-Lz-YwK">
+                                            <font key="font" metaFont="system" size="10"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="cOv-Yl-KdH">
+                                        <rect key="frame" x="30" y="476" width="98" height="16"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Subtitle delay:" id="Wkz-wW-sOM">
+                                            <font key="font" metaFont="systemBold"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="VbE-TV-lb5">
+                                        <rect key="frame" x="30" y="430" width="20" height="11"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="-5s" id="uCX-EC-jXM">
+                                            <font key="font" metaFont="label" size="9"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="r77-VA-Z1b">
+                                        <rect key="frame" x="242" y="430" width="21" height="11"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="+5s" id="xfX-wr-DTJ">
+                                            <font key="font" metaFont="label" size="9"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="eOz-bB-vzM" userLabel="CustomDelayEdit Text Field">
+                                        <rect key="frame" x="269" y="440" width="50" height="21"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="50" id="ptd-kK-aWm"/>
+                                        </constraints>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="left" title="0" drawsBackground="YES" usesSingleLineMode="YES" id="bZu-Wx-06O" customClass="RoundedTextFieldCell" customModule="IINA" customModuleProvider="target">
+                                            <numberFormatter key="formatter" formatterBehavior="default10_4" numberStyle="decimal" minimumIntegerDigits="1" maximumIntegerDigits="2000000000" maximumFractionDigits="3" id="HxX-is-3eO"/>
+                                            <font key="font" metaFont="system"/>
+                                            <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                        <connections>
+                                            <action selector="customSubDelayEditFinishedAction:" target="-2" id="oMk-9O-MYn"/>
+                                        </connections>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="4U2-kT-76O">
+                                        <rect key="frame" x="317" y="443" width="15" height="16"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="s" id="bsT-FB-GhF">
+                                            <font key="font" metaFont="system"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kzp-GR-Sy4">
+                                        <rect key="frame" x="139" y="430" width="15" height="11"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="0s" id="LEZ-fv-buL">
+                                            <font key="font" metaFont="label" size="9"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <switch horizontalHuggingPriority="750" verticalHuggingPriority="750" baseWritingDirection="leftToRight" alignment="left" translatesAutoresizingMaskIntoConstraints="NO" id="9f0-0q-rg2">
+                                        <rect key="frame" x="302" y="827" width="42" height="25"/>
+                                        <connections>
+                                            <action selector="hideSubAction:" target="-2" id="I9P-h7-1Vv"/>
+                                        </connections>
+                                    </switch>
+                                    <switch horizontalHuggingPriority="750" verticalHuggingPriority="750" baseWritingDirection="leftToRight" alignment="left" translatesAutoresizingMaskIntoConstraints="NO" id="Ji9-kR-VBA">
+                                        <rect key="frame" x="302" y="704" width="42" height="25"/>
+                                        <connections>
+                                            <action selector="hideSecSubAction:" target="-2" id="QOg-07-Szj"/>
+                                        </connections>
+                                    </switch>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="9xm-5m-Q7G">
+                                        <rect key="frame" x="18" y="326" width="44" height="16"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Scale:" id="Wbx-Ti-qiS">
+                                            <font key="font" metaFont="systemBold"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <button translatesAutoresizingMaskIntoConstraints="NO" id="8ZC-Wx-nt7">
+                                        <rect key="frame" x="326" y="318" width="16" height="21"/>
+                                        <buttonCell key="cell" type="square" bezelStyle="shadowlessSquare" image="NSRefreshFreestandingTemplate" imagePosition="only" alignment="center" controlSize="small" refusesFirstResponder="YES" imageScaling="proportionallyUpOrDown" inset="2" id="ojj-5V-n3t">
+                                            <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                            <font key="font" metaFont="message" size="11"/>
+                                        </buttonCell>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="16" id="GIz-PJ-9SR"/>
+                                            <constraint firstAttribute="width" constant="16" id="HE1-PU-O12"/>
+                                        </constraints>
+                                        <connections>
+                                            <action selector="subScaleReset:" target="-2" id="wfC-aE-U04"/>
+                                        </connections>
+                                    </button>
+                                    <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="B8f-KH-BaO">
+                                        <rect key="frame" x="18" y="292" width="326" height="28"/>
+                                        <sliderCell key="cell" continuous="YES" refusesFirstResponder="YES" alignment="left" minValue="-5" maxValue="5" tickMarkPosition="above" sliderType="linear" id="Qpw-NH-Unh"/>
+                                        <connections>
+                                            <action selector="subScaleSliderAction:" target="-2" id="zEB-hd-cz8"/>
+                                        </connections>
+                                    </slider>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="OEX-Gn-xCa">
+                                        <rect key="frame" x="30" y="402" width="61" height="16"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Position:" id="t03-36-Zge">
+                                            <font key="font" metaFont="systemBold"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ipr-WR-eax">
+                                        <rect key="frame" x="18" y="270" width="73" height="16"/>
+                                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Text Style:" id="ZBd-13-lA1">
+                                            <font key="font" metaFont="systemBold"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="uSx-qN-Wxd">
+                                        <rect key="frame" x="30" y="506" width="302" height="21"/>
+                                        <segmentedCell key="cell" controlSize="small" borderStyle="border" alignment="left" segmentDistribution="fillEqually" style="rounded" trackingMode="selectOne" id="88M-pi-2Hc">
+                                            <font key="font" metaFont="smallSystem"/>
+                                            <segments>
+                                                <segment label="Primary Subtitles" selected="YES"/>
+                                                <segment label="Secondary Subtitles" tag="1"/>
+                                            </segments>
+                                        </segmentedCell>
+                                        <connections>
+                                            <action selector="subSegmentedControlAction:" target="-2" id="G3a-hY-Qcj"/>
+                                        </connections>
+                                    </segmentedControl>
+                                    <slider verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lzW-d6-Asr">
+                                        <rect key="frame" x="30" y="368" width="302" height="28"/>
+                                        <sliderCell key="cell" continuous="YES" refusesFirstResponder="YES" alignment="left" maxValue="100" tickMarkPosition="above" sliderType="linear" id="fZU-F1-3pO"/>
+                                        <connections>
+                                            <action selector="subPosSliderAction:" target="-2" id="Top-XW-i2A"/>
+                                        </connections>
+                                    </slider>
+                                    <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Lkf-Yn-nsR" userLabel="Subtitle style options disclaimer">
+                                        <rect key="frame" x="18" y="43" width="326" height="28"/>
+                                        <textFieldCell key="cell" sendsActionOnEndEditing="YES" alignment="left" title="Subtitle style options may break ASS rendering, and some of them will be disabled depending on subtitle type." id="wBD-pZ-Bvu">
+                                            <font key="font" metaFont="message" size="11"/>
+                                            <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                            <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                        </textFieldCell>
+                                    </textField>
+                                    <box title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="7LX-zh-k2A">
+                                        <rect key="frame" x="17" y="80" width="328" height="180"/>
+                                        <view key="contentView" id="Af7-Zt-hXH">
+                                            <rect key="frame" x="4" y="5" width="320" height="172"/>
+                                            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                                            <subviews>
+                                                <colorWell wellStyle="minimal" translatesAutoresizingMaskIntoConstraints="NO" id="9mo-uL-hfC" customClass="RoundedColorWell" customModule="IINA" customModuleProvider="target">
+                                                    <rect key="frame" x="49" y="119" width="29" height="25"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="21" id="Rgf-Cu-gr0"/>
+                                                        <constraint firstAttribute="width" constant="21" id="tlC-zK-dZi"/>
+                                                    </constraints>
+                                                    <color key="color" red="1" green="1" blue="1" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <connections>
+                                                        <action selector="subTextColorAction:" target="-2" id="K9J-nN-LTp"/>
+                                                    </connections>
+                                                </colorWell>
+                                                <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="xtF-tn-m9W" userLabel="Text font size">
+                                                    <rect key="frame" x="124" y="119" width="78" height="22"/>
+                                                    <popUpButtonCell key="cell" type="push" title="55" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" refusesFirstResponder="YES" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="mep-aa-rk7" id="qha-uU-Cos" userLabel="Cell">
+                                                        <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                        <font key="font" metaFont="message" size="11"/>
+                                                        <menu key="menu" id="NDG-BT-qrU">
+                                                            <items>
+                                                                <menuItem title="30" id="JeH-nY-dU8"/>
+                                                                <menuItem title="35" id="zcb-7y-OVG"/>
+                                                                <menuItem title="40" id="Sp8-cj-Zrx"/>
+                                                                <menuItem title="45" id="OVn-Oj-YAr"/>
+                                                                <menuItem title="50" id="YTM-1c-Gl0"/>
+                                                                <menuItem title="55" state="on" id="mep-aa-rk7"/>
+                                                                <menuItem title="60" id="CFK-kH-8hR"/>
+                                                                <menuItem title="65" id="n2O-ot-Bir"/>
+                                                                <menuItem title="70" id="AmU-VN-wGN"/>
+                                                            </items>
+                                                        </menu>
+                                                    </popUpButtonCell>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="70" id="d7u-5q-vDg"/>
+                                                    </constraints>
+                                                    <connections>
+                                                        <action selector="subTextSizeAction:" target="-2" id="Z3b-cC-c1V"/>
+                                                    </connections>
+                                                </popUpButton>
+                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jj7-9J-PmG">
+                                                    <rect key="frame" x="10" y="12" width="36" height="14"/>
+                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Color:" id="6LO-6y-IsA">
+                                                        <font key="font" metaFont="message" size="11"/>
+                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
+                                                <textField focusRingType="none" horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="vLY-cB-GEf">
+                                                    <rect key="frame" x="83" y="124" width="39" height="14"/>
+                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Size:" id="s9l-Hb-SCk">
+                                                        <font key="font" metaFont="message" size="11"/>
+                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
+                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xdm-hT-rQs">
+                                                    <rect key="frame" x="10" y="90" width="51" height="14"/>
+                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="BORDER" id="GlZ-YU-dNm">
+                                                        <font key="font" metaFont="smallSystemBold"/>
+                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
+                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BcK-R6-e8c">
+                                                    <rect key="frame" x="10" y="68" width="36" height="14"/>
+                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Color:" id="ANn-CR-JOV">
+                                                        <font key="font" metaFont="message" size="11"/>
+                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
+                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="kaq-YT-MxI">
+                                                    <rect key="frame" x="10" y="124" width="36" height="14"/>
+                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Color:" id="3kI-6i-ujt">
+                                                        <font key="font" metaFont="message" size="11"/>
+                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
+                                                <textField focusRingType="none" horizontalHuggingPriority="249" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="7Lw-84-lts">
+                                                    <rect key="frame" x="83" y="68" width="39" height="14"/>
+                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="right" title="Width:" id="22j-ra-GAY">
+                                                        <font key="font" metaFont="message" size="11"/>
+                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
+                                                <colorWell wellStyle="minimal" translatesAutoresizingMaskIntoConstraints="NO" id="U2e-zB-Kue" customClass="RoundedColorWell" customModule="IINA" customModuleProvider="target">
+                                                    <rect key="frame" x="49" y="63" width="29" height="25"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="21" id="OaA-1O-DoB"/>
+                                                        <constraint firstAttribute="width" constant="21" id="kwW-fi-4RZ"/>
+                                                    </constraints>
+                                                    <color key="color" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                                    <connections>
+                                                        <action selector="subTextBorderColorAction:" target="-2" id="ACh-s2-ew1"/>
+                                                    </connections>
+                                                </colorWell>
+                                                <colorWell wellStyle="minimal" translatesAutoresizingMaskIntoConstraints="NO" id="Ure-tT-JEy" customClass="RoundedColorWell" customModule="IINA" customModuleProvider="target">
+                                                    <rect key="frame" x="49" y="7" width="29" height="25"/>
+                                                    <constraints>
+                                                        <constraint firstAttribute="height" constant="21" id="Ivi-Q0-PSs"/>
+                                                        <constraint firstAttribute="width" constant="21" id="qQW-fy-gq5"/>
+                                                    </constraints>
+                                                    <color key="color" red="1" green="1" blue="1" alpha="0.0" colorSpace="calibratedRGB"/>
+                                                    <connections>
+                                                        <action selector="subTextBgColorAction:" target="-2" id="hoQ-1z-12N"/>
+                                                    </connections>
+                                                </colorWell>
+                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="WJ6-Fb-q7a">
+                                                    <rect key="frame" x="10" y="34" width="86" height="14"/>
+                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="BACKGROUND" id="uqb-mz-A22">
+                                                        <font key="font" metaFont="smallSystemBold"/>
+                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
+                                                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="jTT-rB-qLu">
+                                                    <rect key="frame" x="10" y="146" width="300" height="14"/>
+                                                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="FONT" id="g6B-DC-lJ0">
+                                                        <font key="font" metaFont="smallSystemBold"/>
+                                                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                                    </textFieldCell>
+                                                </textField>
+                                                <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bkX-rt-2bg" userLabel="Text Border Width">
+                                                    <rect key="frame" x="124" y="63" width="78" height="22"/>
+                                                    <popUpButtonCell key="cell" type="push" title="3" bezelStyle="rounded" alignment="left" controlSize="small" lineBreakMode="truncatingTail" refusesFirstResponder="YES" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="h6k-DT-fv5" id="xGc-Oh-HJO">
+                                                        <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                                                        <font key="font" metaFont="message" size="11"/>
+                                                        <menu key="menu" id="LnU-HE-pGc">
+                                                            <items>
+                                                                <menuItem title="0" id="3eG-mV-UGW"/>
+                                                                <menuItem title="0.25" id="DdO-VX-HCz"/>
+                                                                <menuItem title="0.5" id="avJ-cW-Iws"/>
+                                                                <menuItem title="1" id="nvA-Ae-4XS"/>
+                                                                <menuItem title="1.5" id="JbG-Ur-b55"/>
+                                                                <menuItem title="2" id="bxa-ha-AXL"/>
+                                                                <menuItem title="2.5" id="nPr-QJ-Ty3"/>
+                                                                <menuItem title="3" state="on" id="h6k-DT-fv5"/>
+                                                                <menuItem title="4" id="ssK-tS-ogL"/>
+                                                                <menuItem title="5" id="7su-au-nwq"/>
+                                                            </items>
+                                                        </menu>
+                                                    </popUpButtonCell>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="70" id="Udn-GZ-bGb"/>
+                                                    </constraints>
+                                                    <connections>
+                                                        <action selector="subTextBorderWidthAction:" target="-2" id="qyR-r0-5LO"/>
+                                                    </connections>
+                                                </popUpButton>
+                                                <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="qGz-rB-dsV">
+                                                    <rect key="frame" x="204" y="116" width="76" height="27"/>
+                                                    <buttonCell key="cell" type="push" title="Font..." bezelStyle="rounded" alignment="center" controlSize="small" refusesFirstResponder="YES" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="ghy-e7-7Of">
+                                                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                                                        <font key="font" metaFont="message" size="11"/>
+                                                    </buttonCell>
+                                                    <constraints>
+                                                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="64" id="0zp-I9-Wwd"/>
+                                                    </constraints>
+                                                    <connections>
+                                                        <action selector="subFontAction:" target="-2" id="suw-pH-n9w"/>
+                                                    </connections>
+                                                </button>
+                                            </subviews>
+                                            <constraints>
+                                                <constraint firstItem="qGz-rB-dsV" firstAttribute="firstBaseline" secondItem="xtF-tn-m9W" secondAttribute="firstBaseline" id="3Eq-V6-soB"/>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="qGz-rB-dsV" secondAttribute="trailing" constant="12" id="4A1-C0-lIc"/>
+                                                <constraint firstItem="jTT-rB-qLu" firstAttribute="leading" secondItem="Af7-Zt-hXH" secondAttribute="leading" constant="12" id="5O5-mn-fCE"/>
+                                                <constraint firstItem="U2e-zB-Kue" firstAttribute="leading" secondItem="BcK-R6-e8c" secondAttribute="trailing" constant="8" id="65d-js-nhu"/>
+                                                <constraint firstAttribute="bottom" secondItem="jj7-9J-PmG" secondAttribute="bottom" constant="12" id="6fH-Jn-ujf"/>
+                                                <constraint firstItem="vLY-cB-GEf" firstAttribute="leading" secondItem="9mo-uL-hfC" secondAttribute="trailing" constant="12" id="8Vf-dn-rZf"/>
+                                                <constraint firstItem="bkX-rt-2bg" firstAttribute="leading" secondItem="7Lw-84-lts" secondAttribute="trailing" constant="8" id="939-fu-npK"/>
+                                                <constraint firstItem="kaq-YT-MxI" firstAttribute="top" secondItem="jTT-rB-qLu" secondAttribute="bottom" constant="8" id="9pC-xj-1nZ"/>
+                                                <constraint firstItem="BcK-R6-e8c" firstAttribute="top" secondItem="xdm-hT-rQs" secondAttribute="bottom" constant="8" id="EIw-94-ed6"/>
+                                                <constraint firstItem="WJ6-Fb-q7a" firstAttribute="leading" secondItem="Af7-Zt-hXH" secondAttribute="leading" constant="12" id="F57-GW-5X8"/>
+                                                <constraint firstItem="xtF-tn-m9W" firstAttribute="firstBaseline" secondItem="vLY-cB-GEf" secondAttribute="firstBaseline" id="G5p-Ab-r3M"/>
+                                                <constraint firstItem="Ure-tT-JEy" firstAttribute="leading" secondItem="jj7-9J-PmG" secondAttribute="trailing" constant="8" id="GlA-sc-4aV"/>
+                                                <constraint firstItem="7Lw-84-lts" firstAttribute="centerY" secondItem="U2e-zB-Kue" secondAttribute="centerY" id="Htc-Fd-Cm1"/>
+                                                <constraint firstItem="9mo-uL-hfC" firstAttribute="centerY" secondItem="kaq-YT-MxI" secondAttribute="centerY" id="KEN-mY-ULr"/>
+                                                <constraint firstAttribute="trailing" secondItem="jTT-rB-qLu" secondAttribute="trailing" constant="12" id="N5f-vc-50s"/>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="xdm-hT-rQs" secondAttribute="trailing" constant="20" symbolic="YES" id="OX2-t3-H3Q"/>
+                                                <constraint firstItem="WJ6-Fb-q7a" firstAttribute="top" secondItem="BcK-R6-e8c" secondAttribute="bottom" constant="20" id="OYB-fW-sD1"/>
+                                                <constraint firstItem="9mo-uL-hfC" firstAttribute="leading" secondItem="kaq-YT-MxI" secondAttribute="trailing" constant="8" id="THb-yf-myj"/>
+                                                <constraint firstItem="jTT-rB-qLu" firstAttribute="top" secondItem="Af7-Zt-hXH" secondAttribute="top" constant="12" id="Ve8-74-C39"/>
+                                                <constraint firstItem="xtF-tn-m9W" firstAttribute="leading" secondItem="vLY-cB-GEf" secondAttribute="trailing" constant="8" id="WhN-1A-O6Z"/>
+                                                <constraint firstItem="vLY-cB-GEf" firstAttribute="width" secondItem="7Lw-84-lts" secondAttribute="width" id="Yf7-sF-HSW"/>
+                                                <constraint firstItem="U2e-zB-Kue" firstAttribute="centerY" secondItem="BcK-R6-e8c" secondAttribute="centerY" id="i61-Ap-Dx2"/>
+                                                <constraint firstItem="xdm-hT-rQs" firstAttribute="top" secondItem="kaq-YT-MxI" secondAttribute="bottom" constant="20" id="iXN-xa-vik"/>
+                                                <constraint firstItem="kaq-YT-MxI" firstAttribute="leading" secondItem="Af7-Zt-hXH" secondAttribute="leading" constant="12" id="inC-da-nUo"/>
+                                                <constraint firstItem="qGz-rB-dsV" firstAttribute="leading" secondItem="xtF-tn-m9W" secondAttribute="trailing" constant="12" id="ivi-6P-L50"/>
+                                                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="WJ6-Fb-q7a" secondAttribute="trailing" constant="20" symbolic="YES" id="jPg-xe-u7t"/>
+                                                <constraint firstItem="bkX-rt-2bg" firstAttribute="firstBaseline" secondItem="7Lw-84-lts" secondAttribute="firstBaseline" id="kFG-eO-qrQ"/>
+                                                <constraint firstItem="jj7-9J-PmG" firstAttribute="leading" secondItem="Af7-Zt-hXH" secondAttribute="leading" constant="12" id="pRY-0Z-2pR"/>
+                                                <constraint firstItem="7Lw-84-lts" firstAttribute="leading" secondItem="U2e-zB-Kue" secondAttribute="trailing" constant="12" id="sCn-ZY-OEP"/>
+                                                <constraint firstItem="Ure-tT-JEy" firstAttribute="centerY" secondItem="jj7-9J-PmG" secondAttribute="centerY" id="t82-Me-2bY"/>
+                                                <constraint firstItem="vLY-cB-GEf" firstAttribute="centerY" secondItem="9mo-uL-hfC" secondAttribute="centerY" id="tvm-SS-Tc1"/>
+                                                <constraint firstItem="BcK-R6-e8c" firstAttribute="leading" secondItem="Af7-Zt-hXH" secondAttribute="leading" constant="12" id="yHH-zJ-4LP"/>
+                                                <constraint firstItem="xdm-hT-rQs" firstAttribute="leading" secondItem="Af7-Zt-hXH" secondAttribute="leading" constant="12" id="yJg-Uq-KhW"/>
+                                                <constraint firstItem="jj7-9J-PmG" firstAttribute="top" secondItem="WJ6-Fb-q7a" secondAttribute="bottom" constant="8" id="yM7-UH-dD5"/>
+                                            </constraints>
+                                        </view>
+                                    </box>
+                                </subviews>
+                                <constraints>
+                                    <constraint firstAttribute="trailing" secondItem="LMp-7Y-Rxg" secondAttribute="trailing" id="0Gl-lc-Bm7"/>
+                                    <constraint firstAttribute="trailing" secondItem="1Fq-4o-8Hh" secondAttribute="trailing" id="1hL-1o-nGN"/>
+                                    <constraint firstItem="cOv-Yl-KdH" firstAttribute="top" secondItem="uSx-qN-Wxd" secondAttribute="bottom" constant="16" id="1pU-WQ-8au"/>
+                                    <constraint firstItem="0ir-bk-Itm" firstAttribute="top" secondItem="uSx-qN-Wxd" secondAttribute="top" constant="-12" id="1sw-Bc-baf"/>
+                                    <constraint firstItem="zQu-u6-goi" firstAttribute="top" secondItem="M2U-rq-X2L" secondAttribute="bottom" constant="8" id="26L-W9-3iG"/>
+                                    <constraint firstItem="lzW-d6-Asr" firstAttribute="top" secondItem="OEX-Gn-xCa" secondAttribute="bottom" constant="8" symbolic="YES" id="2wF-65-uMD"/>
+                                    <constraint firstItem="kzp-GR-Sy4" firstAttribute="centerX" secondItem="dXz-x4-sm5" secondAttribute="centerX" id="33J-Xb-Xbh"/>
+                                    <constraint firstAttribute="trailing" secondItem="uSx-qN-Wxd" secondAttribute="trailing" constant="32" id="4N2-mY-Uir"/>
+                                    <constraint firstItem="9f0-0q-rg2" firstAttribute="centerY" secondItem="mYH-DV-e4F" secondAttribute="centerY" id="6px-Sx-9dj"/>
+                                    <constraint firstItem="VdJ-nq-zaM" firstAttribute="centerX" secondItem="dXz-x4-sm5" secondAttribute="leading" priority="800" constant="120" id="7t1-v0-J55"/>
+                                    <constraint firstItem="r77-VA-Z1b" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="kzp-GR-Sy4" secondAttribute="trailing" id="8Vz-fK-wJu"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="cOv-Yl-KdH" secondAttribute="trailing" symbolic="YES" id="9Qi-Yg-Fnx"/>
+                                    <constraint firstItem="uSx-qN-Wxd" firstAttribute="top" secondItem="zQu-u6-goi" secondAttribute="bottom" constant="32" id="9aD-1Y-69c"/>
+                                    <constraint firstItem="kzp-GR-Sy4" firstAttribute="top" secondItem="dXz-x4-sm5" secondAttribute="bottom" constant="1" id="9mp-6s-MHB"/>
+                                    <constraint firstItem="eOz-bB-vzM" firstAttribute="firstBaseline" secondItem="4U2-kT-76O" secondAttribute="firstBaseline" id="A37-KG-QaU"/>
+                                    <constraint firstItem="VdJ-nq-zaM" firstAttribute="top" secondItem="cOv-Yl-KdH" secondAttribute="bottom" constant="4" id="Axq-IW-PvK"/>
+                                    <constraint firstItem="VdJ-nq-zaM" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="dXz-x4-sm5" secondAttribute="leading" id="CCu-4g-OKS"/>
+                                    <constraint firstItem="7LX-zh-k2A" firstAttribute="top" secondItem="ipr-WR-eax" secondAttribute="bottom" constant="12" id="Czl-Ke-76C"/>
+                                    <constraint firstItem="YIE-pv-gCK" firstAttribute="leading" secondItem="zQu-u6-goi" secondAttribute="trailing" constant="8" id="DPc-T2-84N"/>
+                                    <constraint firstItem="8ZC-Wx-nt7" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="9xm-5m-Q7G" secondAttribute="trailing" constant="8" symbolic="YES" id="EJV-9A-iSr"/>
+                                    <constraint firstItem="dXz-x4-sm5" firstAttribute="top" secondItem="VdJ-nq-zaM" secondAttribute="bottom" constant="1" id="Fdp-D4-VPU"/>
+                                    <constraint firstItem="ipr-WR-eax" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="20" symbolic="YES" id="GJa-kl-cZG"/>
+                                    <constraint firstItem="3xe-mv-ORw" firstAttribute="top" secondItem="1Fq-4o-8Hh" secondAttribute="bottom" constant="20" id="I4y-iB-fWM"/>
+                                    <constraint firstItem="9xm-5m-Q7G" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="20" symbolic="YES" id="Ion-Pe-Xk3"/>
+                                    <constraint firstItem="mYH-DV-e4F" firstAttribute="top" secondItem="Wuf-PX-OYd" secondAttribute="top" constant="20" id="Izb-ki-XeU"/>
+                                    <constraint firstItem="Lkf-Yn-nsR" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="20" symbolic="YES" id="J5o-SU-epm"/>
+                                    <constraint firstItem="Lkf-Yn-nsR" firstAttribute="top" secondItem="7LX-zh-k2A" secondAttribute="bottom" constant="13" id="KLz-m8-d8U"/>
+                                    <constraint firstItem="Ji9-kR-VBA" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="3xe-mv-ORw" secondAttribute="trailing" constant="8" id="L0n-h9-nNd"/>
+                                    <constraint firstItem="7LX-zh-k2A" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="20" symbolic="YES" id="LGI-fp-Ys5"/>
+                                    <constraint firstItem="eOz-bB-vzM" firstAttribute="leading" secondItem="dXz-x4-sm5" secondAttribute="trailing" constant="8" id="LTf-pu-8fz"/>
+                                    <constraint firstItem="Ji9-kR-VBA" firstAttribute="centerY" secondItem="3xe-mv-ORw" secondAttribute="centerY" id="MFX-GK-WcM"/>
+                                    <constraint firstItem="lzW-d6-Asr" firstAttribute="leading" secondItem="OEX-Gn-xCa" secondAttribute="leading" id="Mia-2d-0Te"/>
+                                    <constraint firstItem="LMp-7Y-Rxg" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" id="O1s-aJ-7eK"/>
+                                    <constraint firstItem="8ZC-Wx-nt7" firstAttribute="firstBaseline" secondItem="9xm-5m-Q7G" secondAttribute="firstBaseline" id="OXd-wT-lGK"/>
+                                    <constraint firstAttribute="bottom" secondItem="Lkf-Yn-nsR" secondAttribute="bottom" constant="43" id="P51-zb-a92"/>
+                                    <constraint firstAttribute="trailing" secondItem="Lkf-Yn-nsR" secondAttribute="trailing" constant="20" symbolic="YES" id="PUa-CC-Z0Q"/>
+                                    <constraint firstItem="VbE-TV-lb5" firstAttribute="leading" secondItem="dXz-x4-sm5" secondAttribute="leading" id="Q0F-ty-AhB"/>
+                                    <constraint firstItem="0ir-bk-Itm" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="20" symbolic="YES" id="QwI-HD-6Sz"/>
+                                    <constraint firstItem="B8f-KH-BaO" firstAttribute="top" secondItem="9xm-5m-Q7G" secondAttribute="bottom" constant="8" symbolic="YES" id="W1h-j5-1KT"/>
+                                    <constraint firstItem="lzW-d6-Asr" firstAttribute="bottom" secondItem="0ir-bk-Itm" secondAttribute="bottom" constant="-12" id="X0h-W2-tPJ"/>
+                                    <constraint firstItem="cOv-Yl-KdH" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="32" id="XVY-2L-hRa"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="ipr-WR-eax" secondAttribute="trailing" constant="20" symbolic="YES" id="Xqi-cr-Zcr"/>
+                                    <constraint firstItem="M2U-rq-X2L" firstAttribute="top" secondItem="LMp-7Y-Rxg" secondAttribute="bottom" constant="20" id="Y58-bK-q43"/>
+                                    <constraint firstItem="kzp-GR-Sy4" firstAttribute="firstBaseline" secondItem="VbE-TV-lb5" secondAttribute="firstBaseline" id="ZeT-rD-nRd"/>
+                                    <constraint firstItem="uSx-qN-Wxd" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="32" id="bnw-GB-lTA"/>
+                                    <constraint firstItem="ipr-WR-eax" firstAttribute="top" secondItem="B8f-KH-BaO" secondAttribute="bottom" constant="12" id="c2C-0A-9vr"/>
+                                    <constraint firstAttribute="trailing" secondItem="4U2-kT-76O" secondAttribute="trailing" constant="32" id="cG1-zO-3Hw"/>
+                                    <constraint firstItem="1Fq-4o-8Hh" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" id="eCR-6x-gEL"/>
+                                    <constraint firstItem="r77-VA-Z1b" firstAttribute="firstBaseline" secondItem="VbE-TV-lb5" secondAttribute="firstBaseline" id="fRc-yO-K49"/>
+                                    <constraint firstAttribute="trailing" secondItem="8ZC-Wx-nt7" secondAttribute="trailing" constant="20" symbolic="YES" id="fXL-dK-K3k"/>
+                                    <constraint firstItem="OEX-Gn-xCa" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="32" id="fYl-bc-V56"/>
+                                    <constraint firstItem="9f0-0q-rg2" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="mYH-DV-e4F" secondAttribute="trailing" constant="8" id="hl1-vl-yic"/>
+                                    <constraint firstItem="1Fq-4o-8Hh" firstAttribute="top" secondItem="mYH-DV-e4F" secondAttribute="bottom" constant="12" id="hl3-X4-nod"/>
+                                    <constraint firstItem="OEX-Gn-xCa" firstAttribute="top" secondItem="VbE-TV-lb5" secondAttribute="bottom" constant="12" id="hmb-st-dnt"/>
+                                    <constraint firstItem="r77-VA-Z1b" firstAttribute="trailing" secondItem="dXz-x4-sm5" secondAttribute="trailing" id="kSN-80-IMR"/>
+                                    <constraint firstItem="lzW-d6-Asr" firstAttribute="centerX" secondItem="Wuf-PX-OYd" secondAttribute="centerX" id="lDd-s9-Jfa"/>
+                                    <constraint firstItem="YIE-pv-gCK" firstAttribute="centerY" secondItem="zQu-u6-goi" secondAttribute="centerY" id="lUf-kQ-zMz"/>
+                                    <constraint firstItem="kzp-GR-Sy4" firstAttribute="leading" relation="greaterThanOrEqual" secondItem="VbE-TV-lb5" secondAttribute="trailing" id="llG-p4-ckS"/>
+                                    <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="OEX-Gn-xCa" secondAttribute="trailing" constant="32" id="qdd-SN-rDl"/>
+                                    <constraint firstItem="eOz-bB-vzM" firstAttribute="centerY" secondItem="dXz-x4-sm5" secondAttribute="centerY" id="rgl-9k-oY7"/>
+                                    <constraint firstItem="4U2-kT-76O" firstAttribute="leading" secondItem="eOz-bB-vzM" secondAttribute="trailing" id="rnJ-T0-g1e"/>
+                                    <constraint firstAttribute="trailing" secondItem="0ir-bk-Itm" secondAttribute="trailing" constant="20" symbolic="YES" id="uGz-Yc-xe7"/>
+                                    <constraint firstItem="9xm-5m-Q7G" firstAttribute="top" secondItem="lzW-d6-Asr" secondAttribute="bottom" constant="32" id="ubO-C0-vLx"/>
+                                    <constraint firstItem="LMp-7Y-Rxg" firstAttribute="top" secondItem="3xe-mv-ORw" secondAttribute="bottom" constant="12" id="uj7-Lc-oLk"/>
+                                    <constraint firstAttribute="trailing" secondItem="7LX-zh-k2A" secondAttribute="trailing" constant="20" symbolic="YES" id="wd8-Lc-k23"/>
+                                    <constraint firstItem="dXz-x4-sm5" firstAttribute="leading" secondItem="Wuf-PX-OYd" secondAttribute="leading" constant="32" id="ydW-mS-48Z"/>
+                                </constraints>
+                            </customView>
+                        </subviews>
+                        <constraints>
+                            <constraint firstItem="zQu-u6-goi" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="1jU-tm-xfg"/>
+                            <constraint firstItem="Wuf-PX-OYd" firstAttribute="top" secondItem="pm4-x9-WJ5" secondAttribute="top" id="Asb-va-Eiv"/>
+                            <constraint firstItem="PJb-5N-8QM" firstAttribute="leading" secondItem="pm4-x9-WJ5" secondAttribute="leading" constant="20" id="BQV-10-Aft"/>
+                            <constraint firstItem="9f0-0q-rg2" firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="E3K-iB-zmF"/>
+                            <constraint firstItem="3xe-mv-ORw" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="EM8-9Q-Yhw"/>
+                            <constraint firstItem="M2U-rq-X2L" firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="H2R-H8-0CG"/>
+                            <constraint firstItem="Wuf-PX-OYd" firstAttribute="leading" secondItem="pm4-x9-WJ5" secondAttribute="leading" id="Hee-mM-GuU"/>
+                            <constraint firstItem="B8f-KH-BaO" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="KiN-OM-Cn5"/>
+                            <constraint firstAttribute="trailing" secondItem="Wuf-PX-OYd" secondAttribute="trailing" id="NTd-uf-my8"/>
+                            <constraint firstItem="Ji9-kR-VBA" firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="RAY-i7-3Pp"/>
+                            <constraint firstItem="YIE-pv-gCK" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="SXw-h1-5CU"/>
+                            <constraint firstItem="mYH-DV-e4F" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="aMT-hN-hi6"/>
+                            <constraint firstItem="M2U-rq-X2L" firstAttribute="leading" secondItem="PJb-5N-8QM" secondAttribute="leading" id="cph-Mm-h9J"/>
+                            <constraint firstAttribute="bottom" secondItem="Wuf-PX-OYd" secondAttribute="bottom" id="loV-NP-OEC"/>
+                            <constraint firstItem="PJb-5N-8QM" firstAttribute="top" secondItem="pm4-x9-WJ5" secondAttribute="top" id="m2Z-kA-64n"/>
+                            <constraint firstItem="B8f-KH-BaO" firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" id="pHd-ob-TjH"/>
+                            <constraint firstAttribute="trailing" secondItem="PJb-5N-8QM" secondAttribute="trailing" constant="20" id="wXW-Nt-gpv"/>
+                        </constraints>
+                    </customView>
+                </subviews>
+                <constraints>
+                    <constraint firstItem="pm4-x9-WJ5" firstAttribute="top" secondItem="epy-wp-Ja5" secondAttribute="top" id="1bs-mX-gdk"/>
+                    <constraint firstAttribute="trailing" secondItem="pm4-x9-WJ5" secondAttribute="trailing" id="HgD-xH-Xz0"/>
+                    <constraint firstItem="pm4-x9-WJ5" firstAttribute="leading" secondItem="epy-wp-Ja5" secondAttribute="leading" id="kbf-OJ-lKt"/>
+                </constraints>
+                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+            </clipView>
+            <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="jEt-nA-sGO">
+                <rect key="frame" x="-100" y="-100" width="360" height="16"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </scroller>
+            <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="3ZS-ug-kkq">
+                <rect key="frame" x="347" y="0.0" width="15" height="867"/>
+                <autoresizingMask key="autoresizingMask"/>
+            </scroller>
+            <point key="canvasLocation" x="752" y="-513.5"/>
+        </scrollView>
     </objects>
     <resources>
         <image name="NSRefreshFreestandingTemplate" width="19" height="19"/>

--- a/iina/QuickSettingViewController.swift
+++ b/iina/QuickSettingViewController.swift
@@ -98,7 +98,8 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
   var observers: [NSObjectProtocol] = []
 
   @IBOutlet weak var videoTabScrollView: NSScrollView!
-  @IBOutlet weak var videoTabContentViewWidthConstraint: NSLayoutConstraint!
+  @IBOutlet weak var audioTabScrollView: NSScrollView!
+  @IBOutlet weak var subtitlesTabScrollView: NSScrollView!
 
   @IBOutlet weak var videoTabBtn: NSButton!
   @IBOutlet weak var audioTabBtn: NSButton!
@@ -202,6 +203,12 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
 
   override func viewDidLoad() {
     super.viewDidLoad()
+
+    let tabScrollViews = [videoTabScrollView, audioTabScrollView, subtitlesTabScrollView]
+    for (view, item) in zip(tabScrollViews, tabView.tabViewItems) {
+      item.view = view
+    }
+
     withAllTableViews { (view, _) in
       view.delegate = self
       view.dataSource = self


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
We are using NSTabView for the quick settings, and currently all the views are curling up in the `AllTabsTabView` in the xib editor, which is very inconvenient to modify the UI elements in each view. By separating and spreading them out, it's more straightforward and pleasant to work with.

Before (in xib):
![image](https://github.com/user-attachments/assets/1ea63432-5c6b-466a-a034-24ed20de8b01)

After:
![image](https://github.com/user-attachments/assets/ef790768-5317-48ae-9325-c62677ded134)

Other fixed along the way:
- Fixed the horizontal scroller always appear in the audio tab table view
- Remove some unused code

If you find any outstanding PR modifying `QuickSettingViewContoller.xib` which could be merged soon, please comment below so that I'll hold back this PR.
