### PR TITLE
Fix typo in plugin iina.core, #5648

### DIFF
--- a/iina/JavascriptAPICore.swift
+++ b/iina/JavascriptAPICore.swift
@@ -143,7 +143,7 @@ fileprivate func serialize(track: MPVTrack) -> [String: Any] {
   return [
     "id": track.id,
     "title": track.title ?? NSNull(),
-    "formattedTitie": track.readableTitle,
+    "formattedTitle": track.readableTitle,
     "lang": track.lang ?? NSNull(),
     "codec": track.codec ?? NSNull(),
     "isDefault": track.isDefault,


### PR DESCRIPTION
This commit will correct the spelling of "formattedTitle" in JavascriptAPICore.serialize.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5648.

---

**Description:**
