### PR TITLE
Fix playlist no longer shows resizing cursor, #4768

### DIFF
--- a/iina/Base.lproj/MainWindowController.xib
+++ b/iina/Base.lproj/MainWindowController.xib
@@ -71,7 +71,7 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
             <rect key="contentRect" x="196" y="240" width="640" height="400"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1415"/>
-            <view key="contentView" id="se5-gp-TjO">
+            <view key="contentView" id="se5-gp-TjO" customClass="MainWindowContentView" customModule="IINA" customModuleProvider="target">
                 <rect key="frame" x="0.0" y="0.0" width="640" height="400"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>

--- a/iina/MainWindow.swift
+++ b/iina/MainWindow.swift
@@ -58,3 +58,10 @@ class MainWindow: NSWindow {
     forceKeyAndMain ? true : super.canBecomeMain
   }
 }
+
+class MainWindowContentView: NSView {
+  override func resetCursorRects() {
+    guard let controller = window?.windowController as? MainWindowController, controller.sideBarStatus == .playlist else { return }
+    addCursorRect(controller.playlistDraggingRect, cursor: .resizeLeftRight)
+  }
+}

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -137,7 +137,18 @@ class MainWindowController: PlayerWindowController {
 
   var mousePosRelatedToWindow: CGPoint?
   var isDragging: Bool = false
-  var isResizingSidebar: Bool = false
+  var isResizingSidebar: Bool = false {
+    didSet {
+      if isResizingSidebar {
+        window?.disableCursorRects()
+        NSCursor.resizeLeftRight.push()
+      } else {
+        NSCursor.pop()
+        window?.resetCursorRects()
+        window?.enableCursorRects()
+      }
+    }
+  }
 
   var pipStatus = PIPStatus.notInPIP
   var isInInteractiveMode: Bool = false
@@ -900,6 +911,13 @@ class MainWindowController: PlayerWindowController {
     NSCursor.setHiddenUntilMouseMoves(true)
   }
 
+  var playlistDraggingRect: NSRect {
+    let sf = sideBarView.frame
+    let originX = videoView.userInterfaceLayoutDirection == .rightToLeft ?
+        sf.width + 4 : sf.origin.x - 4
+    return NSMakeRect(originX, sf.origin.y, 4, sf.height)
+  }
+
   override func mouseDown(with event: NSEvent) {
     if Logger.enabled && Logger.Level.preferred >= .verbose {
       log("MainWindow mouseDown @ \(event.locationInWindow)", level: .verbose)
@@ -912,10 +930,7 @@ class MainWindowController: PlayerWindowController {
     mousePosRelatedToWindow = event.locationInWindow
     // playlist resizing
     if sideBarStatus == .playlist {
-      let sf = sideBarView.frame
-      let originX = videoView.userInterfaceLayoutDirection == .rightToLeft ?
-          sf.width + 4 : sf.origin.x - 4
-      if NSPointInRect(mousePosRelatedToWindow!, NSMakeRect(originX, sf.origin.y, 4, sf.height)) {
+      if NSPointInRect(mousePosRelatedToWindow!, playlistDraggingRect) {
         isResizingSidebar = true
         shouldCallSuper = false
       }
@@ -2082,6 +2097,7 @@ class MainWindowController: PlayerWindowController {
     }) {
       self.sidebarAnimationState = .shown
       self.sideBarStatus = type
+      self.window?.resetCursorRects()
     }
   }
 

--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -946,11 +946,6 @@ class PlaylistPrefixButton: NSButton {
 
 class PlaylistView: NSView {
 
-  override func resetCursorRects() {
-    let rect = NSRect(x: frame.origin.x - 4, y: frame.origin.y, width: 4, height: frame.height)
-    addCursorRect(rect, cursor: .resizeLeftRight)
-  }
-
   override func mouseDown(with event: NSEvent) {}
 
   // override var allowsVibrancy: Bool { return true }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4768.

---

**Description:**
This PR:
- Makes the content view of the main window a custom `MainWindowContentView` to override `resetCursorRects()` for manipulating the cursor behavior
  - This was previously done in playlist view; the related code is deleted in this PR.
- Observes `isResizingSidebar` to push a `.resizeLeftRight` cursor during playlist resizing
  - Note that when controlling NSCursor manually, cursor rects should be disabled to prevent AppKit from interfering.
- Resets the cursor rects after resizing