### PR TITLE
Close support cover artwork in Now Playing module, #5336

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -159,6 +159,7 @@
 		496B19921E2968530035AF10 /* PIP.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 496B19911E2968530035AF10 /* PIP.framework */; };
 		51096C0B2CD88BEC00702C31 /* MPVOptionDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51096C0A2CD88BEC00702C31 /* MPVOptionDefaults.swift */; };
 		5111B18B2C8BCEAC00DEC0AC /* TouchBarSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5111B18A2C8BCEAC00DEC0AC /* TouchBarSettings.swift */; };
+		5114FA942DC704CE00D02435 /* NowPlayingInfoManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5114FA932DC704CE00D02435 /* NowPlayingInfoManager.swift */; };
 		512B8FDD2BC2376E00AF41BF /* OutlineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512B8FDC2BC2376E00AF41BF /* OutlineView.swift */; };
 		513A4FFA29B53F8100A8EA7D /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513A4FF929B53F8100A8EA7D /* Atomic.swift */; };
 		515B5E5A2A579903001FCD49 /* iina-plugin in Copy Executables */ = {isa = PBXBuildFile; fileRef = E38558872A484A2D0083772D /* iina-plugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
@@ -1185,6 +1186,7 @@
 		49F7E3BF2920D65C002DA28E /* Availability.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Availability.xcconfig; sourceTree = "<group>"; };
 		51096C0A2CD88BEC00702C31 /* MPVOptionDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MPVOptionDefaults.swift; sourceTree = "<group>"; };
 		5111B18A2C8BCEAC00DEC0AC /* TouchBarSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchBarSettings.swift; sourceTree = "<group>"; };
+		5114FA932DC704CE00D02435 /* NowPlayingInfoManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingInfoManager.swift; sourceTree = "<group>"; };
 		512B8FDC2BC2376E00AF41BF /* OutlineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutlineView.swift; sourceTree = "<group>"; };
 		513A4FF929B53F8100A8EA7D /* Atomic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
 		51537C7229FA26DD00F9A472 /* Nightly.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Nightly.xcconfig; sourceTree = "<group>"; };
@@ -2457,6 +2459,7 @@
 				84FBCB371EEACDDD0076C77C /* FFmpegController.m */,
 				842904E11F0EC01600478376 /* AutoFileMatcher.swift */,
 				846121BC1F35FCA500ABB39C /* DraggingDetect.swift */,
+				5114FA932DC704CE00D02435 /* NowPlayingInfoManager.swift */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";
@@ -3112,6 +3115,7 @@
 				84BEEC421DFEE46200F945CA /* StreamReader.swift in Sources */,
 				E3CAD4AF2146DB47000B373A /* JavascriptAPI.swift in Sources */,
 				84C644601E92BA2700B1410B /* TimeLabelOverflowedView.swift in Sources */,
+				5114FA942DC704CE00D02435 /* NowPlayingInfoManager.swift in Sources */,
 				E3958565253133E80096811F /* SidebarTabView.swift in Sources */,
 				E3C12F6B201F281F00297964 /* FirstRunManager.swift in Sources */,
 				84EB1F071D2F5E76004FA5A1 /* Utility.swift in Sources */,

--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -8,6 +8,7 @@
 
 import Cocoa
 import CryptoKit
+import MediaPlayer
 
 extension NSSlider {
   /**
@@ -581,6 +582,11 @@ extension NSTextField {
 }
 
 extension NSImage {
+  var cgImage: CGImage? {
+    var rect = CGRect.init(origin: .zero, size: self.size)
+    return self.cgImage(forProposedRect: &rect, context: nil, hints: nil)
+  }
+
   func tinted(_ tintColor: NSColor) -> NSImage {
     guard self.isTemplate else { return self }
 
@@ -594,6 +600,14 @@ extension NSImage {
     image.isTemplate = false
 
     return image
+  }
+
+  /// `cornerRadius`: if greater than 0, round the corners by this radius
+  func resized(newWidth: Int, newHeight: Int, cornerRadius: CGFloat = 0) -> NSImage {
+    if let cgImageNew = cgImage?.resized(newWidth: newWidth, newHeight: newHeight, cornerRadius: cornerRadius) {
+      return NSImage(cgImage: cgImageNew, size: NSSize(width: newWidth, height: newHeight))
+    }
+    return self
   }
 
   func rounded() -> NSImage {
@@ -811,5 +825,108 @@ extension Process {
     process.waitUntilExit()
 
     return (process, stdout, stderr)
+  }
+}
+
+extension CGImage {
+  var nsImage: NSImage { NSImage(cgImage: self, size: size) }
+  var size: CGSize { CGSize(width: width, height: height) }
+
+  /// `cornerRadius`: if greater than 0, round the corners by this radius
+  func resized(newWidth: Int, newHeight: Int, cornerRadius: CGFloat = 0) -> CGImage {
+    guard newWidth != width || newHeight != height else {
+      return self
+    }
+
+    guard newWidth > 0, newHeight > 0 else {
+      Logger.fatal("NSImage.resized: invalid width (\(newWidth)) or height (\(newHeight)) - both must be greater than 0")
+    }
+
+    // Use raw CoreGraphics calls instead of their NS equivalents. They are > 10x faster, and only downside is that the image's
+    // dimensions must be integer values instead of decimals.
+    let newImage = CGImage.buildBitmapImage(width: Int(newWidth), height: Int(newHeight)) { cgContext in
+      let outputRect = CGRect(x: 0, y: 0, width: newWidth, height: newHeight)
+      if cornerRadius > 0.0 {
+        cgContext.beginPath()
+        cgContext.addPath(CGPath(roundedRect: outputRect, cornerWidth: cornerRadius, cornerHeight: cornerRadius, transform: nil))
+        cgContext.closePath()
+        cgContext.clip()
+      }
+      cgContext.draw(self, in: outputRect)
+    }
+
+    return newImage
+  }
+
+  /// Builds a bitmap image efficiently using CoreGraphics APIs.
+  ///
+  /// If it's found useful for any more situations, should put in its own class
+  static func buildBitmapImage(width: Int, height: Int, _ drawingCalls: (CGContext) -> Void) -> CGImage {
+    guard let compositeImageRep = CGImage.makeNewImgRep(width: width, height: height) else {
+      Logger.fatal("DrawImageInBitmapImageContext: Failed to create NSBitmapImageRep!")
+    }
+
+    guard let context = NSGraphicsContext(bitmapImageRep: compositeImageRep) else {
+      Logger.fatal("DrawImageInBitmapImageContext: Failed to create NSGraphicsContext!")
+    }
+
+    context.cgContext.interpolationQuality = .high
+    drawingCalls(context.cgContext)
+
+    return compositeImageRep.cgImage!
+  }
+
+  /// Creates RGB image with alpha channel
+  static func makeNewImgRep(width: Int, height: Int) -> NSBitmapImageRep? {
+    return NSBitmapImageRep(
+      bitmapDataPlanes: nil,
+      pixelsWide: width,
+      pixelsHigh: height,
+      bitsPerSample: 8,
+      samplesPerPixel: 4,
+      hasAlpha: true,
+      isPlanar: false,
+      colorSpaceName: NSColorSpaceName.calibratedRGB,
+      bytesPerRow: 0,
+      bitsPerPixel: 0)
+  }
+}
+
+extension CGSize {
+  var heightInt: Int { Int(height) }
+  var widthInt: Int { Int(width) }
+
+  /// Crops the current size to fit within a target aspect ratio, reducing either the width or height to match the aspect ratio of the
+  /// target rectangle.
+  /// - Parameter targetAspect: A rectangle or size structure that contains the desired aspect ratio.
+  /// - Returns: The cropped `NSSize` that fits within the given aspect ratio.
+  func crop(withAspect targetAspect: CGFloat) -> NSSize {
+    if aspect > targetAspect {  // self is wider, crop width, use same height
+      return NSSize(width: round(height * targetAspect), height: height)
+    } else {
+      return NSSize(width: width, height: round(width / targetAspect))
+    }
+  }
+
+  func getCropRect(withAspect aspect: CGFloat) -> NSRect {
+    let croppedSize = crop(withAspect: aspect)
+    let cropped = NSMakeRect(round((width - croppedSize.width) / 2),
+                             round((height - croppedSize.height) / 2),
+                             croppedSize.width,
+                             croppedSize.height)
+    return cropped
+  }
+}
+
+extension MPNowPlayingPlaybackState: @retroactive CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case .unknown: return "unknown"
+    case .playing: return "playing"
+    case .paused: return "paused"
+    case .stopped: return "stopped"
+    case .interrupted: return "interrupted"
+    @unknown default: return String(self.rawValue)
+    }
   }
 }

--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -556,6 +556,18 @@ extension NSMenuItem {
 
 
 extension URL {
+  /// A string representing the URL in the format mpv uses for
+  /// [playlist/N/filename](https://mpv.io/manual/stable/#command-interface-playlist/n/filename].
+  var mpvStr: String {
+    guard isFileURL else {
+      return absoluteString
+    }
+    guard #available(macOS 13.0, *) else {
+      return path
+    }
+    return path(percentEncoded: false)
+  }
+
   var creationDate: Date? {
     (try? resourceValues(forKeys: [.creationDateKey]))?.creationDate
   }
@@ -915,18 +927,5 @@ extension CGSize {
                              croppedSize.width,
                              croppedSize.height)
     return cropped
-  }
-}
-
-extension MPNowPlayingPlaybackState: @retroactive CustomStringConvertible {
-  public var description: String {
-    switch self {
-    case .unknown: return "unknown"
-    case .playing: return "playing"
-    case .paused: return "paused"
-    case .stopped: return "stopped"
-    case .interrupted: return "interrupted"
-    @unknown default: return String(self.rawValue)
-    }
   }
 }

--- a/iina/FFmpegController.h
+++ b/iina/FFmpegController.h
@@ -56,6 +56,14 @@
 - (void)generateThumbnailForFile:(nonnull NSString *)file
                       thumbWidth:(int)thumbWidth;
 
+/// Read artwork from the file with the given URL.
+///
+/// This method will open the file and search the streams for one that contains front cover artwork. If found the image data will be read
+/// from the stream and an `NSImage` will be constructed and returned.
+/// - Parameter url: URL of the file to read artwork from.
+/// - Returns: An initialized NSImage object containing the artwork or null if no artwork was found.
++ (nullable NSImage *)readArtworkFromURL:(nonnull NSURL *)url;
+
 + (nullable NSDictionary *)probeVideoInfoForFile:(nonnull NSString *)file;
 
 @end

--- a/iina/FFmpegController.m
+++ b/iina/FFmpegController.m
@@ -717,6 +717,65 @@ return -1;\
   }
 }
 
+// MARK: - Media Artwork
+
++ (NSImage *)readArtworkFromURL:(nonnull NSURL *)url
+{
+  AVFormatContext *pFormatCtx = NULL;
+
+  @try {
+    int ret = avformat_open_input(&pFormatCtx, url.fileSystemRepresentation, NULL, NULL);
+    if (ret < 0) {
+      LOG_ERROR(@"Failed to open file %@ when searching for artwork: %s (%d)", url, av_err2str(ret), ret);
+      return NULL;
+    }
+
+    ret = avformat_find_stream_info(pFormatCtx, NULL);
+    if (ret < 0) {
+      LOG_ERROR(@"Failed to obtain stream info from file %@ when searching for artwork: %s (%d)",
+                url, av_err2str(ret), ret);
+      return NULL;
+    }
+
+    // Search the streams for one that contains front cover artwork.
+    AVPacket* packet = NULL;
+    for (int i = 0; i < pFormatCtx->nb_streams; i++) {
+      AVStream* stream = pFormatCtx->streams[i];
+
+      // For this stream to be cover artwork it must be an attached picture (APIC).
+      if ((stream->disposition & AV_DISPOSITION_ATTACHED_PIC) == 0) { continue; }
+
+      // The stream must contain metadata with the key "title" and value "thumbnail".
+      AVDictionaryEntry *tag = NULL;
+      tag = av_dict_get(stream->metadata, "title", NULL, 0);
+      if (tag == NULL || strcmp(tag->value, "thumbnail") != 0) { continue; }
+
+      // As well as metadata with the key "comment" and value "Cover (front)".
+      tag = av_dict_get(stream->metadata, "comment", NULL, 0);
+      if (tag == NULL || strcmp(tag->value, "Cover (front)") != 0) { continue; }
+
+      // Found front cover artwork.
+      packet = &stream->attached_pic;
+      break;
+    }
+
+    if (!packet) {
+      return NULL;
+    }
+
+    // Form an image from the stream's data.
+    NSData *data = [[NSData alloc] initWithBytes:packet->data length:packet->size];
+    NSImage *image = [[NSImage alloc] initWithData:data];
+    if (!image) {
+      LOG_ERROR(@"Cannot create image from artwork for file: %@", url);
+    }
+    return image;
+  }
+  @finally {
+    avformat_close_input(&pFormatCtx);
+  }
+}
+
 // MARK: - Logging
 
 #if DEBUG

--- a/iina/MPVTrack.swift
+++ b/iina/MPVTrack.swift
@@ -12,24 +12,29 @@ class MPVTrack: NSObject {
 
   /** For binding a none track object to menu, id = 0 */
   static let noneVideoTrack: MPVTrack = {
-    let track = MPVTrack(id: 0, type: .video, isDefault: false, isForced: false, isSelected: false, isExternal: false)
+    let track = MPVTrack(id: 0, type: .video, isDefault: false, isForced: false, isImage: false,
+                         isSelected: false, isExternal: false)
     track.title = NSLocalizedString("track.none", comment: "<None>")
     return track
   }()
   /** For binding a none track object to menu, id = 0 */
   static let noneAudioTrack: MPVTrack = {
-    let track = MPVTrack(id: 0, type: .audio, isDefault: false, isForced: false, isSelected: false, isExternal: false)
+    let track = MPVTrack(id: 0, type: .audio, isDefault: false, isForced: false, isImage: false,
+                         isSelected: false, isExternal: false)
     track.title = NSLocalizedString("track.none", comment: "<None>")
     return track
   }()
   /** For binding a none track object to menu, id = 0 */
   static let noneSubTrack: MPVTrack = {
-    let track = MPVTrack(id: 0, type: .sub, isDefault: false, isForced: false, isSelected: false, isExternal: false)
+    let track = MPVTrack(id: 0, type: .sub, isDefault: false, isForced: false, isImage: false,
+                         isSelected: false, isExternal: false)
     track.title = NSLocalizedString("track.none", comment: "<None>")
     return track
   }()
   /** For binding a none track object to menu, id = 0 */
-  static let noneSecondSubTrack = MPVTrack(id: 0, type: .secondSub, isDefault: false, isForced: false, isSelected: false, isExternal: false)
+  static let noneSecondSubTrack = MPVTrack(id: 0, type: .secondSub, isDefault: false,
+                                           isForced: false, isImage: false,isSelected: false,
+                                           isExternal: false)
 
   static func emptyTrack(for type: TrackType) -> MPVTrack {
     switch type {
@@ -56,6 +61,7 @@ class MPVTrack: NSObject {
   var lang: String?
   var isDefault: Bool
   var isForced: Bool
+  var isImage: Bool
   var isSelected: Bool
   var isExternal: Bool
   var externalFilename: String?
@@ -121,11 +127,12 @@ class MPVTrack: NSObject {
 
   var decoderDesc: String?
 
-  init(id: Int, type: TrackType, isDefault: Bool, isForced: Bool, isSelected: Bool, isExternal: Bool) {
+  init(id: Int, type: TrackType, isDefault: Bool, isForced: Bool, isImage: Bool, isSelected: Bool, isExternal: Bool) {
     self.id = id
     self.type = type
     self.isDefault = isDefault
     self.isForced = isForced
+    self.isImage = isImage
     self.isSelected = isSelected
     self.isExternal = isExternal
   }

--- a/iina/MPVTrack.swift
+++ b/iina/MPVTrack.swift
@@ -12,29 +12,24 @@ class MPVTrack: NSObject {
 
   /** For binding a none track object to menu, id = 0 */
   static let noneVideoTrack: MPVTrack = {
-    let track = MPVTrack(id: 0, type: .video, isDefault: false, isForced: false, isImage: false,
-                         isSelected: false, isExternal: false)
+    let track = MPVTrack(id: 0, type: .video, isDefault: false, isForced: false, isSelected: false, isExternal: false)
     track.title = NSLocalizedString("track.none", comment: "<None>")
     return track
   }()
   /** For binding a none track object to menu, id = 0 */
   static let noneAudioTrack: MPVTrack = {
-    let track = MPVTrack(id: 0, type: .audio, isDefault: false, isForced: false, isImage: false,
-                         isSelected: false, isExternal: false)
+    let track = MPVTrack(id: 0, type: .audio, isDefault: false, isForced: false, isSelected: false, isExternal: false)
     track.title = NSLocalizedString("track.none", comment: "<None>")
     return track
   }()
   /** For binding a none track object to menu, id = 0 */
   static let noneSubTrack: MPVTrack = {
-    let track = MPVTrack(id: 0, type: .sub, isDefault: false, isForced: false, isImage: false,
-                         isSelected: false, isExternal: false)
+    let track = MPVTrack(id: 0, type: .sub, isDefault: false, isForced: false, isSelected: false, isExternal: false)
     track.title = NSLocalizedString("track.none", comment: "<None>")
     return track
   }()
   /** For binding a none track object to menu, id = 0 */
-  static let noneSecondSubTrack = MPVTrack(id: 0, type: .secondSub, isDefault: false,
-                                           isForced: false, isImage: false,isSelected: false,
-                                           isExternal: false)
+  static let noneSecondSubTrack = MPVTrack(id: 0, type: .secondSub, isDefault: false, isForced: false, isSelected: false, isExternal: false)
 
   static func emptyTrack(for type: TrackType) -> MPVTrack {
     switch type {
@@ -127,7 +122,8 @@ class MPVTrack: NSObject {
 
   var decoderDesc: String?
 
-  init(id: Int, type: TrackType, isDefault: Bool, isForced: Bool, isImage: Bool, isSelected: Bool, isExternal: Bool) {
+  init(id: Int, type: TrackType, isDefault: Bool, isForced: Bool, isImage: Bool = false,
+       isSelected: Bool, isExternal: Bool) {
     self.id = id
     self.type = type
     self.isDefault = isDefault

--- a/iina/NowPlayingInfoManager.swift
+++ b/iina/NowPlayingInfoManager.swift
@@ -504,7 +504,7 @@ class NowPlayingInfoManager {
 
       // When streaming artwork can be found in video tracks either because the stream contains
       // embedded artwork or an image to use for artwork was specified using --cover-art-files.
-      // But the other sources of artwork, Quick Look and the OSC thumbnails are not avaiable when
+      // But the other sources of artwork, Quick Look and the OSC thumbnails are not available when
       // streaming.
       guard !isNetworkResource else {
         DispatchQueue.main.async { self.artworkUpdateComplete() }
@@ -631,7 +631,7 @@ class NowPlayingInfoManager {
   private init() {
     // Because showing artwork is a complex operation there is an internal setting that can be
     // changed to disable this feature should any problems with it be discovered. No need to listen
-    // for changes to the track list if we are not seaching tracks for artwork.
+    // for changes to the track list if we are not searching tracks for artwork.
     guard Preference.bool(for: .enableNowPlayingArtwork) else { return }
     observe(.iinaTracklistChanged) { [unowned self] notification in
       // A track list change can not establish a Now Playing session. If one is not active ignore

--- a/iina/NowPlayingInfoManager.swift
+++ b/iina/NowPlayingInfoManager.swift
@@ -40,7 +40,7 @@ class NowPlayingInfoManager {
 
   /// The number of video tracks the last time the tracks were searched for artwork.
   private var artworkLastTrackCount = 0
-  
+
   /// Maximum number of times to request  [QLThumbnailGenerator](https://developer.apple.com/documentation/quicklookthumbnailing/qlthumbnailgenerator)
   /// generate a thumbnail for the current media item.
   private let artworkQLGenerationMaxRetries = 3
@@ -48,10 +48,10 @@ class NowPlayingInfoManager {
   /// Number of times IINA has requested  [QLThumbnailGenerator](https://developer.apple.com/documentation/quicklookthumbnailing/qlthumbnailgenerator)
   /// generate a thumbnail for the current media item.
   private var artworkQLGenerationRetries = 0
-  
+
   /// Ticket used to coordinate with background tasks performing work to update the artwork shown by Now Playing.
   private var artworkTicket = 0
-  
+
   /// Whether work is currently being performed in the background to update the artwork shown by Now Playing.
   private var artworkUpdateInProgress = false
 
@@ -60,10 +60,10 @@ class NowPlayingInfoManager {
 
   /// The URL of the media item whose artwork could be being shown in Now Playing.
   private var artworkURL: URL?
-  
+
   /// Whether a Now Playing session is active.
   private var isActive = false
-  
+
   /// Established notification observers.
   private var observers: [NSObjectProtocol] = []
 
@@ -85,7 +85,7 @@ class NowPlayingInfoManager {
   /// - Important: This method **must** be run on the main thread because it references `PlayerCore.lastActive`.
   func updateInfo(withTitle: Bool = false) {
     guard RemoteCommandController.useSystemMediaControl else { return }
-    
+
     let center = MPNowPlayingInfoCenter.default()
     let activePlayer = PlayerCore.lastActive
     guard activePlayer.info.state.active else {
@@ -99,7 +99,13 @@ class NowPlayingInfoManager {
       }
       return
     }
-    
+
+    guard let url = activePlayer.info.currentURL else {
+      // Internal error, should not occur.
+      log("Ignoring update request because currentURL is `nil`", level: .error)
+      return
+    }
+
     // Because showing artwork is a complex operation there is an internal setting that can be
     // changed to disable this feature should any problems with it be discovered.
     if Preference.bool(for: .enableNowPlayingArtwork) {
@@ -109,21 +115,16 @@ class NowPlayingInfoManager {
       if activePlayer.info.isNetworkResource {
         abandonArtwork()
       }
-      if let url = activePlayer.info.currentURL {
-        if url != artworkURL {
-          if artworkURL != nil {
-            log("Abandoning artwork due to media item changing", level: .verbose)
-          }
-          abandonArtwork()
-          artworkURL = url
+      if url != artworkURL {
+        if let artworkURL {
+          log("Abandoning artwork due to media item changing", artworkURL, level: .verbose)
         }
-      } else {
         abandonArtwork()
+        artworkURL = url
       }
       // If the best kind of artwork (front cover) is not being displayed then try and update
       // to a better kind of artwork.
-      if artworkKind.need(.frontCover), !activePlayer.info.isNetworkResource,
-         let url = activePlayer.info.currentURL {
+      if artworkKind.need(.frontCover), !activePlayer.info.isNetworkResource {
         updateArtwork(activePlayer, url, activePlayer.info.videoTracks)
       }
     } else {
@@ -146,9 +147,27 @@ class NowPlayingInfoManager {
       }
     }
 
+    info[MPNowPlayingInfoPropertyAssetURL] = url
+    activePlayer.info.$playlist.withLock { playlist in
+      info[MPNowPlayingInfoPropertyPlaybackQueueCount] = playlist.count
+      if let index = playlist.firstIndex(where: { $0.filename == url.path }) {
+        info[MPNowPlayingInfoPropertyPlaybackQueueIndex] = index
+      } else {
+        // This can occur when the playlist is still being populated.
+        info.removeValue(forKey: MPNowPlayingInfoPropertyPlaybackQueueIndex)
+      }
+    }
+    if activePlayer.info.chapters.isEmpty {
+      info.removeValue(forKey: MPNowPlayingInfoPropertyChapterCount)
+      info.removeValue(forKey: MPNowPlayingInfoPropertyChapterNumber)
+    } else {
+      info[MPNowPlayingInfoPropertyChapterCount] = activePlayer.info.chapters.count
+      info[MPNowPlayingInfoPropertyChapterNumber] = activePlayer.info.chapter
+    }
+
     let duration = activePlayer.info.videoDuration?.second ?? 0
     let time = activePlayer.info.videoPosition?.second ?? 0
-    
+
     // When playback is paused Now Playing expects the playback rate to be set to zero. If this is
     // not done the slider in Now Playing may incorrectly display a playback time of zero.
     let paused = activePlayer.info.state == .paused
@@ -158,7 +177,6 @@ class NowPlayingInfoManager {
     info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = time
     info[MPNowPlayingInfoPropertyPlaybackRate] = speed
     info[MPNowPlayingInfoPropertyDefaultPlaybackRate] = 1
-    info[MPNowPlayingInfoPropertyAssetURL] = activePlayer.info.currentURL
 
     center.nowPlayingInfo = info
 
@@ -172,13 +190,13 @@ class NowPlayingInfoManager {
     center.playbackState = paused ? .paused : .playing
 
     let suffix = """
-      elapsed playback time: \(time) rate: \(speed) state: \(center.playbackState)
+      set elapsed playback time: \(time) rate: \(speed) state: \(center.playbackState),
       """
     if isActive {
-      log("Updated Now Playing information, \(suffix)", level: .verbose)
+      log("Updated Now Playing information, \(suffix)", url, level: .verbose)
     } else {
       isActive = true
-      log("Started Now Playing session, \(suffix)")
+      log("Started Now Playing session, \(suffix)", url)
     }
     RemoteCommandController.shared.enable()
   }
@@ -201,6 +219,7 @@ class NowPlayingInfoManager {
   private func abandonArtwork() {
     artworkTicket += 1
     artworkKind = .none
+    artworkQLGenerationRetries = 0
     artworkUpdatePending = false
     artworkURL = nil
     MPNowPlayingInfoCenter.default().nowPlayingInfo?.removeValue(
@@ -245,7 +264,7 @@ class NowPlayingInfoManager {
     // The album art is an external file.
     guard let filename = track.externalFilename else {
       // Internal error. This should not occur.
-      log("External artwork track is missing external-filename", level: .error)
+      log("External artwork track is missing external-filename", url, level: .error)
       return nil
     }
     guard let image = NSImage(contentsOfFile: filename) else {

--- a/iina/NowPlayingInfoManager.swift
+++ b/iina/NowPlayingInfoManager.swift
@@ -58,9 +58,6 @@ class NowPlayingInfoManager {
   /// Whether a request to update the artwork came in while an artwork update was being performed in the background.
   private var artworkUpdatePending = false
 
-  /// The URL of the media item whose artwork could be being shown in Now Playing.
-  private var artworkURL: URL?
-
   /// Whether a Now Playing session is active.
   private var isActive = false
 
@@ -79,6 +76,9 @@ class NowPlayingInfoManager {
   /// This matches the size mpv uses. Using sizes larger than this can cause `QLThumbnailGenerator` to fail.
   private let qlThumbnailSize = CGSize(width: 2000, height: 2000)
 
+  /// The URL of the media item in the Now Playing session.
+  private var url: URL?
+
   /// Update the information shown by macOS in the
   /// [Control Center](https://support.apple.com/guide/mac-help/quickly-change-settings-mchl50f94f8f/mac)
   /// Now Playing module.
@@ -87,91 +87,87 @@ class NowPlayingInfoManager {
     guard RemoteCommandController.useSystemMediaControl else { return }
 
     let center = MPNowPlayingInfoCenter.default()
-    let activePlayer = PlayerCore.lastActive
-    guard activePlayer.info.state.active else {
+    let player = PlayerCore.lastActive
+    guard player.info.state.active else {
       if isActive {
         RemoteCommandController.shared.disable()
-        abandonArtwork()
+        if let url {
+          discardArtwork(url)
+        }
         center.nowPlayingInfo = nil
         center.playbackState = .stopped
         isActive = false
+        url = nil
         log("Ended Now Playing session")
       }
       return
     }
 
-    guard let url = activePlayer.info.currentURL else {
+    guard let currentURL = player.info.currentURL else {
       // Internal error, should not occur.
-      log("Ignoring update request because currentURL is `nil`", level: .error)
+      log("Ignoring update request because currentURL is nil", level: .error)
       return
     }
-
-    // Because showing artwork is a complex operation there is an internal setting that can be
-    // changed to disable this feature should any problems with it be discovered.
-    if Preference.bool(for: .enableNowPlayingArtwork) {
-      // If the media item has changed then if artwork is being displayed it needs to be abandoned.
-      // NOTE this MUST be done before copying the nowPlayingInfo array below as abandonArtwork
-      // works directly on nowPlayingInfo.
-      if activePlayer.info.isNetworkResource {
-        abandonArtwork()
+    if currentURL != url {
+      guard withTitle else {
+        // Internal error, URL should only change when being told to change the title.
+        log("Attempt to change URL to: \(currentURL.mpvStr) with title set to false", level: .error)
+        return
       }
-      if url != artworkURL {
-        if let artworkURL {
-          log("Abandoning artwork due to media item changing", artworkURL, level: .verbose)
-        }
-        abandonArtwork()
-        artworkURL = url
+      if let url {
+        log("Switching Now Playing session from: \(url.mpvStr)\n  to: \(currentURL.mpvStr)")
+        // If the media item has changed then if artwork is being displayed or being worked on in
+        // the background it must be discarded.
+        discardArtwork(url)
+      } else {
+        log("Starting Now Playing session", currentURL)
       }
-      // If the best kind of artwork (front cover) is not being displayed then try and update
-      // to a better kind of artwork.
-      if artworkKind.need(.frontCover), !activePlayer.info.isNetworkResource {
-        updateArtwork(activePlayer, url, activePlayer.info.videoTracks)
-      }
-    } else {
-      log("Showing cover artwork is disabled", level: .verbose)
+      url = currentURL
     }
-    
+
+    // Obtain a copy of the nowPlayingInfo dictionary. NOTE this MUST be done AFTER any calls to
+    // discardArtwork as that method works directly on the nowPlayingInfo dictionary.
     var info = center.nowPlayingInfo ?? [String: Any]()
     if withTitle {
-      if activePlayer.currentMediaIsAudio == .isAudio {
+      if player.currentMediaIsAudio == .isAudio {
         info[MPNowPlayingInfoPropertyMediaType] = MPNowPlayingInfoMediaType.audio.rawValue
-        let (title, album, artist) = activePlayer.getMusicMetadata()
+        let (title, album, artist) = player.getMusicMetadata()
         info[MPMediaItemPropertyTitle] = title
         info[MPMediaItemPropertyAlbumTitle] = album
         info[MPMediaItemPropertyArtist] = artist
       } else {
         info[MPNowPlayingInfoPropertyMediaType] = MPNowPlayingInfoMediaType.video.rawValue
-        info[MPMediaItemPropertyTitle] = activePlayer.getMediaTitle(withExtension: false)
+        info[MPMediaItemPropertyTitle] = player.getMediaTitle(withExtension: false)
         info.removeValue(forKey: MPMediaItemPropertyAlbumTitle)
         info.removeValue(forKey: MPMediaItemPropertyArtist)
       }
     }
 
     info[MPNowPlayingInfoPropertyAssetURL] = url
-    activePlayer.info.$playlist.withLock { playlist in
+    player.info.$playlist.withLock { playlist in
       info[MPNowPlayingInfoPropertyPlaybackQueueCount] = playlist.count
-      if let index = playlist.firstIndex(where: { $0.filename == url.path }) {
+      if let index = playlist.firstIndex(where: { $0.filename == currentURL.mpvStr }) {
         info[MPNowPlayingInfoPropertyPlaybackQueueIndex] = index
       } else {
         // This can occur when the playlist is still being populated.
         info.removeValue(forKey: MPNowPlayingInfoPropertyPlaybackQueueIndex)
       }
     }
-    if activePlayer.info.chapters.isEmpty {
+    if player.info.chapters.isEmpty {
       info.removeValue(forKey: MPNowPlayingInfoPropertyChapterCount)
       info.removeValue(forKey: MPNowPlayingInfoPropertyChapterNumber)
     } else {
-      info[MPNowPlayingInfoPropertyChapterCount] = activePlayer.info.chapters.count
-      info[MPNowPlayingInfoPropertyChapterNumber] = activePlayer.info.chapter
+      info[MPNowPlayingInfoPropertyChapterCount] = player.info.chapters.count
+      info[MPNowPlayingInfoPropertyChapterNumber] = player.info.chapter
     }
 
-    let duration = activePlayer.info.videoDuration?.second ?? 0
-    let time = activePlayer.info.videoPosition?.second ?? 0
+    let duration = player.info.videoDuration?.second ?? 0
+    let time = player.info.videoPosition?.second ?? 0
 
     // When playback is paused Now Playing expects the playback rate to be set to zero. If this is
     // not done the slider in Now Playing may incorrectly display a playback time of zero.
-    let paused = activePlayer.info.state == .paused
-    let speed = paused ? 0 : activePlayer.info.playSpeed
+    let paused = player.info.state == .paused
+    let speed = paused ? 0 : player.info.playSpeed
 
     info[MPMediaItemPropertyPlaybackDuration] = duration
     info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = time
@@ -182,54 +178,42 @@ class NowPlayingInfoManager {
 
     // If under "When media is opened" the "Pause" setting is enabled then playback will be
     // initially paused. For reasons unknown changing the media and not initially playing causes
-    // Now Playing to drop IINA and go back to showing the Music app. Setting playbackState to
-    // playing and immediately setting it to paused avoids Now Playing prevents this.
+    // Now Playing to drop IINA and go back to showing the Music app. Workaround this problem by
+    // setting playbackState initially to playing and then immediately set it to paused.
     if withTitle, paused {
       center.playbackState = .playing
     }
     center.playbackState = paused ? .paused : .playing
 
+    // Because showing artwork is a complex operation there is an internal setting that can be
+    // changed to disable this feature should any problems with it be discovered.
+    if Preference.bool(for: .enableNowPlayingArtwork) {
+      // If the best kind of artwork (front cover) is not being displayed then try and update
+      // to a better kind of artwork.
+      if artworkKind.need(.frontCover) {
+        updateArtwork(player, currentURL, player.info.videoTracks)
+      }
+    } else {
+      log("Showing cover artwork is disabled", level: .verbose)
+    }
+
     let suffix = """
       set elapsed playback time: \(time) rate: \(speed) state: \(center.playbackState),
       """
     if isActive {
-      log("Updated Now Playing information, \(suffix)", url, level: .verbose)
+      log("Updated Now Playing information, \(suffix)", currentURL, level: .verbose)
     } else {
       isActive = true
-      log("Started Now Playing session, \(suffix)", url)
+      log("Started Now Playing session, \(suffix)", currentURL)
     }
     RemoteCommandController.shared.enable()
   }
   
   // MARK: - Artwork
   
-  /// Abandon any existing artwork and any artwork update that is in progress.
-  ///
-  /// This method:
-  /// - Invalidates the ticket held by any background artwork update task
-  /// - Resets `artworkKind` back to `none`, to indicate artwork is needed
-  /// - Clears any pending artwork update
-  /// - Removes any existing artwork set in `nowPlayingInfo`
-  /// - Important: The `artworkUpdateInProgress` flag is intentionally not cleared to prevent multiple background
-  ///     artwork updates from running at the same time. This could happen as background work does not only occur in the
-  ///     `artworkQueue`.  [QLThumbnailGenerator](https://developer.apple.com/documentation/quicklookthumbnailing/qlthumbnailgenerator)
-  ///     has its own threads. The background work is allowed to complete and the results are then discarded due to the change in
-  ///     `artworkTicket`.
-  /// - Important: This method **must** be run on the main thread to avoid data races.
-  private func abandonArtwork() {
-    artworkTicket += 1
-    artworkKind = .none
-    artworkQLGenerationRetries = 0
-    artworkUpdatePending = false
-    artworkURL = nil
-    MPNowPlayingInfoCenter.default().nowPlayingInfo?.removeValue(
-      forKey: MPMediaItemPropertyArtwork)
-    guard artworkUpdateInProgress else { return }
-    log("Will abandon the results of the current in progress artwork update", level: .verbose)
-  }
-  
-  /// Complete the current artwork update and process any pending update.
-  /// - Important: This method **must** be run on the main thread because it references `PlayerCore.lastActive`.
+  /// Indicate the current artwork update has completed and process any pending artwork update.
+  /// - Important: This method **must** be run on the main thread because it references `PlayerCore.lastActive` and to
+  ///         avoid data races.
   private func artworkUpdateComplete() {
     artworkUpdateInProgress = false
     guard artworkUpdatePending else { return }
@@ -237,12 +221,11 @@ class NowPlayingInfoManager {
     artworkUpdatePending = false
     // If we already have the best kind of artwork there is nothing to do.
     guard artworkKind.need(.frontCover) else { return }
-    // Player could have changed, or started playing different media.
-    let player = PlayerCore.lastActive
-    guard player.info.state.active, !player.info.isNetworkResource,
-          let url = player.info.currentURL else { return }
+    // Player could have changed while artwork was being processed in the background. Make certain
+    // the current player is active. All other checks will be handled by updateInfo.
+    guard PlayerCore.lastActive.info.state.active else { return }
     log("Processing pending artwork update", level: .verbose)
-    updateArtwork(player, url, player.info.videoTracks)
+    updateInfo()
   }
   
   /// Construct an image for the artwork represented by the given video track.
@@ -274,6 +257,36 @@ class NowPlayingInfoManager {
     return image
   }
 
+  /// Discard any existing artwork and any artwork update that is in progress.
+  ///
+  /// This method:
+  /// - Invalidates the ticket held by any background artwork update task
+  /// - Resets `artworkKind` back to `none`, to indicate artwork is needed
+  /// - Clears any pending artwork update
+  /// - Discards any existing artwork set in `nowPlayingInfo`
+  /// - Important: The `artworkUpdateInProgress` flag is intentionally not cleared to prevent multiple background
+  ///     artwork updates from running at the same time. This could happen as background work does not only occur in the
+  ///     `artworkQueue`.  [QLThumbnailGenerator](https://developer.apple.com/documentation/quicklookthumbnailing/qlthumbnailgenerator)
+  ///     has its own threads. The background work is allowed to complete and the results are then discarded due to the change in
+  ///     `artworkTicket`.
+  /// - Important: This method **must** be run on the main thread to avoid data races.
+  /// - Parameter url: The URL of the media item.
+  private func discardArtwork(_ url: URL) {
+    // Because showing artwork is a complex operation there is an internal setting that can be
+    // changed to disable this feature should any problems with it be discovered.
+    guard Preference.bool(for: .enableNowPlayingArtwork) else { return }
+    // Changing artworkTicket will cause any background task to discard its work when it finishes.
+    artworkTicket += 1
+    artworkKind = .none
+    artworkQLGenerationRetries = 0
+    artworkUpdatePending = false
+    artworkLastTrackCount = 0
+    MPNowPlayingInfoCenter.default().nowPlayingInfo?.removeValue(
+      forKey: MPMediaItemPropertyArtwork)
+    guard artworkUpdateInProgress else { return }
+    log("Will discard the results of the current in progress artwork update", url, level: .verbose)
+  }
+
   /// Constructs a
   /// [MPMediaItemArtwork](https://developer.apple.com/documentation/mediaplayer/mpmediaitemartwork)
   /// object for the given image.
@@ -289,8 +302,7 @@ class NowPlayingInfoManager {
         log("Video widthxheight unknown, using image size for bounds", level: .verbose)
         return size
       }
-      // If the video size is not larger than the image size then use the image size.
-      guard Int(size.width * size.height) < width * height else {
+      guard Int(size.width * size.height) <= width * height else {
         log("Video size (\(width)x\(height)) is smaller than image, using image size for bounds",
             level: .verbose)
         return size
@@ -331,12 +343,12 @@ class NowPlayingInfoManager {
     guard center.nowPlayingInfo != nil else {
       // This is an internal error. The artworkTicket should be checked before calling this method.
       // That should prevent this method from being called when there is no session.
-      log("No active Now Playing session, discarding \(artworkKind)", url, level: .error)
+      log("No active Now Playing session, discarded \(artworkKind)", url, level: .error)
       return
     }
     guard let cgImage = image.cgImage else {
       // This should not occur.
-      log("Unable to construct a CGImage, discarding \(artworkKind)", url, level: .error)
+      log("Unable to construct a CGImage, discarded \(artworkKind)", url, level: .error)
       return
     }
     log("Found \(artworkKind)", url)
@@ -346,7 +358,7 @@ class NowPlayingInfoManager {
   
   /// Found front cover artwork.
   ///
-  /// This method will check to see if this background work has been abandoned and if not then it will display the given artwork
+  /// This method will check to see if this background work has been discarded and if not then it will display the given artwork
   /// image in Now Playing.
   /// - Parameters:
   ///   - player: The `PlayerCore` that is playing the media item.
@@ -429,8 +441,9 @@ class NowPlayingInfoManager {
         foundFrontCoverArtwork(player, url, ticket, image)
         return true
       }
+      // The media item is an image.
       guard let image = NSImage(contentsOf: url) else {
-        log("Unable to create an image from: \(url.path)", level: .error)
+        log("Unable to create an image from: \(url)", level: .error)
         continue
       }
       foundFrontCoverArtwork(player, url, ticket, image)
@@ -481,13 +494,22 @@ class NowPlayingInfoManager {
       return
     }
     artworkUpdateInProgress = true
-    artworkURL = url
+    // Copy state that can change for use by the background task.
+    let isNetworkResource = player.info.isNetworkResource
     let ticket = artworkTicket
     let tracks = player.info.videoTracks
-    artworkLastTrackCount = tracks.count
     artworkQueue.async { [self] in
       // Look for front cover artwork. If found, no need to do anything more.
       guard !searchTracksForArtwork(player, url, ticket, tracks) else { return }
+
+      // When streaming artwork can be found in video tracks either because the stream contains
+      // embedded artwork or an image to use for artwork was specified using --cover-art-files.
+      // But the other sources of artwork, Quick Look and the OSC thumbnails are not avaiable when
+      // streaming.
+      guard !isNetworkResource else {
+        DispatchQueue.main.async { self.artworkUpdateComplete() }
+        return
+      }
 
       // If we already have a Quick Look thumbnail then nothing more to do. NOTE that we are
       // reading artworkKind from a background thread and it may not represent the media item
@@ -542,7 +564,7 @@ class NowPlayingInfoManager {
       return
     }
     guard player.info.thumbnailsReady else {
-      log("OSC thumbnails are not still being generated or read from the cache", level: .verbose)
+      log("OSC thumbnails are still being generated or read from the cache", url, level: .verbose)
       return
     }
     // If we don't know the duration of the video assume it is twice the position at which
@@ -566,7 +588,7 @@ class NowPlayingInfoManager {
   }
 
   private func log(_ message: String, _ url: URL, level: Logger.Level = .debug) {
-    log(message + " for: \(url.path)", level: level)
+    log(message + " for: \(url.mpvStr)", level: level)
   }
 
   private func observe(_ name: Notification.Name, block: @escaping (Notification) -> Void) {
@@ -608,29 +630,54 @@ class NowPlayingInfoManager {
 
   private init() {
     // Because showing artwork is a complex operation there is an internal setting that can be
-    // changed to disable this feature should any problems with it be discovered.
+    // changed to disable this feature should any problems with it be discovered. No need to listen
+    // for changes to the track list if we are not seaching tracks for artwork.
     guard Preference.bool(for: .enableNowPlayingArtwork) else { return }
     observe(.iinaTracklistChanged) { [unowned self] notification in
+      // A track list change can not establish a Now Playing session. If one is not active ignore
+      // this notification. If the best kind of artwork has already been found then there is no
+      // need to search tracks for a better kind of artwork.
       guard isActive, artworkKind.need(.frontCover) else { return }
       guard let player = notification.object as? PlayerCore else {
         // This is an internal error. The notification object must be a PlayerCore.
         log("iinaTracklistChanged notification object is not a PlayerCore", level: .error)
         return
       }
-      guard player == PlayerCore.lastActive, player.info.state.active,
-            !player.info.isNetworkResource, let url = player.info.currentURL else { return }
-      let tracks = player.info.videoTracks
+      // Only the active player can own the Now Playing session, ignore track list changes for
+      // background players. If the URL does not match then that means the player is in the process
+      // of loading new media. Must wait for the player to call updateInfo when the media starts
+      // playing.
+      guard player == PlayerCore.lastActive, let currentURL = player.info.currentURL,
+            currentURL == url else { return }
       // The track list can change a lot due to subtitle tracks being loaded. Avoid trying to update
       // the artwork if the number of video tracks has not changed since the last time they were
       // searched for artwork.
-      guard  tracks.count != artworkLastTrackCount else { return }
-      updateArtwork(player, url, player.info.videoTracks)
+      let tracks = player.info.videoTracks
+      guard tracks.count != artworkLastTrackCount else { return }
+      artworkLastTrackCount = tracks.count
+      log("Processing change in number of video tracks (\(tracks.count))", currentURL)
+      updateInfo()
     }
   }
 
   deinit {
     observers.forEach {
       NotificationCenter.default.removeObserver($0)
+    }
+  }
+}
+
+// MARK: - Extensions
+
+extension MPNowPlayingPlaybackState: @retroactive CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case .unknown: return "unknown"
+    case .playing: return "playing"
+    case .paused: return "paused"
+    case .stopped: return "stopped"
+    case .interrupted: return "interrupted"
+    @unknown default: return String(self.rawValue)
     }
   }
 }

--- a/iina/NowPlayingInfoManager.swift
+++ b/iina/NowPlayingInfoManager.swift
@@ -146,7 +146,7 @@ class NowPlayingInfoManager {
       }
     }
 
-    let duration = PlayerCore.lastActive.info.videoDuration?.second ?? 0
+    let duration = activePlayer.info.videoDuration?.second ?? 0
     let time = activePlayer.info.videoPosition?.second ?? 0
     
     // When playback is paused Now Playing expects the playback rate to be set to zero. If this is
@@ -158,6 +158,7 @@ class NowPlayingInfoManager {
     info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = time
     info[MPNowPlayingInfoPropertyPlaybackRate] = speed
     info[MPNowPlayingInfoPropertyDefaultPlaybackRate] = 1
+    info[MPNowPlayingInfoPropertyAssetURL] = activePlayer.info.currentURL
 
     center.nowPlayingInfo = info
 

--- a/iina/NowPlayingInfoManager.swift
+++ b/iina/NowPlayingInfoManager.swift
@@ -31,9 +31,14 @@ class NowPlayingInfoManager {
   /// The `NowPlayingInfoManager` singleton object.
   static let shared = NowPlayingInfoManager()
 
+  /// Minimum size for artwork.
+  ///
+  /// This is the size of the space the Now Playing module provides for displaying artwork..
+  private let artworkDesiredSize = 768.0
+
   /// Portions of the work to update the artwork shown in Now Playing are performed in the background.
   private let artworkQueue: DispatchQueue = DispatchQueue(label: "com.colliderli.iina.artwork",
-                                                          qos: .background)
+                                                          qos: .utility)
 
   /// Kind of artwork being shown in Now Playing.
   @Atomic private var artworkKind: ArtworkKind = .none
@@ -208,9 +213,9 @@ class NowPlayingInfoManager {
     }
     RemoteCommandController.shared.enable()
   }
-  
+
   // MARK: - Artwork
-  
+
   /// Indicate the current artwork update has completed and process any pending artwork update.
   /// - Important: This method **must** be run on the main thread because it references `PlayerCore.lastActive` and to
   ///         avoid data races.
@@ -227,7 +232,7 @@ class NowPlayingInfoManager {
     log("Processing pending artwork update", level: .verbose)
     updateInfo()
   }
-  
+
   /// Construct an image for the artwork represented by the given video track.
   /// - Parameters:
   ///   - url: The URL of the media item.
@@ -298,16 +303,27 @@ class NowPlayingInfoManager {
     // If available, use the video size for the bounds size. Otherwise fall back to the image size.
     let size = image.size
     let boundsSize: CGSize = {
-      guard let width = player.info.videoWidth, let height = player.info.videoHeight else {
-        log("Video widthxheight unknown, using image size for bounds", level: .verbose)
+      guard size.width < artworkDesiredSize || size.height < artworkDesiredSize else {
+        // The image size is equal to or larger than size of the area the Now Playing module
+        // provides for artwork.
         return size
       }
-      guard Int(size.width * size.height) <= width * height else {
-        log("Video size (\(width)x\(height)) is smaller than image, using image size for bounds",
-            level: .verbose)
-        return size
+      // The image is smaller than the size desired by the Now Playing module. If the image's size
+      // is used for boundsSize then the Now Playing module will specify a small size for the new
+      // size of the image and will then add grey bars around the image when displaying the artwork.
+      // To avoid the grey bars our request handler below will crop and resize the image as needed,
+      // but to get Now Playing to request the full size it can handle boundsSize must be large
+      // enough. Scale up the image size.
+      let width: Double
+      let height: Double
+      if size.width > size.height {
+        height = artworkDesiredSize
+        width = height * size.aspect
+      } else {
+        width = artworkDesiredSize
+        height = width / size.aspect
       }
-      log("Artwork bounds size: \(width)x\(height)", level: .verbose)
+      log("Artwork scaled up bounds size: \(width)x\(height)", level: .verbose)
       return CGSize(width: width, height: height)
     }()
     return MPMediaItemArtwork(boundsSize: boundsSize) { [self] size in
@@ -326,7 +342,7 @@ class NowPlayingInfoManager {
       return image.nsImage.resized(newWidth: size.widthInt, newHeight: size.heightInt)
     }
   }
-  
+
   /// Display the given artwork image in Now Playing.
   ///
   /// This method constructs a [MPMediaItemArtwork](https://developer.apple.com/documentation/mediaplayer/mpmediaitemartwork)
@@ -355,7 +371,7 @@ class NowPlayingInfoManager {
     center.nowPlayingInfo?[MPMediaItemPropertyArtwork] = formMPMediaItemArtwork(player, cgImage)
     self.artworkKind = artworkKind
   }
-  
+
   /// Found front cover artwork.
   ///
   /// This method will check to see if this background work has been discarded and if not then it will display the given artwork
@@ -417,7 +433,7 @@ class NowPlayingInfoManager {
       }
     }
   }
-  
+
   /// Search the given video tracks for front cover art.
   ///
   /// Container formats such as Matroska support embedding cover art. An external file can be specified as cover art using the mpv
@@ -452,7 +468,7 @@ class NowPlayingInfoManager {
     log("Did not find front cover artwork", url, level: .verbose)
     return false
   }
-  
+
   /// Update the artwork supplied in [MPMediaItemPropertyArtwork](https://developer.apple.com/documentation/mediaplayer/mpmediaitempropertyartwork), if needed.
   ///
   /// There are 3 kinds of artwork. In order of most preferred to least preferred they are:
@@ -524,7 +540,7 @@ class NowPlayingInfoManager {
         }
         return
       }
-      
+
       // Quick Look thumbnail generation may initially fail due to thumbnail creation taking too
       // long. But because the generator caches thumbnails a following request for the same
       // thumbnail may succeed. Thus we want to retry generation requests, but limit the number
@@ -549,7 +565,7 @@ class NowPlayingInfoManager {
       generateQLThumbnail(player, url, ticket)
     }
   }
-  
+
   /// Use an On Screen Controller thumbnail for the artwork (if available).
   /// - Parameters:
   ///   - player: The `PlayerCore` that is playing the media item.

--- a/iina/NowPlayingInfoManager.swift
+++ b/iina/NowPlayingInfoManager.swift
@@ -1,0 +1,620 @@
+//
+//  NowPlayingInfoManager.swift
+//  iina
+//
+//  Created by low-batt on 5/3/25.
+//  Copyright © 2025 lhc. All rights reserved.
+//
+
+import Foundation
+import MediaPlayer
+import QuickLookThumbnailing
+
+/// Manager that supports using the macOS
+/// [Control Center](https://support.apple.com/guide/mac-help/quickly-change-settings-mchl50f94f8f/mac)
+/// Now Playing module.
+///
+/// The macOS [Control Center](https://support.apple.com/guide/mac-help/quickly-change-settings-mchl50f94f8f/mac)
+/// contains a Now Playing module. This module can also be configured to be directly accessible from the menu bar. Now Playing
+/// displays the title of the media currently  playing and other information about the state of playback. It also can be used to control
+/// playback.
+///
+/// The IINA setting `Use system media control` found on the `Key Bindings` tab of IINA's settings controls use of this
+/// macOS feature. This class handles the use of the AppKit class
+/// [MPNowPlayingInfoCenter](https://developer.apple.com/documentation/mediaplayer/mpnowplayinginfocenter)
+/// which allows IINA to populate the information shown in the Now Playing module. This class makes use of the IINA class
+/// `RemoteCommandController` to address the other aspect of [becoming a now playable app](https://developer.apple.com/documentation/mediaplayer/becoming-a-now-playable-app)], handling
+/// remote commands.
+/// - Important: As IINA is assuming control over a shared macOS feature it is critical that IINA releases control when no media is
+///     open. See issue [#4331](https://github.com/iina/iina/issues/4331).
+class NowPlayingInfoManager {
+  /// The `NowPlayingInfoManager` singleton object.
+  static let shared = NowPlayingInfoManager()
+
+  /// Portions of the work to update the artwork shown in Now Playing are performed in the background.
+  private let artworkQueue: DispatchQueue = DispatchQueue(label: "com.colliderli.iina.artwork",
+                                                          qos: .background)
+
+  /// Kind of artwork being shown in Now Playing.
+  @Atomic private var artworkKind: ArtworkKind = .none
+
+  /// The number of video tracks the last time the tracks were searched for artwork.
+  private var artworkLastTrackCount = 0
+  
+  /// Maximum number of times to request  [QLThumbnailGenerator](https://developer.apple.com/documentation/quicklookthumbnailing/qlthumbnailgenerator)
+  /// generate a thumbnail for the current media item.
+  private let artworkQLGenerationMaxRetries = 3
+
+  /// Number of times IINA has requested  [QLThumbnailGenerator](https://developer.apple.com/documentation/quicklookthumbnailing/qlthumbnailgenerator)
+  /// generate a thumbnail for the current media item.
+  private var artworkQLGenerationRetries = 0
+  
+  /// Ticket used to coordinate with background tasks performing work to update the artwork shown by Now Playing.
+  private var artworkTicket = 0
+  
+  /// Whether work is currently being performed in the background to update the artwork shown by Now Playing.
+  private var artworkUpdateInProgress = false
+
+  /// Whether a request to update the artwork came in while an artwork update was being performed in the background.
+  private var artworkUpdatePending = false
+
+  /// The URL of the media item whose artwork could be being shown in Now Playing.
+  private var artworkURL: URL?
+  
+  /// Whether a Now Playing session is active.
+  private var isActive = false
+  
+  /// Established notification observers.
+  private var observers: [NSObjectProtocol] = []
+
+  /// Playback position to obtain an On Screen Controller thumbnail at.
+  ///
+  /// This matches the default playback position used by
+  /// [QuickLook Video](https://github.com/Marginal/QLVideo/tree/master) for creating thumbnails.
+  private let oscThumbnailPosition = 60.0
+
+  /// Size of thumbnail to request [QLThumbnailGenerator](https://developer.apple.com/documentation/quicklookthumbnailing/qlthumbnailgenerator)
+  /// generate.
+  ///
+  /// This matches the size mpv uses. Using sizes larger than this can cause `QLThumbnailGenerator` to fail.
+  private let qlThumbnailSize = CGSize(width: 2000, height: 2000)
+
+  /// Update the information shown by macOS in the
+  /// [Control Center](https://support.apple.com/guide/mac-help/quickly-change-settings-mchl50f94f8f/mac)
+  /// Now Playing module.
+  /// - Important: This method **must** be run on the main thread because it references `PlayerCore.lastActive`.
+  func updateInfo(withTitle: Bool = false) {
+    guard RemoteCommandController.useSystemMediaControl else { return }
+    
+    let center = MPNowPlayingInfoCenter.default()
+    let activePlayer = PlayerCore.lastActive
+    guard activePlayer.info.state.active else {
+      if isActive {
+        RemoteCommandController.shared.disable()
+        abandonArtwork()
+        center.nowPlayingInfo = nil
+        center.playbackState = .stopped
+        isActive = false
+        log("Ended Now Playing session")
+      }
+      return
+    }
+    
+    // Because showing artwork is a complex operation there is an internal setting that can be
+    // changed to disable this feature should any problems with it be discovered.
+    if Preference.bool(for: .enableNowPlayingArtwork) {
+      // If the media item has changed then if artwork is being displayed it needs to be abandoned.
+      // NOTE this MUST be done before copying the nowPlayingInfo array below as abandonArtwork
+      // works directly on nowPlayingInfo.
+      if activePlayer.info.isNetworkResource {
+        abandonArtwork()
+      }
+      if let url = activePlayer.info.currentURL {
+        if url != artworkURL {
+          if artworkURL != nil {
+            log("Abandoning artwork due to media item changing", level: .verbose)
+          }
+          abandonArtwork()
+          artworkURL = url
+        }
+      } else {
+        abandonArtwork()
+      }
+      // If the best kind of artwork (front cover) is not being displayed then try and update
+      // to a better kind of artwork.
+      if artworkKind.need(.frontCover), !activePlayer.info.isNetworkResource,
+         let url = activePlayer.info.currentURL {
+        updateArtwork(activePlayer, url, activePlayer.info.videoTracks)
+      }
+    } else {
+      log("Showing cover artwork is disabled", level: .verbose)
+    }
+    
+    var info = center.nowPlayingInfo ?? [String: Any]()
+    if withTitle {
+      if activePlayer.currentMediaIsAudio == .isAudio {
+        info[MPNowPlayingInfoPropertyMediaType] = MPNowPlayingInfoMediaType.audio.rawValue
+        let (title, album, artist) = activePlayer.getMusicMetadata()
+        info[MPMediaItemPropertyTitle] = title
+        info[MPMediaItemPropertyAlbumTitle] = album
+        info[MPMediaItemPropertyArtist] = artist
+      } else {
+        info[MPNowPlayingInfoPropertyMediaType] = MPNowPlayingInfoMediaType.video.rawValue
+        info[MPMediaItemPropertyTitle] = activePlayer.getMediaTitle(withExtension: false)
+        info.removeValue(forKey: MPMediaItemPropertyAlbumTitle)
+        info.removeValue(forKey: MPMediaItemPropertyArtist)
+      }
+    }
+
+    let duration = PlayerCore.lastActive.info.videoDuration?.second ?? 0
+    let time = activePlayer.info.videoPosition?.second ?? 0
+    
+    // When playback is paused Now Playing expects the playback rate to be set to zero. If this is
+    // not done the slider in Now Playing may incorrectly display a playback time of zero.
+    let paused = activePlayer.info.state == .paused
+    let speed = paused ? 0 : activePlayer.info.playSpeed
+
+    info[MPMediaItemPropertyPlaybackDuration] = duration
+    info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = time
+    info[MPNowPlayingInfoPropertyPlaybackRate] = speed
+    info[MPNowPlayingInfoPropertyDefaultPlaybackRate] = 1
+
+    center.nowPlayingInfo = info
+
+    // If under "When media is opened" the "Pause" setting is enabled then playback will be
+    // initially paused. For reasons unknown changing the media and not initially playing causes
+    // Now Playing to drop IINA and go back to showing the Music app. Setting playbackState to
+    // playing and immediately setting it to paused avoids Now Playing prevents this.
+    if withTitle, paused {
+      center.playbackState = .playing
+    }
+    center.playbackState = paused ? .paused : .playing
+
+    let suffix = """
+      elapsed playback time: \(time) rate: \(speed) state: \(center.playbackState)
+      """
+    if isActive {
+      log("Updated Now Playing information, \(suffix)", level: .verbose)
+    } else {
+      isActive = true
+      log("Started Now Playing session, \(suffix)")
+    }
+    RemoteCommandController.shared.enable()
+  }
+  
+  // MARK: - Artwork
+  
+  /// Abandon any existing artwork and any artwork update that is in progress.
+  ///
+  /// This method:
+  /// - Invalidates the ticket held by any background artwork update task
+  /// - Resets `artworkKind` back to `none`, to indicate artwork is needed
+  /// - Clears any pending artwork update
+  /// - Removes any existing artwork set in `nowPlayingInfo`
+  /// - Important: The `artworkUpdateInProgress` flag is intentionally not cleared to prevent multiple background
+  ///     artwork updates from running at the same time. This could happen as background work does not only occur in the
+  ///     `artworkQueue`.  [QLThumbnailGenerator](https://developer.apple.com/documentation/quicklookthumbnailing/qlthumbnailgenerator)
+  ///     has its own threads. The background work is allowed to complete and the results are then discarded due to the change in
+  ///     `artworkTicket`.
+  /// - Important: This method **must** be run on the main thread to avoid data races.
+  private func abandonArtwork() {
+    artworkTicket += 1
+    artworkKind = .none
+    artworkUpdatePending = false
+    artworkURL = nil
+    MPNowPlayingInfoCenter.default().nowPlayingInfo?.removeValue(
+      forKey: MPMediaItemPropertyArtwork)
+    guard artworkUpdateInProgress else { return }
+    log("Will abandon the results of the current in progress artwork update", level: .verbose)
+  }
+  
+  /// Complete the current artwork update and process any pending update.
+  /// - Important: This method **must** be run on the main thread because it references `PlayerCore.lastActive`.
+  private func artworkUpdateComplete() {
+    artworkUpdateInProgress = false
+    guard artworkUpdatePending else { return }
+    // An artwork update was requested while one was being processed in a background task.
+    artworkUpdatePending = false
+    // If we already have the best kind of artwork there is nothing to do.
+    guard artworkKind.need(.frontCover) else { return }
+    // Player could have changed, or started playing different media.
+    let player = PlayerCore.lastActive
+    guard player.info.state.active, !player.info.isNetworkResource,
+          let url = player.info.currentURL else { return }
+    log("Processing pending artwork update", level: .verbose)
+    updateArtwork(player, url, player.info.videoTracks)
+  }
+  
+  /// Construct an image for the artwork represented by the given video track.
+  /// - Parameters:
+  ///   - url: The URL of the media item.
+  ///   - track: Video track representing the image.
+  /// - Returns: The image or `nil` if the image could not be constructed.
+  private func constructImage(_ url: URL, _ track: MPVTrack) -> NSImage? {
+    guard track.isExternal else {
+      // The album art is embedded in the track. At this time there is not an API to obtain the
+      // image from mpv. Read the artwork from the file.
+      guard let image = FFmpegController.readArtwork(from: url) else {
+        // If this happens it means mpv has different criteria for what it considers cover art.
+        log("Embedded front cover artwork not found", url, level: .warning)
+        return nil
+      }
+      return image
+    }
+    // The album art is an external file.
+    guard let filename = track.externalFilename else {
+      // Internal error. This should not occur.
+      log("External artwork track is missing external-filename", level: .error)
+      return nil
+    }
+    guard let image = NSImage(contentsOfFile: filename) else {
+      log("Unable to create an image for external artwork file: \(filename)", level: .error)
+      return nil
+    }
+    return image
+  }
+
+  /// Constructs a
+  /// [MPMediaItemArtwork](https://developer.apple.com/documentation/mediaplayer/mpmediaitemartwork)
+  /// object for the given image.
+  /// - Parameters:
+  ///   - player: The `PlayerCore` for which to find artwork for.
+  ///   - image: Artwork image for the media item.
+  /// - Returns: The constructed `MPMediaItemArtwork` object.
+  private func formMPMediaItemArtwork(_ player: PlayerCore, _ image: CGImage) -> MPMediaItemArtwork {
+    // If available, use the video size for the bounds size. Otherwise fall back to the image size.
+    let size = image.size
+    let boundsSize: CGSize = {
+      guard let width = player.info.videoWidth, let height = player.info.videoHeight else {
+        log("Video widthxheight unknown, using image size for bounds", level: .verbose)
+        return size
+      }
+      // If the video size is not larger than the image size then use the image size.
+      guard Int(size.width * size.height) < width * height else {
+        log("Video size (\(width)x\(height)) is smaller than image, using image size for bounds",
+            level: .verbose)
+        return size
+      }
+      log("Artwork bounds size: \(width)x\(height)", level: .verbose)
+      return CGSize(width: width, height: height)
+    }()
+    return MPMediaItemArtwork(boundsSize: boundsSize) { [self] size in
+      // Crop to aspect ratio of requested size, rather than stretching/squeezing. Then resize.
+      let cropRect = image.size.getCropRect(withAspect: size.aspect)
+      let suffix = """
+        \(Int(image.width))x\(Int(image.height)) artwork image \
+        to \(Int(size.width))x\(Int(size.height))
+        """
+      if let artwork = image.cropping(to: cropRect)?.resized(newWidth: size.widthInt,
+                                                             newHeight: size.heightInt).nsImage {
+        log("Cropped and resized \(suffix)", level: .verbose)
+        return artwork
+      }
+      log("Unable to crop \(suffix)", level: .warning)
+      return image.nsImage.resized(newWidth: size.widthInt, newHeight: size.heightInt)
+    }
+  }
+  
+  /// Display the given artwork image in Now Playing.
+  ///
+  /// This method constructs a [MPMediaItemArtwork](https://developer.apple.com/documentation/mediaplayer/mpmediaitemartwork)
+  /// object and sets [MPMediaItemPropertyArtwork](https://developer.apple.com/documentation/mediaplayer/mpmediaitempropertyartwork)
+  /// in [nowPlayingInfo](https://developer.apple.com/documentation/mediaplayer/mpnowplayinginfocenter/nowplayinginfo).
+  /// - Parameters:
+  ///   - player: The `PlayerCore` that is playing the media item.
+  ///   - url: The URL of the media item.
+  ///   - image: The artwork image.
+  ///   - artworkKind: The kind of artwork being displayed (front cover, Quick Look thumbnail, etc.).
+  private func foundArtwork(_ player: PlayerCore, _ url: URL, _ image: NSImage,
+                            _ artworkKind: ArtworkKind) {
+    let center = MPNowPlayingInfoCenter.default()
+    guard center.nowPlayingInfo != nil else {
+      // This is an internal error. The artworkTicket should be checked before calling this method.
+      // That should prevent this method from being called when there is no session.
+      log("No active Now Playing session, discarding \(artworkKind)", url, level: .error)
+      return
+    }
+    guard let cgImage = image.cgImage else {
+      // This should not occur.
+      log("Unable to construct a CGImage, discarding \(artworkKind)", url, level: .error)
+      return
+    }
+    log("Found \(artworkKind)", url)
+    center.nowPlayingInfo?[MPMediaItemPropertyArtwork] = formMPMediaItemArtwork(player, cgImage)
+    self.artworkKind = artworkKind
+  }
+  
+  /// Found front cover artwork.
+  ///
+  /// This method will check to see if this background work has been abandoned and if not then it will display the given artwork
+  /// image in Now Playing.
+  /// - Parameters:
+  ///   - player: The `PlayerCore` that is playing the media item.
+  ///   - url: The URL of the media item.
+  ///   - ticket: Value of `artworkTicket` when this update was initiated.
+  ///   - image: The artwork image.
+  private func foundFrontCoverArtwork(_ player: PlayerCore, _ url: URL, _ ticket: Int,
+                                      _ image: NSImage) {
+    // Must run this on the main thread to properly coordinate background work.
+    DispatchQueue.main.async { [self] in
+      defer { artworkUpdateComplete() }
+      guard artworkTicket == ticket else {
+        log("Discarded stale \(ArtworkKind.frontCover)", url, level: .verbose)
+        return
+      }
+      foundArtwork(player, url, image, .frontCover)
+    }
+  }
+
+  /// Generate a Quick Look thumbnail to use as artwork.
+  ///
+  /// This method requests
+  /// [QLThumbnailGenerator](https://developer.apple.com/documentation/quicklookthumbnailing/qlthumbnailgenerator)
+  /// generate a thumbnail. Generation occurs in the background and a handler is called upon completion. Generation may not be
+  /// successful as by default `QLThumbnailGenerator` does not support many of the media files IINA does. The Quick Look
+  /// system supports thumbnail extensions. If a user has installed [QuickLook Video](https://github.com/Marginal/QLVideo/tree/master)
+  /// `QLThumbnailGenerator` will be able to generate thumbnails for most types of video files.
+  /// - Parameters:
+  ///   - player: The `PlayerCore` that is playing the media item.
+  ///   - url: The URL of the media item.
+  ///   - ticket: Value of `artworkTicket` when this update was initiated.
+  private func generateQLThumbnail(_ player: PlayerCore, _ url: URL, _ ticket: Int) {
+    log("Requesting QLThumbnailGenerator generate a thumbnail", url, level: .verbose)
+    // Because the artwork display in Now Playing is so tiny a low quality thumbnail is sufficient.
+    let request = QLThumbnailGenerator.Request(fileAt: url, size: qlThumbnailSize, scale: 1,
+                                               representationTypes: .lowQualityThumbnail)
+    QLThumbnailGenerator.shared.generateBestRepresentation(for: request) { thumbnail, error in
+      DispatchQueue.main.async { [self] in
+        defer { artworkUpdateComplete() }
+        guard artworkTicket == ticket else {
+          log("Discarded stale QLThumbnailGenerator results", url, level: .verbose)
+          return
+        }
+        if let error {
+          // This is intentionally not logged as an error because by default the generator does not
+          // support many of the media files IINA does, so failures are expected.
+          log("QLThumbnailGenerator failed: \(error)", level: .verbose)
+        }
+        guard let image = thumbnail?.nsImage else {
+          log("QLThumbnailGenerator did not generate a thumbnail", url, level: .verbose)
+          // Fall back to using an OSC thumbnail for the artwork.
+          useOSCThumbnail(player, url)
+          return
+        }
+        foundArtwork(player, url, image, .qlThumbnail)
+      }
+    }
+  }
+  
+  /// Search the given video tracks for front cover art.
+  ///
+  /// Container formats such as Matroska support embedding cover art. An external file can be specified as cover art using the mpv
+  /// option [cover-art-files](https://mpv.io/manual/stable/#options-cover-art-files). If the media being "played" is
+  /// an image file then it will be used as the artwork.
+  /// - Parameters:
+  ///   - player: The `PlayerCore` that is playing the media item.
+  ///   - url: The URL of the media item.
+  ///   - ticket: Value of `artworkTicket` when this update was initiated.
+  ///   - tracks: Video tracks to search.
+  /// - Returns: `True` if artwork was found; `false` otherwise.
+  private func searchTracksForArtwork(_ player: PlayerCore, _ url: URL, _ ticket: Int,
+                                      _ tracks: [MPVTrack]) -> Bool {
+    guard !tracks.isEmpty else { return false }
+    log("Searching \(tracks.count) tracks for front cover artwork", url, level: .verbose)
+    for track in tracks {
+      // Only interested in tracks representing an image.
+      guard track.isImage else { continue }
+      if track.isAlbumart {
+        guard let image = constructImage(url, track) else { continue }
+        foundFrontCoverArtwork(player, url, ticket, image)
+        return true
+      }
+      guard let image = NSImage(contentsOf: url) else {
+        log("Unable to create an image from: \(url.path)", level: .error)
+        continue
+      }
+      foundFrontCoverArtwork(player, url, ticket, image)
+      return true
+    }
+    log("Did not find front cover artwork", url, level: .verbose)
+    return false
+  }
+  
+  /// Update the artwork supplied in [MPMediaItemPropertyArtwork](https://developer.apple.com/documentation/mediaplayer/mpmediaitempropertyartwork), if needed.
+  ///
+  /// There are 3 kinds of artwork. In order of most preferred to least preferred they are:
+  /// - Front cover artwork
+  /// - Quick Look thumbnail
+  /// - On Screen Controller thumbnail
+  ///
+  /// What kind of artwork is available can change over time as the media item is being loaded:
+  /// - Front cover artwork will not be available until mpv has populated the video track
+  /// - Quick Look thumbnail is generated asynchronously and may not be available on the first request
+  /// - On Screen Controller thumbnail will not be available until IINA has generated thumbnails
+  ///
+  /// The best artwork available at the time of this update will be used. A future call to this method may upgrade the artwork if a
+  /// better kind of artwork becomes available.
+  ///
+  /// There may not be any artwork available for the media item:
+  /// - Front cover artwork may not have been supplied
+  /// - Quick Look thumbnail may be missing because by default Quick Look does not support all the types of media IINA does
+  /// - On Screen Controller thumbnail may be missing because the user disabled the `Enable thumbnail preview` setting
+  ///
+  /// When `MPMediaItemPropertyArtwork` is not supplied the Now Playing module will use IINA's app icon.
+  ///
+  /// Longer operations are performed in the background using `artworkQueue` or by [QLThumbnailGenerator](https://developer.apple.com/documentation/quicklookthumbnailing/qlthumbnailgenerator)
+  /// using its own threads. The main thread is used for coordination with the background work.
+  /// - Parameters:
+  ///   - player: The `PlayerCore` that is playing the media item.
+  ///   - url: The URL of the media item.
+  ///   - tracks: The current list of video tracks.
+  private func updateArtwork(_ player: PlayerCore, _ url: URL, _ tracks: [MPVTrack]) {
+    guard !artworkUpdateInProgress else {
+      // An artwork update is currently in progress in the background. Something could have
+      // changed, such as a video track being added, or OSC thumbnails becoming available that
+      // could change the artwork selection. Do not allow concurrent processing. Remember an
+      // updated is pending and process it once the current update has completed.
+      if !artworkUpdatePending {
+        log("Artwork update pending", level: .verbose)
+      }
+      artworkUpdatePending = true
+      return
+    }
+    artworkUpdateInProgress = true
+    artworkURL = url
+    let ticket = artworkTicket
+    let tracks = player.info.videoTracks
+    artworkLastTrackCount = tracks.count
+    artworkQueue.async { [self] in
+      // Look for front cover artwork. If found, no need to do anything more.
+      guard !searchTracksForArtwork(player, url, ticket, tracks) else { return }
+
+      // If we already have a Quick Look thumbnail then nothing more to do. NOTE that we are
+      // reading artworkKind from a background thread and it may not represent the media item
+      // currently being processed in artworkQueue and could change at any point in time. This
+      // is not a problem has actions are coordinated using the ticket once running on the main
+      // thread.
+      guard artworkKind.need(.qlThumbnail) else {
+        DispatchQueue.main.async { [self] in
+          defer { artworkUpdateComplete() }
+          guard artworkTicket == ticket else { return }
+          log("Already using a Quick Look thumbnail for artwork", url, level: .verbose)
+        }
+        return
+      }
+      
+      // Quick Look thumbnail generation may initially fail due to thumbnail creation taking too
+      // long. But because the generator caches thumbnails a following request for the same
+      // thumbnail may succeed. Thus we want to retry generation requests, but limit the number
+      // of retries as the generator may be failing due to it not supporting the kind of media.
+      if artworkQLGenerationRetries == artworkQLGenerationMaxRetries {
+        log("Maximum number of Quick Look thumbnail generation attempts reached", level: .verbose)
+      }
+      artworkQLGenerationRetries += 1
+      guard artworkQLGenerationRetries <= artworkQLGenerationMaxRetries else {
+        // Skip Quick Look generation and fall back to using an OSC thumbnail for the artwork.
+        DispatchQueue.main.async { [self] in
+          defer { artworkUpdateComplete() }
+          guard artworkTicket == ticket else { return }
+          useOSCThumbnail(player, url)
+        }
+        return
+      }
+
+      // Try and generate a Quick Look thumbnail. Because QLThumbnailGenerator generates thumbnails
+      // in the background and then calls a completion handler, the fallback to an OSC thumbnail
+      // is handled in generateQLThumbnail.
+      generateQLThumbnail(player, url, ticket)
+    }
+  }
+  
+  /// Use an On Screen Controller thumbnail for the artwork (if available).
+  /// - Parameters:
+  ///   - player: The `PlayerCore` that is playing the media item.
+  ///   - url: The URL of the media item.
+  private func useOSCThumbnail(_ player: PlayerCore, _ url: URL) {
+    guard artworkKind.need(.oscThumbnail) else {
+      log("Already using an OSC thumbnail for artwork", url, level: .verbose)
+       return
+    }
+    guard Preference.bool(for: .enableThumbnailPreview) else {
+      log("OSC thumbnail previews are disabled", level: .verbose)
+      return
+    }
+    guard player.info.thumbnailsReady else {
+      log("OSC thumbnails are not still being generated or read from the cache", level: .verbose)
+      return
+    }
+    // If we don't know the duration of the video assume it is twice the position at which
+    // we would like to obtain a thumbnail.
+    let twice = 2 * oscThumbnailPosition
+    let duration = player.info.videoDuration ?? VideoTime(twice)
+    // If the video is short then obtain a thumbnail at the midpoint of the video. This somewhat
+    // matches up with how QuickLook Video selects the position at which to create a thumbnail.
+    let position = duration.second < twice ? duration.second / 2 : oscThumbnailPosition
+    guard let thumbnail = player.info.getThumbnail(forSecond: position)?.image else {
+      log("Did not find an OSC thumbnail at \(position)", url, level: .verbose)
+      return
+    }
+    foundArtwork(player, url, thumbnail, .oscThumbnail)
+  }
+
+  // MARK: - Utils
+
+  private func log(_ message: String, level: Logger.Level = .debug) {
+    Logger.log(message, level: level, subsystem: Logger.Sub.nowPlaying)
+  }
+
+  private func log(_ message: String, _ url: URL, level: Logger.Level = .debug) {
+    log(message + " for: \(url.path)", level: level)
+  }
+
+  private func observe(_ name: Notification.Name, block: @escaping (Notification) -> Void) {
+    observers.append(NotificationCenter.default.addObserver(forName: name, object: nil,
+                                                            queue: .main, using: block))
+  }
+
+  // MARK: - Artwork Kinds
+
+  /// The various kinds  of artwork for a media item.
+  ///
+  /// There are 3 kinds of artwork. In order of most preferred to least preferred they are:
+  /// - Front cover artwork
+  /// - Quick Look thumbnail
+  /// - On Screen Controller thumbnail
+  enum ArtworkKind: Int, CustomStringConvertible {
+    case none
+    case oscThumbnail
+    case qlThumbnail
+    case frontCover
+
+    /// Description of the artwork kind for use in log messages.
+    var description: String {
+      switch self {
+      case .none: return "none"
+      case .oscThumbnail: return "OSC thumbnail"
+      case .qlThumbnail: return "Quick Look thumbnail"
+      case .frontCover: return "front cover artwork"
+      }
+    }
+
+    /// Determine if the given kind of artwork is preferred over this kind.
+    /// - Parameter kind: The kind of artwork to compare to this kind.
+    /// - Returns: `True` if the given artwork kind is needed; `false` otherwise.
+    @inlinable func need(_ kind: ArtworkKind) -> Bool { self.rawValue < kind.rawValue }
+  }
+
+  // MARK: - Initializer
+
+  private init() {
+    // Because showing artwork is a complex operation there is an internal setting that can be
+    // changed to disable this feature should any problems with it be discovered.
+    guard Preference.bool(for: .enableNowPlayingArtwork) else { return }
+    observe(.iinaTracklistChanged) { [unowned self] notification in
+      guard isActive, artworkKind.need(.frontCover) else { return }
+      guard let player = notification.object as? PlayerCore else {
+        // This is an internal error. The notification object must be a PlayerCore.
+        log("iinaTracklistChanged notification object is not a PlayerCore", level: .error)
+        return
+      }
+      guard player == PlayerCore.lastActive, player.info.state.active,
+            !player.info.isNetworkResource, let url = player.info.currentURL else { return }
+      let tracks = player.info.videoTracks
+      // The track list can change a lot due to subtitle tracks being loaded. Avoid trying to update
+      // the artwork if the number of video tracks has not changed since the last time they were
+      // searched for artwork.
+      guard  tracks.count != artworkLastTrackCount else { return }
+      updateArtwork(player, url, player.info.videoTracks)
+    }
+  }
+
+  deinit {
+    observers.forEach {
+      NotificationCenter.default.removeObserver($0)
+    }
+  }
+}
+
+extension Logger.Sub {
+  static let nowPlaying = Logger.makeSubsystem("now-playing")
+}

--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -61,7 +61,7 @@ class PlaybackInfo {
       case .playing:
         PlayerCore.checkStatusForSleep()
         if player == PlayerCore.lastActive {
-          NowPlayingInfoManager.shared.updateInfo(state: .playing)
+          NowPlayingInfoManager.shared.updateInfo()
           if player.mainWindow.pipStatus == .inPIP {
             player.mainWindow.pip.playing = true
           }
@@ -69,7 +69,7 @@ class PlaybackInfo {
       case .paused:
         PlayerCore.checkStatusForSleep()
         if player == PlayerCore.lastActive {
-          NowPlayingInfoManager.shared.updateInfo(state: .paused)
+          NowPlayingInfoManager.shared.updateInfo()
           if player.mainWindow.pipStatus == .inPIP {
             player.mainWindow.pip.playing = false
           }

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -465,6 +465,15 @@ class PlayerCore: NSObject {
     log("Opening \(path) in main window")
     info.currentURL = url
     info.isNetworkResource = isNetwork
+    info.audioTracks = []
+    info.chapters.removeAll()
+    info.playlist.removeAll()
+    info.subTracks = []
+    info.thumbnails = []
+    info.thumbnailsReady = false
+    info.videoDuration = nil
+    info.videoPosition = nil
+    info.videoTracks = []
     if isNetwork {
       AppDelegate.shared.openURLWindow.showLoadingScreen(playerCore: self)
     }

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -466,14 +466,16 @@ class PlayerCore: NSObject {
     info.currentURL = url
     info.isNetworkResource = isNetwork
     info.audioTracks = []
-    info.chapters.removeAll()
-    info.playlist.removeAll()
+    info.chapters = []
+    info.playlist = []
     info.subTracks = []
     info.thumbnails = []
     info.thumbnailsReady = false
     info.videoDuration = nil
+    info.videoHeight = nil
     info.videoPosition = nil
     info.videoTracks = []
+    info.videoWidth = nil
     if isNetwork {
       AppDelegate.shared.openURLWindow.showLoadingScreen(playerCore: self)
     }

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -7,7 +7,6 @@
 //
 
 import Cocoa
-import MediaPlayer
 
 class PlayerCore: NSObject {
 
@@ -1849,7 +1848,7 @@ class PlayerCore: NSObject {
       }
     }
 
-    NowPlayingInfoManager.shared.updateInfo(state: .playing, withTitle: true)
+    NowPlayingInfoManager.shared.updateInfo(withTitle: true)
 
     // Auto load
     $backgroundQueueTicket.withLock { $0 += 1 }
@@ -2073,6 +2072,9 @@ class PlayerCore: NSObject {
     guard mainWindow.loaded, info.state.loaded else { return }
     if (info.state == .paused) != paused {
       sendOSD(paused ? .pause : .resume)
+      // The NowPlayingInfoManager is notified when playback is paused or resumed. The video
+      // position must be updated before notifying the manager.
+      syncUITime()
       info.state = paused ? .paused : .playing
       refreshSyncUITimer()
       // Follow energy efficiency best practices and ensure IINA is absolutely idle when the video
@@ -2525,6 +2527,9 @@ class PlayerCore: NSObject {
             self.info.thumbnailsReady = true
             self.info.thumbnailsProgress = 1
             self.refreshTouchBarSlider()
+            // OSC thumbnails may be used in Now Playing. Notify the manager thumbnails are now
+            // available.
+            DispatchQueue.main.async { NowPlayingInfoManager.shared.updateInfo() }
           } else {
             self.log("Cannot read thumbnail from cache", level: .error)
           }
@@ -2567,6 +2572,7 @@ class PlayerCore: NSObject {
                              type: MPVTrack.TrackType(rawValue: trackType)!,
                              isDefault: mpv.getFlag(MPVProperty.trackListNDefault(index)),
                              isForced: mpv.getFlag(MPVProperty.trackListNForced(index)),
+                             isImage: mpv.getFlag(MPVProperty.trackListNImage(index)),
                              isSelected: mpv.getFlag(MPVProperty.trackListNSelected(index)),
                              isExternal: mpv.getFlag(MPVProperty.trackListNExternal(index)))
         track.srcId = mpv.getInt(MPVProperty.trackListNSrcId(index))
@@ -2875,6 +2881,8 @@ extension PlayerCore: FFmpegControllerDelegate {
       info.thumbnailsReady = true
       info.thumbnailsProgress = 1
       refreshTouchBarSlider()
+      // OSC thumbnails may be used in Now Playing. Notify the manager thumbnails are now available.
+      DispatchQueue.main.async { NowPlayingInfoManager.shared.updateInfo() }
       if let cacheName = info.mpvMd5 {
         backgroundQueue.async {
           ThumbnailCache.write(self.info.thumbnails, forName: cacheName, forVideo: self.info.currentURL)
@@ -2883,97 +2891,4 @@ extension PlayerCore: FFmpegControllerDelegate {
       events.emit(.thumbnailsReady)
     }
   }
-}
-
-/// Manager that supports using the macOS
-/// [Control Center](https://support.apple.com/guide/mac-help/quickly-change-settings-mchl50f94f8f/mac)
-/// Now Playing module.
-///
-/// The macOS [Control Center](https://support.apple.com/guide/mac-help/quickly-change-settings-mchl50f94f8f/mac)
-/// contains a Now Playing module. This module can also be configured to be directly accessible from the menu bar. Now Playing
-/// displays the title of the media currently  playing and other information about the state of playback. It also can be used to control
-/// playback.
-///
-/// The IINA setting `Use system media control` found on the `Key Bindings` tab of IINA's settings controls use of this
-/// macOS feature. This class handles the use of the AppKit class
-/// [MPNowPlayingInfoCenter](https://developer.apple.com/documentation/mediaplayer/mpnowplayinginfocenter)
-/// which allows IINA to populate the information shown in the Now Playing module. This class makes use of the IINA class
-/// `RemoteCommandController` to address the other aspect of [becoming a now playable app](https://developer.apple.com/documentation/mediaplayer/becoming-a-now-playable-app)], handling
-/// remote commands.
-/// - Important: As IINA is assuming control over a shared macOS feature it is critical that IINA releases control when no media is
-///     open. See issue [#4331](https://github.com/iina/iina/issues/4331).
-class NowPlayingInfoManager {
-  /// The `NowPlayingInfoManager` singleton object.
-  static let shared = NowPlayingInfoManager()
-
-  /// Whether a Now Playing session is active.
-  private var isActive = false
-
-  /// Update the information shown by macOS in the
-  /// [Control Center](https://support.apple.com/guide/mac-help/quickly-change-settings-mchl50f94f8f/mac)
-  /// Now Playing module.
-  /// - Important: This method **must** be run on the main thread because it references `PlayerCore.lastActive`.
-  func updateInfo(state: MPNowPlayingPlaybackState? = nil, withTitle: Bool = false) {
-    guard RemoteCommandController.useSystemMediaControl else { return }
-    let center = MPNowPlayingInfoCenter.default()
-    var info = center.nowPlayingInfo ?? [String: Any]()
-
-    let activePlayer = PlayerCore.lastActive
-    guard activePlayer.info.state.active else {
-      RemoteCommandController.shared.disable()
-      center.nowPlayingInfo = nil
-      center.playbackState = .stopped
-      isActive = false
-      log("Ended Now Playing session")
-      return
-    }
-    if withTitle {
-      if activePlayer.currentMediaIsAudio == .isAudio {
-        info[MPNowPlayingInfoPropertyMediaType] = MPNowPlayingInfoMediaType.audio.rawValue
-        let (title, album, artist) = activePlayer.getMusicMetadata()
-        info[MPMediaItemPropertyTitle] = title
-        info[MPMediaItemPropertyAlbumTitle] = album
-        info[MPMediaItemPropertyArtist] = artist
-      } else {
-        info[MPNowPlayingInfoPropertyMediaType] = MPNowPlayingInfoMediaType.video.rawValue
-        info[MPMediaItemPropertyTitle] = activePlayer.getMediaTitle(withExtension: false)
-        info[MPMediaItemPropertyAlbumTitle] = ""
-        info[MPMediaItemPropertyArtist] = ""
-      }
-    }
-
-    let duration = PlayerCore.lastActive.info.videoDuration?.second ?? 0
-    let time = activePlayer.info.videoPosition?.second ?? 0
-    let speed = activePlayer.info.playSpeed
-
-    info[MPMediaItemPropertyPlaybackDuration] = duration
-    info[MPNowPlayingInfoPropertyElapsedPlaybackTime] = time
-    info[MPNowPlayingInfoPropertyPlaybackRate] = speed
-    info[MPNowPlayingInfoPropertyDefaultPlaybackRate] = 1
-
-    center.nowPlayingInfo = info
-
-    if state != nil {
-      center.playbackState = state!
-    }
-    if isActive {
-      log("Updated Now Playing information", level: .verbose)
-    } else {
-      isActive = true
-      log("Started Now Playing session")
-    }
-    RemoteCommandController.shared.enable()
-  }
-
-  // MARK: - Private Functions
-
-  private func log(_ message: String, level: Logger.Level = .debug) {
-    Logger.log(message, level: level, subsystem: Logger.Sub.nowPlaying)
-  }
-
-  private init() {}
-}
-
-extension Logger.Sub {
-  static let nowPlaying = Logger.makeSubsystem("now-playing")
 }

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -328,6 +328,10 @@ struct Preference {
     /// To confirm this the workaround is being disabled by default using this preference. Should all go well this workaround will be
     /// removed in the future.
     static let enableHdrWorkaround = Key("enableHdrWorkaround")
+
+    /// Internal setting to allow disabling the new feature that shows cover artwork in the Now Playing module in case a serious
+    /// problem is encountered.
+    static let enableNowPlayingArtwork = Key("enableNowPlayingArtwork")
   }
 
   // MARK: - Enums
@@ -963,7 +967,8 @@ struct Preference {
     .recentDocuments: [Any](),
 
     .enableFFmpegImageDecoder: true,
-    .enableHdrWorkaround: false
+    .enableHdrWorkaround: false,
+    .enableNowPlayingArtwork: true
   ]
 
 


### PR DESCRIPTION
This commit will:
- Move `NowPlayingInfoManager` out of `PlayerCore` and into its own file
- Change `PlayerCore.pauseChanged` to call `syncUITime` before changing the state so that `PlaybackInfo.videoPosition` is up to date when `NowPlayingInfoManager.updateInfo` is called
- Change updateInfo to set `MPNowPlayingInfoPropertyPlaybackRate` to zero when playback is paused as required by Now Playing
- Change updateInfo to set `playbackState` to `playing` before setting it to `paused` when playback is paused from the start to workaround a Now Playing problem
- Remove the state parameter from the `updateInfo` method and change the method to use the `state` property in `PlaybackInfo`
- Change `updateInfo` to remove `MPMediaItemPropertyAlbumTitle` and `MPMediaItemPropertyArtist` when not needed instead of setting them to the empty string
- Add a `cgImage` property and a `resized` method to the `NSImage` extension
- Add a `CGImage` extension
- Add a `CGSize` extension
- Add a `MPNowPlayingPlaybackState` extension that adopts the `CustomStringConvertible` property to allow values to be easily logged
- Add an `isImage` property to `MPVTrack`
- Add a `readArtwork` method to `FFmpegController`
- Add calls to `NowPlayingInfoManager.updateInfo` when thumbnails are ready
- Add support for setting `MPMediaItemPropertyArtwork` in `nowPlayingInfo` to `NowPlayingInfoManager`
- Add a new `enableNowPlayingArtwork` internal setting that can be used to disable showing artwork should a serious problem be discovered

This commit is builds upon the pioneering work done by @svobs to add support for showing artwork in Now Playing. NowPlayingInfoManager will first try and find a video track that represents cover art and use that for the Now Playing artwork. If that fails it will then ask the macOS Quick Look system to generate a thumbnail to use as Now Playing artwork. If that fails then it will try and use an OSC thumbnail.

This commit also corrects several existing problems with Now Playing found during testing.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5336.

---

**Description:**
