### PR TITLE
Add Screenshot menu item and functionality

### DIFF
--- a/iina/Base.lproj/MainMenu.xib
+++ b/iina/Base.lproj/MainMenu.xib
@@ -301,6 +301,12 @@ CA
                                 <modifierMask key="keyEquivalentModifierMask"/>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="pEu-eU-Er6"/>
+                            <menuItem title="Take Screenshot" keyEquivalent="S" id="bGe-0j-hF5">
+                                <modifierMask key="keyEquivalentModifierMask" shift="YES" command="YES"/>
+                                <connections>
+                                    <action selector="takeScreenshotMenuItemClicked:" target="-1" id="L9S-4f-S9b"/>
+                                </connections>
+                            </menuItem>
                             <menuItem title="A-B Loop" id="i3P-Xw-8D7">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                             </menuItem>

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -3019,6 +3019,10 @@ class MainWindowController: PlayerWindowController {
     }
   }
 
+  @IBAction func takeScreenshotMenuItemClicked(_ sender: Any) {
+    player.screenshot()
+  }
+
   // MARK: - Utility
 
   private func resetCollectionBehavior() {


### PR DESCRIPTION
This commit introduces a "Take Screenshot" menu item in the "Playback" menu (⇧⌘S).

- Added the menu item to `iina/Base.lproj/MainMenu.xib`.
- Implemented the corresponding `takeScreenshotMenuItemClicked` action in `MainWindowController.swift` to call the existing `player.screenshot()` method.

- [ ] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
