### PR TITLE
Fix momentary black screen when exiting full screen mode, #5600

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -1823,5 +1823,5 @@ fileprivate func mpvGetOpenGLFunc(_ ctx: UnsafeMutableRawPointer?, _ name: Unsaf
 
 fileprivate func mpvUpdateCallback(_ ctx: UnsafeMutableRawPointer?) {
   let layer = bridge(ptr: ctx!) as ViewLayer
-  layer.update()
+  layer.updateFromMPV()
 }

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -1844,5 +1844,5 @@ fileprivate func mpvGetOpenGLFunc(_ ctx: UnsafeMutableRawPointer?, _ name: Unsaf
 
 fileprivate func mpvUpdateCallback(_ ctx: UnsafeMutableRawPointer?) {
   let layer = bridge(ptr: ctx!) as ViewLayer
-  layer.update()
+  layer.updateFromMPV()
 }

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -217,6 +217,13 @@ class MainWindowController: PlayerWindowController {
     case animating(toFullscreen: Bool, legacy: Bool, priorWindowedFrame: NSRect)
     case fullscreen(legacy: Bool, priorWindowedFrame: NSRect)
 
+    var isAnimating: Bool {
+      switch self {
+      case .animating: return true
+      default: return false
+      }
+    }
+
     var isFullscreen: Bool {
       switch self {
       case .fullscreen: return true
@@ -1318,10 +1325,9 @@ class MainWindowController: PlayerWindowController {
 
   func window(_ window: NSWindow, startCustomAnimationToEnterFullScreenOn screen: NSScreen, withDuration duration: TimeInterval) {
     NSAnimationContext.runAnimationGroup({ context in
-      context.duration = duration
-      window.animator().setFrame(screen.frame, display: true, animate: !Preference.bool(for: PK.disableAnimations))
-    }, completionHandler: nil)
-
+      context.duration = AccessibilityPreferences.adjustedDuration(duration)
+      window.animator().setFrame(screen.frame, display: true)
+    })
   }
 
   func window(_ window: NSWindow, startCustomAnimationToExitFullScreenWithDuration duration: TimeInterval) {
@@ -1331,9 +1337,9 @@ class MainWindowController: PlayerWindowController {
     let priorWindowedFrame = fsState.priorWindowedFrame!
 
     NSAnimationContext.runAnimationGroup({ context in
-      context.duration = duration
-      window.animator().setFrame(priorWindowedFrame, display: true, animate: !Preference.bool(for: PK.disableAnimations))
-    }, completionHandler: nil)
+      context.duration = AccessibilityPreferences.adjustedDuration(duration)
+      window.animator().setFrame(priorWindowedFrame, display: true)
+    })
 
     NSMenu.setMenuBarVisible(true)
   }
@@ -1403,7 +1409,23 @@ class MainWindowController: PlayerWindowController {
 
     videoView.needsLayout = true
     videoView.layoutSubtreeIfNeeded()
+
     forceDraw("entered full screen mode")
+
+    // The volume slider and the toolbar views in the floating OSC will be detached and not shown
+    // in the floating OSC if the window is too narrow. Once in full screen mode there is enough
+    // space for the full OSC to be shown. Sometimes, but not always, the subview holding the
+    // pause/resume and left/right buttons will not be centered after the OSC expands to full
+    // size. Forcing layout corrects this. See issue #5244.
+    if oscPosition == .floating {
+      fragControlView.needsLayout = true
+    }
+
+    // For legacy full screen resuming drawing is handled by legacyAnimateToFullscreen after
+    // animations have finished.
+    if notification.name != .iinaLegacyFullScreen {
+      videoView.resumeDrawingNewFrames()
+    }
 
     if Preference.bool(for: .blackOutMonitor) {
       blackOutOtherMonitors()
@@ -1584,7 +1606,23 @@ class MainWindowController: PlayerWindowController {
 
     videoView.needsLayout = true
     videoView.layoutSubtreeIfNeeded()
+
     forceDraw("exited full screen mode")
+
+    // The volume slider and the toolbar views in the floating OSC will be detached and not shown in
+    // the floating OSC if the window is too narrow. Once in full screen mode there is enough space
+    // for the full OSC to be shown. Sometimes, but not always, the subview holding the pause/resume
+    // and left/right buttons will not be centered after the OSC expands to full size. Forcing
+    // layout corrects this. See issue #5244.
+    if oscPosition == .floating {
+      fragControlView.needsLayout = true
+    }
+
+    // For legacy full screen resuming drawing is handled by legacyAnimateToWindowed after
+    // animations have finished.
+    if notification.name != .iinaLegacyFullScreen {
+      videoView.resumeDrawingNewFrames()
+    }
 
     if Preference.bool(for: .pauseWhenLeavingFullScreen) && player.info.state == .playing {
       player.pause()
@@ -1637,26 +1675,34 @@ class MainWindowController: PlayerWindowController {
     forceDraw("failed to exit full screen mode")
   }
 
+  /// Take the window in or out of full screen mode.
+  ///
+  /// Before entering or exiting full screen mode this method suspends drawing of new video frames from mpv to avoid lagging. See
+  /// the `ViewLayer.suspendDrawingNewFrames` function for details.
   func toggleWindowFullScreen() {
     guard let window = self.window else { fatalError("make sure the window exists before animating") }
 
     switch fsState {
     case .windowed:
       guard !player.isInMiniPlayer else { return }
-      if Preference.bool(for: .useLegacyFullScreen) {
-        log("Will enter legacy full screen mode")
-        self.legacyAnimateToFullscreen()
-      } else {
-        log("Requesting AppKit enter full screen mode")
-        window.toggleFullScreen(self)
+      videoView.suspendDrawingNewFrames { [self] in
+        if Preference.bool(for: .useLegacyFullScreen) {
+          log("Will enter legacy full screen mode")
+          legacyAnimateToFullscreen()
+        } else {
+          log("Requesting AppKit enter full screen mode")
+          appKitToggleWindowFullScreen()
+        }
       }
     case let .fullscreen(legacy, oldFrame):
-      if legacy {
-        log("Will exit legacy full screen mode")
-        self.legacyAnimateToWindowed(framePriorToBeingInFullscreen: oldFrame)
-      } else {
-        log("Requesting AppKit exit full screen mode")
-        window.toggleFullScreen(self)
+      videoView.suspendDrawingNewFrames { [self] in
+        if legacy {
+          log("Will exit legacy full screen mode")
+          legacyAnimateToWindowed(framePriorToBeingInFullscreen: oldFrame)
+        } else {
+          log("Requesting AppKit exit full screen mode")
+          appKitToggleWindowFullScreen()
+        }
       }
     case let .animating(toFullscreen, legacy, _):
       let legacyAppKit = legacy ? "IINA" : "AppKit"
@@ -1668,48 +1714,73 @@ class MainWindowController: PlayerWindowController {
     }
   }
 
+  /// Take the window in or out of full screen mode.
+  ///
+  /// This function calls
+  /// [NSWindow.toggleFullScreen](https://developer.apple.com/documentation/appkit/nswindow/togglefullscreen(_:))
+  /// to use the AppKit supplied full screen experience.
+  private func appKitToggleWindowFullScreen() {
+    guard let window else { fatalError("make sure the window exists before animating") }
+    guard Preference.bool(for: PK.disableAnimations) else {
+      window.toggleFullScreen(self)
+      return
+    }
+    NSAnimationContext.beginGrouping()
+    defer { NSAnimationContext.endGrouping() }
+    NSAnimationContext.current.duration = 0
+    window.toggleFullScreen(self)
+  }
+
   private func restoreDockSettings() {
     log("Restoring dock settings")
     NSApp.presentationOptions.remove(.autoHideMenuBar)
     NSApp.presentationOptions.remove(.autoHideDock)
   }
 
+  /// Takes the window out of a custom fullscreen mode.
+  /// - Important: This function is _very sensitive_ to changes. See `legacyAnimateToFullscreen`.
   private func legacyAnimateToWindowed(framePriorToBeingInFullscreen: NSRect) {
-    guard let window = self.window else { fatalError("make sure the window exists before animating") }
+    guard let window = self.window as? MainWindow else {
+      fatalError("make sure the window exists before animating")
+    }
+    // An animation group is used to wait until animations are finished before resuming drawing of
+    // new frames.
+    NSAnimationContext.runAnimationGroup({ context in
+      context.duration = AccessibilityPreferences.adjustedDuration(UIAnimationDuration)
 
-    // call delegate
-    windowWillExitFullScreen(Notification(name: .iinaLegacyFullScreen))
-    // stylemask
-    window.styleMask.remove(.borderless)
-    window.styleMask.insert(.resizable)
-    if #available(macOS 10.16, *) {
-      window.styleMask.insert(.titled)
-      window.hasShadow = true
-      (window as! MainWindow).forceKeyAndMain = false
-      window.level = .normal
-    } else {
-      window.styleMask.remove(.fullScreen)
-    }
- 
-    restoreDockSettings()
-    // restore window frame and aspect ratio
-    let videoSize = player.videoSizeForDisplay
-    let aspectRatio = NSSize(width: videoSize.0, height: videoSize.1)
-    let useAnimation = {
-      // Animation causes lagging under the macOS Tahoe beta, so don't allow it for now.
-      guard #unavailable(macOS 26) else { return false }
-      return !Preference.bool(for: .disableAnimations)
-    }()
-    if useAnimation {
-      // firstly resize to a big frame with same aspect ratio for better visual experience
-      let aspectFrame = aspectRatio.shrink(toSize: window.frame.size).centeredRect(in: window.frame)
-      window.setFrame(aspectFrame, display: true, animate: false)
-    }
-    // then animate to the original frame
-    window.setFrame(framePriorToBeingInFullscreen, display: true, animate: useAnimation)
-    window.aspectRatio = aspectRatio
-    // call delegate
-    windowDidExitFullScreen(Notification(name: .iinaLegacyFullScreen))
+      // Certain videos will display a distorted picture while animating using the default layer
+      // contents placement policy scaleAxesIndependently.
+      videoView.layerContentsPlacement = .scaleProportionallyToFill
+
+      // call delegate
+      windowWillExitFullScreen(Notification(name: .iinaLegacyFullScreen))
+
+      // stylemask
+      window.styleMask.remove(.borderless)
+      window.styleMask.insert(.resizable)
+      if #available(macOS 10.16, *) {
+        window.styleMask.insert(.titled)
+        window.hasShadow = true
+        window.forceKeyAndMain = false
+        window.level = .normal
+      } else {
+        window.styleMask.remove(.fullScreen)
+      }
+
+      restoreDockSettings()
+
+      // restore window frame and aspect ratio
+      window.animator().setFrame(framePriorToBeingInFullscreen, display: true)
+      let videoSize = player.videoSizeForDisplay
+      let aspectRatio = NSSize(width: videoSize.0, height: videoSize.1)
+      window.aspectRatio = aspectRatio
+
+      // call delegate
+      windowDidExitFullScreen(Notification(name: .iinaLegacyFullScreen))
+    }, completionHandler: { [self] in
+      videoView.layerContentsPlacement = .scaleAxesIndependently
+      videoView.resumeDrawingNewFrames()
+    })
   }
 
   /// Set the window frame and if needed the content view frame to appropriately use the full screen.
@@ -1717,54 +1788,97 @@ class MainWindowController: PlayerWindowController {
   /// For screens that contain a camera housing the content view will be adjusted to not use that area of the screen.
   private func setWindowFrameForLegacyFullScreen() {
     guard let window = self.window else { return }
-    let useAnimation = {
-      // Animation causes lagging under the macOS Tahoe beta, so don't allow it for now.
-      guard #unavailable(macOS 26) else { return false }
-      return !Preference.bool(for: .disableAnimations)
-    }()
     let screen = window.screen ?? NSScreen.main!
-    window.setFrame(screen.frame, display: true, animate: useAnimation)
+    window.animator().setFrame(screen.frame, display: true)
     guard let unusable = screen.cameraHousingHeight else { return }
     // This screen contains an embedded camera. Shorten the height of the window's content view's
     // frame to avoid having part of the window obscured by the camera housing.
     let view = window.contentView!
-    view.setFrameSize(NSMakeSize(view.frame.width, screen.frame.height - unusable))
+    view.animator().setFrameSize(NSMakeSize(view.frame.width, screen.frame.height - unusable))
   }
 
+  /// Takes the window into a custom fullscreen mode.
+  ///
+  /// If the IINA `Use legacy full screen` setting is enabled this function will be used to enter full screen mode instead of calling
+  /// the AppKit method
+  /// [toggleFullScreen](https://developer.apple.com/documentation/appkit/nswindow/togglefullscreen(_:))
+  /// that uses the system provided full screen experience. Some users do not like that the system provided full screen mode is tied to
+  /// [spaces](https://support.apple.com/guide/mac-help/work-in-multiple-spaces-mh14112/mac). Others
+  /// appreciate that legacy full screen mode provides the ability to fully disable animations when entering and exiting full screen.
+  /// - Important: This function is _very sensitive_ to changes. Any changes in this area of IINA _must be_ extensively tested.
+  ///     There are timing related problems lurking that only show up with some videos on some screens. Sometimes the problems
+  ///     only show up under repeated testing.
+  ///
+  ///     In macOS Big Sur Apple broke legacy full screen mode by changing AppKit to refuse to allow use of the window style mask
+  ///     [fullScreen](https://developer.apple.com/documentation/appkit/nswindow/stylemask-swift.struct/fullscreen)
+  ///     outside of the system provided full screen experience. For this reason IINA must use a combination of other style masks to
+  ///     achieve the same effect. One part of this is removing / inserting the
+  ///     [titled](https://developer.apple.com/documentation/appkit/nswindow/stylemask-swift.struct/titled)
+  ///     style mask. Unfortunately AppKit behavior differs from when the status of a window's title is changed internally by AppKit
+  ///     due to the presence or absence of the `fullScreen` style versus when the `titled` style mask is removed and
+  ///     inserted. Removing or inserting `titled` in the window's
+  ///     [styleMask](https://developer.apple.com/documentation/appkit/nswindow/stylemask-swift.property)
+  ///     causes AppKit to erase and redraw the window. This causes the black background of the views to be drawn before drawing
+  ///     the views. The result is an irritating momentary black flash that disturbs the entering / exiting transition.
+  ///
+  ///     As a result the sequence of operations is critical and designed to minimize the time a black window is displayed before the
+  ///     views are drawn in order to make the erasing of the window imperceptible.
+  ///
+  ///     The mpv player does not suffer from this problem as it does not remove and insert the title and instead merely hides or
+  ///     shows its own custom title view.
   private func legacyAnimateToFullscreen() {
-    guard let window = self.window else { fatalError("make sure the window exists before animating") }
-    // call delegate
-    windowWillEnterFullScreen(Notification(name: .iinaLegacyFullScreen))
-    // stylemask
-    window.styleMask.insert(.borderless)
-    window.styleMask.remove(.resizable)
-    if #available(macOS 10.16, *) {
-      window.styleMask.remove(.titled)
-      window.hasShadow = false
-      (window as! MainWindow).forceKeyAndMain = true
-      window.level = .floating
-    } else {
-      window.styleMask.insert(.fullScreen)
+    guard let window = self.window as? MainWindow else {
+      fatalError("make sure the window exists before animating")
     }
-    // cancel aspect ratio
-    window.resizeIncrements = NSSize(width: 1, height: 1)
-    // auto hide menubar and dock
-    NSApp.presentationOptions.insert(.autoHideMenuBar)
-    NSApp.presentationOptions.insert(.autoHideDock)
-    // set window frame and in some cases content view frame
-    setWindowFrameForLegacyFullScreen()
+    // Using an animation group is important for Macs with a camera housing as it combines setting
+    // the window's frame with resizing the content view to stay within the safe area. This is also
+    // used to wait until animations are finished before resuming drawing of new frames.
+    NSAnimationContext.runAnimationGroup({ context in
+      context.duration = AccessibilityPreferences.adjustedDuration(UIAnimationDuration)
 
-    // The volume slider and the toolbar views in the floating OSC will be detached and not shown in
-    // the floating OSC if the window is too narrow. Once in full screen mode there is enough space
-    // for the full OSC to be shown. Sometimes, but not always, the subview holding the pause/resume
-    // and left/right buttons will not be centered after the OSC expands to full size. Forcing
-    // layout corrects this. See issue #5244.
-    if oscPosition == .floating {
-      fragControlView.needsLayout = true
-    }
+      // Certain videos will display a distorted picture while animating using the default layer
+      // contents placement policy scaleAxesIndependently.
+      videoView.layerContentsPlacement = .scaleProportionallyToFill
 
-    // call delegate
-    windowDidEnterFullScreen(Notification(name: .iinaLegacyFullScreen))
+      // call delegate
+      windowWillEnterFullScreen(Notification(name: .iinaLegacyFullScreen))
+
+      // stylemask
+      window.styleMask.insert(.borderless)
+      window.styleMask.remove(.resizable)
+      if #available(macOS 10.16, *) {
+        window.styleMask.remove(.titled)
+        window.hasShadow = false
+        window.forceKeyAndMain = true
+        window.level = .floating
+      } else {
+        window.styleMask.insert(.fullScreen)
+      }
+      // cancel aspect ratio
+      window.resizeIncrements = NSSize(width: 1, height: 1)
+
+      // auto hide menubar and dock
+      NSApp.presentationOptions.insert(.autoHideMenuBar)
+      NSApp.presentationOptions.insert(.autoHideDock)
+
+      // set window frame and in some cases content view frame
+      setWindowFrameForLegacyFullScreen()
+
+      // The volume slider and the toolbar views in the floating OSC will be detached and not shown
+      // in the floating OSC if the window is too narrow. Once in full screen mode there is enough
+      // space for the full OSC to be shown. Sometimes, but not always, the subview holding the
+      // pause/resume and left/right buttons will not be centered after the OSC expands to full
+      // size. Forcing layout corrects this. See issue #5244.
+      if oscPosition == .floating {
+        fragControlView.needsLayout = true
+      }
+
+      // call delegate
+      windowDidEnterFullScreen(Notification(name: .iinaLegacyFullScreen))
+    }, completionHandler: { [self] in
+      videoView.layerContentsPlacement = .scaleAxesIndependently
+      videoView.resumeDrawingNewFrames()
+    })
   }
 
   // MARK: - Window delegate: Size
@@ -1867,11 +1981,19 @@ class MainWindowController: PlayerWindowController {
     videoView.videoLayer.inLiveResize = true
   }
 
-  // resize framebuffer in videoView after resizing.
+  /// A live resize operation on the window has ended.
+  ///
+  /// When resizing has finished mpv must be updated with the current window's scale.
+  /// - Important: Entering and exiting full screen mode may trigger more than one resizing sequence resulting in multiple calls to
+  ///     `updateWindowParametersForMPV`. That function calls `mpv.setDouble` to set `windowScale`. Instruments
+  ///     shows that causes a main thread micro hang of greater than 300 ms. As video rendering is suspended when entering and
+  ///     exiting full screen mode there is no need to update mpv. That will be done by `windowDidEnterFullScreen` or
+  ///     `windowDidExitFullScreen`.
   func windowDidEndLiveResize(_ notification: Notification) {
     // Must not access mpv while it is asynchronously processing stop and quit commands.
-    // See comments in windowWillExitFullScreen for details.
-    guard player.info.state.active else { return }
+    // See comments in windowWillExitFullScreen for details. This includes setting of inLiveResize
+    // because setting that property forces drawing.
+    guard player.info.state.active, !fsState.isAnimating else { return }
     videoView.videoLayer.inLiveResize = false
     updateWindowParametersForMPV()
   }

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -171,6 +171,13 @@ class MainWindowController: PlayerWindowController {
     case animating(toFullscreen: Bool, legacy: Bool, priorWindowedFrame: NSRect)
     case fullscreen(legacy: Bool, priorWindowedFrame: NSRect)
 
+    var isAnimating: Bool {
+      switch self {
+      case .animating: return true
+      default: return false
+      }
+    }
+
     var isFullscreen: Bool {
       switch self {
       case .fullscreen: return true
@@ -1354,9 +1361,9 @@ class MainWindowController: PlayerWindowController {
 
   func window(_ window: NSWindow, startCustomAnimationToEnterFullScreenOn screen: NSScreen, withDuration duration: TimeInterval) {
     NSAnimationContext.runAnimationGroup({ context in
-      context.duration = duration
-      window.animator().setFrame(screen.frame, display: true, animate: !Preference.bool(for: PK.disableAnimations))
-    }, completionHandler: nil)
+      context.duration = AccessibilityPreferences.adjustedDuration(duration)
+      window.animator().setFrame(screen.frame, display: true)
+    })
   }
 
   func window(_ window: NSWindow, startCustomAnimationToExitFullScreenWithDuration duration: TimeInterval) {
@@ -1366,9 +1373,9 @@ class MainWindowController: PlayerWindowController {
     let priorWindowedFrame = fsState.priorWindowedFrame!
 
     NSAnimationContext.runAnimationGroup({ context in
-      context.duration = duration
-      window.animator().setFrame(priorWindowedFrame, display: true, animate: !Preference.bool(for: PK.disableAnimations))
-    }, completionHandler: nil)
+      context.duration = AccessibilityPreferences.adjustedDuration(duration)
+      window.animator().setFrame(priorWindowedFrame, display: true)
+    })
 
     NSMenu.setMenuBarVisible(true)
   }
@@ -1437,7 +1444,23 @@ class MainWindowController: PlayerWindowController {
 
     videoView.needsLayout = true
     videoView.layoutSubtreeIfNeeded()
+
     forceDraw("entered full screen mode")
+
+    // The volume slider and the toolbar views in the floating OSC will be detached and not shown
+    // in the floating OSC if the window is too narrow. Once in full screen mode there is enough
+    // space for the full OSC to be shown. Sometimes, but not always, the subview holding the
+    // pause/resume and left/right buttons will not be centered after the OSC expands to full
+    // size. Forcing layout corrects this. See issue #5244.
+    if oscPosition == .floating {
+      fragControlView.needsLayout = true
+    }
+
+    // For legacy full screen resuming drawing is handled by legacyAnimateToFullscreen after
+    // animations have finished.
+    if notification.name != .iinaLegacyFullScreen {
+      videoView.resumeDrawingNewFrames()
+    }
 
     if Preference.bool(for: .blackOutMonitor) {
       blackOutOtherMonitors()
@@ -1602,7 +1625,23 @@ class MainWindowController: PlayerWindowController {
 
     videoView.needsLayout = true
     videoView.layoutSubtreeIfNeeded()
+
     forceDraw("exited full screen mode")
+
+    // The volume slider and the toolbar views in the floating OSC will be detached and not shown in
+    // the floating OSC if the window is too narrow. Once in full screen mode there is enough space
+    // for the full OSC to be shown. Sometimes, but not always, the subview holding the pause/resume
+    // and left/right buttons will not be centered after the OSC expands to full size. Forcing
+    // layout corrects this. See issue #5244.
+    if oscPosition == .floating {
+      fragControlView.needsLayout = true
+    }
+
+    // For legacy full screen resuming drawing is handled by legacyAnimateToWindowed after
+    // animations have finished.
+    if notification.name != .iinaLegacyFullScreen {
+      videoView.resumeDrawingNewFrames()
+    }
 
     if Preference.bool(for: .pauseWhenLeavingFullScreen) && player.info.state == .playing {
       player.pause()
@@ -1655,26 +1694,34 @@ class MainWindowController: PlayerWindowController {
     forceDraw("failed to exit full screen mode")
   }
 
+  /// Take the window in or out of full screen mode.
+  ///
+  /// Before entering or exiting full screen mode this method suspends drawing of new video frames from mpv to avoid lagging. See
+  /// the `ViewLayer.suspendDrawingNewFrames` function for details.
   func toggleWindowFullScreen() {
     guard let window = self.window else { fatalError("make sure the window exists before animating") }
 
     switch fsState {
     case .windowed:
       guard !player.isInMiniPlayer else { return }
-      if Preference.bool(for: .useLegacyFullScreen) {
-        log("Will enter legacy full screen mode")
-        self.legacyAnimateToFullscreen()
-      } else {
-        log("Requesting AppKit enter full screen mode")
-        window.toggleFullScreen(self)
+      videoView.suspendDrawingNewFrames { [self] in
+        if Preference.bool(for: .useLegacyFullScreen) {
+          log("Will enter legacy full screen mode")
+          legacyAnimateToFullscreen()
+        } else {
+          log("Requesting AppKit enter full screen mode")
+          appKitToggleWindowFullScreen()
+        }
       }
     case let .fullscreen(legacy, oldFrame):
-      if legacy {
-        log("Will exit legacy full screen mode")
-        self.legacyAnimateToWindowed(framePriorToBeingInFullscreen: oldFrame)
-      } else {
-        log("Requesting AppKit exit full screen mode")
-        window.toggleFullScreen(self)
+      videoView.suspendDrawingNewFrames { [self] in
+        if legacy {
+          log("Will exit legacy full screen mode")
+          legacyAnimateToWindowed(framePriorToBeingInFullscreen: oldFrame)
+        } else {
+          log("Requesting AppKit exit full screen mode")
+          appKitToggleWindowFullScreen()
+        }
       }
     case let .animating(toFullscreen, legacy, _):
       let legacyAppKit = legacy ? "IINA" : "AppKit"
@@ -1686,44 +1733,69 @@ class MainWindowController: PlayerWindowController {
     }
   }
 
+  /// Take the window in or out of full screen mode.
+  ///
+  /// This function calls
+  /// [NSWindow.toggleFullScreen](https://developer.apple.com/documentation/appkit/nswindow/togglefullscreen(_:))
+  /// to use the AppKit supplied full screen experience.
+  private func appKitToggleWindowFullScreen() {
+    guard let window else { fatalError("make sure the window exists before animating") }
+    guard Preference.bool(for: PK.disableAnimations) else {
+      window.toggleFullScreen(self)
+      return
+    }
+    NSAnimationContext.beginGrouping()
+    defer { NSAnimationContext.endGrouping() }
+    NSAnimationContext.current.duration = 0
+    window.toggleFullScreen(self)
+  }
+
   private func restoreDockSettings() {
     log("Restoring dock settings")
     NSApp.presentationOptions.remove(.autoHideMenuBar)
     NSApp.presentationOptions.remove(.autoHideDock)
   }
 
+  /// Takes the window out of a custom fullscreen mode.
+  /// - Important: This function is _very sensitive_ to changes. See `legacyAnimateToFullscreen`.
   private func legacyAnimateToWindowed(framePriorToBeingInFullscreen: NSRect) {
-    guard let window = self.window else { fatalError("make sure the window exists before animating") }
-
-    // call delegate
-    windowWillExitFullScreen(Notification(name: .iinaLegacyFullScreen))
-    // stylemask
-    window.styleMask.remove(.borderless)
-    window.styleMask.insert(.resizable)
-    window.styleMask.insert(.titled)
-    window.hasShadow = true
-    (window as! MainWindow).forceKeyAndMain = false
-    window.level = .normal
-
-    restoreDockSettings()
-    // restore window frame and aspect ratio
-    let videoSize = player.videoSizeForDisplay
-    let aspectRatio = NSSize(width: videoSize.0, height: videoSize.1)
-    let useAnimation = {
-      // Animation causes lagging under the macOS Tahoe beta, so don't allow it for now.
-      guard #unavailable(macOS 26) else { return false }
-      return !Preference.bool(for: .disableAnimations)
-    }()
-    if useAnimation {
-      // firstly resize to a big frame with same aspect ratio for better visual experience
-      let aspectFrame = aspectRatio.shrink(toSize: window.frame.size).centeredRect(in: window.frame)
-      window.setFrame(aspectFrame, display: true, animate: false)
+    guard let window = self.window as? MainWindow else {
+      fatalError("make sure the window exists before animating")
     }
-    // then animate to the original frame
-    window.setFrame(framePriorToBeingInFullscreen, display: true, animate: useAnimation)
-    setWindowAspectRatio(aspectRatio)
-    // call delegate
-    windowDidExitFullScreen(Notification(name: .iinaLegacyFullScreen))
+    // An animation group is used to wait until animations are finished before resuming drawing of
+    // new frames.
+    NSAnimationContext.runAnimationGroup({ context in
+      context.duration = AccessibilityPreferences.adjustedDuration(UIAnimationDuration)
+
+      // Certain videos will display a distorted picture while animating using the default layer
+      // contents placement policy scaleAxesIndependently.
+      videoView.layerContentsPlacement = .scaleProportionallyToFill
+
+      // call delegate
+      windowWillExitFullScreen(Notification(name: .iinaLegacyFullScreen))
+
+      // stylemask
+      window.styleMask.remove(.borderless)
+      window.styleMask.insert(.resizable)
+      window.styleMask.insert(.titled)
+      window.hasShadow = true
+      window.forceKeyAndMain = false
+      window.level = .normal
+
+      restoreDockSettings()
+
+      // restore window frame and aspect ratio
+      window.animator().setFrame(framePriorToBeingInFullscreen, display: true)
+      let videoSize = player.videoSizeForDisplay
+      let aspectRatio = NSSize(width: videoSize.0, height: videoSize.1)
+      window.aspectRatio = aspectRatio
+
+      // call delegate
+      windowDidExitFullScreen(Notification(name: .iinaLegacyFullScreen))
+    }, completionHandler: { [self] in
+      videoView.layerContentsPlacement = .scaleAxesIndependently
+      videoView.resumeDrawingNewFrames()
+    })
   }
 
   /// Set the window frame and if needed the content view frame to appropriately use the full screen.
@@ -1731,51 +1803,93 @@ class MainWindowController: PlayerWindowController {
   /// For screens that contain a camera housing the content view will be adjusted to not use that area of the screen.
   private func setWindowFrameForLegacyFullScreen() {
     guard let window = self.window else { return }
-    let useAnimation = {
-      // Animation causes lagging under the macOS Tahoe beta, so don't allow it for now.
-      guard #unavailable(macOS 26) else { return false }
-      return !Preference.bool(for: .disableAnimations)
-    }()
     let screen = window.screen ?? NSScreen.main!
-    window.setFrame(screen.frame, display: true, animate: useAnimation)
+    window.animator().setFrame(screen.frame, display: true)
     guard let unusable = screen.cameraHousingHeight else { return }
     // This screen contains an embedded camera. Shorten the height of the window's content view's
     // frame to avoid having part of the window obscured by the camera housing.
     let view = window.contentView!
-    view.setFrameSize(NSMakeSize(view.frame.width, screen.frame.height - unusable))
+    view.animator().setFrameSize(NSMakeSize(view.frame.width, screen.frame.height - unusable))
   }
 
+  /// Takes the window into a custom fullscreen mode.
+  ///
+  /// If the IINA `Use legacy full screen` setting is enabled this function will be used to enter full screen mode instead of calling
+  /// the AppKit method
+  /// [toggleFullScreen](https://developer.apple.com/documentation/appkit/nswindow/togglefullscreen(_:))
+  /// that uses the system provided full screen experience. Some users do not like that the system provided full screen mode is tied to
+  /// [spaces](https://support.apple.com/guide/mac-help/work-in-multiple-spaces-mh14112/mac). Others
+  /// appreciate that legacy full screen mode provides the ability to fully disable animations when entering and exiting full screen.
+  /// - Important: This function is _very sensitive_ to changes. Any changes in this area of IINA _must be_ extensively tested.
+  ///     There are timing related problems lurking that only show up with some videos on some screens. Sometimes the problems
+  ///     only show up under repeated testing.
+  ///
+  ///     In macOS Big Sur Apple broke legacy full screen mode by changing AppKit to refuse to allow use of the window style mask
+  ///     [fullScreen](https://developer.apple.com/documentation/appkit/nswindow/stylemask-swift.struct/fullscreen)
+  ///     outside of the system provided full screen experience. For this reason IINA must use a combination of other style masks to
+  ///     achieve the same effect. One part of this is removing / inserting the
+  ///     [titled](https://developer.apple.com/documentation/appkit/nswindow/stylemask-swift.struct/titled)
+  ///     style mask. Unfortunately AppKit behavior differs from when the status of a window's title is changed internally by AppKit
+  ///     due to the presence or absence of the `fullScreen` style versus when the `titled` style mask is removed and
+  ///     inserted. Removing or inserting `titled` in the window's
+  ///     [styleMask](https://developer.apple.com/documentation/appkit/nswindow/stylemask-swift.property)
+  ///     causes AppKit to erase and redraw the window. This causes the black background of the views to be drawn before drawing
+  ///     the views. The result is an irritating momentary black flash that disturbs the entering / exiting transition.
+  ///
+  ///     As a result the sequence of operations is critical and designed to minimize the time a black window is displayed before the
+  ///     views are drawn in order to make the erasing of the window imperceptible.
+  ///
+  ///     The mpv player does not suffer from this problem as it does not remove and insert the title and instead merely hides or
+  ///     shows its own custom title view.
   private func legacyAnimateToFullscreen() {
-    guard let window = self.window else { fatalError("make sure the window exists before animating") }
-    // call delegate
-    windowWillEnterFullScreen(Notification(name: .iinaLegacyFullScreen))
-    // stylemask
-    window.styleMask.insert(.borderless)
-    window.styleMask.remove(.resizable)
-    window.styleMask.remove(.titled)
-    window.hasShadow = false
-    (window as! MainWindow).forceKeyAndMain = true
-    window.level = .floating
-
-    // cancel aspect ratio
-    window.resizeIncrements = NSSize(width: 1, height: 1)
-    // auto hide menubar and dock
-    NSApp.presentationOptions.insert(.autoHideMenuBar)
-    NSApp.presentationOptions.insert(.autoHideDock)
-    // set window frame and in some cases content view frame
-    setWindowFrameForLegacyFullScreen()
-
-    // The volume slider and the toolbar views in the floating OSC will be detached and not shown in
-    // the floating OSC if the window is too narrow. Once in full screen mode there is enough space
-    // for the full OSC to be shown. Sometimes, but not always, the subview holding the pause/resume
-    // and left/right buttons will not be centered after the OSC expands to full size. Forcing
-    // layout corrects this. See issue #5244.
-    if oscPosition == .floating {
-      fragControlView.needsLayout = true
+    guard let window = self.window as? MainWindow else {
+      fatalError("make sure the window exists before animating")
     }
+    // Using an animation group is important for Macs with a camera housing as it combines setting
+    // the window's frame with resizing the content view to stay within the safe area. This is also
+    // used to wait until animations are finished before resuming drawing of new frames.
+    NSAnimationContext.runAnimationGroup({ context in
+      context.duration = AccessibilityPreferences.adjustedDuration(UIAnimationDuration)
 
-    // call delegate
-    windowDidEnterFullScreen(Notification(name: .iinaLegacyFullScreen))
+      // Certain videos will display a distorted picture while animating using the default layer
+      // contents placement policy scaleAxesIndependently.
+      videoView.layerContentsPlacement = .scaleProportionallyToFill
+
+      // call delegate
+      windowWillEnterFullScreen(Notification(name: .iinaLegacyFullScreen))
+
+      // stylemask
+      window.styleMask.insert(.borderless)
+      window.styleMask.remove(.resizable)
+      window.styleMask.remove(.titled)
+      window.hasShadow = false
+      window.forceKeyAndMain = true
+      window.level = .floating
+      // cancel aspect ratio
+      window.resizeIncrements = NSSize(width: 1, height: 1)
+
+      // auto hide menubar and dock
+      NSApp.presentationOptions.insert(.autoHideMenuBar)
+      NSApp.presentationOptions.insert(.autoHideDock)
+
+      // set window frame and in some cases content view frame
+      setWindowFrameForLegacyFullScreen()
+
+      // The volume slider and the toolbar views in the floating OSC will be detached and not shown
+      // in the floating OSC if the window is too narrow. Once in full screen mode there is enough
+      // space for the full OSC to be shown. Sometimes, but not always, the subview holding the
+      // pause/resume and left/right buttons will not be centered after the OSC expands to full
+      // size. Forcing layout corrects this. See issue #5244.
+      if oscPosition == .floating {
+        fragControlView.needsLayout = true
+      }
+
+      // call delegate
+      windowDidEnterFullScreen(Notification(name: .iinaLegacyFullScreen))
+    }, completionHandler: { [self] in
+      videoView.layerContentsPlacement = .scaleAxesIndependently
+      videoView.resumeDrawingNewFrames()
+    })
   }
 
   // MARK: - Window delegate: Size
@@ -1844,11 +1958,19 @@ class MainWindowController: PlayerWindowController {
     liveText.clearAnalysis()
   }
 
-  // resize framebuffer in videoView after resizing.
+  /// A live resize operation on the window has ended.
+  ///
+  /// When resizing has finished mpv must be updated with the current window's scale.
+  /// - Important: Entering and exiting full screen mode may trigger more than one resizing sequence resulting in multiple calls to
+  ///     `updateWindowParametersForMPV`. That function calls `mpv.setDouble` to set `windowScale`. Instruments
+  ///     shows that causes a main thread micro hang of greater than 300 ms. As video rendering is suspended when entering and
+  ///     exiting full screen mode there is no need to update mpv. That will be done by `windowDidEnterFullScreen` or
+  ///     `windowDidExitFullScreen`.
   func windowDidEndLiveResize(_ notification: Notification) {
     // Must not access mpv while it is asynchronously processing stop and quit commands.
-    // See comments in windowWillExitFullScreen for details.
-    guard player.info.state.active else { return }
+    // See comments in windowWillExitFullScreen for details. This includes setting of inLiveResize
+    // because setting that property forces drawing.
+    guard player.info.state.active, !fsState.isAnimating else { return }
     videoView.videoLayer.inLiveResize = false
     updateWindowParametersForMPV()
     liveText.requestAnalysis()

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -411,6 +411,14 @@ class VideoView: NSView {
       return "Unrecognized core video return code"
     }
   }
+
+  // MARK: - Suspending Background Rendering
+
+  func suspendDrawingNewFrames(_ body: @escaping () -> ()) {
+    videoLayer.suspendDrawingNewFrames(body)
+  }
+
+  func resumeDrawingNewFrames() { videoLayer.resumeDrawingNewFrames() }
 }
 
 // MARK: - HDR

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -410,6 +410,14 @@ class VideoView: NSView {
       return "Unrecognized core video return code"
     }
   }
+
+  // MARK: - Suspending Background Rendering
+
+  func suspendDrawingNewFrames(_ body: @escaping () -> ()) {
+    videoLayer.suspendDrawingNewFrames(body)
+  }
+
+  func resumeDrawingNewFrames() { videoLayer.resumeDrawingNewFrames() }
 }
 
 // MARK: - HDR

--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -80,14 +80,17 @@ class ViewLayer: CAOpenGLLayer {
 
   private var fbo: GLint = 1
 
-  /// Lock used to allow the main thread priority access to `displayLock`.
-  private var mainThreadPriorityLock = MainThreadPriorityLock()
+  /// When `true` drawing will proceed even if mpv indicates nothing needs to be done.
+  @Atomic private var forceDraw = false
+
+  /// When `true` drawing of new video frames from mpv is suspended.
+  @Atomic var isSuspended = false
+
+  // Lock used to allow the main thread priority access to `displayLock`.
+  private let mainThreadPriorityLock = MainThreadPriorityLock()
 
   /// When `true` the frame needs to be rendered.
   @Atomic private var needsFlip = false
-
-  /// When `true` drawing will proceed even if mpv indicates nothing needs to be done.
-  @Atomic private var forceDraw = false
 
   /// Indicates whether the view is being rendered as part of a live resizing operation.
   ///
@@ -133,6 +136,9 @@ class ViewLayer: CAOpenGLLayer {
   /// [contentsScale](https://developer.apple.com/documentation/quartzcore/calayer/1410746-contentsscale).
   /// To trigger this start IINA playing on an external monitor with a different scale factor with a MacBook in closed clamshell mode then
   /// unplug the external monitor.
+  /// - Important: _Do not_ copy the value of `inLiveResize`. Setting that property triggers drawing which may cause a
+  ///     deadlock. This can be reproduced by playing a video in full screen mode and clicking on `Custom…` in the `Crop`
+  ///     submenu.
   /// - Parameter layer: The layer from which custom fields should be copied.
   override init(layer: Any) {
     let previousLayer = layer as! ViewLayer
@@ -145,7 +151,6 @@ class ViewLayer: CAOpenGLLayer {
     backgroundColor = previousLayer.backgroundColor
     wantsExtendedDynamicRangeContent = previousLayer.wantsExtendedDynamicRangeContent
     contentsFormat = previousLayer.contentsFormat
-    inLiveResize = previousLayer.inLiveResize
     isAsynchronous = previousLayer.isAsynchronous
     Logger.log("Created view layer shadow copy")
   }
@@ -158,15 +163,16 @@ class ViewLayer: CAOpenGLLayer {
 
   override func canDraw(inCGLContext ctx: CGLContextObj, pixelFormat pf: CGLPixelFormatObj,
                         forLayerTime t: CFTimeInterval, displayTime ts: UnsafePointer<CVTimeStamp>?) -> Bool {
+    guard !forceDraw else { return true }
     // When in live resize, skip all drawing calls on the main thread.
     // Setting isAsynchronous = true is enough to prevent jittering.
-    guard !(inLiveResize && Thread.isMainThread) else { return false }
+    guard !(Thread.isMainThread && inLiveResize) else { return false }
+    if !inLiveResize {
+      isAsynchronous = false
+    }
     return videoView.$isUninited.withReadLock() { isUninited in
       guard !isUninited else { return false }
-      if !inLiveResize {
-        isAsynchronous = false
-      }
-      return forceDraw || videoView.player.mpv.shouldRenderUpdateFrame()
+      return videoView.player.mpv.shouldRenderUpdateFrame()
     }
   }
 
@@ -230,7 +236,10 @@ class ViewLayer: CAOpenGLLayer {
   ///     main thread". See issue [#5038](https://github.com/iina/iina/issues/5038).
   override func display() {
 
-    // May need to block other threads to allow the main thread to lock displayLock.
+    // Testing revealed that the main thread encounters lock starvation while trying to acquire the
+    // display lock when the mpvGLQueue thread is constantly locking and unlocking the lock,
+    // sometimes causing the spinning beach ball of death to be displayed. Must block other threads
+    // when the main thread wants the lock.
     mainThreadPriorityLock.beforeLocking()
     displayLock.lock()
     defer { displayLock.unlock() }
@@ -241,7 +250,7 @@ class ViewLayer: CAOpenGLLayer {
     if Thread.isMainThread {
       super.display()
     } else {
-      // When not on the main thread use an explicit transaction.
+      // Must use an explicit transaction when not on the main thread.
       CATransaction.begin()
       super.display()
       CATransaction.commit()
@@ -252,6 +261,7 @@ class ViewLayer: CAOpenGLLayer {
     // resizing. Must call flush to ensure any implicit transaction is flushed.
     CATransaction.flush()
 
+    // If the frame was not drawn then must tell mpv to skip rendering this frame.
     guard isUpdate && needsFlip else { return }
 
     // Must lock the OpenGL context before calling mpv render methods. The OpenGL context must
@@ -279,11 +289,58 @@ class ViewLayer: CAOpenGLLayer {
   }
 
   func update(force: Bool = false) {
-    mpvGLQueue.async { [self] in
-      if force { forceDraw = true }
-      needsFlip = true
-      display()
+    if force { forceDraw = true }
+    needsFlip = true
+    display()
+  }
+
+  /// A request to reload the content of this layer coming from mpv.
+  ///
+  /// Requests from mpv are processed in a background thread to avoid overloading the main thread, This differs from the mpv player
+  /// which uses the main thread for all rendering now that it is using a Metal layer.
+  /// - Note: IINA will block update requests from mpv while entering/exiting full screen mode. See issue
+  ///     [#5600](https://github.com/iina/iina/issues/5600).
+  func updateFromMPV() {
+    guard !isSuspended else { return }
+    mpvGLQueue.async { self.update() }
+  }
+
+  // MARK: - Suspending Background Rendering
+
+  /// Suspend drawing of new video frames from mpv.
+  ///
+  /// This is a workaround for momentary hangs that occur when entering and exiting full screen mode. Use of
+  /// `mainThreadPriorityLock` has reduced the conflicts between the main thread and the `mpvGLQueue` thread, but the
+  /// main thread still experiences blocking when entering and exiting full screen mode if the background rendering thread is active.
+  /// The lagging does not always occur as it is timing related. But when it does it is bad enough that the disruption caused by
+  /// suspending processing of frames is preferred. See issue [#5600](https://github.com/iina/iina/issues/5600).
+  /// - Important: The call to `suspend` only stops new tasks from executing. At the time this function is called a
+  ///     `mpvGLQueue` thread could be drawing a frame. IINA needs to wait to start entering or exiting full screen mode until the
+  ///     current drawing task finishes. To accomplish this suspension of the `mpvGLQueue` is performed by a task submitted to
+  ///     that queue. At that point the queue is know to be idle and the closure is submitted to the main thread.
+  /// - Parameter body: Closure to execute once drawing of new video frames has been suspended.
+  func suspendDrawingNewFrames(_ body: @escaping () -> ()) {
+    guard !isSuspended else {
+      // Internal error. Should never happen.
+      Logger.log("Ignored attempt to suspend drawing when already suspended", level: .error)
+      body()
+      return
     }
+    isSuspended = true
+    mpvGLQueue.async { [self] in
+      mpvGLQueue.suspend()
+      DispatchQueue.main.async { body() }
+    }
+  }
+
+  /// Resume drawing of new video frames from mpv.
+  func resumeDrawingNewFrames() {
+    guard isSuspended else {
+      Logger.log("Ignored attempt to resume drawing when not suspended", level: .error)
+      return
+    }
+    isSuspended = false
+    mpvGLQueue.resume()
   }
 
   // MARK: - Core OpenGL Context and Pixel Format

--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -80,14 +80,17 @@ class ViewLayer: CAOpenGLLayer {
 
   private var fbo: GLint = 1
 
-  /// Lock used to allow the main thread priority access to `displayLock`.
-  private var mainThreadPriorityLock = MainThreadPriorityLock()
+  /// When `true` drawing will proceed even if mpv indicates nothing needs to be done.
+  @Atomic private var forceDraw = false
+
+  /// When `true` drawing of new video frames from mpv is suspended.
+  @Atomic var isSuspended = false
+
+  // Lock used to allow the main thread priority access to `displayLock`.
+  private let mainThreadPriorityLock = MainThreadPriorityLock()
 
   /// When `true` the frame needs to be rendered.
   @Atomic private var needsFlip = false
-
-  /// When `true` drawing will proceed even if mpv indicates nothing needs to be done.
-  @Atomic private var forceDraw = false
 
   /// Indicates whether the view is being rendered as part of a live resizing operation.
   ///
@@ -136,6 +139,9 @@ class ViewLayer: CAOpenGLLayer {
   /// [contentsScale](https://developer.apple.com/documentation/quartzcore/calayer/1410746-contentsscale).
   /// To trigger this start IINA playing on an external monitor with a different scale factor with a MacBook in closed clamshell mode then
   /// unplug the external monitor.
+  /// - Important: _Do not_ copy the value of `inLiveResize`. Setting that property triggers drawing which may cause a
+  ///     deadlock. This can be reproduced by playing a video in full screen mode and clicking on `Custom…` in the `Crop`
+  ///     submenu.
   /// - Parameter layer: The layer from which custom fields should be copied.
   override init(layer: Any) {
     let previousLayer = layer as! ViewLayer
@@ -148,7 +154,6 @@ class ViewLayer: CAOpenGLLayer {
     backgroundColor = previousLayer.backgroundColor
     wantsExtendedDynamicRangeContent = previousLayer.wantsExtendedDynamicRangeContent
     contentsFormat = previousLayer.contentsFormat
-    inLiveResize = previousLayer.inLiveResize
     isAsynchronous = previousLayer.isAsynchronous
     Logger.log("Created view layer shadow copy")
   }
@@ -161,15 +166,16 @@ class ViewLayer: CAOpenGLLayer {
 
   override func canDraw(inCGLContext ctx: CGLContextObj, pixelFormat pf: CGLPixelFormatObj,
                         forLayerTime t: CFTimeInterval, displayTime ts: UnsafePointer<CVTimeStamp>?) -> Bool {
+    guard !forceDraw else { return true }
     // When in live resize, skip all drawing calls on the main thread.
     // Setting isAsynchronous = true is enough to prevent jittering.
-    guard !(inLiveResize && Thread.isMainThread) else { return false }
+    guard !(Thread.isMainThread && inLiveResize) else { return false }
+    if !inLiveResize {
+      isAsynchronous = false
+    }
     return videoView.$isUninited.withReadLock() { isUninited in
       guard !isUninited else { return false }
-      if !inLiveResize {
-        isAsynchronous = false
-      }
-      return forceDraw || videoView.player.mpv.shouldRenderUpdateFrame()
+      return videoView.player.mpv.shouldRenderUpdateFrame()
     }
   }
 
@@ -264,7 +270,10 @@ class ViewLayer: CAOpenGLLayer {
   ///     main thread". See issue [#5038](https://github.com/iina/iina/issues/5038).
   override func display() {
 
-    // May need to block other threads to allow the main thread to lock displayLock.
+    // Testing revealed that the main thread encounters lock starvation while trying to acquire the
+    // display lock when the mpvGLQueue thread is constantly locking and unlocking the lock,
+    // sometimes causing the spinning beach ball of death to be displayed. Must block other threads
+    // when the main thread wants the lock.
     mainThreadPriorityLock.beforeLocking()
     displayLock.lock()
     defer { displayLock.unlock() }
@@ -275,7 +284,7 @@ class ViewLayer: CAOpenGLLayer {
     if Thread.isMainThread {
       super.display()
     } else {
-      // When not on the main thread use an explicit transaction.
+      // Must use an explicit transaction when not on the main thread.
       CATransaction.begin()
       super.display()
       CATransaction.commit()
@@ -286,6 +295,7 @@ class ViewLayer: CAOpenGLLayer {
     // resizing. Must call flush to ensure any implicit transaction is flushed.
     CATransaction.flush()
 
+    // If the frame was not drawn then must tell mpv to skip rendering this frame.
     guard isUpdate && needsFlip else { return }
 
     // Must lock the OpenGL context before calling mpv render methods. The OpenGL context must
@@ -313,11 +323,58 @@ class ViewLayer: CAOpenGLLayer {
   }
 
   func update(force: Bool = false) {
-    mpvGLQueue.async { [self] in
-      if force { forceDraw = true }
-      needsFlip = true
-      display()
+    if force { forceDraw = true }
+    needsFlip = true
+    display()
+  }
+
+  /// A request to reload the content of this layer coming from mpv.
+  ///
+  /// Requests from mpv are processed in a background thread to avoid overloading the main thread, This differs from the mpv player
+  /// which uses the main thread for all rendering now that it is using a Metal layer.
+  /// - Note: IINA will block update requests from mpv while entering/exiting full screen mode. See issue
+  ///     [#5600](https://github.com/iina/iina/issues/5600).
+  func updateFromMPV() {
+    guard !isSuspended else { return }
+    mpvGLQueue.async { self.update() }
+  }
+
+  // MARK: - Suspending Background Rendering
+
+  /// Suspend drawing of new video frames from mpv.
+  ///
+  /// This is a workaround for momentary hangs that occur when entering and exiting full screen mode. Use of
+  /// `mainThreadPriorityLock` has reduced the conflicts between the main thread and the `mpvGLQueue` thread, but the
+  /// main thread still experiences blocking when entering and exiting full screen mode if the background rendering thread is active.
+  /// The lagging does not always occur as it is timing related. But when it does it is bad enough that the disruption caused by
+  /// suspending processing of frames is preferred. See issue [#5600](https://github.com/iina/iina/issues/5600).
+  /// - Important: The call to `suspend` only stops new tasks from executing. At the time this function is called a
+  ///     `mpvGLQueue` thread could be drawing a frame. IINA needs to wait to start entering or exiting full screen mode until the
+  ///     current drawing task finishes. To accomplish this suspension of the `mpvGLQueue` is performed by a task submitted to
+  ///     that queue. At that point the queue is know to be idle and the closure is submitted to the main thread.
+  /// - Parameter body: Closure to execute once drawing of new video frames has been suspended.
+  func suspendDrawingNewFrames(_ body: @escaping () -> ()) {
+    guard !isSuspended else {
+      // Internal error. Should never happen.
+      Logger.log("Ignored attempt to suspend drawing when already suspended", level: .error)
+      body()
+      return
     }
+    isSuspended = true
+    mpvGLQueue.async { [self] in
+      mpvGLQueue.suspend()
+      DispatchQueue.main.async { body() }
+    }
+  }
+
+  /// Resume drawing of new video frames from mpv.
+  func resumeDrawingNewFrames() {
+    guard isSuspended else {
+      Logger.log("Ignored attempt to resume drawing when not suspended", level: .error)
+      return
+    }
+    isSuspended = false
+    mpvGLQueue.resume()
   }
 
   private func framebufferSnapshot(width: Int, height: Int) -> NSImage? {


### PR DESCRIPTION
This commit will:
- Add `suspendDrawingNewFrames` and `resumeDrawingNewFrames` to `ViewLayer` to provide the ability to suspend drawing of new video frames from mpv
- Add similar methods to `ViewView` that delegate to `ViewLayer`
- Add an `isSuspended` property to `ViewLayer`
- Add a `updateFromMPV` function to `ViewLayer`
- Change `MVPController.mpvUpdateCallback` to call `updateFromMPV`
- Remove setting of `inLiveResize` in the shadow copy initializer to correct a hang
- Correct checking for forced drawing in `canDraw`
- Change forced drawing back to using the main thread
- Change `MainWindowController.toggleWindowFullScreen` to suspend drawing of new video frames from mpv before starting to enter or exit full screen mode
- Change `legacyAnimateToFullscreen` and `legacyAnimateToWindowed` to wrap operations in a `NSAnimationContext`
- Change `windowDidEndLiveResize` to not call `updateWindowParametersForMPV` when entering or exiting full screen mode

This actually does not fix the momentary black screen that occurs when entering or exiting full screen mode when using legacy full screen mode. The black screen is caused by AppKit erasing the window and then drawing a black background. The changes order operations to minimize the time a black window is displayed before the views are drawn in order to make the erasing of the window imperceptible.

This also corrects problems with the floating OSC being malformed after entering / exiting full screen mode. And a hang when attempting to apply a custom crop when in full screen mode.

These changes remove the fix for issue #5352, "Audio Stutter and Dropped Frames When Entering Full-Screen Mode". The fix for that issue allowed background drawing to continue while entering and exiting full screen mode. This works some of the time, but frequently the main thread hangs for enough time to noticeably disrupt animations. This bad behavior is more apparent to the user than the dropped frames.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5600.

---

**Description:**
