### PR TITLE
Fix window resize behavior

### DIFF
--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -270,11 +270,11 @@ extension NSRect {
     if newOrigin.y < biggerRect.origin.y {
       newOrigin.y = biggerRect.origin.y
     }
-    if newOrigin.x + width > biggerRect.origin.x + biggerRect.width {
-      newOrigin.x = biggerRect.origin.x + biggerRect.width - width
+    if newOrigin.x + newSize.width > biggerRect.origin.x + biggerRect.width {
+      newOrigin.x = biggerRect.origin.x + biggerRect.width - newSize.width
     }
-    if newOrigin.y + height > biggerRect.origin.y + biggerRect.height {
-      newOrigin.y = biggerRect.origin.y + biggerRect.height - height
+    if newOrigin.y + newSize.height > biggerRect.origin.y + biggerRect.height {
+      newOrigin.y = biggerRect.origin.y + biggerRect.height - newSize.height
     }
     return NSRect(origin: newOrigin, size: newSize)
   }

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2499,6 +2499,10 @@ class MainWindowController: PlayerWindowController {
   /// - Parameter window: Window to determine the screen for.
   /// - Returns: Screen to use for the given window.
   private func determineScreenToUse(_ window: NSWindow) -> NSScreen {
+    // If the window is currently showing on a screen, use this screen
+    if window.isOnActiveSpace, let currentScreen = window.screen {
+      return currentScreen
+    }
     guard let rectString = UserDefaults.standard.value(forKey: "MainWindowLastPosition") as? String else {
       return window.selectDefaultScreen()
     }
@@ -2542,15 +2546,14 @@ class MainWindowController: PlayerWindowController {
       // - Resize the window to fit video size
       // - Use physical resolution on Retina displays
       // - Direct use of the mpv geometry option
-      let geometrySet = !(player.mpv.getString(MPVOption.Window.geometry) ?? "").isEmpty
       let resizeTiming = Preference.enum(for: .resizeWindowTiming) as Preference.ResizeWindowTiming
       switch resizeTiming {
       case .always:
         needResizeWindow = true
       case .onlyWhenOpen:
-        needResizeWindow = player.info.justOpenedFile || geometrySet || shouldApplyInitialWindowSize
+        needResizeWindow = player.info.justOpenedFile || shouldApplyInitialWindowSize
       case .never:
-        needResizeWindow = geometrySet || shouldApplyInitialWindowSize
+        needResizeWindow = shouldApplyInitialWindowSize
       }
     } else {
       // video size changed during playback
@@ -2614,13 +2617,10 @@ class MainWindowController: PlayerWindowController {
       // user is navigating in playlist. remain same window width.
       let newHeight = frame.width / CGFloat(width) * CGFloat(height)
       let newSize = NSSize(width: frame.width, height: newHeight).satisfyMinSizeWithSameAspectRatio(minSize)
-      rect = NSRect(origin: frame.origin, size: newSize)
+      rect = frame.centeredResize(to: newSize)
       log("Adjusted height of window preserving width: \(rect)")
     }
 
-    // maybe not a good position, consider putting these at playback-restart
-    player.info.justOpenedFile = false
-    player.info.justStartedFile = false
     shouldApplyInitialWindowSize = false
 
     if fsState.isFullscreen {

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2507,7 +2507,7 @@ class MainWindowController: PlayerWindowController {
       return window.selectDefaultScreen()
     }
     let rect = NSRectFromString(rectString)
-    guard let lastScreen = NSScreen.screens.first(where: { NSPointInRect(rect.origin, $0.visibleFrame) }) else {
+    guard let lastScreen = NSScreen.screens.first(where: { NSPointInRect(rect.origin, $0.frame) }) else {
       // The previous window origin is not on any screen. Could be an external screen is no longer
       // connected or the arrangement of the screens has changed.
       log("MainWindowLastPosition \(rect.origin) is not within any screens")

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -2205,6 +2205,9 @@ class PlayerCore: NSObject {
     // restart even while paused. See issue #5337.
     syncUI(.time)
     reloadSavedIINAfilters()
+    
+    info.justOpenedFile = false
+    info.justStartedFile = false
 
     NowPlayingInfoManager.shared.updateInfo()
 

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -2206,6 +2206,10 @@ class PlayerCore: NSObject {
     syncUI(.time)
     reloadSavedIINAfilters()
     
+    // The new video's size is guaranteed to be available. Reset the flags used for window resizing.
+    // We can't put this in MPV_EVENT_VIDEO_RECONFIG because it can be emitted with the old video's size
+    // after switching to a new video.
+    // We should keep these flags until a MPV_EVENT_VIDEO_RECONFIG with the new video's size.
     info.justOpenedFile = false
     info.justStartedFile = false
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5665, #5669.

---

**Description:**

Let's define the expected behavior for window resizing.

- **Initial position**: Only applies when the window is opened for the first time.
  - Internally this is synced with mpv's `geometry`, and we may have different behavior with mpv. That's acceptable since IINA is GUI-focused.
  - Even if the user set `geometry` in their conf, it still only applied once. If the user wants a fixed position, they should also set _Resize to fit_ to disabled.  They can also write plugins / user scripts to further control the window size.
  - The previous screen should still be remembered, and we put the window on that screen, if available.
- **Resize to fit**:
  - **Always**: Every time when a new video is played, resize the window.
  - **When opened manually**: Only when the video is opened manually (From menu, drag & drop, etc.). Navigating through the playlist, whether automatically or manually through shortcuts, should NOT resize the video.
  - **Disabled**: Should NOT resize the video in any cases, other than the first time when we apply the initial position. If the window aspect ratio changed, make minimal change and keep the window's center position.
- When resizing, _minimal_ change should be made. The window's center position should not change, and it should not move to another screen in any circumstances. We can have more enhancements later.


@low-batt @uiryuu Please have a look and test these scenarios:

|                 | Window opened | Open new video in window | Navigate in playlist |
|-----------------|---------------|--------------------------|----------------------|
| Always          | Initial       | Y                        | Y                    |
| Opened manually | Initial       | Y                        | N                    |
| Disabled        | Initial       | N                        | N                    |

Initial = Apply initial position when it's configured, otherwise center on the last used screen
Y = Resize, keep window center
N = No resize unless aspect ratio changed
