### PR TITLE
Fix sometimes window goes offscreen/random position when changing demensions

### DIFF
--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -270,11 +270,11 @@ extension NSRect {
     if newOrigin.y < biggerRect.origin.y {
       newOrigin.y = biggerRect.origin.y
     }
-    if newOrigin.x + width > biggerRect.origin.x + biggerRect.width {
-      newOrigin.x = biggerRect.origin.x + biggerRect.width - width
+    if newOrigin.x + newSize.width > biggerRect.origin.x + biggerRect.width {
+      newOrigin.x = biggerRect.origin.x + biggerRect.width - newSize.width
     }
-    if newOrigin.y + height > biggerRect.origin.y + biggerRect.height {
-      newOrigin.y = biggerRect.origin.y + biggerRect.height - height
+    if newOrigin.y + newSize.height > biggerRect.origin.y + biggerRect.height {
+      newOrigin.y = biggerRect.origin.y + biggerRect.height - newSize.height
     }
     return NSRect(origin: newOrigin, size: newSize)
   }

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1596,6 +1596,10 @@ class MainWindowController: PlayerWindowController {
 
   func windowDidResize(_ notification: Notification) {
     guard let window = window else { return }
+    
+    if case .animating(_, _, _) = fsState, player.info.state == .paused {
+      forceDraw("Window entered full screen animation while paused")
+    }
 
     // interactive mode
     if isInInteractiveMode {

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -693,6 +693,8 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
       AppDelegate.shared.openFile(self)
     case .openURL:
       AppDelegate.shared.openURL(self)
+    case .deleteCurrentFile:
+      menuActionHandler.menuDeleteCurrentFile(.dummy)
     case .deleteCurrentFileHard:
       menuActionHandler.menuDeleteCurrentFileHard(.dummy)
     default:


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #(?).

---

**Description:**
The calculations should be using `newSize` instead of `size`. According to blame, this appears to be a 9-year-old problem...

I vaguely remember that there's an issue (or multiple) complaining that the window jumps to a random position when advancing to the next video in the playlist. Hopefully this PR can resolve that/those issues.