### PR TITLE
Change Logger.log to take a closure for the message

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -1307,7 +1307,7 @@ class RemoteCommandController {
 
   // MARK: - Private Functions
 
-  private func log(_ message: String, level: Logger.Level = .debug) {
+  private func log(_ message: @autoclosure () -> String, level: Logger.Level = .debug) {
     Logger.log(message, level: level, subsystem: Logger.Sub.nowPlaying)
   }
 

--- a/iina/AutoFileMatcher.swift
+++ b/iina/AutoFileMatcher.swift
@@ -29,7 +29,7 @@ class AutoFileMatcher {
   
   private let subsystem: Logger.Subsystem
 
-  private func log(_ message: String, level: Logger.Level = .debug) {
+  private func log(_ message: @autoclosure () -> String, level: Logger.Level = .debug) {
     Logger.log(message, level: level, subsystem: subsystem)
   }
 

--- a/iina/HistoryController.swift
+++ b/iina/HistoryController.swift
@@ -102,7 +102,7 @@ class HistoryController: NSObject {
     save()
   }
 
-  private func log(_ message: String, level: Logger.Level = .debug) {
+  private func log(_ message: @autoclosure () -> String, level: Logger.Level = .debug) {
     Logger.log(message, level: level, subsystem: Logger.Sub.history)
   }
 }

--- a/iina/Logger.swift
+++ b/iina/Logger.swift
@@ -193,12 +193,46 @@ class Logger: NSObject {
     return "\(time) [\(subsystem.rawValue)][\(level.description)] \(message)\(appendNewlineAtTheEnd ? "\n" : "")"
   }
 
-  static func log(_ message: String, level: Level = .debug, subsystem: Subsystem = .general) {
+  /// Log a message.
+  ///
+  /// Emit a message to the log file if logging is enabled and logging is configured to log messages at the given level.
+  /// - Important: The message is passed as a closure instead of a `String` so that if the message includes string interpolations
+  ///     the evaluation of the expressions and construction of the string can be delayed until it is known that the message will be
+  ///     written to the log file and not discarded due to logging either being disabled or configured to not emit messages at the given
+  ///     level. This method uses [autoclosure](https://docs.swift.org/swift-book/documentation/the-swift-programming-language/closures/#Autoclosures) so that
+  ///     callers do not to need to supply an explicit closure.
+  /// - Parameters:
+  ///   - message: A closure that when executed gives the message to log.
+  ///   - level: The log level of the message.
+  ///   - subsystem: The subsystem emitting this message.
+  static func log(_ message: @autoclosure () -> String, level: Level = .debug,
+                  subsystem: Subsystem = .general) {
+    log(message, level: level, subsystem: subsystem)
+  }
+
+  /// Log a message.
+  ///
+  /// Emit a message to the log file if logging is enabled and logging is configured to log messages at the given level.
+  /// - Important: The message is passed as a closure instead of a `String` so that if the message includes string interpolations
+  ///     the evaluation of the expressions and construction of the string can be delayed until it is known that the message will be
+  ///     written to the log file and not discarded due to logging either being disabled or configured to not emit messages at the given
+  ///     level.
+  /// - Note: This method is intended to only be called by the above `log` method and utility `log` methods used in some
+  ///     classes to supply the subsystem associated with that class.
+  /// - Parameters:
+  ///   - message: A closure that when executed gives the message to log.
+  ///   - level: The log level of the message.
+  ///   - subsystem: The subsystem emitting this message.
+  static func log(_ message: () -> String, level: Level = .debug, subsystem: Subsystem = .general) {
     #if !DEBUG
     guard enabled else { return }
     #endif
 
     guard level.rawValue >= Preference.integer(for: .logLevel) else { return }
+
+    // Now that we know the message will not be discarded, call the closure to construct the message
+    // string to log.
+    let message = message()
 
     let date = Date()
     let string = formatMessage(message, level, subsystem, true, date)

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -1696,7 +1696,7 @@ class MPVController: NSObject {
     }
   }
 
-  private func log(_ message: String, level: Logger.Level = .debug) {
+  private func log(_ message: @autoclosure () -> String, level: Logger.Level = .debug) {
     Logger.log(message, level: level, subsystem: subsystem)
   }
 

--- a/iina/MPVOptionDefaults.swift
+++ b/iina/MPVOptionDefaults.swift
@@ -133,7 +133,7 @@ class MPVOptionDefaults {
     return errorCode
   }
 
-  private static func log(_ message: String, level: Logger.Level = .debug) {
+  private static func log(_ message: @autoclosure () -> String, level: Logger.Level = .debug) {
     Logger.log(message, level: level, subsystem: Logger.Sub.mpvDefaults)
   }
 }

--- a/iina/NowPlayingInfoManager.swift
+++ b/iina/NowPlayingInfoManager.swift
@@ -599,7 +599,7 @@ class NowPlayingInfoManager {
 
   // MARK: - Utils
 
-  private func log(_ message: String, level: Logger.Level = .debug) {
+  private func log(_ message: @autoclosure () -> String, level: Logger.Level = .debug) {
     Logger.log(message, level: level, subsystem: Logger.Sub.nowPlaying)
   }
 

--- a/iina/OnlineSubtitle.swift
+++ b/iina/OnlineSubtitle.swift
@@ -296,7 +296,7 @@ class OnlineSubtitle: NSObject {
     }
   }
 
-  private static func log(_ message: String, level: Logger.Level = .debug) {
+  private static func log(_ message: @autoclosure () -> String, level: Logger.Level = .debug) {
     Logger.log(message, level: level, subsystem: Logger.Sub.onlinesub)
   }
 }

--- a/iina/OpenSubClient.swift
+++ b/iina/OpenSubClient.swift
@@ -512,7 +512,7 @@ class OpenSubClient {
     return headers
   }
 
-  private func log(_ message: String, level: Logger.Level = .debug) {
+  private func log(_ message: @autoclosure () -> String, level: Logger.Level = .debug) {
     Logger.log(message, level: level, subsystem: Logger.Sub.opensubapi)
   }
 

--- a/iina/OpenSubSubtitle.swift
+++ b/iina/OpenSubSubtitle.swift
@@ -386,7 +386,7 @@ class OpenSub {
     }
   }
 
-  private static func log(_ message: String, level: Logger.Level = .debug) {
+  private static func log(_ message: @autoclosure () -> String, level: Logger.Level = .debug) {
     Logger.log(message, level: level, subsystem: Logger.Sub.opensub)
   }
 }

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -131,7 +131,7 @@ class PlayerCore: NSObject {
 
   lazy var subsystem = Logger.makeSubsystem("player\(label!)")
 
-  func log(_ message: String, level: Logger.Level = .debug) {
+  func log(_ message: @autoclosure () -> String, level: Logger.Level = .debug) {
     Logger.log(message, level: level, subsystem: subsystem)
   }
 

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -682,7 +682,7 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
 
   // MARK: - Utils
 
-  func log(_ message: String, level: Logger.Level = .debug) {
+  func log(_ message: @autoclosure () -> String, level: Logger.Level = .debug) {
     Logger.log(message, level: level, subsystem: subsystem)
   }
 }

--- a/iina/ThumbnailCache.swift
+++ b/iina/ThumbnailCache.swift
@@ -23,7 +23,7 @@ class ThumbnailCache {
     .compressionFactor: 0.75
   ]
   
-  private static func log(_ message: String, level: Logger.Level = .debug) {
+  private static func log(_ message: @autoclosure () -> String, level: Logger.Level = .debug) {
     Logger.log(message, level: level, subsystem: subsystem)
   }
 

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -522,7 +522,7 @@ extension VideoView {
     Logger.log(message, level: level, subsystem: hdrSubsystem)
   }
 
-  func log(_ message: String, level: Logger.Level = .debug) {
+  func log(_ message: @autoclosure () -> String, level: Logger.Level = .debug) {
     Logger.log(message, level: level, subsystem: subsystem)
   }
 }


### PR DESCRIPTION
This commit will:
- Change the type of the message parameter of `Logger.log` to be `() -> String`
- Add a `log` method to `Logger` that takes a message parameter of type `@autoclosure () -> String` and calls the existing `log `method
- Change the type of the message parameter of utility log methods supply the subsystem of the associated class to be `@autoclosure () -> String`

Passing the message as a closure instead of a string is useful when the message includes string interpolations as it allows the evaluation of the expressions and construction of the string to be delayed until it is known that the message will be written to the log file and not discarded due to logging either being disabled or configured to not emit messages at the required level.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
