### PR TITLE
Fix wait cursor sometimes shown when resizing window, #5620

### DIFF
--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -247,6 +247,11 @@ class ViewLayer: CAOpenGLLayer {
       CATransaction.commit()
     }
 
+    // The call to commit will not render the explicit transaction if it is nested in an implicit
+    // transaction. This can happen when drawing is being forced after a change to the view such as
+    // resizing. Must call flush to ensure any implicit transaction is flushed.
+    CATransaction.flush()
+
     guard isUpdate && needsFlip else { return }
 
     // Must lock the OpenGL context before calling mpv render methods. The OpenGL context must

--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -80,6 +80,9 @@ class ViewLayer: CAOpenGLLayer {
 
   private var fbo: GLint = 1
 
+  /// Lock used to allow the main thread priority access to `displayLock`.
+  private var mainThreadPriorityLock = MainThreadPriorityLock()
+
   /// When `true` the frame needs to be rendered.
   @Atomic private var needsFlip = false
 
@@ -220,26 +223,29 @@ class ViewLayer: CAOpenGLLayer {
   override func copyCGLContext(forPixelFormat pf: CGLPixelFormatObj) -> CGLContextObj { cglContext }
 
   /// Reload the content of this layer.
-  ///
   /// - Important: Because this method is called by tasks on the `mpvGLQueue` an explicit
   ///     [CATransaction](https://developer.apple.com/documentation/quartzcore/catransaction) **must**
   ///     be used. Otherwise if `CA_ASSERT_MAIN_THREAD_TRANSACTIONS` is set to check for unintended UI operations on
   ///     something other than the main thread, IINA will crash with a SIGABRT reporting "an implicit transaction wasn't created on a
   ///     main thread". See issue [#5038](https://github.com/iina/iina/issues/5038).
   override func display() {
+
+    // May need to block other threads to allow the main thread to lock displayLock.
+    mainThreadPriorityLock.beforeLocking()
     displayLock.lock()
     defer { displayLock.unlock() }
+    mainThreadPriorityLock.afterLocked()
 
     let isUpdate = needsFlip
 
-    CATransaction.begin()
-    super.display()
-    CATransaction.commit()
-
-    // The call to commit will not render the explicit transaction if it is nested in an implicit
-    // transaction. This can happen when drawing is being forced after a change to the view such as
-    // resizing. Must call flush to ensure any implicit transaction is flushed.
-    CATransaction.flush()
+    if Thread.isMainThread {
+      super.display()
+    } else {
+      // When not on the main thread use an explicit transaction.
+      CATransaction.begin()
+      super.display()
+      CATransaction.commit()
+    }
 
     guard isUpdate && needsFlip else { return }
 
@@ -441,5 +447,49 @@ class ViewLayer: CAOpenGLLayer {
 
   func ignoreGLError() {
     glGetError()
+  }
+}
+
+// MARK: - Main Thread Priority
+
+/// Lock used to give the main thread priority access to another lock.
+///
+/// Testing revealed that the main thread encounters lock starvation while trying to acquire `displayLock` when the `mpvGLQueue`
+/// thread is constantly locking and unlocking the lock during playback. This sometimes results in a severe hang causing the spinning
+/// beach ball of death to be displayed. This lock uses a
+/// [NSCondition](https://developer.apple.com/documentation/foundation/nscondition) to block other threads
+/// when the main thread needs to lock a lock, giving the main thread a chance to acquire the lock.
+private class MainThreadPriorityLock {
+
+  private let lock = NSCondition()
+
+  /// `True` when the main thread is waiting to lock a lock; `false` otherwise.
+  private var needsLock = false
+
+  /// All threads call this before attempting to lock a lock the main thread has trouble acquiring.
+  ///
+  /// When called by the main thread this function will record that the main thread is waiting for a lock. When called by other threads
+  /// this function will block the thread if the main thread is waiting, allowing it to proceed once the main thread has locked the lock.
+  func beforeLocking() {
+    lock.lock()
+    defer { lock.unlock() }
+    guard Thread.isMainThread else {
+      while needsLock { lock.wait() }
+      return
+    }
+    needsLock = true
+  }
+
+  /// All threads call this after locking a lock the main thread has trouble acquiring.
+  ///
+  /// When called by the main thread this function will record that the main thread has the lock and will allow any blocked threads to
+  /// proceed. When called by other threads this function does nothing. This avoids the caller only calling this when running on the
+  /// main thread.
+  func afterLocked() {
+    guard Thread.isMainThread else { return }
+    lock.lock()
+    defer { lock.unlock() }
+    needsLock = false
+    lock.broadcast()
   }
 }


### PR DESCRIPTION
This commit will:
- Add a class `MainThreadPriorityLock` to `ViewLayer`
- Add a `mainThreadPriorityLock` property to `ViewLayer`
- Change `ViewLayer.display` to use `mainThreadPriorityLock` to block other threads when the main thread needs to lock `displayLock`
- Change `display` to only create a `CATransaction` when not running on the main thread and remove the call to `flush`

This corrects a problem where the main thread would experience lock starvation when trying to lock `displayLock` while playback is in progress.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5620.

---

**Description:**
