### PR TITLE
Fix invalid entries in audio device list

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -177,6 +177,7 @@
 		51AC1CAB2A9FBF3700DF7079 /* OpenSubClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC1CAA2A9FBF3700DF7079 /* OpenSubClient.swift */; };
 		51C1BA3A291CA76700C1208A /* InfoDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C1BA39291CA76700C1208A /* InfoDictionary.swift */; };
 		51C889D52C42FF7F007B2584 /* PlayerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C889D42C42FF7F007B2584 /* PlayerState.swift */; };
+		51CA83E22E35AD6300A44B22 /* MPVAudioDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51CA83E12E35AD6300A44B22 /* MPVAudioDevice.swift */; };
 		51CACB9529D500290034CEE5 /* VideoPIPViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51CACB9429D500290034CEE5 /* VideoPIPViewController.swift */; };
 		51DE55C92A6646710050AD06 /* Sysctl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DE55C82A6646710050AD06 /* Sysctl.swift */; };
 		51E63DFB29CFB031008AFC20 /* PlaySlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E63DFA29CFB031008AFC20 /* PlaySlider.swift */; };
@@ -1211,6 +1212,7 @@
 		51C1BA39291CA76700C1208A /* InfoDictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InfoDictionary.swift; sourceTree = "<group>"; };
 		51C3ED782C234BFA004546F9 /* imgutils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = imgutils.h; sourceTree = "<group>"; };
 		51C889D42C42FF7F007B2584 /* PlayerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerState.swift; sourceTree = "<group>"; };
+		51CA83E12E35AD6300A44B22 /* MPVAudioDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPVAudioDevice.swift; sourceTree = "<group>"; };
 		51CACB9429D500290034CEE5 /* VideoPIPViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPIPViewController.swift; sourceTree = "<group>"; };
 		51DE55C82A6646710050AD06 /* Sysctl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sysctl.swift; sourceTree = "<group>"; };
 		51E63DFA29CFB031008AFC20 /* PlaySlider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaySlider.swift; sourceTree = "<group>"; };
@@ -2485,6 +2487,7 @@
 				8450403F1E0ACADD0079C194 /* MPVNode.swift */,
 				842F55A41EA17E7E0081D475 /* IINACommand.swift */,
 				3412DB8D2C2FC64800BBC142 /* Equalizations.swift */,
+				51CA83E12E35AD6300A44B22 /* MPVAudioDevice.swift */,
 			);
 			name = Data;
 			sourceTree = "<group>";
@@ -3209,6 +3212,7 @@
 				841A599D1E1FF5800079E177 /* SleepPreventer.swift in Sources */,
 				51165FBC2E1D91290060B817 /* ReadWriteAtomic.swift in Sources */,
 				84ED99FF1E009C8100A5159B /* PrefAdvancedViewController.swift in Sources */,
+				51CA83E22E35AD6300A44B22 /* MPVAudioDevice.swift in Sources */,
 				840AF5841E73CE3900F4AF92 /* OpenSubSubtitle.swift in Sources */,
 				E32B157D21BC27B100CDBCEA /* JavascriptAPIMenu.swift in Sources */,
 				84AABE8B1DBF634600D138FD /* CharEncoding.swift in Sources */,

--- a/iina/MPVAudioDevice.swift
+++ b/iina/MPVAudioDevice.swift
@@ -1,0 +1,84 @@
+//
+//  MPVAudioDevice.swift
+//  iina
+//
+//  Created by low-batt on 7/26/25.
+//  Copyright © 2025 lhc. All rights reserved.
+//
+
+import Foundation
+
+/// A mpv audio device.
+///
+/// Thie represents one of the audio devices returned by mpv in the value of the property
+/// [audio-device-list](https://mpv.io/manual/stable/#command-interface-audio-device-list) or saved in IINA's
+/// settings as the preferred audio device.
+struct MPVAudioDevice: CustomStringConvertible {
+
+  /// Human readable free form text describing the audio device.
+  let desc: String
+
+  /// `True` if this audio device is not currently connected, false otherwise.
+  let isMissing: Bool
+
+  /// Audio API-specific ID.,
+  ///
+  /// This ID is intended to be passed as the value of the
+  /// [--audio-device](https://mpv.io/manual/stable/#options-audio-device) mpv option when selecting this device.
+  /// The pseudo device with the name set to `auto` selects the default audio output driver and the default device. With the exception
+  /// of that device the `name` starts with a mpv-specific `<driver>/` prefix, tying the device to a specific audio output driver.
+  let name: String
+
+  /// A string describing the audio device that is suitable for use as a menu item title.
+  var description: String {
+    guard isMissing else { return "[\(desc)] \(name)" }
+    return "[\(desc) (missing)] \(name)"
+  }
+
+  /// Audio output driver required by this audio device (if applicable).
+  var driver: String? {
+    guard !name.starts(with: "avfoundation/") else { return "avfoundation" }
+    guard !name.starts(with: "coreaudio/") else { return "coreaudio" }
+    // This is "auto" which corresponds to the default audio output driver and the default device.
+    return nil
+  }
+
+  /// The `name` (audio API-specific ID) with the `<driver>/` prefix removed.
+  private var nameWithoutDriver: String {
+    guard let driver else { return name }
+    return String(name.suffix(name.count - driver.count - 1))
+  }
+
+  /// Construct an audio device.
+  ///
+  /// The device is given as a dictionary that contains two entries describing the device:
+  /// - `name`: Audio API-specific ID, to be passed as the value of the `audio-device` mpv option
+  /// - `description`: Human readable free form text describing the audio device
+  /// - Parameter device: Dictionary describing the device.
+  init(_ device: [String: String]) {
+    desc = device["description"]!
+    name = device["name"]!
+    isMissing = false
+  }
+
+  /// Construct an audio device.
+  /// - Parameters:
+  ///   - desc: Human readable free form text describing the audio device.
+  ///   - name: Audio API-specific ID.
+  ///   - isMissing: Whether this audio device is currently connected.
+  init(desc: String, name: String, isMissing: Bool = false) {
+    self.desc = desc
+    self.name = name
+    self.isMissing = isMissing
+  }
+
+  /// Construct an audio device from an existing device, replacing the audio output driver.
+  /// - Parameters:
+  ///   - device: Audio device to base the new device on.
+  ///   - driver: Audio output driver to use in `name`.
+  init(_ device: MPVAudioDevice, _ driver: String) {
+    self.desc = device.desc
+    self.name = "\(driver)/\(device.nameWithoutDriver)"
+    isMissing = false
+  }
+}

--- a/iina/MPVAudioDevice.swift
+++ b/iina/MPVAudioDevice.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// A mpv audio device.
 ///
-/// Thie represents one of the audio devices returned by mpv in the value of the property
+/// This represents one of the audio devices returned by mpv in the value of the property
 /// [audio-device-list](https://mpv.io/manual/stable/#command-interface-audio-device-list) or saved in IINA's
 /// settings as the preferred audio device.
 struct MPVAudioDevice: CustomStringConvertible {

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -140,7 +140,8 @@ class MPVController: NSObject {
     MPVProperty.videoParamsRotate: MPV_FORMAT_INT64,
     MPVProperty.videoParamsPrimaries: MPV_FORMAT_STRING,
     MPVProperty.videoParamsGamma: MPV_FORMAT_STRING,
-    MPVProperty.idleActive: MPV_FORMAT_FLAG
+    MPVProperty.idleActive: MPV_FORMAT_FLAG,
+    MPVProperty.currentAo: MPV_FORMAT_STRING
   ]
 
   /// Map from mpv codec name to core media video codec types.
@@ -1450,6 +1451,9 @@ class MPVController: NSObject {
       }
       guard idleActive else { break }
       DispatchQueue.main.async { self.player.idleActiveChanged() }
+
+    case MPVProperty.currentAo:
+      DispatchQueue.main.async { self.player.currentAoChanged() }
 
     default:
       // Utility.log("MPV property changed (unhandled): \(name)")

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -534,10 +534,10 @@ class MenuController: NSObject, NSMenuDelegate {
     let devices = PlayerCore.active.getAudioDevices()
     let currAudioDevice = PlayerCore.active.mpv.getString(MPVProperty.audioDevice)
     audioDeviceMenu.removeAllItems()
-    devices.forEach { d in
-      let name = d["name"]!
-      let desc = d["description"]!
-      audioDeviceMenu.addItem(withTitle: "[\(desc)] \(name)", action: #selector(AppDelegate.menuSelectAudioDevice(_:)), tag: nil, obj: name, stateOn: name == currAudioDevice)
+    devices.forEach { device in
+      audioDeviceMenu.addItem(withTitle: String(describing: device),
+                              action: #selector(AppDelegate.menuSelectAudioDevice(_:)), tag: nil,
+                              obj: device.name, stateOn: device.name == currAudioDevice)
     }
   }
 

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -577,7 +577,9 @@ class PlayerCore: NSObject {
     mpv.mpvInit()
     events.emit(.mpvInitialized)
 
-    if !getAudioDevices().contains(where: { $0["name"] == Preference.string(for: .audioDevice)! }) {
+    let audioDevice = Preference.string(for: .audioDevice)!
+    if !getAudioDevices().contains(where: { $0.name == audioDevice }) {
+      log("Audio device configured in settings not found, will default to auto:\n  \(audioDevice)")
       setAudioDevice("auto")
     }
   }
@@ -1709,13 +1711,54 @@ class PlayerCore: NSObject {
     return result
   }
 
-  func getAudioDevices() -> [[String: String]] {
+  /// Return the list of audio devices.
+  ///
+  /// This function obtains the list of audio devices from mpv using the
+  /// [audio-device-list](https://mpv.io/manual/stable/#command-interface-audio-device-list) property. It then
+  /// filters out audio devices that are not applicable based on the current IINA audio output driver setting
+  /// (`audioDriverEnableAVFoundation`) and returns the results as a list of `MPVAudioDevice` objects.
+  ///
+  /// A mpv audio device is tied to a specific audio output driver (with the exception of the `auto` pseudo device). Thus an individual
+  /// audio device appears twice in the list, once for the `coreaudio` driver and once for the `avfoundation` driver. This allows
+  /// you to select both an audio device and a driver at the same time when setting the
+  /// [--audio-device](https://mpv.io/manual/stable/#options-audio-device) mpv option. The documentation for
+  /// [--audio-device](https://mpv.io/manual/stable/#options-audio-device) contains this caution:
+  /// ```
+  /// However, the --ao option will strictly force a specific AO. To avoid confusion, don't use --ao
+  /// and --audio-device together.
+  /// ```
+  /// What the manual means by confusion is that if [--ao](https://mpv.io/manual/stable/#audio-output-drivers-ao)
+  /// has been set to a specific audio output driver and
+  /// [--audio-device](https://mpv.io/manual/stable/#options-audio-device) is then set to an audio device for a
+  /// driver that is not contained in the list of drivers specified by
+  /// [--ao](https://mpv.io/manual/stable/#audio-output-drivers-ao) then mpv will not be able to use that audio
+  /// device and will fall back to the default audio device.
+  ///
+  /// IINA sets [--ao](https://mpv.io/manual/stable/#audio-output-drivers-ao) to either `coreaudio` or
+  /// `avfoundation` based on the IINA `audioDriverEnableAVFoundation` setting. This is intentional as the
+  /// `avfoundation` driver is experimental and has some problems that still need to be resolved. We want the user to explicitly
+  /// choose to use the `avfoundation` driver, not accidentally choose it when selecting an audio output device.
+  ///
+  /// The [audio-device-list](https://mpv.io/manual/stable/#command-interface-audio-device-list) property
+  /// returns the full list of audio devices regardless of the
+  /// [--ao](https://mpv.io/manual/stable/#audio-output-drivers-ao) setting. Thus IINA must filter the list and
+  /// remove audio devices tied to an audio output device that is not configured in
+  /// [--ao](https://mpv.io/manual/stable/#audio-output-drivers-ao).
+  /// - Returns: An array of `MPVAudioDevice` objects  that identify the available audio devices.
+  func getAudioDevices() -> [MPVAudioDevice] {
     let raw = mpv.getNode(MPVProperty.audioDeviceList)
-    if let list = raw as? [[String: String]] {
-      return list
-    } else {
-      return []
+    guard let list = raw as? [[String: String]] else { return [] }
+    let ignore = Preference.bool(for: .audioDriverEnableAVFoundation) ? "coreaudio" : "avfoundation"
+    var result: [MPVAudioDevice] = []
+    for dict in list {
+      let device = MPVAudioDevice(dict)
+      guard device.driver != ignore else {
+        log("Ignored audio device due to audio driver setting:\n \(device)", level: .verbose)
+        continue
+      }
+      result.append(device)
     }
+    return result
   }
 
   func setAudioDevice(_ name: String) {
@@ -2043,6 +2086,34 @@ class PlayerCore: NSObject {
     syncUI(.time)
     syncUI(.chapterList)
     postNotification(.iinaMediaTitleChanged)
+  }
+
+  /// The mpv [current-ao](https://mpv.io/manual/stable/#command-interface-current-ao) property changed.
+  ///
+  /// When the audio output driver changes it may cause the currently selected audio device to be invalid because a mpv audio device
+  /// is tied to a specific audio output driver. Attempt to find and configure the same audio device with the current audio output driver.
+  func currentAoChanged() {
+    guard let currentAo = mpv.getString(MPVProperty.currentAo),
+          let audioDevice = mpv.getString(MPVProperty.audioDevice) else { return }
+    let device = MPVAudioDevice(desc: "", name: audioDevice)
+    let invalid = currentAo == "coreaudio" ? "avfoundation" : "coreaudio"
+    guard device.driver == invalid else { return }
+    let replacement = MPVAudioDevice(device, currentAo)
+    let audioDevices = getAudioDevices()
+    // Make certain the replacement device is in the list of audio devices.
+    let found = audioDevices.contains { $0.name == replacement.name }
+    guard found else {
+      // Should not occur.
+      log("Failed to find replacement audio device \(replacement.name) in:\n  \(audioDevices)",
+          level: .error)
+      return
+    }
+    log("""
+        Audio output driver changed to \(currentAo), changing audio device
+          from \(audioDevice)
+          to \(replacement.name)
+        """)
+    mpv.setString(MPVProperty.audioDevice, replacement.name)
   }
 
   func fullscreenChanged() {

--- a/iina/PrefCodecViewController.swift
+++ b/iina/PrefCodecViewController.swift
@@ -59,30 +59,17 @@ class PrefCodecViewController: PreferenceViewController, PreferenceWindowEmbedda
       audioDriverExperimentalIndicator.image = NSImage.findSFSymbol(["flask.fill"])
     }
 
-    audioDevicePopUp.removeAllItems()
-    let audioDevices = PlayerCore.active.getAudioDevices()
-    var selected = false
-    audioDevices.forEach { device in
-      audioDevicePopUp.addItem(withTitle: "[\(device["description"]!)] \(device["name"]!)")
-      audioDevicePopUp.lastItem!.representedObject = device
-      if device["name"] == Preference.string(for: .audioDevice) {
-        audioDevicePopUp.select(audioDevicePopUp.lastItem!)
-        selected = true
-      }
-    }
-    if !selected {
-      let device = ["name": Preference.string(for: .audioDevice)!,
-                    "description": Preference.string(for: .audioDeviceDesc)!]
-      audioDevicePopUp.addItem(withTitle: "[\(device["description"]!) (missing)] \(device["name"]!)")
-      audioDevicePopUp.lastItem!.representedObject = device
-      audioDevicePopUp.select(audioDevicePopUp.lastItem!)
-    }
+    updateAudioDevicePopUp()
+
+    // The list of audio devices changes based on the audio driver setting.
+    UserDefaults.standard.addObserver(self, forKeyPath: PK.audioDriverEnableAVFoundation.rawValue,
+                                      options: .new, context: nil)
   }
 
   @IBAction func audioDeviceAction(_ sender: Any) {
-    let device = audioDevicePopUp.selectedItem!.representedObject as! [String: String]
-    Preference.set(device["name"]!, for: .audioDevice)
-    Preference.set(device["description"]!, for: .audioDeviceDesc)
+    let device = audioDevicePopUp.selectedItem!.representedObject as! MPVAudioDevice
+    Preference.set(device.name, for: .audioDevice)
+    Preference.set(device.desc, for: .audioDeviceDesc)
   }
 
   @IBAction func spdifBtnAction(_ sender: AnyObject) {
@@ -103,6 +90,60 @@ class PrefCodecViewController: PreferenceViewController, PreferenceWindowEmbedda
     if Preference.string(for: .audioLanguage) != csv {
       Logger.log("Saving \(Preference.Key.audioLanguage.rawValue): \"\(csv)\"", level: .verbose)
       Preference.set(csv, for: .audioLanguage)
+    }
+  }
+
+  /// Update the list of audio devices.
+  ///
+  /// The list needs to be updated whenever the configured audio output driver changes as mpv audio devices are tied to a specific
+  /// audio output driver. The selected audio device may need to be updated to one using the currently configured audio output driver.
+  private func updateAudioDevicePopUp() {
+    audioDevicePopUp.removeAllItems()
+    let audioDevices = PlayerCore.active.getAudioDevices()
+    let audioDevice = Preference.string(for: .audioDevice)!
+    var selected = false
+    audioDevices.forEach { device in
+      audioDevicePopUp.addItem(withTitle: device.description)
+      audioDevicePopUp.lastItem!.representedObject = device
+      if device.name == audioDevice {
+        audioDevicePopUp.select(audioDevicePopUp.lastItem!)
+        selected = true
+      }
+    }
+    if !selected {
+      // The configured audio device may not have been found because the configured audio output
+      // driver was changed. Try and find the same audio device but with the currently configured
+      // audio output driver.
+      let description = Preference.string(for: .audioDeviceDesc)!
+      let device = MPVAudioDevice(desc: description, name: audioDevice)
+      let avfoundationEnabled = Preference.bool(for: PK.audioDriverEnableAVFoundation)
+      let invalid = avfoundationEnabled ? "coreaudio" : "avfoundation"
+      if device.driver == invalid {
+        // The configured audio device is not for the currently configured audio output driver. Try
+        // and find the same device with the configured driver.
+        let driver = avfoundationEnabled ? "avfoundation" : "coreaudio"
+        let replacement = MPVAudioDevice(device, driver)
+        let index = audioDevicePopUp.indexOfItem(withTitle: String(describing: replacement))
+        if index != -1 {
+          // Update the audio device configured in settings with the corresponding device that is
+          // for the currently configured audio output driver.
+          Logger.log("""
+              Audio output driver changed to \(driver), changing audio device setting
+                from: \(audioDevice)
+                to: \(replacement.name)
+              """)
+          audioDevicePopUp.selectItem(at: index)
+          Preference.set(replacement.name, for: .audioDevice)
+          selected = true
+        }
+      }
+    }
+    if !selected {
+      let device = MPVAudioDevice(desc: Preference.string(for: .audioDeviceDesc)!,
+                                  name: audioDevice, isMissing: true)
+      audioDevicePopUp.addItem(withTitle: String(describing: device))
+      audioDevicePopUp.lastItem!.representedObject = device
+      audioDevicePopUp.select(audioDevicePopUp.lastItem!)
     }
   }
 
@@ -129,6 +170,18 @@ class PrefCodecViewController: PreferenceViewController, PreferenceWindowEmbedda
       return
     }
     Preference.set(newValue, for: .toneMappingTargetPeak)
+  }
+
+  override func observeValue(forKeyPath keyPath: String?, of object: Any?,
+                             change: [NSKeyValueChangeKey : Any]?,
+                             context: UnsafeMutableRawPointer?) {
+    guard let keyPath = keyPath else { return }
+    switch keyPath {
+    case PK.audioDriverEnableAVFoundation.rawValue:
+      updateAudioDevicePopUp()
+    default:
+      return
+    }
   }
 
   @IBAction func toneMappingHelpAction(_ sender: Any) {


### PR DESCRIPTION
This commit will:
- Add a new struct `MPVAudioDevice` to represent an audio device
- Change `PlayerCore.getAudioDevices` to return a list of `MPVAudioDevice` objects and filter out devices based on audio output driver setting
- Change `MPVController` to observe the `current-ao` property and inform `PlayerCore` when it changes
- Add a `currentAoChanged` function to `PlayerCore` that attempts to adjust the current selected audio device when the audio output driver changes
- Change `PrefCodecViewController` to update the list of audio devices when the audio output driver changes and attempt to adjust the selected preferred audio device

These changes avoid placing the burden on the user to change the audio device after changing the audio output driver (coreaudio/avfoundation).

See the `PlayerCore.getAudioDevices` documentation comment for a full discussion.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
