### PR TITLE
Close gapless audio playback, #5433

### DIFF
--- a/iina/AppData.swift
+++ b/iina/AppData.swift
@@ -67,6 +67,7 @@ struct AppData {
   static let algorithmHelpLink = "https://mpv.io/manual/stable/#options-tone-mapping"
   static let disableAnimationsHelpLink = "https://developer.apple.com/design/human-interface-guidelines/accessibility#Motion"
   static let gainAdjustmentHelpLink = "https://mpv.io/manual/stable/#options-replaygain"
+  static let gaplessAudioHelpLink = "https://mpv.io/manual/stable/#options-gapless-audio"
   static let audioDriverHellpLink = "https://mpv.io/manual/stable/#audio-output-drivers-coreaudio"
 
   static let widthWhenNoVideo = 640

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -392,6 +392,10 @@
 "hwdec.auto" = "Enable hardware decoding. However, most of the video filters won't work properly.";
 "hwdec.auto-copy" = "Enable hardware decoding. It will consume double the memory but work with video filters.";
 
+"gaplessAudio.no" = "Playback of consecutive audio files may result in silence or disruption at the point of file change.";
+"gaplessAudio.weak" = "If the audio format the decoder output changes, the audio device is closed and reopened, disrupting gapless playback.";
+"gaplessAudio.yes" = "The audio device is opened using parameters chosen for the first file played and is then kept open for gapless playback. Following files may be resampled.";
+
 "subencoding.auto" = "Auto detect";
 
 "osc_toolbar.settings" = "Quick Settings";

--- a/iina/Base.lproj/PrefCodecViewController.xib
+++ b/iina/Base.lproj/PrefCodecViewController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23090" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="23727" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23090"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="23727"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -12,6 +12,7 @@
                 <outlet property="audioDriverExperimentalIndicator" destination="Dbe-hj-GvX" id="WHH-NB-aY0"/>
                 <outlet property="audioLangTokenField" destination="Mib-1U-RcV" id="r2O-EA-DIJ"/>
                 <outlet property="enableToneMappingBtn" destination="Ty3-Qg-ysu" id="m0d-uT-DYO"/>
+                <outlet property="gaplessAudioDescriptionTextField" destination="cUT-Lx-JsB" id="JHp-yj-6cH"/>
                 <outlet property="hwdecDescriptionTextField" destination="0Re-PY-hmC" id="AXN-kV-1hB"/>
                 <outlet property="sectionAudioView" destination="bsP-Kc-xXR" id="1QS-jd-Kg7"/>
                 <outlet property="sectionReplayGainView" destination="co0-g1-6K5" id="bow-xz-T7j"/>
@@ -97,7 +98,7 @@
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="120" id="P27-F4-Ogg"/>
                     </constraints>
                     <connections>
-                        <action selector="hwdecAction:" target="-2" id="7dj-Fp-1mw"/>
+                        <action selector="hwdecAction:" target="-2" id="JwW-iM-2z8"/>
                         <binding destination="pxc-7C-SGP" name="selectedTag" keyPath="values.hardwareDecoder" id="sDU-i2-6lN"/>
                     </connections>
                 </popUpButton>
@@ -358,11 +359,11 @@
             <point key="canvasLocation" x="783" y="560"/>
         </customView>
         <customView id="bsP-Kc-xXR">
-            <rect key="frame" x="0.0" y="0.0" width="480" height="302"/>
+            <rect key="frame" x="0.0" y="0.0" width="480" height="367"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
             <subviews>
                 <textField identifier="SectionTitleAudio" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="0Ig-J7-VYp">
-                    <rect key="frame" x="-2" y="278" width="46" height="16"/>
+                    <rect key="frame" x="-2" y="343" width="46" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="Audio:" id="sV5-dL-MUt">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -370,7 +371,7 @@
                     </textFieldCell>
                 </textField>
                 <textField focusRingType="none" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ld5-Mm-4Pt">
-                    <rect key="frame" x="269" y="101" width="58" height="21"/>
+                    <rect key="frame" x="269" y="180" width="58" height="21"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="58" id="Dwo-eo-Aga"/>
                     </constraints>
@@ -391,7 +392,7 @@
                     </connections>
                 </textField>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="81P-il-Bo2">
-                    <rect key="frame" x="118" y="8" width="145" height="16"/>
+                    <rect key="frame" x="118" y="87" width="145" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Preferred language:" id="wjt-O6-KbC">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -399,7 +400,7 @@
                     </textFieldCell>
                 </textField>
                 <tokenField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Mib-1U-RcV" customClass="LanguageTokenField" customModule="IINA" customModuleProvider="target">
-                    <rect key="frame" x="269" y="5" width="211" height="21"/>
+                    <rect key="frame" x="269" y="84" width="211" height="21"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="160" id="NAx-xr-hr8"/>
                     </constraints>
@@ -413,7 +414,7 @@
                     </connections>
                 </tokenField>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SEM-Qm-KeU">
-                    <rect key="frame" x="335" y="104" width="92" height="14"/>
+                    <rect key="frame" x="335" y="183" width="92" height="14"/>
                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Default: 0 (Auto)" id="2yO-To-el7">
                         <font key="font" metaFont="label" size="11"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -421,7 +422,7 @@
                     </textFieldCell>
                 </textField>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Taj-6a-uFI">
-                    <rect key="frame" x="118" y="72" width="145" height="16"/>
+                    <rect key="frame" x="118" y="151" width="145" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="S/PDIF output:" id="up6-6A-4sn">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -429,7 +430,7 @@
                     </textFieldCell>
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="iAK-W4-XCh">
-                    <rect key="frame" x="267" y="71" width="52" height="18"/>
+                    <rect key="frame" x="267" y="150" width="52" height="18"/>
                     <buttonCell key="cell" type="check" title="AC3" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="1uU-MC-7Yh">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -440,7 +441,7 @@
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="FJ2-As-AUm">
-                    <rect key="frame" x="325" y="71" width="52" height="18"/>
+                    <rect key="frame" x="325" y="150" width="52" height="18"/>
                     <buttonCell key="cell" type="check" title="DTS" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="Le8-wj-Pei">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -451,7 +452,7 @@
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="haq-Mp-LHn">
-                    <rect key="frame" x="383" y="71" width="77" height="18"/>
+                    <rect key="frame" x="383" y="150" width="77" height="18"/>
                     <buttonCell key="cell" type="check" title="DTS-HD" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="I34-op-NZK">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -462,7 +463,7 @@
                     </connections>
                 </button>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="GmR-Si-ivP">
-                    <rect key="frame" x="118" y="167" width="143" height="18"/>
+                    <rect key="frame" x="118" y="246" width="143" height="18"/>
                     <buttonCell key="cell" type="check" title="Initial volume:" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="g4c-vG-URh">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -472,7 +473,7 @@
                     </connections>
                 </button>
                 <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="tPo-qr-GqN">
-                    <rect key="frame" x="269" y="165" width="58" height="21"/>
+                    <rect key="frame" x="269" y="244" width="58" height="21"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="58" id="OFp-VC-TGz"/>
                     </constraints>
@@ -492,7 +493,7 @@
                     </connections>
                 </textField>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JFX-OT-X7j">
-                    <rect key="frame" x="118" y="136" width="145" height="16"/>
+                    <rect key="frame" x="118" y="215" width="145" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Maximum volume:" id="44m-ge-naq">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -500,7 +501,7 @@
                     </textFieldCell>
                 </textField>
                 <textField focusRingType="none" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="iB2-dA-Y1E">
-                    <rect key="frame" x="269" y="133" width="58" height="21"/>
+                    <rect key="frame" x="269" y="212" width="58" height="21"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="58" id="hr5-Dg-Xii"/>
                     </constraints>
@@ -522,7 +523,7 @@
                     </connections>
                 </textField>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2Y8-fb-z9V">
-                    <rect key="frame" x="335" y="136" width="64" height="14"/>
+                    <rect key="frame" x="335" y="215" width="64" height="14"/>
                     <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="(100-1000)" id="cJP-ep-847">
                         <font key="font" metaFont="label" size="11"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
@@ -530,7 +531,7 @@
                     </textFieldCell>
                 </textField>
                 <popUpButton horizontalHuggingPriority="200" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Min-k4-E1V">
-                    <rect key="frame" x="266" y="33" width="76" height="25"/>
+                    <rect key="frame" x="266" y="112" width="76" height="25"/>
                     <popUpButtonCell key="cell" type="push" title="Item 1" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" imageScaling="proportionallyDown" inset="2" selectedItem="iQf-Gb-IuO" id="Eau-zf-my0">
                         <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="message"/>
@@ -548,7 +549,7 @@
                     </connections>
                 </popUpButton>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="V2U-ze-ZXE">
-                    <rect key="frame" x="118" y="40" width="145" height="16"/>
+                    <rect key="frame" x="118" y="119" width="145" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Preferred audio device:" id="sLR-vV-xn2">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -556,7 +557,7 @@
                     </textFieldCell>
                 </textField>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qQz-rr-NFX">
-                    <rect key="frame" x="118" y="104" width="145" height="16"/>
+                    <rect key="frame" x="118" y="183" width="145" height="16"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Number of threads:" id="tO4-pw-2W9">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -564,7 +565,7 @@
                     </textFieldCell>
                 </textField>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="kG3-P9-brK">
-                    <rect key="frame" x="118" y="278" width="81" height="16"/>
+                    <rect key="frame" x="118" y="343" width="81" height="16"/>
                     <textFieldCell key="cell" lineBreakMode="clipping" title="Audio driver:" id="Zco-Ba-Idk">
                         <font key="font" usesAppearanceFont="YES"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -572,7 +573,7 @@
                     </textFieldCell>
                 </textField>
                 <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="up4-ch-kMU">
-                    <rect key="frame" x="205" y="277" width="93" height="18"/>
+                    <rect key="frame" x="205" y="342" width="93" height="18"/>
                     <buttonCell key="cell" type="radio" title="Core Audio" bezelStyle="regularSquare" imagePosition="left" inset="2" id="fSC-Em-JR4">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -586,7 +587,7 @@
                     </connections>
                 </button>
                 <button tag="1" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="G7x-f6-vZn">
-                    <rect key="frame" x="205" y="255" width="111" height="18"/>
+                    <rect key="frame" x="205" y="320" width="111" height="18"/>
                     <buttonCell key="cell" type="radio" title="AVFoundation" bezelStyle="regularSquare" imagePosition="left" alignment="left" inset="2" id="GvK-IC-26c">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
@@ -596,7 +597,7 @@
                     </connections>
                 </button>
                 <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="Zv0-Cg-282">
-                    <rect key="frame" x="118" y="194" width="364" height="56"/>
+                    <rect key="frame" x="118" y="273" width="364" height="42"/>
                     <textFieldCell key="cell" allowsUndo="NO" id="2Md-pv-gSi">
                         <font key="font" metaFont="smallSystem"/>
                         <string key="title">AVFoundation is a new, experimental audio driver offering Spatial Audio support. However, you may encounter some issues when using AVFoundation, such as audio delays.</string>
@@ -605,7 +606,7 @@
                     </textFieldCell>
                 </textField>
                 <button horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9pR-Z7-Xzm">
-                    <rect key="frame" x="437" y="271" width="25" height="25"/>
+                    <rect key="frame" x="437" y="336" width="25" height="25"/>
                     <buttonCell key="cell" type="help" bezelStyle="helpButton" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="d2k-lz-Ecc">
                         <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                         <font key="font" metaFont="system"/>
@@ -615,7 +616,7 @@
                     </connections>
                 </button>
                 <imageView horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="Dbe-hj-GvX">
-                    <rect key="frame" x="316" y="256" width="16" height="16"/>
+                    <rect key="frame" x="316" y="321" width="16" height="16"/>
                     <constraints>
                         <constraint firstAttribute="width" constant="16" id="aRV-dO-XZr"/>
                         <constraint firstAttribute="height" constant="16" id="gBQ-Qw-F7g"/>
@@ -623,6 +624,53 @@
                     <imageCell key="cell" refusesFirstResponder="YES" alignment="left" imageScaling="proportionallyDown" image="NSInfo" id="Xgb-Xb-1b0"/>
                     <color key="contentTintColor" name="systemIndigoColor" catalog="System" colorSpace="catalog"/>
                 </imageView>
+                <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="cUT-Lx-JsB" userLabel="Gapless audio description">
+                    <rect key="frame" x="118" y="5" width="364" height="42"/>
+                    <textFieldCell key="cell" allowsUndo="NO" title="Gapless audio description" id="RHe-Of-BeL">
+                        <font key="font" metaFont="smallSystem"/>
+                        <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3Az-kB-Dig" userLabel="Gapless audio">
+                    <rect key="frame" x="118" y="55" width="94" height="16"/>
+                    <textFieldCell key="cell" lineBreakMode="clipping" title="Gapless audio:" id="8Fa-ft-1tC">
+                        <font key="font" usesAppearanceFont="YES"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+                <popUpButton verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="s6Q-v3-mdH" userLabel="Gapless audio setting">
+                    <rect key="frame" x="265" y="50" width="99" height="25"/>
+                    <popUpButtonCell key="cell" type="push" title="Weak" bezelStyle="rounded" alignment="left" lineBreakMode="truncatingTail" state="on" borderStyle="borderAndBezel" tag="1" imageScaling="proportionallyDown" inset="2" selectedItem="nsT-r3-brW" id="SGU-iT-QxJ">
+                        <behavior key="behavior" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="message"/>
+                        <menu key="menu" id="nWj-he-Pe3">
+                            <items>
+                                <menuItem title="Disabled" id="ti2-JH-nXX" userLabel="Disabled"/>
+                                <menuItem title="Weak" state="on" tag="1" id="nsT-r3-brW" userLabel="Weak"/>
+                                <menuItem title="Strong" tag="2" id="6vc-ad-xaq" userLabel="Strong"/>
+                            </items>
+                        </menu>
+                    </popUpButtonCell>
+                    <constraints>
+                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="92" id="r2a-oL-gsA"/>
+                    </constraints>
+                    <connections>
+                        <action selector="gaplessAudioAction:" target="-2" id="ky7-Fl-7hH"/>
+                        <binding destination="pxc-7C-SGP" name="selectedTag" keyPath="values.gaplessAudio" id="xLc-TJ-35X"/>
+                    </connections>
+                </popUpButton>
+                <button horizontalHuggingPriority="750" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="bUd-S5-WZo" userLabel="Gapless audio help button">
+                    <rect key="frame" x="365" y="50" width="25" height="25"/>
+                    <buttonCell key="cell" type="help" bezelStyle="helpButton" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="rqm-EO-RPh">
+                        <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
+                        <font key="font" metaFont="system"/>
+                    </buttonCell>
+                    <connections>
+                        <action selector="gaplessAudioHelpAction:" target="-2" id="9N6-w0-Tx8"/>
+                    </connections>
+                </button>
             </subviews>
             <constraints>
                 <constraint firstItem="0Ig-J7-VYp" firstAttribute="trailing" relation="lessThanOrEqual" secondItem="bsP-Kc-xXR" secondAttribute="leading" constant="120" id="0kB-CC-aOZ"/>
@@ -634,6 +682,7 @@
                 <constraint firstItem="FJ2-As-AUm" firstAttribute="leading" secondItem="iAK-W4-XCh" secondAttribute="trailing" constant="8" id="6RS-MT-Lye"/>
                 <constraint firstItem="SEM-Qm-KeU" firstAttribute="baseline" secondItem="qQz-rr-NFX" secondAttribute="baseline" id="7vQ-GV-CwF"/>
                 <constraint firstItem="Min-k4-E1V" firstAttribute="baseline" secondItem="V2U-ze-ZXE" secondAttribute="baseline" id="AA2-dS-l85"/>
+                <constraint firstItem="9pR-Z7-Xzm" firstAttribute="leading" secondItem="up4-ch-kMU" secondAttribute="trailing" constant="142" id="ASW-JK-zWX"/>
                 <constraint firstItem="V2U-ze-ZXE" firstAttribute="top" secondItem="Taj-6a-uFI" secondAttribute="bottom" constant="16" id="Cz3-am-bNA"/>
                 <constraint firstItem="2Y8-fb-z9V" firstAttribute="leading" secondItem="iB2-dA-Y1E" secondAttribute="trailing" constant="10" id="DGA-Wx-ymL"/>
                 <constraint firstItem="iAK-W4-XCh" firstAttribute="leading" secondItem="Taj-6a-uFI" secondAttribute="trailing" constant="8" id="Djp-60-fJn"/>
@@ -643,17 +692,22 @@
                 <constraint firstItem="Taj-6a-uFI" firstAttribute="leading" secondItem="qQz-rr-NFX" secondAttribute="leading" id="HVG-Ej-rXB"/>
                 <constraint firstItem="iB2-dA-Y1E" firstAttribute="baseline" secondItem="JFX-OT-X7j" secondAttribute="baseline" id="Hzj-UD-ijr"/>
                 <constraint firstItem="JFX-OT-X7j" firstAttribute="leading" secondItem="GmR-Si-ivP" secondAttribute="leading" id="I31-ox-2xc"/>
-                <constraint firstAttribute="trailing" secondItem="9pR-Z7-Xzm" secondAttribute="trailing" constant="20" symbolic="YES" id="IGJ-wK-y7n"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="9pR-Z7-Xzm" secondAttribute="trailing" constant="20" symbolic="YES" id="IGJ-wK-y7n"/>
                 <constraint firstItem="GmR-Si-ivP" firstAttribute="leading" secondItem="bsP-Kc-xXR" secondAttribute="leading" constant="120" id="Ia4-Na-nDb"/>
+                <constraint firstItem="3Az-kB-Dig" firstAttribute="top" secondItem="81P-il-Bo2" secondAttribute="bottom" constant="16" id="Jac-xi-QkC"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="s6Q-v3-mdH" secondAttribute="trailing" constant="20" symbolic="YES" id="K7B-IZ-lYs"/>
                 <constraint firstItem="GmR-Si-ivP" firstAttribute="baseline" secondItem="tPo-qr-GqN" secondAttribute="baseline" id="Kfw-cb-Hvx"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="haq-Mp-LHn" secondAttribute="trailing" constant="20" symbolic="YES" id="LMy-Qc-WxW"/>
                 <constraint firstItem="FJ2-As-AUm" firstAttribute="baseline" secondItem="Taj-6a-uFI" secondAttribute="baseline" id="Mk4-y3-85e"/>
+                <constraint firstAttribute="trailing" secondItem="cUT-Lx-JsB" secondAttribute="trailing" id="Ndu-HK-BtG"/>
                 <constraint firstItem="G7x-f6-vZn" firstAttribute="leading" secondItem="up4-ch-kMU" secondAttribute="leading" id="OX3-D6-zIt"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Min-k4-E1V" secondAttribute="trailing" id="S3H-O7-luE"/>
                 <constraint firstItem="Zv0-Cg-282" firstAttribute="top" secondItem="G7x-f6-vZn" secondAttribute="bottom" constant="6" id="SMi-ba-Sf6"/>
                 <constraint firstItem="Dbe-hj-GvX" firstAttribute="centerY" secondItem="G7x-f6-vZn" secondAttribute="centerY" id="TSB-Uw-zQt"/>
                 <constraint firstItem="Mib-1U-RcV" firstAttribute="baseline" secondItem="81P-il-Bo2" secondAttribute="baseline" id="TaN-5q-JkU"/>
+                <constraint firstAttribute="bottom" secondItem="cUT-Lx-JsB" secondAttribute="bottom" constant="5" id="U99-5c-Zie"/>
                 <constraint firstItem="qQz-rr-NFX" firstAttribute="top" secondItem="JFX-OT-X7j" secondAttribute="bottom" constant="16" id="UZz-YF-NJU"/>
+                <constraint firstItem="cUT-Lx-JsB" firstAttribute="top" secondItem="s6Q-v3-mdH" secondAttribute="bottom" constant="7" id="VTa-We-xsG"/>
                 <constraint firstItem="SEM-Qm-KeU" firstAttribute="leading" secondItem="Ld5-Mm-4Pt" secondAttribute="trailing" constant="10" id="XQJ-sQ-uRI"/>
                 <constraint firstItem="Ld5-Mm-4Pt" firstAttribute="baseline" secondItem="qQz-rr-NFX" secondAttribute="baseline" id="XUx-Ay-3Vg"/>
                 <constraint firstItem="haq-Mp-LHn" firstAttribute="leading" secondItem="FJ2-As-AUm" secondAttribute="trailing" constant="8" id="Yoi-b9-09a"/>
@@ -661,10 +715,11 @@
                 <constraint firstItem="kG3-P9-brK" firstAttribute="leading" secondItem="bsP-Kc-xXR" secondAttribute="leading" constant="120" id="aox-ir-MK2"/>
                 <constraint firstItem="0Ig-J7-VYp" firstAttribute="leading" secondItem="bsP-Kc-xXR" secondAttribute="leading" id="bQP-WT-1em"/>
                 <constraint firstItem="G7x-f6-vZn" firstAttribute="top" secondItem="up4-ch-kMU" secondAttribute="bottom" constant="6" id="cBB-sn-shG"/>
+                <constraint firstItem="3Az-kB-Dig" firstAttribute="leading" secondItem="81P-il-Bo2" secondAttribute="leading" id="cbe-iP-gb9"/>
                 <constraint firstItem="9pR-Z7-Xzm" firstAttribute="firstBaseline" secondItem="up4-ch-kMU" secondAttribute="firstBaseline" id="cgA-mx-l2i"/>
                 <constraint firstItem="iAK-W4-XCh" firstAttribute="baseline" secondItem="Taj-6a-uFI" secondAttribute="baseline" id="dc8-TY-kwD"/>
                 <constraint firstItem="Zv0-Cg-282" firstAttribute="leading" secondItem="kG3-P9-brK" secondAttribute="leading" id="eRb-QE-VU6"/>
-                <constraint firstAttribute="bottom" secondItem="81P-il-Bo2" secondAttribute="bottom" constant="8" id="f20-LO-Hfh"/>
+                <constraint firstAttribute="bottom" secondItem="81P-il-Bo2" secondAttribute="bottom" constant="87" id="f20-LO-Hfh"/>
                 <constraint firstItem="Mib-1U-RcV" firstAttribute="leading" secondItem="81P-il-Bo2" secondAttribute="trailing" constant="8" id="fNv-WQ-9OU"/>
                 <constraint firstItem="kG3-P9-brK" firstAttribute="firstBaseline" secondItem="0Ig-J7-VYp" secondAttribute="firstBaseline" id="fgR-EV-flk"/>
                 <constraint firstItem="V2U-ze-ZXE" firstAttribute="leading" secondItem="81P-il-Bo2" secondAttribute="leading" id="fsy-Vf-9Lg"/>
@@ -673,18 +728,24 @@
                 <constraint firstItem="81P-il-Bo2" firstAttribute="top" secondItem="V2U-ze-ZXE" secondAttribute="bottom" constant="16" id="gMc-nv-dCU"/>
                 <constraint firstItem="2Y8-fb-z9V" firstAttribute="baseline" secondItem="JFX-OT-X7j" secondAttribute="baseline" id="hcw-Zy-KYa"/>
                 <constraint firstItem="V2U-ze-ZXE" firstAttribute="leading" secondItem="Taj-6a-uFI" secondAttribute="leading" id="ihk-QO-OVH"/>
+                <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="bUd-S5-WZo" secondAttribute="trailing" id="kMO-br-iBK"/>
                 <constraint firstItem="iB2-dA-Y1E" firstAttribute="leading" secondItem="Ld5-Mm-4Pt" secondAttribute="leading" id="kcg-dw-fNL"/>
+                <constraint firstItem="cUT-Lx-JsB" firstAttribute="leading" secondItem="3Az-kB-Dig" secondAttribute="leading" id="mfh-wt-4Kw"/>
                 <constraint firstAttribute="trailing" secondItem="Mib-1U-RcV" secondAttribute="trailing" id="miB-ES-pWJ"/>
                 <constraint firstItem="81P-il-Bo2" firstAttribute="leading" secondItem="Taj-6a-uFI" secondAttribute="leading" id="ng1-wg-y3Q"/>
                 <constraint firstItem="tPo-qr-GqN" firstAttribute="top" secondItem="Zv0-Cg-282" secondAttribute="bottom" constant="8" id="nwD-we-Jln"/>
+                <constraint firstItem="s6Q-v3-mdH" firstAttribute="centerY" secondItem="bUd-S5-WZo" secondAttribute="centerY" id="o27-aI-41f"/>
                 <constraint firstItem="qQz-rr-NFX" firstAttribute="leading" secondItem="JFX-OT-X7j" secondAttribute="leading" id="o3R-T9-bFc"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="SEM-Qm-KeU" secondAttribute="trailing" constant="12" id="o5t-2S-zuj"/>
+                <constraint firstItem="3Az-kB-Dig" firstAttribute="firstBaseline" secondItem="s6Q-v3-mdH" secondAttribute="baseline" constant="2" id="qJA-58-ak4"/>
                 <constraint firstItem="JFX-OT-X7j" firstAttribute="top" secondItem="GmR-Si-ivP" secondAttribute="bottom" constant="16" id="qjh-2X-tg8"/>
                 <constraint firstItem="Min-k4-E1V" firstAttribute="leading" secondItem="V2U-ze-ZXE" secondAttribute="trailing" constant="8" id="sU8-FC-tAa"/>
                 <constraint firstItem="Ld5-Mm-4Pt" firstAttribute="leading" secondItem="qQz-rr-NFX" secondAttribute="trailing" constant="8" id="sf9-lW-dIs"/>
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="2Y8-fb-z9V" secondAttribute="trailing" constant="12" id="urz-59-vwm"/>
                 <constraint firstItem="iB2-dA-Y1E" firstAttribute="leading" secondItem="JFX-OT-X7j" secondAttribute="trailing" constant="8" id="vpv-fy-V0A"/>
+                <constraint firstItem="s6Q-v3-mdH" firstAttribute="leading" secondItem="3Az-kB-Dig" secondAttribute="trailing" constant="58" id="wbg-xw-pZc"/>
                 <constraint firstItem="0Ig-J7-VYp" firstAttribute="top" secondItem="bsP-Kc-xXR" secondAttribute="top" constant="8" id="xTx-Rf-Dxq"/>
+                <constraint firstItem="bUd-S5-WZo" firstAttribute="leading" secondItem="s6Q-v3-mdH" secondAttribute="trailing" constant="8" id="xaA-1R-c2U"/>
                 <constraint firstAttribute="trailing" secondItem="Zv0-Cg-282" secondAttribute="trailing" id="zwS-JE-2G4"/>
             </constraints>
             <point key="canvasLocation" x="792" y="114"/>
@@ -723,7 +784,6 @@
                         </menu>
                     </popUpButtonCell>
                     <connections>
-                        <action selector="hwdecAction:" target="-2" id="L6n-FN-KBK"/>
                         <binding destination="pxc-7C-SGP" name="selectedTag" keyPath="values.replayGain" id="AAe-kQ-P9n"/>
                     </connections>
                 </popUpButton>

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -415,6 +415,12 @@ class MPVController: NSObject {
     setUserOption(PK.replayGainFallback, type: .float, forName: MPVOption.Audio.replaygainFallback,
                   verboseIfDefault: true)
 
+    setUserOption(PK.gaplessAudio, type: .other, forName: MPVOption.Audio.gaplessAudio,
+                  verboseIfDefault: true) { key in
+      let value = Preference.integer(for: key)
+      return Preference.GaplessAudioOption(rawValue: value)?.mpvString ?? "weak"
+    }
+
     // - Sub
 
     chkErr(setOptionString(MPVOption.Subtitles.subAuto, "no", level: .verbose))

--- a/iina/PrefCodecViewController.swift
+++ b/iina/PrefCodecViewController.swift
@@ -41,6 +41,8 @@ class PrefCodecViewController: PreferenceViewController, PreferenceWindowEmbedda
 
   @IBOutlet weak var audioDevicePopUp: NSPopUpButton!
 
+  @IBOutlet weak var gaplessAudioDescriptionTextField: NSTextField!
+
   @IBOutlet weak var enableToneMappingBtn: NSButton!
   @IBOutlet weak var toneMappingTargetPeakTextField: NSTextField!
   @IBOutlet weak var toneMappingAlgorithmPopUpBtn: NSPopUpButton!
@@ -49,6 +51,7 @@ class PrefCodecViewController: PreferenceViewController, PreferenceWindowEmbedda
     super.viewDidLoad()
     audioLangTokenField.commaSeparatedValues = Preference.string(for: .audioLanguage) ?? ""
     updateHwdecDescription()
+    updateGaplessAudioDescription()
     updateToneMappingUI()
   }
 
@@ -111,6 +114,15 @@ class PrefCodecViewController: PreferenceViewController, PreferenceWindowEmbedda
     hwdecDescriptionTextField.stringValue = hwdec.localizedDescription
   }
 
+  @IBAction func gaplessAudioAction(_ sender: Any) {
+    updateGaplessAudioDescription()
+  }
+
+  private func updateGaplessAudioDescription() {
+    let gaplessAudio: Preference.GaplessAudioOption = Preference.enum(for: .gaplessAudio)
+    gaplessAudioDescriptionTextField.stringValue = gaplessAudio.localizedDescription
+  }
+
   // Prefs → UI
   private func updateToneMappingUI() {
     toneMappingTargetPeakTextField.integerValue = Preference.integer(for: .toneMappingTargetPeak)
@@ -145,6 +157,10 @@ class PrefCodecViewController: PreferenceViewController, PreferenceWindowEmbedda
 
   @IBAction func gainAdjustmentHelpAction(_ sender: Any) {
     NSWorkspace.shared.open(URL(string: AppData.gainAdjustmentHelpLink)!)
+  }
+
+  @IBAction func gaplessAudioHelpAction(_ sender: Any) {
+    NSWorkspace.shared.open(URL(string: AppData.gaplessAudioHelpLink)!)
   }
 
   @IBAction func audioDriverHelpAction(_ sender: Any) {

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -193,6 +193,8 @@ struct Preference {
     static let replayGainClip = Key("replayGainClip")
     static let replayGainFallback = Key("replayGainFallback")
 
+    static let gaplessAudio = Key("gaplessAudio")
+
     static let userEQPresets = Key("userEQPresets")
 
     // Subtitle
@@ -781,6 +783,32 @@ struct Preference {
     }
   }
 
+  enum GaplessAudioOption: Int, InitializingFromKey {
+    case disabled = 0
+    case weak
+    case strong
+
+    static var defaultValue = GaplessAudioOption.weak
+
+    init?(key: Key) {
+      self.init(rawValue: Preference.integer(for: key))
+    }
+
+    var localizedDescription: String {
+      return NSLocalizedString("gaplessAudio." + mpvString, comment: mpvString)
+    }
+
+    var mpvString: String {
+      get {
+        switch self {
+        case .disabled: return "no"
+        case .weak : return "weak"
+        case .strong: return "yes"
+        }
+      }
+    }
+  }
+
   enum DefaultRepeatMode: Int {
     case playlist = 0
     case file
@@ -889,6 +917,7 @@ struct Preference {
     .replayGainPreamp: 0,
     .replayGainClip: false,
     .replayGainFallback: 0,
+    .gaplessAudio: GaplessAudioOption.weak.rawValue,
 
     .subAutoLoadIINA: IINAAutoLoadAction.iina.rawValue,
     .subAutoLoadPriorityString: "",

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -392,6 +392,10 @@
 "hwdec.auto" = "Enable hardware decoding. However, most of the video filters won't work properly.";
 "hwdec.auto-copy" = "Enable hardware decoding. It will consume double the memory but work with video filters.";
 
+"gaplessAudio.no" = "Playback of consecutive audio files may result in silence or disruption at the point of file change.";
+"gaplessAudio.weak" = "If the audio format the decoder output changes, the audio device is closed and reopened, disrupting gapless playback.";
+"gaplessAudio.yes" = "The audio device is opened using parameters chosen for the first file played and is then kept open for gapless playback. Following files may be resampled.";
+
 "subencoding.auto" = "Auto detect";
 
 "osc_toolbar.settings" = "Quick Settings";

--- a/iina/en.lproj/PrefCodecViewController.strings
+++ b/iina/en.lproj/PrefCodecViewController.strings
@@ -10,6 +10,12 @@
 /* Class = "NSTextFieldCell"; title = "Number of threads:"; ObjectID = "50C-1R-wlJ"; */
 "50C-1R-wlJ.title" = "Number of threads:";
 
+/* Class = "NSMenuItem"; title = "Strong"; ObjectID = "6vc-ad-xaq"; */
+"6vc-ad-xaq.title" = "Strong";
+
+/* Class = "NSTextFieldCell"; title = "Gapless audio:"; ObjectID = "8Fa-ft-1tC"; */
+"8Fa-ft-1tC.title" = "Gapless audio:";
+
 /* Class = "NSButtonCell"; title = "Force dedicated GPU"; ObjectID = "YUr-aJ-xfC"; */
 "YUr-aJ-xfC.title" = "Force dedicated GPU";
 
@@ -27,6 +33,9 @@
 
 /* Class = "NSTextFieldCell"; title = "Video:"; ObjectID = "m5P-5f-5uo"; */
 "m5P-5f-5uo.title" = "Video:";
+
+/* Class = "NSMenuItem"; title = "Weak"; ObjectID = "nsT-r3-brW"; */
+"nsT-r3-brW.title" = "Weak";
 
 /* Class = "NSTextFieldCell"; title = "Hardware decoder:"; ObjectID = "nwg-2K-G2G"; */
 "nwg-2K-G2G.title" = "Hardware decoder:";
@@ -93,6 +102,9 @@
 
 /* Class = "NSMenuItem"; title = "No adjustment"; ObjectID = "k7b-6o-lCK"; */
 "k7b-6o-lCK.title" = "No adjustment";
+
+/* Class = "NSMenuItem"; title = "Disabled"; ObjectID = "ti2-JH-nXX"; */
+"ti2-JH-nXX.title" = "Disabled";
 
 /* Class = "NSMenuItem"; title = "Track gain"; ObjectID = "w6E-lw-g7g"; */
 "w6E-lw-g7g.title" = "Track gain";


### PR DESCRIPTION
This commit will add a new `Gapless audio` setting in the `Audio` section on the `Video/Audio` tab of IINA's settings.

Previously gapless audio did not work because IINA always paused playback when loading a file. This was a workaround added a long time ago for a problem that is no longer reproducible. Commit 9f556bf removed the workaround allowing gapless audio to work. This commit provides a UI to control it.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5433.

---

**Description:**
