### PR TITLE
Fix playback of .m3u8 audio prevents screensaver, #5448

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -2848,7 +2848,6 @@ class PlayerCore: NSObject {
   var currentMediaIsAudio = CurrentMediaIsAudioStatus.unknown
 
   func checkCurrentMediaIsAudio() -> CurrentMediaIsAudioStatus {
-    guard !info.isNetworkResource else { return .notAudio }
     let noVideoTrack = info.videoTracks.isEmpty
     let noAudioTrack = info.audioTracks.isEmpty
     if noVideoTrack && noAudioTrack {


### PR DESCRIPTION
This commit will change `PlayerCore.checkCurrentMediaIsAudio` to properly detect if audio is being streamed.

This corrects both the problem with not automatically switching to music mode as well as the problem with not allowing the screensaver to start.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5448.

---

**Description:**
