### PR TITLE
Toggle playback speed between 1x and last used speed, #5389

### DIFF
--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -50,7 +50,7 @@
 "quicksetting.deinterlace" = "Deinterlace";
 "quicksetting.hdr" = "HDR";
 "quicksetting.hide" = "Hide";
-"quicksetting.reset_speed" = "Reset speed to 1x";
+"quicksetting.reset_or_restore_speed" = "Reset speed to 1x or Restore last speed";
 
 // EQ Presets
 "eq.preset.flat" = "Flat";

--- a/iina/Base.lproj/MainMenu.xib
+++ b/iina/Base.lproj/MainMenu.xib
@@ -287,7 +287,7 @@ CA
                             <menuItem title="Speed Down to 0.9x" tag="3" alternate="YES" id="DUP-nm-BJt">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                             </menuItem>
-                            <menuItem title="Reset Speed" tag="5" id="5Gn-90-oDu">
+                            <menuItem title="Reset or Restore Speed" tag="5" id="5Gn-90-oDu">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                             </menuItem>
                             <menuItem isSeparatorItem="YES" id="k1k-sG-1C3"/>

--- a/iina/Base.lproj/PrefControlViewController.xib
+++ b/iina/Base.lproj/PrefControlViewController.xib
@@ -252,7 +252,7 @@
                                 <menuItem title="Pause/Resume" tag="2" id="Dm7-JG-fLd"/>
                                 <menuItem title="Enter/Exit picture-in-picture" tag="4" id="rvS-xA-7bv"/>
                                 <menuItem title="A-B loop" tag="5" id="GHK-4G-DAj"/>
-                                <menuItem title="Reset speed" tag="6" id="Zbp-ok-mMJ"/>
+                                <menuItem title="Reset or Restore Speed" tag="6" id="Zbp-ok-mMJ"/>
                                 <menuItem title="None" id="wkV-Gq-B0T"/>
                             </items>
                         </menu>
@@ -274,7 +274,7 @@
                                 <menuItem title="Pause/Resume" tag="2" id="mOX-Fi-oTv"/>
                                 <menuItem title="Enter/Exit picture-in-picture" tag="4" id="ibM-4r-SQA"/>
                                 <menuItem title="A-B loop" tag="5" id="65z-Gm-oZu"/>
-                                <menuItem title="Reset speed" tag="6" id="ig1-kk-RZu"/>
+                                <menuItem title="Reset or Restore Speed" tag="6" id="ig1-kk-RZu"/>
                                 <menuItem title="None" id="oOk-y6-lek"/>
                             </items>
                         </menu>
@@ -307,7 +307,7 @@
                                 </menuItem>
                                 <menuItem title="Enter/Exit picture-in-picture" tag="4" id="3Pm-nn-HpB"/>
                                 <menuItem title="A-B loop" tag="5" id="iLX-jW-Tdw" userLabel="A-B loop"/>
-                                <menuItem title="Reset speed" tag="6" id="Vv4-AU-kGj"/>
+                                <menuItem title="Reset or Restore Speed" tag="6" id="Vv4-AU-kGj"/>
                                 <menuItem title="None" id="unj-zt-RyU"/>
                             </items>
                         </menu>

--- a/iina/Base.lproj/QuickSettingViewController.xib
+++ b/iina/Base.lproj/QuickSettingViewController.xib
@@ -490,7 +490,7 @@
                                     <constraint firstAttribute="width" constant="16" id="Gst-Sh-NwE"/>
                                 </constraints>
                                 <connections>
-                                    <action selector="resetSpeedAction:" target="-2" id="2Ms-5F-wpA"/>
+                                    <action selector="resetOrRestoreSpeedAction:" target="-2" id="2Ms-5F-wpA"/>
                                 </connections>
                             </button>
                             <customView autoresizesSubviews="NO" horizontalHuggingPriority="200" horizontalCompressionResistancePriority="700" translatesAutoresizingMaskIntoConstraints="NO" id="5v4-Te-950" userLabel="SpeedSlider Container View">

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -120,7 +120,7 @@ extension MainMenuActionHandler {
 
   @objc func menuChangeSpeed(_ sender: NSMenuItem) {
     if sender.tag == 5 {
-      player.setSpeed(1)
+      player.resetOrRestoreSpeed()
       return
     }
     if let multiplier = sender.representedObject as? Double {

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1054,8 +1054,8 @@ class MainWindowController: PlayerWindowController {
       menuTogglePIP(.dummy)
     case .abLoop:
       player.abLoop()
-    case .resetSpeed:
-      player.setSpeed(1.0)
+    case .resetOrRestoreSpeed:
+      player.resetOrRestoreSpeed()
     default:
       break
     }

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1209,6 +1209,12 @@ class PlayerCore: NSObject {
     let speed = speed < AppData.mpvMinPlaybackSpeed ? AppData.mpvMinPlaybackSpeed : speed
     mpv.setDouble(MPVOption.PlaybackControl.speed, speed)
   }
+  
+  func resetOrRestoreSpeed() {
+    let lastPlaybackSpeed = Preference.double(for: .lastPlaybackSpeed)
+    let speed = info.playSpeed == 1 ? lastPlaybackSpeed : 1
+    setSpeed(speed)
+  }
 
   func setVideoAspect(_ aspect: String) {
     if Regex.aspect.matches(aspect) {
@@ -2170,6 +2176,9 @@ class PlayerCore: NSObject {
 
   func speedChanged(_ speed: Double) {
     guard info.state.active else { return }
+    if speed != 1 {
+      Preference.set(speed, for: .lastPlaybackSpeed)
+    }
     info.playSpeed = speed
     sendOSD(.speed(speed))
     mainWindow.updateSpeedLabel(speed: speed)

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -87,6 +87,8 @@ struct Preference {
 
     static let autoRepeat = Key("autoRepeat")
     static let defaultRepeatMode = Key("defaultRepeatMode")
+    
+    static let lastPlaybackSpeed = Key("lastPlaybackSpeed")
 
     /** Show chapter pos in progress bar (bool) */
     static let showChapterPos = Key("showChapterPos")
@@ -410,7 +412,7 @@ struct Preference {
     case hideOSC
     case togglePIP
     case abLoop
-    case resetSpeed
+    case resetOrRestoreSpeed
 
     static var defaultValue = MouseClickAction.none
 
@@ -836,6 +838,8 @@ struct Preference {
 
     .autoRepeat: false,
     .defaultRepeatMode: DefaultRepeatMode.playlist.rawValue,
+    
+    .lastPlaybackSpeed: 1.0,
 
     .usePhysicalResolution: true,
     .initialWindowSizePosition: "",

--- a/iina/QuickSettingViewController.swift
+++ b/iina/QuickSettingViewController.swift
@@ -225,7 +225,7 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
       pendingSwitchRequest = nil
     }
 
-    speedResetBtn.toolTip = NSLocalizedString("quicksetting.reset_speed", comment: "Reset speed to 1x")
+    speedResetBtn.toolTip = NSLocalizedString("quicksetting.reset_or_restore_speed", comment: "Reset speed to 1x or Restore last speed")
 
     subLoadSegmentedControl.image(forSegment: 1)?.isTemplate = true
     switchHorizontalLine.wantsLayer = true
@@ -675,8 +675,8 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
     view.layout()
   }
 
-  @IBAction func resetSpeedAction(_ sender: AnyObject) {
-    player.setSpeed(1.0)
+  @IBAction func resetOrRestoreSpeedAction(_ sender: AnyObject) {
+    player.resetOrRestoreSpeed()
   }
 
   @IBAction func speedChangedAction(_ sender: NSSlider) {
@@ -726,7 +726,6 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
     let newSpeed = constrainSpeed(inputSpeed)
     speedSlider.doubleValue = convertSpeedToSliderValue(newSpeed)
     customSpeedTextField.doubleValue = newSpeed
-    speedResetBtn.isHidden = newSpeed == 1.0
     if player.info.playSpeed != newSpeed {
       player.setSpeed(newSpeed)
     }

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -50,7 +50,7 @@
 "quicksetting.deinterlace" = "Deinterlace";
 "quicksetting.hdr" = "HDR";
 "quicksetting.hide" = "Hide";
-"quicksetting.reset_speed" = "Reset speed to 1x";
+"quicksetting.reset_or_restore_speed" = "Reset speed to 1x or Restore last speed";
 
 // EQ Presets
 "eq.preset.flat" = "Flat";

--- a/iina/en.lproj/MainMenu.strings
+++ b/iina/en.lproj/MainMenu.strings
@@ -41,7 +41,7 @@
 "4sb-4s-VLi.title" = "Quit IINA";
 
 /* Class = "NSMenuItem"; title = "Reset Speed"; ObjectID = "5Gn-90-oDu"; */
-"5Gn-90-oDu.title" = "Reset Speed";
+"5Gn-90-oDu.title" = "Reset or Restore Speed";
 
 /* Class = "NSMenuItem"; title = "About IINA"; ObjectID = "5kV-Vb-QxS"; */
 "5kV-Vb-QxS.title" = "About IINA";

--- a/iina/en.lproj/PrefControlViewController.strings
+++ b/iina/en.lproj/PrefControlViewController.strings
@@ -76,8 +76,8 @@
 /* Class = "NSMenuItem"; title = "Adjust volume"; ObjectID = "SYg-hW-b6r"; */
 "SYg-hW-b6r.title" = "Adjust volume";
 
-/* Class = "NSMenuItem"; title = "Reset speed"; ObjectID = "Vv4-AU-kGj"; */
-"Vv4-AU-kGj.title" = "Reset speed";
+/* Class = "NSMenuItem"; title = "Reset or Restore Speed"; ObjectID = "Vv4-AU-kGj"; */
+"Vv4-AU-kGj.title" = "Reset or Restore Speed";
 
 /* Class = "NSMenuItem"; title = "Adjust playback speed"; ObjectID = "XXq-G1-9sl"; */
 "XXq-G1-9sl.title" = "Adjust playback speed";
@@ -85,8 +85,8 @@
 /* Class = "NSTextFieldCell"; title = "Sensitivity for volume:"; ObjectID = "YQH-1a-WcM"; */
 "YQH-1a-WcM.title" = "Sensitivity for volume:";
 
-/* Class = "NSMenuItem"; title = "Reset speed"; ObjectID = "Zbp-ok-mMJ"; */
-"Zbp-ok-mMJ.title" = "Reset speed";
+/* Class = "NSMenuItem"; title = "Reset or Restore Speed"; ObjectID = "Zbp-ok-mMJ"; */
+"Zbp-ok-mMJ.title" = "Reset or Restore Speed";
 
 /* Class = "NSTextFieldCell"; title = "Sensitivity for speed:"; ObjectID = "aa0-Qo-1nw"; */
 "aa0-Qo-1nw.title" = "Sensitivity for speed:";
@@ -115,8 +115,8 @@
 /* Class = "NSMenuItem"; title = "A-B loop"; ObjectID = "iLX-jW-Tdw"; */
 "iLX-jW-Tdw.title" = "A-B loop";
 
-/* Class = "NSMenuItem"; title = "Reset speed"; ObjectID = "ig1-kk-RZu"; */
-"ig1-kk-RZu.title" = "Reset speed";
+/* Class = "NSMenuItem"; title = "Reset or Restore Speed"; ObjectID = "ig1-kk-RZu"; */
+"ig1-kk-RZu.title" = "Reset or Restore Speed";
 
 /* Class = "NSMenuItem"; title = "None"; ObjectID = "jnR-2I-4x4"; */
 "jnR-2I-4x4.title" = "None";


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5389 

---

This commit changes the playback speed reset button to toggle between 1x speed and the last-used playback speed.
Also, I've modified QuickSettingViewController so that the reset button no longer disappears when the speed is 1x.

### Seeking Advice
I've changed the menu item text from "Reset Speed" to "Reset or Restore Speed", but I'm not sure about the wording. I'm wondering if "Reset/Restore Speed" might be better.

Also, I'm concerned that the tooltip I wrote for this might be too long. Is it okay?
<img width="556" alt="SCR-20250621-teal" src="https://github.com/user-attachments/assets/34d71b9b-05ac-47e1-8351-85fd8acccf1a" />

### Help Needed
I dont know how to modify the description and action for this in the Key Bindings preferences panel.
<img width="821" alt="SCR-20250621-tdxk" src="https://github.com/user-attachments/assets/8c815a68-5e02-4850-ad9c-9e8c8b4ffe43" />
