### PR TITLE
Fix short hang upon starting a video, #5531

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -161,6 +161,8 @@
 		51096C0B2CD88BEC00702C31 /* MPVOptionDefaults.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51096C0A2CD88BEC00702C31 /* MPVOptionDefaults.swift */; };
 		5111B18B2C8BCEAC00DEC0AC /* TouchBarSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5111B18A2C8BCEAC00DEC0AC /* TouchBarSettings.swift */; };
 		5114FA942DC704CE00D02435 /* NowPlayingInfoManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5114FA932DC704CE00D02435 /* NowPlayingInfoManager.swift */; };
+		51165FBC2E1D91290060B817 /* ReadWriteAtomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51165FBB2E1D91290060B817 /* ReadWriteAtomic.swift */; };
+		51165FC02E1D91940060B817 /* ReadWriteLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51165FBF2E1D91940060B817 /* ReadWriteLock.swift */; };
 		512B8FDD2BC2376E00AF41BF /* OutlineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512B8FDC2BC2376E00AF41BF /* OutlineView.swift */; };
 		513A4FFA29B53F8100A8EA7D /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513A4FF929B53F8100A8EA7D /* Atomic.swift */; };
 		515B5E5A2A579903001FCD49 /* iina-plugin in Copy Executables */ = {isa = PBXBuildFile; fileRef = E38558872A484A2D0083772D /* iina-plugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
@@ -1189,6 +1191,8 @@
 		51096C0A2CD88BEC00702C31 /* MPVOptionDefaults.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MPVOptionDefaults.swift; sourceTree = "<group>"; };
 		5111B18A2C8BCEAC00DEC0AC /* TouchBarSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TouchBarSettings.swift; sourceTree = "<group>"; };
 		5114FA932DC704CE00D02435 /* NowPlayingInfoManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NowPlayingInfoManager.swift; sourceTree = "<group>"; };
+		51165FBB2E1D91290060B817 /* ReadWriteAtomic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadWriteAtomic.swift; sourceTree = "<group>"; };
+		51165FBF2E1D91940060B817 /* ReadWriteLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadWriteLock.swift; sourceTree = "<group>"; };
 		512B8FDC2BC2376E00AF41BF /* OutlineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutlineView.swift; sourceTree = "<group>"; };
 		513A4FF929B53F8100A8EA7D /* Atomic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
 		51537C7229FA26DD00F9A472 /* Nightly.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Nightly.xcconfig; sourceTree = "<group>"; };
@@ -2414,6 +2418,7 @@
 				84A886E21E24F2D3008755BB /* Sub */,
 				8497A4831D2FF573005F504F /* iina-Bridging-Header.h */,
 				513A4FF929B53F8100A8EA7D /* Atomic.swift */,
+				51165FBF2E1D91940060B817 /* ReadWriteLock.swift */,
 				51854CD92A1C489300C40B78 /* FFmpegLogger.swift */,
 				84EB1F061D2F5E76004FA5A1 /* Utility.swift */,
 				8461C52F1D462488006E91FF /* VideoTime.swift */,
@@ -2446,6 +2451,7 @@
 				51C1BA39291CA76700C1208A /* InfoDictionary.swift */,
 				51DE55C82A6646710050AD06 /* Sysctl.swift */,
 				519CCABC2BFFAEF10079DCAF /* HardwareDecodeCapabilities.swift */,
+				51165FBB2E1D91290060B817 /* ReadWriteAtomic.swift */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -3194,6 +3200,7 @@
 				840AF5821E732C8F00F4AF92 /* JustXMLRPC.swift in Sources */,
 				E3513AF820EF79C500F8C347 /* PreferenceWindowController.swift in Sources */,
 				841A599D1E1FF5800079E177 /* SleepPreventer.swift in Sources */,
+				51165FBC2E1D91290060B817 /* ReadWriteAtomic.swift in Sources */,
 				84ED99FF1E009C8100A5159B /* PrefAdvancedViewController.swift in Sources */,
 				840AF5841E73CE3900F4AF92 /* OpenSubSubtitle.swift in Sources */,
 				E32B157D21BC27B100CDBCEA /* JavascriptAPIMenu.swift in Sources */,
@@ -3214,6 +3221,7 @@
 				E30D2EBD21F5FD2600E1FF0D /* PluginOverlayView.swift in Sources */,
 				E3FEC1332A30400F00CFD845 /* PluginInputManager.swift in Sources */,
 				8407D1401E3A684C0043895D /* ViewLayer.swift in Sources */,
+				51165FC02E1D91940060B817 /* ReadWriteLock.swift in Sources */,
 				84EB1F051D2F5C5B004FA5A1 /* AppData.swift in Sources */,
 				51F7974728C7E00200812D0D /* Lock.swift in Sources */,
 				84C8D58F1D794CE600D98A0E /* MPVFilter.swift in Sources */,

--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -929,3 +929,20 @@ extension CGSize {
     return cropped
   }
 }
+
+#if DEBUG
+extension DispatchQueue {
+
+  /// Returns the label assigned to the current dispatch queue at creation time.
+  ///
+  /// This method is a Swift wrapper around the
+  /// [dispatch_queue_get_label](https://developer.apple.com/documentation/dispatch/1452939-dispatch_queue_get_label)
+  /// method.
+  /// - Note: This method is intended only to be used when debugging IINA.
+  /// - Returns: The label of the queue, or `nil` if the queue was not provided a label during initialization.
+  static func currentQueueLabel() -> String? {
+    let label = __dispatch_queue_get_label(nil)
+    return String(cString: label, encoding: .utf8)
+  }
+}
+#endif

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -1776,6 +1776,6 @@ fileprivate func mpvGetOpenGLFunc(_ ctx: UnsafeMutableRawPointer?, _ name: Unsaf
 fileprivate func mpvUpdateCallback(_ ctx: UnsafeMutableRawPointer?) {
   let layer = bridge(ptr: ctx!) as ViewLayer
   layer.mpvGLQueue.async {
-    layer.draw()
+    layer.update()
   }
 }

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -1775,7 +1775,5 @@ fileprivate func mpvGetOpenGLFunc(_ ctx: UnsafeMutableRawPointer?, _ name: Unsaf
 
 fileprivate func mpvUpdateCallback(_ ctx: UnsafeMutableRawPointer?) {
   let layer = bridge(ptr: ctx!) as ViewLayer
-  layer.mpvGLQueue.async {
-    layer.update()
-  }
+  layer.update()
 }

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -692,7 +692,9 @@ class MainWindowController: PlayerWindowController {
       NSScreen.log("NSScreen.screens[\(screen.offset)]" , screen.element)
     }
 
-    videoView.videoLayer.draw(forced: true)
+    // If a video is not actively playing then the initial drawing of the view needs to be forced.
+    // The forceDraw method will check to see if drawing is actually needed.
+    forceDraw("window loaded")
   }
 
   /// Returns the position in seconds for the given percent of the total duration of the video the percentage represents.
@@ -1324,7 +1326,7 @@ class MainWindowController: PlayerWindowController {
     videoViewConstraints.values.forEach { $0.constant = 0 }
     videoView.needsLayout = true
     videoView.layoutSubtreeIfNeeded()
-    videoView.videoLayer.draw(forced: true)
+    forceDraw("entered full screen mode")
 
     if Preference.bool(for: .blackOutMonitor) {
       blackOutOtherMonitors()
@@ -1434,7 +1436,7 @@ class MainWindowController: PlayerWindowController {
     videoViewConstraints.values.forEach { $0.constant = 0 }
     videoView.needsLayout = true
     videoView.layoutSubtreeIfNeeded()
-    videoView.videoLayer.draw(forced: true)
+    forceDraw("exited full screen mode")
 
     if Preference.bool(for: .pauseWhenLeavingFullScreen) && player.info.state == .playing {
       player.pause()
@@ -1447,7 +1449,7 @@ class MainWindowController: PlayerWindowController {
 
     resetCollectionBehavior()
     updateWindowParametersForMPV()
-    
+
     player.events.emit(.windowFullscreenChanged, data: false)
   }
 
@@ -1663,7 +1665,7 @@ class MainWindowController: PlayerWindowController {
   }
 
   func windowWillStartLiveResize(_ notification: Notification) {
-    videoView.videoLayer.isAsynchronous = true
+    videoView.videoLayer.inLiveResize = true
   }
 
   // resize framebuffer in videoView after resizing.
@@ -1671,7 +1673,7 @@ class MainWindowController: PlayerWindowController {
     // Must not access mpv while it is asynchronously processing stop and quit commands.
     // See comments in windowWillExitFullScreen for details.
     guard player.info.state.active else { return }
-    videoView.videoLayer.isAsynchronous = false
+    videoView.videoLayer.inLiveResize = false
     updateWindowParametersForMPV()
   }
 
@@ -2213,11 +2215,7 @@ class MainWindowController: PlayerWindowController {
       videoView.needsLayout = true
       videoView.layoutSubtreeIfNeeded()
       // force rerender a frame
-      videoView.videoLayer.mpvGLQueue.async {
-        DispatchQueue.main.sync {
-          self.videoView.videoLayer.draw()
-        }
-      }
+      forceDraw("interactive cropping")
     }
 
     let controlView = mode.viewController()
@@ -3110,14 +3108,11 @@ extension MainWindowController: PIPViewControllerDelegate {
 
     addVideoViewToWindow()
 
-    // Similarly, we need to run a redraw here as well. We check to make sure we
-    // are paused, because this causes a janky animation in either case but as
-    // it's not necessary while the video is playing and significantly more
-    // noticeable, we only redraw if we are paused.
-    let currentTrackIsAlbumArt = player.info.currentTrack(.video)?.isAlbumart ?? false
-    if player.info.state == .paused || currentTrackIsAlbumArt {
-      videoView.videoLayer.draw(forced: true)
-    }
+    // Similarly, we need to run a redraw here as well. We check to make sure we are paused, because
+    // this causes a janky animation in either case but as it's not necessary while the video is
+    // playing and significantly more noticeable, we only redraw if we are paused. The forceDraw
+    // method checks to make sure drawing is required.
+    forceDraw("exiting PiP")
 
     updateTimer()
 

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1164,7 +1164,7 @@ class MainWindowController: PlayerWindowController {
       if recognizer.state == .began {
         // began
         lastMagnification = recognizer.magnification
-        videoView.videoLayer.isAsynchronous = true
+        videoView.videoLayer.inLiveResize = true
         frameWhenStartedPinching = window.frame
       } else if recognizer.state == .changed {
         // changed
@@ -1181,7 +1181,7 @@ class MainWindowController: PlayerWindowController {
         lastMagnification = recognizer.magnification
       } else if recognizer.state == .ended {
         updateWindowParametersForMPV()
-        videoView.videoLayer.isAsynchronous = false
+        videoView.videoLayer.inLiveResize = false
       }
     }
   }

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -180,13 +180,13 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
   }
 
   // MARK: - Window delegate: Size
-  func windowDidResize(_ notification: Notification) {
-    guard let window = window, !window.inLiveResize else { return }
-    videoView.videoLayer.draw()
+
+  func windowWillStartLiveResize(_ notification: Notification) {
+    videoView.videoLayer.inLiveResize = true
   }
 
   func windowDidEndLiveResize(_ notification: Notification) {
-    guard let window = window else { return }
+    guard player.info.state.active, let window = window else { return }
     let windowHeight = normalWindowHeight()
     if isPlaylistVisible {
       // hide
@@ -202,6 +202,7 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
         isPlaylistVisible = true
       }
     }
+    videoView.videoLayer.inLiveResize = false
   }
 
   // MARK: - Window delegate: Activeness status

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -586,6 +586,7 @@ class PlayerCore: NSObject {
     // init mpv render context.
     mpv.mpvInitRendering()
     mainWindow.videoView.startDisplayLink()
+    log("Initialized rendering")
   }
 
   // unload main window video view

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -751,7 +751,7 @@ class PlayerCore: NSObject {
     if showMiniPlayer {
       notifyWindowVideoSizeChanged()
     }
-    videoView.videoLayer.draw(forced: true)
+    mainWindow.forceDraw("entered music mode")
     events.emit(.musicModeChanged, data: true)
   }
 
@@ -799,7 +799,7 @@ class PlayerCore: NSObject {
       mainWindow.updateTitle()
       notifyWindowVideoSizeChanged()
     }
-    mainWindow.videoView.videoLayer.draw(forced: true)
+    mainWindow.forceDraw("exited music mode")
     events.emit(.musicModeChanged, data: false)
   }
 
@@ -1944,7 +1944,7 @@ class PlayerCore: NSObject {
     // Must force drawing to cover the case where this player was previously used to play a video
     // and is now playing an audio file without an album cover and without using music mode.
     // See issue #5403.
-    mainWindow.videoView.videoLayer.draw(forced: true)
+    mainWindow.forceDraw("file loaded")
 
     // Get video size and set the initial window size
     let width = mpv.getInt(MPVProperty.width)

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -654,10 +654,8 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
     guard player.info.state.active else { return }
     let notVideo = player.info.currentTrack(.video)?.isImage ?? true
     guard player.info.state == .paused || notVideo else { return }
-    videoView.videoLayer.mpvGLQueue.async { [self] in
-      log("Forcing drawing, \(reason)")
-      videoView.videoLayer.update(force: true)
-    }
+    log("Forcing drawing, \(reason)")
+    videoView.videoLayer.update(force: true)
   }
 
   // MARK: - IBActions

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -548,10 +548,18 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
 
     NotificationCenter.default.post(name: .iinaMainWindowChanged, object: true)
   }
-  
+
+  /// The window changed its occlusion state.
+  ///
+  /// If the entire window is now occluded then no action is needed. But if the window has become visible then the view may need to
+  /// be drawn.
+  /// - Note: The window [isVisible](https://developer.apple.com/documentation/appkit/nswindow/isvisible)
+  ///     property is intentionally not used. That property is `true` even when the window is fully obscured. Instead the
+  ///     [occlusionState](https://developer.apple.com/documentation/appkit/nswindow/occlusionstate-swift.property)
+  ///     property is used as it will not indicate the window is visible when it is obscured by other windows.
   func windowDidChangeOcclusionState(_ notification: Notification) {
-    // Must force drawing for audio files that have album cover art.
-    videoView.videoLayer.draw(forced: true)
+    guard let window, window.occlusionState.contains(.visible) else { return }
+    forceDraw("window became visible")
   }
 
   func windowDidResignMain(_ notification: Notification) {
@@ -635,6 +643,21 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
 
   func handleVideoSizeChange() {
     fatalError("Must implement in the subclass")
+  }
+
+  /// Force a draw, if needed.
+  ///
+  /// If a video is actively being played then there is no need to force a draw as the view is actively being drawn. Otherwise the view
+  /// must be drawn. Video tracks can be images or cover art. Even when there isn't a video track drawing sometimes must be forced
+  /// to clear a previous image, such as when an audio only file is played in the main window after it was used to play a video.
+  func forceDraw(_ reason: String) {
+    guard player.info.state.active else { return }
+    let notVideo = player.info.currentTrack(.video)?.isImage ?? true
+    guard player.info.state == .paused || notVideo else { return }
+    videoView.videoLayer.mpvGLQueue.async { [self] in
+      log("Forcing drawing, \(reason)")
+      videoView.videoLayer.update(force: true)
+    }
   }
 
   // MARK: - IBActions

--- a/iina/ReadWriteAtomic.swift
+++ b/iina/ReadWriteAtomic.swift
@@ -1,0 +1,40 @@
+//
+//  ReadWriteAtomic.swift
+//  iina
+//
+//  Created by low-batt on 7/8/25.
+//  Copyright © 2025 lhc. All rights reserved.
+//
+
+import Foundation
+
+@propertyWrapper class ReadWriteAtomic<Value> {
+  private let lock = ReadWriteLock()
+
+  var projectedValue: ReadWriteAtomic<Value> {
+      return self
+  }
+
+  private var value: Value
+
+  var wrappedValue: Value {
+    get { lock.read { value } }
+    set { lock.write { value = newValue } }
+  }
+
+  init(wrappedValue: Value) {
+    self.value = wrappedValue
+  }
+
+  func withReadLock<R>(_ body: (Value) throws -> R) rethrows -> R {
+    return try lock.read {
+      return try body(value)
+    }
+  }
+
+  func withWriteLock<R>(_ body: (inout Value) throws -> R) rethrows -> R {
+    return try lock.write {
+      return try body(&value)
+    }
+  }
+}

--- a/iina/ReadWriteLock.swift
+++ b/iina/ReadWriteLock.swift
@@ -1,0 +1,33 @@
+//
+//  ReadWriteLock.swift
+//  iina
+//
+//  Created by low-batt on 7/8/25.
+//  Copyright © 2025 lhc. All rights reserved.
+//
+
+import Foundation
+
+final class ReadWriteLock {
+  private var rwlock = pthread_rwlock_t()
+
+  init() {
+    pthread_rwlock_init(&rwlock, nil)
+  }
+
+  deinit {
+    pthread_rwlock_destroy(&rwlock)
+  }
+
+  func read<T>(_ body: () throws -> T) rethrows -> T {
+    pthread_rwlock_rdlock(&rwlock)
+    defer { pthread_rwlock_unlock(&rwlock) }
+    return try body()
+  }
+
+  func write<T>(_ body: () throws -> T) rethrows -> T {
+    pthread_rwlock_wrlock(&rwlock)
+    defer { pthread_rwlock_unlock(&rwlock) }
+    return try body()
+  }
+}

--- a/iina/VideoPIPViewController.swift
+++ b/iina/VideoPIPViewController.swift
@@ -14,12 +14,11 @@ class VideoPIPViewController: PIPViewController, NSWindowDelegate {
 
   /// Force a draw, if needed.
   ///
-  /// If the image is changing there is no need to force a draw. However if playback is paused, or if playback is in progress but the video
-  /// track is an album art still image then drawing is required.
-  private func forceDraw() {
-    guard let controller = delegate as? MainWindowController, controller.player.info.state == .paused
-            || controller.player.info.currentTrack(.video)?.isAlbumart ?? false else { return }
-    controller.videoView.videoLayer.draw(forced: true)
+  /// The `forceDraw` method in `PlayerWindowController` will check to see if drawing is really needed and if so, force a
+  /// draw of the view.
+  private func forceDraw(_ reason: String) {
+    guard let controller = delegate as? MainWindowController else { return }
+    controller.forceDraw(reason)
   }
 
   /// Force a draw after entering PiP.
@@ -31,7 +30,7 @@ class VideoPIPViewController: PIPViewController, NSWindowDelegate {
   /// asynchronously.
   override func viewDidLayout() {
     super.viewDidLayout()
-    forceDraw()
+    forceDraw("entered PiP")
     guard let window = view.window else {
       // Internal error, should not occur.
       Logger.log("VideoPIPViewController.viewDidLayout window is nil", level: .error)
@@ -46,7 +45,7 @@ class VideoPIPViewController: PIPViewController, NSWindowDelegate {
   /// happen and a frame is displayed. See issue #4268 and PR #4286 for details.
   override func viewDidDisappear() {
     super.viewDidDisappear()
-    forceDraw()
+    forceDraw("exited PiP")
   }
 
   /// PiP window has changed screens.

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -19,7 +19,7 @@ class VideoView: NSView {
     return layer
   }()
 
-  @Atomic var isUninited = false
+  @ReadWriteAtomic var isUninited = false
 
   var draggingTimer: Timer?
 
@@ -85,7 +85,7 @@ class VideoView: NSView {
   func uninit() {
     player.mpv.lockAndSetOpenGLContext()
     defer { player.mpv.unlockOpenGLContext() }
-    $isUninited.withLock() { isUninited in
+    $isUninited.withWriteLock() { isUninited in
       guard !isUninited else { return }
       isUninited = true
 
@@ -534,7 +534,7 @@ fileprivate func displayLinkCallback(
   _ flagsOut: UnsafeMutablePointer<CVOptionFlags>,
   _ context: UnsafeMutableRawPointer?) -> CVReturn {
   let videoView = unsafeBitCast(context, to: VideoView.self)
-  videoView.$isUninited.withLock() { isUninited in
+  videoView.$isUninited.withReadLock() { isUninited in
     guard !isUninited else { return }
     videoView.player.mpv.mpvReportSwap()
   }

--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -75,9 +75,6 @@ class ViewLayer: CAOpenGLLayer {
   private let cglContext: CGLContextObj
   private let cglPixelFormat: CGLPixelFormatObj
 
-  /// Lock to single thread calls to `display`.
-  private let displayLock: NSLocking
-
   private var fbo: GLint = 1
 
   @Atomic private var needsFlip = false
@@ -111,7 +108,6 @@ class ViewLayer: CAOpenGLLayer {
     self.videoView = videoView
     (cglPixelFormat, bufferDepth) = ViewLayer.createPixelFormat(videoView.player)
     cglContext = ViewLayer.createContext(cglPixelFormat)
-    displayLock = NSRecursiveLock()
     super.init()
     autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
     backgroundColor = NSColor.black.cgColor
@@ -133,7 +129,6 @@ class ViewLayer: CAOpenGLLayer {
     videoView = previousLayer.videoView
     cglPixelFormat = previousLayer.cglPixelFormat
     cglContext = previousLayer.cglContext
-    displayLock = previousLayer.displayLock
     super.init(layer: layer)
     autoresizingMask = previousLayer.autoresizingMask
     backgroundColor = previousLayer.backgroundColor
@@ -220,8 +215,6 @@ class ViewLayer: CAOpenGLLayer {
   ///     something other than the main thread, IINA will crash with a SIGABRT reporting "an implicit transaction wasn't created on a
   ///     main thread". See issue [#5038](https://github.com/iina/iina/issues/5038).
   override func display() {
-    displayLock.lock()
-    defer { displayLock.unlock() }
 
     let isUpdate = needsFlip
 

--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -83,24 +83,24 @@ class ViewLayer: CAOpenGLLayer {
   /// Prefix for keys used in
   /// [threadDictionary](https://developer.apple.com/documentation/foundation/thread/threaddictionary).
   ///
-  /// This prefix causes the keys to be specific to this `VideoLayer` instance.
-  private var keyPrefix: String { get { String(self.hashValue) + "." } }
+  /// This prefix causes the keys to be specific to the `VideoLayer` instance.
+  private var keyPrefix: String?
 
   /// When `true` the frame needs to be rendered.
   /// - Note: This flag is a thread local variable.
   private var needsFlip: Bool {
-    get { Thread.current.threadDictionary[needsFlipKey] as? Bool ?? false }
-    set { Thread.current.threadDictionary[needsFlipKey] = newValue }
+    get { Thread.current.threadDictionary[needsFlipKey!] as? Bool ?? false }
+    set { Thread.current.threadDictionary[needsFlipKey!] = newValue }
   }
-  private var needsFlipKey: String { get { keyPrefix + "needsFlip" } }
+  private var needsFlipKey: String?
 
   /// When `true` drawing will proceed even if mpv indicates nothing needs to be done.
   /// - Note: This flag is a thread local variable.
   private var forceDraw: Bool {
-    get { Thread.current.threadDictionary[forceDrawKey] as? Bool ?? false }
-    set { Thread.current.threadDictionary[forceDrawKey] = newValue }
+    get { Thread.current.threadDictionary[forceDrawKey!] as? Bool ?? false }
+    set { Thread.current.threadDictionary[forceDrawKey!] = newValue }
   }
-  private var forceDrawKey: String { get { keyPrefix + "forceDraw" } }
+  private var forceDrawKey: String?
 
   /// Indicates whether the view is being rendered as part of a live resizing operation.
   ///
@@ -137,6 +137,9 @@ class ViewLayer: CAOpenGLLayer {
     if bufferDepth > 8 {
       contentsFormat = .RGBA16Float
     }
+    keyPrefix = String(hashValue) + "."
+    forceDrawKey = keyPrefix! + "forceDraw"
+    needsFlipKey = keyPrefix! + "needsFlip"
     isAsynchronous = false
   }
 
@@ -158,8 +161,12 @@ class ViewLayer: CAOpenGLLayer {
     backgroundColor = previousLayer.backgroundColor
     wantsExtendedDynamicRangeContent = previousLayer.wantsExtendedDynamicRangeContent
     contentsFormat = previousLayer.contentsFormat
+    keyPrefix = String(hashValue) + "."
+    forceDrawKey = keyPrefix! + "forceDraw"
+    needsFlipKey = keyPrefix! + "needsFlip"
     inLiveResize = previousLayer.inLiveResize
     isAsynchronous = previousLayer.isAsynchronous
+    Logger.log("Created view layer shadow copy")
   }
 
   required init?(coder aDecoder: NSCoder) {

--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -75,6 +75,9 @@ class ViewLayer: CAOpenGLLayer {
   private let cglContext: CGLContextObj
   private let cglPixelFormat: CGLPixelFormatObj
 
+  /// Lock to single thread calls to `display`.
+  private let displayLock: NSLocking
+
   private var fbo: GLint = 1
 
   @Atomic private var needsFlip = false
@@ -108,6 +111,7 @@ class ViewLayer: CAOpenGLLayer {
     self.videoView = videoView
     (cglPixelFormat, bufferDepth) = ViewLayer.createPixelFormat(videoView.player)
     cglContext = ViewLayer.createContext(cglPixelFormat)
+    displayLock = NSRecursiveLock()
     super.init()
     autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
     backgroundColor = NSColor.black.cgColor
@@ -129,6 +133,7 @@ class ViewLayer: CAOpenGLLayer {
     videoView = previousLayer.videoView
     cglPixelFormat = previousLayer.cglPixelFormat
     cglContext = previousLayer.cglContext
+    displayLock = previousLayer.displayLock
     super.init(layer: layer)
     autoresizingMask = previousLayer.autoresizingMask
     backgroundColor = previousLayer.backgroundColor
@@ -146,7 +151,10 @@ class ViewLayer: CAOpenGLLayer {
 
   override func canDraw(inCGLContext ctx: CGLContextObj, pixelFormat pf: CGLPixelFormatObj,
                         forLayerTime t: CFTimeInterval, displayTime ts: UnsafePointer<CVTimeStamp>?) -> Bool {
-    videoView.$isUninited.withLock() { isUninited in
+    // When in live resize, skip all drawing calls on the main thread.
+    // Setting isAsynchronous = true is enough to prevent jittering.
+    guard !(inLiveResize && Thread.isMainThread) else { return false }
+    return videoView.$isUninited.withReadLock() { isUninited in
       guard !isUninited else { return false }
       if !inLiveResize {
         isAsynchronous = false
@@ -157,7 +165,7 @@ class ViewLayer: CAOpenGLLayer {
 
   override func draw(inCGLContext ctx: CGLContextObj, pixelFormat pf: CGLPixelFormatObj,
                      forLayerTime t: CFTimeInterval, displayTime ts: UnsafePointer<CVTimeStamp>?) {
-    videoView.$isUninited.withLock() { isUninited in
+    videoView.$isUninited.withReadLock() { isUninited in
       guard !isUninited else { return }
 
       needsFlip = false
@@ -215,6 +223,8 @@ class ViewLayer: CAOpenGLLayer {
   ///     something other than the main thread, IINA will crash with a SIGABRT reporting "an implicit transaction wasn't created on a
   ///     main thread". See issue [#5038](https://github.com/iina/iina/issues/5038).
   override func display() {
+    displayLock.lock()
+    defer { displayLock.unlock() }
 
     let isUpdate = needsFlip
 
@@ -233,7 +243,7 @@ class ViewLayer: CAOpenGLLayer {
     // always be locked before locking the isUninited lock to avoid deadlocks.
     videoView.player.mpv.lockAndSetOpenGLContext()
     defer { videoView.player.mpv.unlockOpenGLContext() }
-    videoView.$isUninited.withLock() { isUninited in
+    videoView.$isUninited.withReadLock() { isUninited in
       guard !isUninited else { return }
 
       // Neither canDraw nor draw(inCGLContext:) were called by AppKit, needs a skip render.
@@ -370,7 +380,7 @@ class ViewLayer: CAOpenGLLayer {
     // deadlocks.
     videoView.player.mpv.lockAndSetOpenGLContext()
     defer { videoView.player.mpv.unlockOpenGLContext() }
-    videoView.$isUninited.withLock() { isUninited in
+    videoView.$isUninited.withReadLock() { isUninited in
       guard !isUninited else { return }
 
       guard let renderContext = videoView.player.mpv.mpvRenderContext else { return }

--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -80,8 +80,27 @@ class ViewLayer: CAOpenGLLayer {
 
   private var fbo: GLint = 1
 
-  @Atomic private var needsFlip = false
-  @Atomic private var forceDraw = false
+  /// Prefix for keys used in
+  /// [threadDictionary](https://developer.apple.com/documentation/foundation/thread/threaddictionary).
+  ///
+  /// This prefix causes the keys to be specific to this `VideoLayer` instance.
+  private var keyPrefix: String { get { String(self.hashValue) + "." } }
+
+  /// When `true` the frame needs to be rendered.
+  /// - Note: This flag is a thread local variable.
+  private var needsFlip: Bool {
+    get { Thread.current.threadDictionary[needsFlipKey] as? Bool ?? false }
+    set { Thread.current.threadDictionary[needsFlipKey] = newValue }
+  }
+  private var needsFlipKey: String { get { keyPrefix + "needsFlip" } }
+
+  /// When `true` drawing will proceed even if mpv indicates nothing needs to be done.
+  /// - Note: This flag is a thread local variable.
+  private var forceDraw: Bool {
+    get { Thread.current.threadDictionary[forceDrawKey] as? Bool ?? false }
+    set { Thread.current.threadDictionary[forceDrawKey] = newValue }
+  }
+  private var forceDrawKey: String { get { keyPrefix + "forceDraw" } }
 
   /// Indicates whether the view is being rendered as part of a live resizing operation.
   ///
@@ -266,10 +285,8 @@ class ViewLayer: CAOpenGLLayer {
   func update(force: Bool = false) {
     mpvGLQueue.async { [self] in
       if force { forceDraw = true }
-      if forceDraw || !inLiveResize {
-        needsFlip = true
-        display()
-      }
+      needsFlip = true
+      display()
     }
   }
 

--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -62,8 +62,7 @@ let attributeLookUp: [UInt32: String] = [
 ///
 /// This class is structured to make it easier to compare it to the reference implementation in the mpv player. Methods and statements
 /// are in the same order as found in the mpv source. However there are differences that cause the implementation to not match up. For
-/// example IINA draws using a background thread whereas mpv uses the main thread. For this reason the locking differs as IINA has to
-/// coordinate access to data that is shared between the main thread and the background thread.
+/// example IINA draws using a background thread whereas mpv uses the main thread.
 class ViewLayer: CAOpenGLLayer {
 
   private weak var videoView: VideoView!
@@ -75,13 +74,31 @@ class ViewLayer: CAOpenGLLayer {
   private let cglContext: CGLContextObj
   private let cglPixelFormat: CGLPixelFormatObj
 
-  /// Lock to single thread calls to `draw(forced:)`.
-  private let drawLock: Lock
+  /// Lock to single thread calls to `display`.
+  private let displayLock: NSLocking
 
   private var fbo: GLint = 1
 
-  private var needsMPVRender = false
-  private var forceRender = false
+  @Atomic private var needsFlip = false
+  @Atomic private var forceDraw = false
+
+  /// Indicates whether the view is being rendered as part of a live resizing operation.
+  ///
+  /// This flag is used to manage setting of the
+  /// [isAsynchronous](https://developer.apple.com/documentation/quartzcore/caopengllayer/isasynchronous)
+  /// property. When `isAsynchronous` is `true` [canDraw](https://developer.apple.com/documentation/quartzcore/caopengllayer/candraw(incglcontext:pixelformat:forlayertime:displaytime:))
+  /// is called periodically to determine if the OpenGL content should be updated. This is used when the window is being resized. When [windowDidEndLiveResize](https://developer.apple.com/documentation/appkit/nswindowdelegate/windowdidendliveresize(_:))
+  /// is called it is important to not set `isAsynchronous` to `false` until a draw has occurred. Setting this flag to `false`
+  /// will cause `canDraw` to set `isAsynchronous` to `false` only once another drawing is in process. This reduces the
+  /// likelihood of seeing a very short momentary black screen when exiting full screen mode.
+  @Atomic var inLiveResize: Bool = false {
+    didSet {
+      if inLiveResize {
+        isAsynchronous = true
+      }
+      update(force: true)
+    }
+  }
 
   /// Returns an initialized `ViewLayer` object.
   ///
@@ -93,7 +110,7 @@ class ViewLayer: CAOpenGLLayer {
     self.videoView = videoView
     (cglPixelFormat, bufferDepth) = ViewLayer.createPixelFormat(videoView.player)
     cglContext = ViewLayer.createContext(cglPixelFormat)
-    drawLock = Lock()
+    displayLock = NSRecursiveLock()
     super.init()
     autoresizingMask = [.layerWidthSizable, .layerHeightSizable]
     backgroundColor = NSColor.black.cgColor
@@ -115,12 +132,13 @@ class ViewLayer: CAOpenGLLayer {
     videoView = previousLayer.videoView
     cglPixelFormat = previousLayer.cglPixelFormat
     cglContext = previousLayer.cglContext
-    drawLock = previousLayer.drawLock
+    displayLock = previousLayer.displayLock
     super.init(layer: layer)
     autoresizingMask = previousLayer.autoresizingMask
     backgroundColor = previousLayer.backgroundColor
     wantsExtendedDynamicRangeContent = previousLayer.wantsExtendedDynamicRangeContent
     contentsFormat = previousLayer.contentsFormat
+    inLiveResize = previousLayer.inLiveResize
     isAsynchronous = previousLayer.isAsynchronous
   }
 
@@ -134,8 +152,10 @@ class ViewLayer: CAOpenGLLayer {
                         forLayerTime t: CFTimeInterval, displayTime ts: UnsafePointer<CVTimeStamp>?) -> Bool {
     videoView.$isUninited.withLock() { isUninited in
       guard !isUninited else { return false }
-      if forceRender { return true }
-      return videoView.player.mpv.shouldRenderUpdateFrame()
+      if !inLiveResize {
+        isAsynchronous = false
+      }
+      return forceDraw || videoView.player.mpv.shouldRenderUpdateFrame()
     }
   }
 
@@ -144,8 +164,10 @@ class ViewLayer: CAOpenGLLayer {
     videoView.$isUninited.withLock() { isUninited in
       guard !isUninited else { return }
 
+      needsFlip = false
+      forceDraw = false
+
       let mpv = videoView.player.mpv!
-      needsMPVRender = false
 
       glClear(GLbitfield(GL_COLOR_BUFFER_BIT))
 
@@ -197,24 +219,28 @@ class ViewLayer: CAOpenGLLayer {
   ///     something other than the main thread, IINA will crash with a SIGABRT reporting "an implicit transaction wasn't created on a
   ///     main thread". See issue [#5038](https://github.com/iina/iina/issues/5038).
   override func display() {
+    displayLock.lock()
+    defer { displayLock.unlock() }
+
+    let isUpdate = needsFlip
+
     CATransaction.begin()
     super.display()
     CATransaction.commit()
 
-    // Must lock the OpenGL context before calling mpv render methods. Can't wait until we have
-    // checked the flags to see if a skip renderer is needed because the OpenGL context must always
-    // be locked before locking the isUninited lock to avoid deadlocks. The flags can't be checked
-    // without locking isUninited to avoid data races.
+    // The call to commit will not render the explicit transaction if it is nested in an implicit
+    // transaction. This can happen when drawing is being forced after a change to the view such as
+    // resizing. Must call flush to ensure any implicit transaction is flushed.
+    CATransaction.flush()
+
+    guard isUpdate && needsFlip else { return }
+
+    // Must lock the OpenGL context before calling mpv render methods. The OpenGL context must
+    // always be locked before locking the isUninited lock to avoid deadlocks.
     videoView.player.mpv.lockAndSetOpenGLContext()
     defer { videoView.player.mpv.unlockOpenGLContext() }
     videoView.$isUninited.withLock() { isUninited in
       guard !isUninited else { return }
-
-      guard !forceRender else {
-        forceRender = false
-        return
-      }
-      guard needsMPVRender else { return }
 
       // Neither canDraw nor draw(inCGLContext:) were called by AppKit, needs a skip render.
       // This can happen when IINA is playing in another space, as might occur when just playing
@@ -230,22 +256,13 @@ class ViewLayer: CAOpenGLLayer {
           mpv_render_context_render(renderContext, &params)
         }
       }
-      needsMPVRender = false
     }
   }
 
-  func draw(forced: Bool = false) {
-    drawLock.withLock() {
-      videoView.$isUninited.withLock() { isUninited in
-        // The properties forceRender and needsMPVRender are always accessed while holding
-        // isUninited's lock. This avoids the need for separate locks to avoid data races with these
-        // flags. No need to check isUninited at this point.
-        needsMPVRender = true
-        if forced { forceRender = true }
-      }
-
-      // Must not call display while holding isUninited's lock as that method will attempt to
-      // acquire the lock and our locks do not support recursion.
+  func update(force: Bool = false) {
+    if force { forceDraw = true }
+    if forceDraw || !inLiveResize {
+      needsFlip = true
       display()
     }
   }

--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -62,12 +62,13 @@ let attributeLookUp: [UInt32: String] = [
 ///
 /// This class is structured to make it easier to compare it to the reference implementation in the mpv player. Methods and statements
 /// are in the same order as found in the mpv source. However there are differences that cause the implementation to not match up. For
-/// example IINA draws using a background thread whereas mpv uses the main thread.
+/// example IINA draws using a background thread whereas mpv uses the main thread. When IINA tested drawing on the main thread
+/// the sliding animation to show and hide the side panels was _very_ slugish and moving the floating OSC was jerky.
 class ViewLayer: CAOpenGLLayer {
 
   private weak var videoView: VideoView!
 
-  let mpvGLQueue = DispatchQueue(label: "com.colliderli.iina.mpvgl", qos: .userInteractive)
+  private let mpvGLQueue = DispatchQueue(label: "com.colliderli.iina.mpvgl", qos: .userInteractive)
 
   private var bufferDepth: GLint = 8
 
@@ -260,10 +261,12 @@ class ViewLayer: CAOpenGLLayer {
   }
 
   func update(force: Bool = false) {
-    if force { forceDraw = true }
-    if forceDraw || !inLiveResize {
-      needsFlip = true
-      display()
+    mpvGLQueue.async { [self] in
+      if force { forceDraw = true }
+      if forceDraw || !inLiveResize {
+        needsFlip = true
+        display()
+      }
     }
   }
 


### PR DESCRIPTION
This commit will:
- Add a `forceDraw` method to `PlayerWindowController` that checks to see if drawing is needed before calling `VideoLayer`
- Change all code that was forcing drawing to use `PlayerWindowController.forceDraw`
- Change force drawing to use the `mpvGLQueue` queue instead of the main thread
- Rename `VideoLayer.draw(forced)` to `update(force)` to match mpv
- Rename the `VideoLayer` properties `needsMPVRender` and `forceRender` to be `needsFlip` and `forceDraw` to match mpv
- Add an `inLiveResize` property to `VideoLayer` and change live resize code to use it to match up with how mpv handles resizing
- Add `@Atomic` to some `VideoLayer` properties to correct TSAN errors

This corrects the momentary spinning beach ball of death sometimes seen when initially opening a file.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5531.

---

**Description:**
