### PR TITLE
Fix entering music mode from legacy FS broken, #5612

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -687,6 +687,11 @@ class PlayerCore: NSObject {
                  level: .verbose, subsystem: subsystem)
     }
 
+    // The call to orderOut handles being in full screen mode if using the AppKit supplied full
+    // screen mode, but if legacy full screen mode is being used then IINA needs to handle it.
+    if mainWindow.fsState.isFullscreen, Preference.bool(for: .useLegacyFullScreen) {
+      mainWindow.toggleWindowFullScreen()
+    }
     // hide main window
     mainWindow.window?.orderOut(self)
 


### PR DESCRIPTION
This commit will change `PlayerCore.switchToMiniPlayer` to check if IINA is currently in full screen and is using legacy full screen mode and if so, manually exit full screen mode before switching to music mode.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5612.

---

**Description:**
