### PR TITLE
Fix compile error in Utility.quickPromptPanel

### DIFF
--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -245,7 +245,9 @@ class Utility {
     input.cell?.isScrollable = true
     input.isBezeled = true
     input.bezelStyle = .roundedBezel
-    input.controlSize = .large
+    if #available(macOS 11.0, *) {
+      input.controlSize = .large
+    }
     if let inputValue = inputValue {
       input.stringValue = inputValue
     }


### PR DESCRIPTION
This commit will change `Utility.quickPromptPanel` to only set the `NSTextField.controlSize` to `large` when running under macOS 11+.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
