### PR TITLE
Fix OSC doesn't appear after exiting full screen mode, #5535

### DIFF
--- a/iina/MainWindow.swift
+++ b/iina/MainWindow.swift
@@ -64,4 +64,24 @@ class MainWindowContentView: NSView {
     guard let controller = window?.windowController as? MainWindowController, controller.sideBarStatus == .playlist else { return }
     addCursorRect(controller.playlistDraggingRect, cursor: .resizeLeftRight)
   }
+
+  /// Invoked automatically when the view’s geometry changes such that its tracking areas need to be recalculated.
+  ///
+  /// Previous to macOS Sequoia this method was not needed, AppKit properly handled the re-computation of the tracking area
+  /// when the view geometry changed. But as of macOS 15 something is going wrong in AppKit and it fails to call `mouseMoved`
+  /// after legacy full screen mode is entered or exited. See issues [#5535](https://github.com/iina/iina/issues/5535)
+  /// and [#5288](https://github.com/iina/iina/issues/5288).
+  /// - Note: This method intentionally does not check for the availability of macOS 15 as this method works fine with older versions
+  ///     of macOS as well. This protects against Apple back porting the bad Sequoia behavior into older versions of macOS which
+  ///     has occurred with past macOS problems.
+  override func updateTrackingAreas() {
+    defer { super.updateTrackingAreas() }
+    guard trackingAreas.count == 1,
+          let controller = window?.windowController as? MainWindowController else { return }
+    controller.log("Recreating tracking area", level: .verbose)
+    removeTrackingArea(trackingAreas[0])
+    addTrackingArea(NSTrackingArea(rect: bounds,
+      options: [.activeAlways, .enabledDuringMouseDrag, .inVisibleRect, .mouseEnteredAndExited, .mouseMoved],
+      owner: controller, userInfo: ["obj": 0]))
+  }
 }

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1541,17 +1541,6 @@ class MainWindowController: PlayerWindowController {
     // set window frame and in some cases content view frame
     setWindowFrameForLegacyFullScreen()
 
-    // Workaround for issue #5288, OSC doesn't appear when playing in full screen. Starting with
-    // macOS 15 Sequoia AppKit sometimes fails to call mouseMoved after entering full screen mode.
-    // Recreating the tracking area corrects whatever is going wrong in AppKit.
-    if #available(macOS 15, *), let cv = window.contentView, cv.trackingAreas.count == 1 {
-      log("Recreating tracking area")
-      cv.removeTrackingArea(cv.trackingAreas[0])
-      cv.addTrackingArea(NSTrackingArea(rect: cv.bounds,
-        options: [.activeAlways, .enabledDuringMouseDrag, .inVisibleRect, .mouseEnteredAndExited, .mouseMoved],
-        owner: self, userInfo: ["obj": 0]))
-    }
-
     // call delegate
     windowDidEnterFullScreen(Notification(name: .iinaLegacyFullScreen))
   }


### PR DESCRIPTION
This commit will:
- Add an `updateTrackingAreas` method to `MainWindowContentView`
- Remove the workaround for issue #5288 from the `legacyAnimateToFullscreen` method in `MainWindowController`

These changes replace the workaround for the OSC not appearing after entering legacy full screen mode with and implementation of updateTrackingAreas which addresses any occurrences of the macOS failure. The `updateTrackingAreas` method is not restricted to the availability of macOS 15 and works on older versions of macOS. This covers Apple back porting the faulty code to older versions of macOS which has occurred in the past with other macOS problems.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5535.

---

**Description:**
