### PR TITLE
Fix hang opening file in mpv_set_property, #5630

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -1136,9 +1136,20 @@ class MPVController: NSObject {
 
     case MPV_EVENT_END_FILE:
       let reason = event.pointee.data.load(as: mpv_end_file_reason.self)
-      DispatchQueue.main.async {
-        self.player.fileEnded(dueToStopCommand: reason == MPV_END_FILE_REASON_STOP)
+      let dueToStopCommand = reason == MPV_END_FILE_REASON_STOP
+      // When the IINA "Pause" setting is enabled under "When media is opened" IINA must tell mpv to
+      // pause playback ASAP. Events are delivered asynchronously. If the IINA
+      // "Play next item automatically" setting is enabled mpv will currently be loading the next
+      // item in the playlist and will immediately start playing it as soon as loading completes.
+      // Thus there is a race condition as to whether IINA can pause playback before mpv starts
+      // playing the media. This is more likely to happen with audio files that can be quickly
+      // loaded. As handling this does not require accessing IINA state not protected by locks and
+      // only available to the main thread along with the requirement to pause playback ASAP we will
+      // not leave this to the PlayerCore function and handle this now before calling fileEnded.
+      if !dueToStopCommand, Preference.bool(for: .pauseWhenOpen) {
+        setFlag(MPVOption.PlaybackControl.pause, true, level: .verbose)
       }
+      DispatchQueue.main.async { self.player.fileEnded(dueToStopCommand) }
 
     case MPV_EVENT_COMMAND_REPLY:
       let reply = event.pointee.reply_userdata

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -485,10 +485,10 @@ class PlayerCore: NSObject {
     miniPlayer.pendingShow = true
     initialWindow.close()
 
-    // Make sure playback does not start once the file is loaded. Playback will be started in the
-    // fileLoaded method once IINA is ready assuming the user has not enabled the setting to pause
-    // when media is opened.
-    mpv.setFlag(MPVOption.PlaybackControl.pause, true, level: .verbose)
+    // If the IINA "Pause" setting is enabled under "When media is opened" then pause mpv playback
+    // before loading the file. Otherwise make sure mpv playback is enabled.
+    let pause = Preference.bool(for: .pauseWhenOpen)
+    mpv.setFlag(MPVOption.PlaybackControl.pause, pause ? true : false, level: .verbose)
 
     // Send load file command
     info.justOpenedFile = true
@@ -1938,14 +1938,10 @@ class PlayerCore: NSObject {
     guard info.state.active else { return }
     log("File loaded")
 
-    // Normally playback will be paused at this point because PlayerCore sets playback to be paused
-    // before loading a file. This is required to be able to support the setting to pause when media
-    // is opened, otherwise there would be a race condition as to whether IINA can pause playback
-    // before mpv has started playing the media. However plugins have direct access to mpv and can
-    // load files. Ensure mpv is paused so IINA and mpv are in sync on the state of playback.
-    info.state = .paused
+    // Normally at this point the file will be playing. However if the IINA "Pause" setting is
+    // enabled under "When media is opened" IINA will have paused playback.
+    info.state =  mpv.getFlag(MPVOption.PlaybackControl.pause) ? .paused : .playing
     syncUI(.playButton)
-    mpv.setFlag(MPVOption.PlaybackControl.pause, true, level: .verbose)
 
     // Must force drawing to cover the case where this player was previously used to play a video
     // and is now playing an audio file without an album cover and without using music mode.
@@ -2009,13 +2005,10 @@ class PlayerCore: NSObject {
     }
     postNotification(.iinaFileLoaded)
     events.emit(.fileLoaded, data: info.currentURL?.absoluteString ?? "")
-    if !(info.justOpenedFile && Preference.bool(for: .pauseWhenOpen)) {
-      mpv.setFlag(MPVOption.PlaybackControl.pause, false, level: .verbose)
-    }
     syncUI(.playlist)
   }
 
-  func fileEnded(dueToStopCommand: Bool) {
+  func fileEnded(_ dueToStopCommand: Bool) {
     // if receive end-file when loading file, might be error
     // wait for idle
     if info.state == .loading {


### PR DESCRIPTION
This commit will:
- Remove setting of the mpv pause option in PlayerCore.fileLoaded
- Change PlayerCore.openMainWindow to set the mpv pause option based on whether the IINA setting to pause playback when opening media is enabled
- Change MPVController.handleEvent to tell mpv to pause playback when the MPV_EVENT_END_FILE is received, if the IINA "Pause" setting is enabled

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5630.

---

**Description:**
