### PR TITLE
Fix no error shown if a online URL failed to load

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -2054,7 +2054,7 @@ class PlayerCore: NSObject {
   func fileEnded(_ dueToStopCommand: Bool) {
     // if receive end-file when loading file, might be error
     // wait for idle
-    if info.state == .loading {
+    if info.state == .loading || info.state == .starting {
       if !dueToStopCommand {
         receivedEndFileWhileLoading = true
       }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue https://github.com/iina/plugin-online-media/issues/6.

---

**Description:**

We are not catching the error when the Javascript mpv hook fails.

It seems that we have already received the `START_FILE` event before the hook is called, therefore `info.state` is `starting` when the hook fails. Previously we only checked if `info.state` is `loading`. I think a quick solution would be also checking for `starting`.

However, I'm not sure whether it was caused by the info.state refactor, the URL loading window change, or a change in mpv.

@low-batt Please have a look.