### PR TITLE
Fix setting video aspect keybinding doesn't work

### DIFF
--- a/iina/Base.lproj/KeyBinding.strings
+++ b/iina/Base.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "Window scale";
 
 "opt.video" = "Video track";
-"opt.video-aspect" = "Video aspect";
+"opt.video-aspect-override" = "Video aspect";
 "opt.contrast" = "Contrast";
 "opt.brightness" = "Brightness";
 "opt.gamma" = "Gamma";

--- a/iina/KeyBindingDataLoader.swift
+++ b/iina/KeyBindingDataLoader.swift
@@ -74,7 +74,7 @@ class KeyBindingDataLoader {
     ("speed", .num),
     ("---", .separator),
     ("video", .num),
-    ("video-aspect", .string),
+    ("video-aspect-override", .string),
     ("contrast", .num),
     ("brightness", .num),
     ("gamma", .num),

--- a/iina/af.lproj/KeyBinding.strings
+++ b/iina/af.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "Vensterskaal";
 
 "opt.video" = "Videosnit";
-"opt.video-aspect" = "Beeldverhouding";
+"opt.video-aspect-override" = "Beeldverhouding";
 "opt.contrast" = "Kontras";
 "opt.brightness" = "Helderheid";
 "opt.gamma" = "Gamma";

--- a/iina/ca.lproj/KeyBinding.strings
+++ b/iina/ca.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "Escala de la finestra";
 
 "opt.video" = "Pista de vídeo";
-"opt.video-aspect" = "Aspecte de vídeo";
+"opt.video-aspect-override" = "Aspecte de vídeo";
 "opt.contrast" = "Contrast";
 "opt.brightness" = "Brillantor";
 "opt.gamma" = "Gamma";

--- a/iina/config/vlc-default-input.conf
+++ b/iina/config/vlc-default-input.conf
@@ -52,7 +52,7 @@ Meta+2 set window-scale 2
 #@iina Alt+O smaller-window
 z cycle-values window-scale 0.25 0.5 1 2
 Z cycle-values window-scale 2 1 0.5 0.25
-a cycle-values video-aspect "-1" "16:9" "4:3" "1:1" "16:10" "2.21:1" "2.35:1" "2.39:1" "5:4"
+a cycle-values video-aspect-override "-1" "16:9" "4:3" "1:1" "16:10" "2.21:1" "2.35:1" "2.39:1" "5:4"
 
 POWER quit
 PLAY cycle pause

--- a/iina/cs.lproj/KeyBinding.strings
+++ b/iina/cs.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "poměr stran okna";
 
 "opt.video" = "video stopu";
-"opt.video-aspect" = "poměr stran videa";
+"opt.video-aspect-override" = "poměr stran videa";
 "opt.contrast" = "kontrast";
 "opt.brightness" = "jas";
 "opt.gamma" = "gama korekci";

--- a/iina/da.lproj/KeyBinding.strings
+++ b/iina/da.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "Vindue skalering";
 
 "opt.video" = "Video";
-"opt.video-aspect" = "Video format";
+"opt.video-aspect-override" = "Video format";
 "opt.contrast" = "Kontrast";
 "opt.brightness" = "Lysstyrke";
 "opt.gamma" = "Gamma";

--- a/iina/de.lproj/KeyBinding.strings
+++ b/iina/de.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "Fenstergröße";
 
 "opt.video" = "Videospur";
-"opt.video-aspect" = "Seitenverhältnis";
+"opt.video-aspect-override" = "Seitenverhältnis";
 "opt.contrast" = "Kontrast";
 "opt.brightness" = "Helligkeit";
 "opt.gamma" = "Gamma";

--- a/iina/en-GB.lproj/KeyBinding.strings
+++ b/iina/en-GB.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "Window scale";
 
 "opt.video" = "Video track";
-"opt.video-aspect" = "Video aspect";
+"opt.video-aspect-override" = "Video aspect";
 "opt.contrast" = "Contrast";
 "opt.brightness" = "Brightness";
 "opt.gamma" = "Gamma";

--- a/iina/en.lproj/KeyBinding.strings
+++ b/iina/en.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "Window scale";
 
 "opt.video" = "Video track";
-"opt.video-aspect" = "Video aspect";
+"opt.video-aspect-override" = "Video aspect";
 "opt.contrast" = "Contrast";
 "opt.brightness" = "Brightness";
 "opt.gamma" = "Gamma";

--- a/iina/es.lproj/KeyBinding.strings
+++ b/iina/es.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "Escala de la ventana";
 
 "opt.video" = "Pista de vídeo";
-"opt.video-aspect" = "Proporción del vídeo";
+"opt.video-aspect-override" = "Proporción del vídeo";
 "opt.contrast" = "Contraste";
 "opt.brightness" = "Brillo";
 "opt.gamma" = "Gama";

--- a/iina/fi.lproj/KeyBinding.strings
+++ b/iina/fi.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "Ikkunan skaalaus";
 
 "opt.video" = "Videoraita";
-"opt.video-aspect" = "Kuvasuhde";
+"opt.video-aspect-override" = "Kuvasuhde";
 "opt.contrast" = "Kontrasti";
 "opt.brightness" = "Kirkkaus";
 "opt.gamma" = "Gamma";

--- a/iina/fr.lproj/KeyBinding.strings
+++ b/iina/fr.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "Échelle de la fenêtre";
 
 "opt.video" = "Piste vidéo";
-"opt.video-aspect" = "Format d'image";
+"opt.video-aspect-override" = "Format d'image";
 "opt.contrast" = "Contraste";
 "opt.brightness" = "Luminosité";
 "opt.gamma" = "Gamma";

--- a/iina/he.lproj/KeyBinding.strings
+++ b/iina/he.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "קנה מידה של החלון";
 
 "opt.video" = "רצועת וידאו";
-"opt.video-aspect" = "קנה מידה של וידאו";
+"opt.video-aspect-override" = "קנה מידה של וידאו";
 "opt.contrast" = "ניגודיות";
 "opt.brightness" = "בהירות";
 "opt.gamma" = "גמא";

--- a/iina/hi.lproj/KeyBinding.strings
+++ b/iina/hi.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "खिड़की का पैमाना";
 
 "opt.video" = "वीडियो ट्रैक";
-"opt.video-aspect" = "वीडियो पहलू";
+"opt.video-aspect-override" = "वीडियो पहलू";
 "opt.contrast" = "कन्ट्रास्ट";
 "opt.brightness" = "चमक";
 "opt.gamma" = "गामा";

--- a/iina/hr.lproj/KeyBinding.strings
+++ b/iina/hr.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "Veličina prozora";
 
 "opt.video" = "Video traka";
-"opt.video-aspect" = "Omjer videa";
+"opt.video-aspect-override" = "Omjer videa";
 "opt.contrast" = "Kontrast";
 "opt.brightness" = "Svjetlost";
 "opt.gamma" = "Gamut";

--- a/iina/hu.lproj/KeyBinding.strings
+++ b/iina/hu.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "Ablak skála";
 
 "opt.video" = "Videsáv";
-"opt.video-aspect" = "Videó képarány";
+"opt.video-aspect-override" = "Videó képarány";
 "opt.contrast" = "Kontraszt";
 "opt.brightness" = "Fényerő";
 "opt.gamma" = "Gamma";

--- a/iina/id.lproj/KeyBinding.strings
+++ b/iina/id.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "Skala window";
 
 "opt.video" = "Trek video";
-"opt.video-aspect" = "Aspek video";
+"opt.video-aspect-override" = "Aspek video";
 "opt.contrast" = "Kontras";
 "opt.brightness" = "Kecerahan";
 "opt.gamma" = "Gamma";

--- a/iina/it.lproj/KeyBinding.strings
+++ b/iina/it.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "Dimensione finestra";
 
 "opt.video" = "Traccia video";
-"opt.video-aspect" = "Aspetto video";
+"opt.video-aspect-override" = "Aspetto video";
 "opt.contrast" = "Contrasto";
 "opt.brightness" = "Luminosità";
 "opt.gamma" = "Gamma";

--- a/iina/ja.lproj/KeyBinding.strings
+++ b/iina/ja.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "ウィンドウの倍率";
 
 "opt.video" = "ビデオトラック";
-"opt.video-aspect" = "ビデオアスペクト";
+"opt.video-aspect-override" = "ビデオアスペクト";
 "opt.contrast" = "コントラスト";
 "opt.brightness" = "輝度";
 "opt.gamma" = "ガンマ値";

--- a/iina/ko.lproj/KeyBinding.strings
+++ b/iina/ko.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "윈도우 크기";
 
 "opt.video" = "비디오 트랙";
-"opt.video-aspect" = "비디오 화면비";
+"opt.video-aspect-override" = "비디오 화면비";
 "opt.contrast" = "대비";
 "opt.brightness" = "밝기";
 "opt.gamma" = "감마";

--- a/iina/nl.lproj/KeyBinding.strings
+++ b/iina/nl.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "Vensterschaal";
 
 "opt.video" = "Videospoor";
-"opt.video-aspect" = "Beeldverhouding";
+"opt.video-aspect-override" = "Beeldverhouding";
 "opt.contrast" = "Contrast";
 "opt.brightness" = "Helderheid";
 "opt.gamma" = "Gamma";

--- a/iina/pl.lproj/KeyBinding.strings
+++ b/iina/pl.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "Rozmiar okna";
 
 "opt.video" = "Ścieżka obrazu";
-"opt.video-aspect" = "Proporcje obrazu";
+"opt.video-aspect-override" = "Proporcje obrazu";
 "opt.contrast" = "Kontrast";
 "opt.brightness" = "Jasność";
 "opt.gamma" = "Gamma";

--- a/iina/pt-BR.lproj/KeyBinding.strings
+++ b/iina/pt-BR.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "Escala da Janela";
 
 "opt.video" = "Trilha de Video";
-"opt.video-aspect" = "Proporção";
+"opt.video-aspect-override" = "Proporção";
 "opt.contrast" = "Contraste";
 "opt.brightness" = "Brilho";
 "opt.gamma" = "Gamma";

--- a/iina/pt.lproj/KeyBinding.strings
+++ b/iina/pt.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "Escala da janela";
 
 "opt.video" = "Faixa de vídeo";
-"opt.video-aspect" = "Proporção do vídeo";
+"opt.video-aspect-override" = "Proporção do vídeo";
 "opt.contrast" = "Contraste";
 "opt.brightness" = "Luminosidade";
 "opt.gamma" = "Gamma";

--- a/iina/ro.lproj/KeyBinding.strings
+++ b/iina/ro.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "Scală fereastră";
 
 "opt.video" = "Pistă video";
-"opt.video-aspect" = "Raport de aspect video";
+"opt.video-aspect-override" = "Raport de aspect video";
 "opt.contrast" = "Contrast";
 "opt.brightness" = "Luminozitate";
 "opt.gamma" = "Gamma";

--- a/iina/ru.lproj/KeyBinding.strings
+++ b/iina/ru.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "Масштаб окна";
 
 "opt.video" = "видеодорожку";
-"opt.video-aspect" = "соотношение сторон";
+"opt.video-aspect-override" = "соотношение сторон";
 "opt.contrast" = "Контраст";
 "opt.brightness" = "Яркость";
 "opt.gamma" = "Гамма";

--- a/iina/sk.lproj/KeyBinding.strings
+++ b/iina/sk.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "Veľkosť okna";
 
 "opt.video" = "Obrazová stopa";
-"opt.video-aspect" = "Pomer strán videa";
+"opt.video-aspect-override" = "Pomer strán videa";
 "opt.contrast" = "Kontrast";
 "opt.brightness" = "Jas";
 "opt.gamma" = "Gama";

--- a/iina/sr-Latn.lproj/KeyBinding.strings
+++ b/iina/sr-Latn.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "Razmera prozora";
 
 "opt.video" = "Video zapis";
-"opt.video-aspect" = "Razmera video zapisa";
+"opt.video-aspect-override" = "Razmera video zapisa";
 "opt.contrast" = "Kontrast";
 "opt.brightness" = "Svetlina";
 "opt.gamma" = "Gama";

--- a/iina/sv.lproj/KeyBinding.strings
+++ b/iina/sv.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "Fönsterskalning";
 
 "opt.video" = "Videospår";
-"opt.video-aspect" = "Videoförhållande";
+"opt.video-aspect-override" = "Videoförhållande";
 "opt.contrast" = "Kontrast";
 "opt.brightness" = "Ljusstyrka";
 "opt.gamma" = "Gammakorrigering";

--- a/iina/tr.lproj/KeyBinding.strings
+++ b/iina/tr.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "Pencere ölçeği";
 
 "opt.video" = "Video parçası";
-"opt.video-aspect" = "Video en–boy oranı";
+"opt.video-aspect-override" = "Video en–boy oranı";
 "opt.contrast" = "Karşıtlık";
 "opt.brightness" = "Parlaklık";
 "opt.gamma" = "Gama";

--- a/iina/uk.lproj/KeyBinding.strings
+++ b/iina/uk.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "масштаб вікна";
 
 "opt.video" = "відеодоріжку";
-"opt.video-aspect" = "пропорції відео";
+"opt.video-aspect-override" = "пропорції відео";
 "opt.contrast" = "контрастність";
 "opt.brightness" = "яскравість";
 "opt.gamma" = "гаму";

--- a/iina/zh-Hans.lproj/KeyBinding.strings
+++ b/iina/zh-Hans.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "窗口缩放";
 
 "opt.video" = "视频轨道";
-"opt.video-aspect" = "视频长宽比";
+"opt.video-aspect-override" = "视频长宽比";
 "opt.contrast" = "对比度";
 "opt.brightness" = "亮度";
 "opt.gamma" = "伽马";

--- a/iina/zh-Hant.lproj/KeyBinding.strings
+++ b/iina/zh-Hant.lproj/KeyBinding.strings
@@ -84,7 +84,7 @@
 "opt.window-scale" = "視窗縮放";
 
 "opt.video" = "影片軌";
-"opt.video-aspect" = "顯示比例";
+"opt.video-aspect-override" = "顯示比例";
 "opt.contrast" = "對比度";
 "opt.brightness" = "亮度";
 "opt.gamma" = "伽瑪";


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5678.

---

**Description:**
This commit:
- Change `video-aspect` to `video-aspect-override` in UI
- Ditto also for `vlc-default-input.conf`
- Replace `video-aspect` to `video-aspect-override` for all localizations (and hopefully crowdin will pick up)
