### PR TITLE
docs: correct dylibs file list url

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,8 +51,8 @@ IINA uses mpv for media playback. To build IINA, you can either fetch copies of 
 ```
 
 > [!TIP]
-> - Change the URL in the shell script if you want to download arch-specific binaries. By default, it will download the universal ones. You can download other binaries from `https://iina.io/dylibs/${ARCH}/fileList.txt` where `ARCH` can be `universal`, `arm64` and `x86_64`.
-> - If you want to build an older IINA version, make sure to download the corresponding dylibs. For example, `https://iina.io/dylibs/1.2.0/universal/fileList.txt`.
+> - Change the URL in the shell script if you want to download arch-specific binaries. By default, it will download the universal ones. You can download other binaries from `https://iina.io/dylibs/${ARCH}/filelist.txt` where `ARCH` can be `universal`, `arm64` and `x86_64`.
+> - If you want to build an older IINA version, make sure to download the corresponding dylibs. For example, `https://iina.io/dylibs/1.2.0/universal/filelist.txt`.
 
 2. Open iina.xcodeproj in the [latest public version of Xcode](https://apps.apple.com/app/xcode/id497799835). *IINA may not build if you use any other version.*
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)

---

**Description:**
I tried to download precompiled dylibs, then i noticed the urls in the doc gives me 404. Then after reading the shell script for downloading dylibs, i saw that the Readme has little mistake in url.