### PR TITLE
Fix unintended fast-forward when dismissing notification banner

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -161,6 +161,8 @@ class MainWindowController: PlayerWindowController {
   // might use another obj to handle slider?
   var isMouseInWindow: Bool = false
   var isMouseInSlider: Bool = false
+  /** flag to ignor abrupt momentum scrolls */
+  private var isMomentumScrollingAllowed = false
 
   var isFastforwarding: Bool = false
 
@@ -1060,7 +1062,25 @@ class MainWindowController: PlayerWindowController {
 
   override func scrollWheel(with event: NSEvent) {
     guard !isInInteractiveMode else { return }
+    if !isMomentumScrollingAllowed && !event.momentumPhase.isEmpty {
+      // ignore delta caused by abrupt momentum phases
+      return
+    }
+    /**
+     reference: https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/EventOverview/HandlingTouchEvents/HandlingTouchEvents.html#//apple_ref/doc/uid/10000060i-CH13
 
+     normal momentum scrolling will be like this:
+        phase=Began momentumPhase=None
+        phase=Changed momentumPhase=None
+        ...
+        **phase=Ended** momentumPhase=None
+        **phase=None** momentumPhase=None
+        phase=None **momentumPhase=Began**
+
+     abnormal momentum scrolling, e.g. after dismissing notification banner quickly like:
+        phase=None **momentumPhase=Began/Changed**
+     */
+    isMomentumScrollingAllowed = event.phase.contains(.ended) || isMouseInWindow // previous
     if isMouseEvent(event, inAnyOf: [fragSliderView]) && playSlider.isEnabled {
       seekOverride = true
     } else if isMouseEvent(event, inAnyOf: [fragVolumeView]) && volumeSlider.isEnabled {
@@ -1115,6 +1135,8 @@ class MainWindowController: PlayerWindowController {
       if controlBarFloating.isDragging { return }
       destroyTimer()
       hideUI()
+      // reset after moved out of window
+      isMomentumScrollingAllowed = false
     } else if obj == 1 {
       // slider
       isMouseInSlider = false

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -161,7 +161,7 @@ class MainWindowController: PlayerWindowController {
   // might use another obj to handle slider?
   var isMouseInWindow: Bool = false
   var isMouseInSlider: Bool = false
-  /** flag to ignor abrupt momentum scrolls */
+  /** flag to ignore abrupt momentum scrolls */
   private var isMomentumScrollingAllowed = false
 
   var isFastforwarding: Bool = false


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5540.

---

**Description:**

Added a check to ensure scroll momentum phase matches expected gesture sequence.