### PR TITLE
Only close the side panel when mouse up detected in video VideoView

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1003,7 +1003,7 @@ class MainWindowController: PlayerWindowController {
 
       // Single click. Note that `event.clickCount` will be 0 if there is at least one call to `mouseDragged()`,
       // but we will only count it as a drag if `isDragging==true`
-      if event.clickCount <= 1 && !isMouseEvent(event, inAnyOf: [sideBarView, subPopoverView]) && sideBarStatus != .hidden {
+      if event.clickCount <= 1 && videoView.lastEventId == event.eventNumber && sideBarStatus != .hidden {
         hideSideBar()
         return
       }

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -42,6 +42,9 @@ class VideoView: NSView {
 
   static let SRGB = CGColorSpaceCreateDeviceRGB()
 
+  // record the last mouse up event which lands on video view
+  var lastEventId: Int?
+
   // MARK: - Attributes
 
   override var mouseDownCanMoveWindow: Bool {
@@ -123,6 +126,7 @@ class VideoView: NSView {
   /// This appears to be a defect in the Cocoa framework. See the issue for details. As a workaround the mouse up event is caught in
   /// the view which then calls the window controller's method.
   override func mouseUp(with event: NSEvent) {
+    lastEventId = event.eventNumber
     // Only check for Big Sur or greater, not if the preference use legacy full screen is enabled as
     // that can be changed while running and once the window title has been removed and added back
     // AppKit malfunctions from then on. The check for running under Big Sur or later isn't really


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5452.

---

**Description:**
Added a variable in `VideoView` to record the last `mouseUp` event which lands on the `VideoView`. If the event doesn't reach to `VideoView`, then it should not trigger a sidebar closure, for instance when the event is in the `NSColorWell`'s popover (see #5452).