### PR TITLE
Fix display link not running when player reused

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -490,6 +490,14 @@ class PlayerCore: NSObject {
     let pause = Preference.bool(for: .pauseWhenOpen)
     mpv.setFlag(MPVOption.PlaybackControl.pause, pause ? true : false, level: .verbose)
 
+    // Normally the display link is started when MainWindowController.windowDidLoad calls initVideo.
+    // However if this player is being reused then the window will have already been loaded and
+    // windowDidLoad will not be called. If playback is not paused make sure the display link is
+    // active.
+    if !pause, mainWindow.loaded {
+      mainWindow.videoView.displayActive()
+    }
+
     // Send load file command
     info.justOpenedFile = true
     info.state = .loading

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -338,6 +338,10 @@ struct Preference {
     /// Internal setting to allow disabling the new feature that shows cover artwork in the Now Playing module in case a serious
     /// problem is encountered.
     static let enableNowPlayingArtwork = Key("enableNowPlayingArtwork")
+
+    /// Internal setting to allow disabling the feature that detects when a display is idle and shuts down the display link to save energy
+    /// in case a problem is found where the display link is shut down when it is needed.
+    static let enableDisplayIdle = Key("enableDisplayIdle")
   }
 
   // MARK: - Enums
@@ -983,7 +987,8 @@ struct Preference {
 
     .enableFFmpegImageDecoder: true,
     .enableHdrWorkaround: false,
-    .enableNowPlayingArtwork: true
+    .enableNowPlayingArtwork: true,
+    .enableDisplayIdle: true
   ]
 
 

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -298,6 +298,10 @@ class VideoView: NSView {
   ///         full screen mode.
   func displayIdle() {
     displayIdleTimer?.invalidate()
+    // Because the display link is critical there is an internal setting that can be changed to
+    // disable shutting down the display link should any problems with this energy saving feature
+    // be discovered.
+    guard Preference.bool(for: .enableDisplayIdle) else { return }
     // The time of 6 seconds was picked to match up with the time QuickTime delays once playback is
     // paused before stopping audio. As mpv does not provide an event indicating a frame step has
     // completed the time used must not be too short or will catch mpv still drawing when stepping.


### PR DESCRIPTION
This commit will:
- Change `PlayerCore.openMainWindow` to call `VideoView.displayActive` if playback is not paused and the window has already been loaded
- Add an `enableDisplayIdle` internal setting to allow disabling the feature that detects when a display is idle and shuts down the display link to save energy
- Change `VideoView.displayIdle` to check the new setting and not shut down the display link if this feature has been disabled

This fixes a regression caused by commit 9f556bf which correctly removed a call that was setting the mpv pause option.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
