### PR TITLE
Use the settings tab title for the window title

### DIFF
--- a/iina/PreferenceWindowController.swift
+++ b/iina/PreferenceWindowController.swift
@@ -299,7 +299,11 @@ class PreferenceWindowController: NSWindowController {
         collapseView.setCollapsed(false, animated: false)
       }
     }
-    
+
+    // As per Apple's Human Interface Guidelines update the window’s title to reflect the currently
+    // visible tab. Although the window's title is hidden it still can be seen in the Window menu
+    // and in the dock menu.
+    vc.view.window?.title = vc.preferenceTabTitle
     return vc
   }
 


### PR DESCRIPTION
This commit will change PreferenceWindowController.loadTab to set the window's title to be the title of the selected tab.

This change is required to make IINA adhere to Apple's Human Interface Guidelines which require the tab's title be used. Although IINA hides the window's title it still can be seen in the Window menu and in the dock menu.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
