### PR TITLE
Remove AV1 from hardware decoding whitelist

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -181,6 +181,8 @@ class MPVController: NSObject {
   /// hardware decoding support on this Mac. This is not comprehensive. This method only covers the recent codecs whose support
   /// for hardware decoding varies among Macs. This merely reduces the dependence upon the FFmpeg fallback to software decoding
   /// feature in some cases.
+  /// - ToDo: **REMOVE** workaround for FFmpeg not supporting AV1 hardware decoding when upgrading to a FFmpeg version
+  ///         that supports it.
   private func adjustCodecWhiteList() {
     // Allow the user to override this behavior.
     guard !userOptionsContains(MPVOption.Video.hwdecCodecs) else {
@@ -209,6 +211,17 @@ class MPVController: NSObject {
       // any of them retain the codec in the option value.
       for codecType in codecTypes {
         if HardwareDecodeCapabilities.shared.isSupported(codecType) {
+          if codecType == kCMVideoCodecType_AV1 {
+            // WORKAROUND missing support for AV1 hardware decoding.
+            // This Mac supports AV1 hardware decoding, but the version of FFmpeg IINA is using does
+            // not. FFmpeg will try to use hardware decoding, which will fail. FFmpeg will then fall
+            // back to software decoding. When FFmpeg does this it logs the warning message "Error
+            // while decoding frame (hardware decoding)!" which is alarming to users. Prevent this
+            // by removing AV1 from the codecs whitelist.
+            needsAdjustment = true
+            log("FFmpeg does not support av1 hardware decoding")
+            continue codecLoop
+          }
           adjusted.append(codec)
           continue codecLoop
         }


### PR DESCRIPTION
This commit will change MPVController.adjustCodecWhiteList to remove av1 from the mpv hwdec-codecs option for Macs with chips that support AV1 hardware decoding.

This change is a workaround that prevents FFmpeg from logging the warning message "Error while decoding frame (hardware decoding)!" which is alarming to users. Once FFmpeg supports AV1 hardware decoding this code can be removed.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
