### PR TITLE
Fix window is resizable in legacy full screen mode, #5609

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -644,18 +644,19 @@ class MainWindowController: PlayerWindowController {
     addObserver(to: .default, forName: NSApplication.didChangeScreenParametersNotification) { [unowned self] _ in
       // This observer handles a situation that the user connected a new screen or removed a screen
       let screenCount = NSScreen.screens.count
-      if self.fsState.isFullscreen && Preference.bool(for: .blackOutMonitor) && self.cachedScreenCount != screenCount {
-        self.removeBlackWindow()
-        self.blackOutOtherMonitors()
+      let countChanged = cachedScreenCount != screenCount
+      if fsState.isFullscreen && Preference.bool(for: .blackOutMonitor) && countChanged {
+        removeBlackWindow()
+        blackOutOtherMonitors()
       }
       // Update the cached value
-      self.cachedScreenCount = screenCount
-      self.videoView.updateDisplayLink()
+      cachedScreenCount = screenCount
+      videoView.updateDisplayLink()
       // In normal full screen mode AppKit will automatically adjust the window frame if the window
       // is moved to a new screen such as when the window is on an external display and that display
       // is disconnected. In legacy full screen mode IINA is responsible for adjusting the window's
       // frame.
-      guard self.fsState.isFullscreen, Preference.bool(for: .useLegacyFullScreen) else { return }
+      guard countChanged, fsState.isFullscreen, Preference.bool(for: .useLegacyFullScreen) else { return }
       setWindowFrameForLegacyFullScreen()
     }
 
@@ -1512,6 +1513,7 @@ class MainWindowController: PlayerWindowController {
     windowWillExitFullScreen(Notification(name: .iinaLegacyFullScreen))
     // stylemask
     window.styleMask.remove(.borderless)
+    window.styleMask.insert(.resizable)
     if #available(macOS 10.16, *) {
       window.styleMask.insert(.titled)
       (window as! MainWindow).forceKeyAndMain = false
@@ -1524,7 +1526,7 @@ class MainWindowController: PlayerWindowController {
     // restore window frame and aspect ratio
     let videoSize = player.videoSizeForDisplay
     let aspectRatio = NSSize(width: videoSize.0, height: videoSize.1)
-    let useAnimation = Preference.bool(for: .legacyFullScreenAnimation)
+    let useAnimation = !Preference.bool(for: .disableAnimations)
     if useAnimation {
       // firstly resize to a big frame with same aspect ratio for better visual experience
       let aspectFrame = aspectRatio.shrink(toSize: window.frame.size).centeredRect(in: window.frame)
@@ -1557,6 +1559,7 @@ class MainWindowController: PlayerWindowController {
     windowWillEnterFullScreen(Notification(name: .iinaLegacyFullScreen))
     // stylemask
     window.styleMask.insert(.borderless)
+    window.styleMask.remove(.resizable)
     if #available(macOS 10.16, *) {
       window.styleMask.remove(.titled)
       (window as! MainWindow).forceKeyAndMain = true

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1526,7 +1526,11 @@ class MainWindowController: PlayerWindowController {
     // restore window frame and aspect ratio
     let videoSize = player.videoSizeForDisplay
     let aspectRatio = NSSize(width: videoSize.0, height: videoSize.1)
-    let useAnimation = !Preference.bool(for: .disableAnimations)
+    let useAnimation = {
+      // Animation causes lagging under the macOS Tahoe beta, so don't allow it for now.
+      guard #unavailable(macOS 26) else { return false }
+      return !Preference.bool(for: .disableAnimations)
+    }()
     if useAnimation {
       // firstly resize to a big frame with same aspect ratio for better visual experience
       let aspectFrame = aspectRatio.shrink(toSize: window.frame.size).centeredRect(in: window.frame)
@@ -1544,8 +1548,13 @@ class MainWindowController: PlayerWindowController {
   /// For screens that contain a camera housing the content view will be adjusted to not use that area of the screen.
   private func setWindowFrameForLegacyFullScreen() {
     guard let window = self.window else { return }
+    let useAnimation = {
+      // Animation causes lagging under the macOS Tahoe beta, so don't allow it for now.
+      guard #unavailable(macOS 26) else { return false }
+      return !Preference.bool(for: .disableAnimations)
+    }()
     let screen = window.screen ?? NSScreen.main!
-    window.setFrame(screen.frame, display: true, animate: !Preference.bool(for: PK.disableAnimations))
+    window.setFrame(screen.frame, display: true, animate: useAnimation)
     guard let unusable = screen.cameraHousingHeight else { return }
     // This screen contains an embedded camera. Shorten the height of the window's content view's
     // frame to avoid having part of the window obscured by the camera housing.

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -59,7 +59,6 @@ struct Preference {
     static let fullScreenWhenOpen = Key("fullScreenWhenOpen")
 
     static let useLegacyFullScreen = Key("useLegacyFullScreen")
-    static let legacyFullScreenAnimation = Key("legacyFullScreenAnimation")
 
     /** Black out other monitors while fullscreen (bool) */
     static let blackOutMonitor = Key("blackOutMonitor")
@@ -821,7 +820,6 @@ struct Preference {
     .pauseWhenOpen: false,
     .fullScreenWhenOpen: false,
     .useLegacyFullScreen: false,
-    .legacyFullScreenAnimation: false,
     .showChapterPos: false,
     .resumeLastPosition: true,
     .preventScreenSaver: true,


### PR DESCRIPTION
This commit will:
- Change `legacyAnimateToFullscreen` to remove `resizable` from the window `styleMask`
- Change `legacyAnimateToWindowed` to insert `resizable` into the `styleMask`
- Change `legacyAnimateToWindowed` to use `disableAnimations` instead of `legacyFullScreenAnimation`
- Remove `legacyFullScreenAnimation` from `Preferences`
- Change the observer for `didChangeScreenParametersNotification` to not call `setWindowFrameForLegacyFullScreen` if the screen count did not change

The change to remove `resizable` from the window `styleMask` will prevent the window from being resized while in full screen mode.

This commit will also replace the `legacyFullScreenAnimation` setting for which there was no UI with the new `disableAnimations` setting which can be set using IINA's settings panel.

When entering/exiting full screen mode IINA changes the app presentation options to enable/disable hiding of the menu bar and dock. As the menu bar and dock are sliding away the observer for
`didChangeScreenParametersNotification` because the moving of the menu bar and dock result in changes to the dimensions of the visible frame. The change to only call `setWindowFrameForLegacyFullScreen` when the screen count changes eliminates extra drawing that disrupts the full screen transition animations.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5609.

---

**Description:**
