### PR TITLE
Fix buffering 100% UI appears when seeking, #5580

### DIFF
--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -37,6 +37,7 @@
 // MainWindowController.swift
 "main.buffering_indicator" = "Buffering… %d%%";
 "main.opening_stream" = "Opening stream…";
+"main.seeking_indicator" = "Seeking…";
 "osc.precision" = "Precision";
 "osc.1s" = "1 second";
 "osc.100ms" = "100 milliseconds";

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2755,19 +2755,30 @@ class MainWindowController: PlayerWindowController {
     }
   }
 
+  /// Update the state of the throbber indicating buffering or seeking is occurring.
+  /// - Important: The mpv
+  ///     [cache-buffering-state](https://mpv.io/manual/stable/#command-interface-cache-buffering-state)
+  ///     property is only valid when
+  ///     [paused-for-cache](https://mpv.io/manual/stable/#command-interface-paused-for-cache) is `true`
+  ///     and can not be used to provide an indication of progress when seeking.
   func updateNetworkState() {
-    let needShowIndicator = player.info.pausedForCache || player.info.isSeeking
-
-    if needShowIndicator {
-      let usedStr = FloatingPointByteCountFormatter.string(fromByteCount: player.info.cacheUsed, prefixedBy: .ki)
-      let speedStr = FloatingPointByteCountFormatter.string(fromByteCount: player.info.cacheSpeed)
-      let bufferingState = player.info.bufferingState
-      bufferIndicatorView.isHidden = false
-      bufferProgressLabel.stringValue = String(format: NSLocalizedString("main.buffering_indicator", comment:"Buffering... %d%%"), bufferingState)
-      bufferDetailLabel.stringValue = "\(usedStr)B (\(speedStr)/s)"
-    } else {
+    guard player.info.pausedForCache || player.info.isSeeking else {
       bufferIndicatorView.isHidden = true
+      return
     }
+    let usedStr = FloatingPointByteCountFormatter.string(fromByteCount: player.info.cacheUsed,
+                                                         countStyle: .binary)
+    let speedStr = FloatingPointByteCountFormatter.string(fromByteCount: player.info.cacheSpeed)
+    if player.info.pausedForCache {
+      let bufferingState = player.info.bufferingState
+      bufferProgressLabel.stringValue = String(format:
+        NSLocalizedString("main.buffering_indicator", comment:"Buffering… %d%%"), bufferingState)
+    } else {
+      bufferProgressLabel.stringValue = NSLocalizedString("main.seeking_indicator",
+                                                          comment: "Seeking…")
+    }
+    bufferDetailLabel.stringValue = "\(usedStr)B (\(speedStr)B/s)"
+    bufferIndicatorView.isHidden = false
   }
 
   func updateArrowButtonImage() {

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -2451,8 +2451,9 @@ class PlayerCore: NSObject {
       if isNetworkStream {
         // Update cache info
         info.pausedForCache = mpv.getFlag(MPVProperty.pausedForCache)
-        info.cacheUsed = ((mpv.getNode(MPVProperty.demuxerCacheState) as? [String: Any])?["fw-bytes"] as? Int) ?? 0
-        info.cacheSpeed = mpv.getInt(MPVProperty.cacheSpeed)
+        let cacheState = mpv.getNode(MPVProperty.demuxerCacheState) as? [String: Any] ?? [:]
+        info.cacheUsed = Int(cacheState["fw-bytes"] as? Int64 ?? 0)
+        info.cacheSpeed = Int(cacheState["raw-input-rate"] as? Int64 ?? 0)
         info.cacheTime = mpv.getInt(MPVProperty.demuxerCacheTime)
         info.bufferingState = mpv.getInt(MPVProperty.cacheBufferingState)
       }

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -37,6 +37,7 @@
 // MainWindowController.swift
 "main.buffering_indicator" = "Buffering… %d%%";
 "main.opening_stream" = "Opening stream…";
+"main.seeking_indicator" = "Seeking…";
 "osc.precision" = "Precision";
 "osc.1s" = "1 second";
 "osc.100ms" = "100 milliseconds";


### PR DESCRIPTION
This commit will:
- Add a new `Seeking…` throbber
- Change `MainWindowController.updateNetworkState` to distinguish between buffering and seeking and not display `cache-buffering-state` when seeking
- Change the formatting of `cacheUsed` to use the correct units
- Change `PlayerCore.syncUI` to use the correct type for `fw-bytes`
- Change `syncUI` to use `demuxer-cache-state/raw-input-rate`, which was obtained when getting the value of `fw-bytes`, instead of getting `cache-speed` from mpv

This corrects multiple problems:
- The percent buffered was being displayed when seeking, but that value is only valid when `paused-for-cache` is `true`
- The number of bytes buffered was being converted to an `Int`, but mpv returns an `Int64`, resulting in the value always being displayed as zero
- The number of bytes buffered was being formatted as if it was in KiB instead of a byte count

This commit corrects the defects reported in #5580, however it does provide the ability to suppress the throbber while seeking. That will be addressed in a separate PR.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5580.

---

**Description:**
