### PR TITLE
Full screen and sync play button after video reconfig

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1976,10 +1976,7 @@ class PlayerCore: NSObject {
     guard info.state.active else { return }
     log("File loaded")
 
-    // Normally at this point the file will be playing. However if the IINA "Pause" setting is
-    // enabled under "When media is opened" IINA will have paused playback.
-    info.state =  mpv.getFlag(MPVOption.PlaybackControl.pause) ? .paused : .playing
-    syncUI(.playButton)
+    info.state = .loaded
 
     // Must force drawing to cover the case where this player was previously used to play a video
     // and is now playing an audio file without an album cover and without using music mode.
@@ -2030,9 +2027,7 @@ class PlayerCore: NSObject {
     if self.isInMiniPlayer {
       miniPlayer.defaultAlbumArt.isHidden = self.info.vid != 0
     }
-    if Preference.bool(for: .fullScreenWhenOpen) && !mainWindow.fsState.isFullscreen && !isInMiniPlayer {
-      mainWindow.toggleWindowFullScreen()
-    }
+
     // add to history
     if let url = info.currentURL {
       let duration = info.videoDuration ?? .zero
@@ -2479,6 +2474,15 @@ class PlayerCore: NSObject {
       currentController.pendingShow = false
       currentController.showWindow(self)
       AppDelegate.shared.openURLWindow.close()
+    }
+    if info.state == .loaded {
+      // Normally at this point the file will be playing. However if the IINA "Pause" setting is
+      // enabled under "When media is opened" IINA will have paused playback.
+      info.state =  mpv.getFlag(MPVOption.PlaybackControl.pause) ? .paused : .playing
+      syncUI(.playButton)
+      if Preference.bool(for: .fullScreenWhenOpen) && !mainWindow.fsState.isFullscreen && !isInMiniPlayer {
+        mainWindow.toggleWindowFullScreen()
+      }
     }
   }
 

--- a/iina/PlayerState.swift
+++ b/iina/PlayerState.swift
@@ -22,11 +22,20 @@ enum PlayerState: Int {
   /// was received.
   case starting
 
-  /// Player is playing the file.
+  /// Player has loaded the file.
   ///
   /// Initially entered when
   /// [MPV_EVENT_FILE_LOADED](https://mpv.io/manual/stable/#command-interface-mpv-event-file-loaded)
-  /// is received indicating file is loaded and playing.
+  /// is received.
+  case loaded
+
+  /// Play has gathered all required information, and begins playing. Note that mpv will first read
+  /// video/audio track info, then reports `MPV_EVENT_FILE_LOADED`. However the playback couldn't
+  /// start until a `MPV_EVENT_VIDEO_RECONFIG` is received.
+  ///
+  /// Initially entered when
+  /// [MPV_EVENT_VIDEO_RECONFIG](https://mpv.io/manual/stable/#command-interface-mpv-event-video-reconfig)
+  /// is received in `loaded` state.
   case playing
 
   /// Playback has paused.
@@ -61,5 +70,5 @@ enum PlayerState: Int {
   @inlinable var active: Bool { self.rawValue < PlayerState.stopping.rawValue }
 
   /// `True` if when the player is in this state the file is loaded, otherwise `false`.
-  @inlinable var loaded: Bool { active && self.rawValue >= PlayerState.playing.rawValue }
+  @inlinable var loaded: Bool { active && self.rawValue >= PlayerState.loaded.rawValue }
 }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5700 & #5676.

---

**Description:**
This commit:
- Splits the old `playing` state into `loaded` and `playing`
- Tries to sync the play button initially and enter full screen when open when `MPV_EVENT_VIDEO_RECONFIG` is received during the `loaded` state

The `loaded` state is set when `MPV_EVENT_FILE_LOADED` is received. After that, an `MPV_EVENT_VIDEO_RECONFIG` will always be generated indicating mpv has began the playback, at which state the state will be transitioned into `playing` or `paused` accordingly.

