### PR TITLE
Fix inappropriate window resizing, #5567

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2533,7 +2533,7 @@ class MainWindowController: PlayerWindowController {
       // - Resize the window to fit video size
       // - Use physical resolution on Retina displays
       // - Direct use of the mpv geometry option
-      let geometrySet = player.mpv.getString(MPVOption.Window.geometry) != nil
+      let geometrySet = !(player.mpv.getString(MPVOption.Window.geometry) ?? "").isEmpty
       let resizeTiming = Preference.enum(for: .resizeWindowTiming) as Preference.ResizeWindowTiming
       switch resizeTiming {
       case .always:


### PR DESCRIPTION
This commit will change the `handleVideoSizeChange` method in `MainWindowController` to correctly check if the mpv `geometry` option is in use.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5567.

---

**Description:**
