### PR TITLE
Fix external subtitle selection inconsistent, #5587

### DIFF
--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -342,8 +342,11 @@ extension MainMenuActionHandler {
 extension MainMenuActionHandler {
   @objc func menuLoadExternalSub(_ sender: NSMenuItem) {
     let currentDir = player.info.currentURL?.deletingLastPathComponent()
-    Utility.quickOpenPanel(title: "Load external subtitle file", chooseDir: false, dir: currentDir,
-                           sheetWindow: player.currentWindow) { url in
+    // In addition to subtitle files allow the user to choose video files as mpv will look for and
+    // load embedded subtitle streams in the video file.
+    Utility.quickOpenPanel(title: "Load external subtitle", chooseDir: false, dir: currentDir,
+                           sheetWindow: player.currentWindow,
+                           allowedFileTypes: Utility.containsSubExt) { url in
       self.player.loadExternalSubFile(url, delay: true)
     }
   }

--- a/iina/QuickSettingViewController.swift
+++ b/iina/QuickSettingViewController.swift
@@ -852,8 +852,11 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
   @IBAction func loadExternalSubAction(_ sender: NSSegmentedControl) {
     if sender.selectedSegment == 0 {
       let currentDir = player.info.currentURL?.deletingLastPathComponent()
+      // In addition to subtitle files allow the user to choose video files as mpv will look for
+      // and load embedded subtitle streams in the video file.
       Utility.quickOpenPanel(title: "Load external subtitle", chooseDir: false, dir: currentDir,
-                             sheetWindow: player.currentWindow, allowedFileTypes: Utility.supportedFileExt[.sub]) { url in
+                             sheetWindow: player.currentWindow,
+                             allowedFileTypes: Utility.containsSubExt) { url in
         // set a delay
         self.player.loadExternalSubFile(url, delay: true)
         self.subTableView.reloadData()

--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -26,6 +26,9 @@ class Utility {
   static let blacklistExt = supportedFileExt[.sub]! + multipleFilePlaylistExt
   static let lut3dExt = ["3dl", "cube", "dat", "m3d"]
 
+  /// File types that are subtitles or can contain subtitles.
+  static let containsSubExt = supportedFileExt[.sub]! + supportedFileExt[.video]!
+
   enum ValidationResult {
     case ok
     case valueIsEmpty


### PR DESCRIPTION
This commit will:
- Add a `containsSubExt` property to `Utility` that contains the file extensions of files that are subtitles or can contain subtitles
- Change `QuickSettingViewController.loadExternalSubAction` from allowing only subtitle files to be selected to including video files that may contain subtitles
- Change `MainMenuActionHandler.menuLoadExternalSub` from allowing all files to be selected to only allowing subtitle files and video files

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5587.

---

**Description:**
