### PR TITLE
Add logging of display attributes

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -165,6 +165,7 @@
 		51165FC02E1D91940060B817 /* ReadWriteLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51165FBF2E1D91940060B817 /* ReadWriteLock.swift */; };
 		511BF43C2E12FF8800E9721E /* VolumeSlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511BF43B2E12FF8800E9721E /* VolumeSlider.swift */; };
 		511BF43E2E1305C800E9721E /* MiniPlaySlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 511BF43D2E1305C800E9721E /* MiniPlaySlider.swift */; };
+		5125117D2E89B2ED00CDAE9F /* Display.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5125117C2E89B2ED00CDAE9F /* Display.swift */; };
 		512B8FDD2BC2376E00AF41BF /* OutlineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512B8FDC2BC2376E00AF41BF /* OutlineView.swift */; };
 		513A4FFA29B53F8100A8EA7D /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513A4FF929B53F8100A8EA7D /* Atomic.swift */; };
 		515B5E5A2A579903001FCD49 /* iina-plugin in Copy Executables */ = {isa = PBXBuildFile; fileRef = E38558872A484A2D0083772D /* iina-plugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
@@ -182,6 +183,7 @@
 		51DE55C92A6646710050AD06 /* Sysctl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DE55C82A6646710050AD06 /* Sysctl.swift */; };
 		51E63DFB29CFB031008AFC20 /* PlaySlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E63DFA29CFB031008AFC20 /* PlaySlider.swift */; };
 		51E63DFD29CFB04C008AFC20 /* PlaySliderLoopKnob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E63DFC29CFB04B008AFC20 /* PlaySliderLoopKnob.swift */; };
+		51EDB4722E85EE10007E5018 /* DisplayController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51EDB4712E85EE10007E5018 /* DisplayController.swift */; };
 		51F7974728C7E00200812D0D /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F7974628C7E00200812D0D /* Lock.swift */; };
 		6100FF2B1EDF9806002CF0FB /* dsa_pub.pem in Resources */ = {isa = PBXBuildFile; fileRef = 6100FF2A1EDF9806002CF0FB /* dsa_pub.pem */; };
 		8400D5C41E17C6D2006785F5 /* AboutWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8400D5C21E17C6D2006785F5 /* AboutWindowController.swift */; };
@@ -1198,6 +1200,7 @@
 		51165FBF2E1D91940060B817 /* ReadWriteLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadWriteLock.swift; sourceTree = "<group>"; };
 		511BF43B2E12FF8800E9721E /* VolumeSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeSlider.swift; sourceTree = "<group>"; };
 		511BF43D2E1305C800E9721E /* MiniPlaySlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlaySlider.swift; sourceTree = "<group>"; };
+		5125117C2E89B2ED00CDAE9F /* Display.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Display.swift; sourceTree = "<group>"; };
 		512B8FDC2BC2376E00AF41BF /* OutlineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutlineView.swift; sourceTree = "<group>"; };
 		513A4FF929B53F8100A8EA7D /* Atomic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
 		51537C7229FA26DD00F9A472 /* Nightly.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Nightly.xcconfig; sourceTree = "<group>"; };
@@ -1218,6 +1221,7 @@
 		51DE55C82A6646710050AD06 /* Sysctl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sysctl.swift; sourceTree = "<group>"; };
 		51E63DFA29CFB031008AFC20 /* PlaySlider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaySlider.swift; sourceTree = "<group>"; };
 		51E63DFC29CFB04B008AFC20 /* PlaySliderLoopKnob.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaySliderLoopKnob.swift; sourceTree = "<group>"; };
+		51EDB4712E85EE10007E5018 /* DisplayController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DisplayController.swift; sourceTree = "<group>"; };
 		51F7974628C7E00200812D0D /* Lock.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Lock.swift; sourceTree = "<group>"; };
 		5879479521A87DD700757A6F /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/MiniPlayerWindowController.strings; sourceTree = "<group>"; };
 		5879479621A87E6100757A6F /* sk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = sk; path = sk.lproj/PreferenceWindowController.strings; sourceTree = "<group>"; };
@@ -2252,6 +2256,7 @@
 				84EC12881F504D2500137C1E /* FilterPresets.strings */,
 				E3CB75BC1FDACB82004DB10A /* SavedFilter.swift */,
 				84C6D3631EB276E9009BF721 /* PlaybackHistory.swift */,
+				5125117C2E89B2ED00CDAE9F /* Display.swift */,
 			);
 			name = Models;
 			sourceTree = "<group>";
@@ -2476,6 +2481,7 @@
 				842904E11F0EC01600478376 /* AutoFileMatcher.swift */,
 				846121BC1F35FCA500ABB39C /* DraggingDetect.swift */,
 				5114FA932DC704CE00D02435 /* NowPlayingInfoManager.swift */,
+				51EDB4712E85EE10007E5018 /* DisplayController.swift */,
 			);
 			name = Controllers;
 			sourceTree = "<group>";
@@ -3206,12 +3212,14 @@
 				519CCABD2BFFAEF10079DCAF /* HardwareDecodeCapabilities.swift in Sources */,
 				E38BA1C0253E54F2000B551D /* JavascriptAPIGlobal.swift in Sources */,
 				E39A11FD240F176E00A67F9F /* StringEncodingName.swift in Sources */,
+				5125117D2E89B2ED00CDAE9F /* Display.swift in Sources */,
 				E33FEEB52229A44F00B59711 /* JavascriptAPIUtils.swift in Sources */,
 				84C6D3671EB2A427009BF721 /* HistoryWindowController.swift in Sources */,
 				9E47DAC01E3CFA6D00457420 /* DurationDisplayTextField.swift in Sources */,
 				E35306F62147F7AF008FE492 /* JavascriptAPIMpv.swift in Sources */,
 				840AF5821E732C8F00F4AF92 /* JustXMLRPC.swift in Sources */,
 				E3513AF820EF79C500F8C347 /* PreferenceWindowController.swift in Sources */,
+				51EDB4722E85EE10007E5018 /* DisplayController.swift in Sources */,
 				841A599D1E1FF5800079E177 /* SleepPreventer.swift in Sources */,
 				51165FBC2E1D91290060B817 /* ReadWriteAtomic.swift in Sources */,
 				84ED99FF1E009C8100A5159B /* PrefAdvancedViewController.swift in Sources */,

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -155,12 +155,36 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
   /// Certain IINA capabilities, such as hardware acceleration, are contingent upon aspects of the Mac IINA is running on. If available,
   /// this method will log:
   /// - macOS version
-  /// - model identifier of the Mac
-  /// - kind of processor
+  /// - Model identifier of the Mac
+  /// - Kind of processor chip
+  /// - Amount of physical memory
+  /// - Thermal state
+  /// - Whether low power mode is active
+  /// - Note: At this time IINA does not listen for changes to the thermal state or whether low power mode is active or not. For now
+  ///         this information is only logged at startup. That might change if some correlation between these states and IINA's
+  ///         behavior is seen.
   private func logPlatformDetails() {
     Logger.log("Running under macOS \(ProcessInfo.processInfo.operatingSystemVersionString)")
-    guard let cpu = Sysctl.shared.machineCpuBrandString, let model = Sysctl.shared.hwModel else { return }
-    Logger.log("On a \(model) with an \(cpu) processor")
+    if let cpu = Sysctl.shared.machineCpuBrandString, let model = Sysctl.shared.hwModel {
+      let memory = ProcessInfo.processInfo.physicalMemory / 1073741824
+      Logger.log("On a \(model) with an \(cpu) processor and \(memory) GiB of RAM")
+    }
+    let thermalState = ProcessInfo.processInfo.thermalState
+    if thermalState != .nominal {
+      Logger.log("Thermal state: \(thermalState)")
+    }
+    if #available(macOS 12, *), ProcessInfo.processInfo.isLowPowerModeEnabled {
+      Logger.log("Low Power Mode is active")
+    }
+  }
+
+  /// Log all the available [screens](https://developer.apple.com/documentation/appkit/nsscreen) and all the
+  /// connected displays.
+  private func logScreenDetails() {
+    DisplayController.shared.addNewDisplays()
+    NSScreen.screens.enumerated().forEach { screen in
+      NSScreen.log("NSScreen.screens[\(screen.offset)]" , screen.element)
+    }
   }
 
   // MARK: - SPUUpdaterDelegate
@@ -207,6 +231,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 
     logBuildDetails()
     logPlatformDetails()
+    logScreenDetails()
 
     Logger.log("App will launch")
 
@@ -1326,5 +1351,22 @@ class RemoteCommandController {
       remoteCommand.skipForwardCommand,
       remoteCommand.stopCommand,
       remoteCommand.togglePlayPauseCommand]
+  }
+}
+
+extension ProcessInfo.ThermalState: @retroactive CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case .nominal:
+      "nominal"
+    case .fair:
+      "fair"
+    case .serious:
+      "serious"
+    case .critical:
+      "critical"
+    @unknown default:
+      "unknown"
+    }
   }
 }

--- a/iina/Display.swift
+++ b/iina/Display.swift
@@ -1,0 +1,190 @@
+//
+//  Display.swift
+//  iina
+//
+//  Created by low-batt on 9/28/25.
+//  Copyright © 2025 lhc. All rights reserved.
+//
+
+import Foundation
+
+fileprivate let rateFormatter = RateFormatter()
+
+/// A display discovered using
+/// [CGGetActiveDisplayList](https://developer.apple.com/documentation/coregraphics/cggetactivedisplaylist(_:_:_:)).
+struct Display: CustomStringConvertible {
+
+  /// A description of this display suitable to include in a log message.
+  var description: String {
+    var description = "Display \(displayId)"
+    var attributes: [String] = []
+    if isBuiltin {
+      attributes.append("builtin")
+    }
+    if CGDisplayIsMain(displayId) != 0 {
+      attributes.append("main")
+    }
+    if CGDisplayIsInMirrorSet(displayId) != 0 {
+      attributes.append("in mirror set")
+    }
+    if CGDisplayIsOnline(displayId) != 0 {
+      attributes.append("online")
+    }
+    if CGDisplayIsAsleep(displayId) != 0 {
+      attributes.append("asleep")
+    }
+    if !attributes.isEmpty {
+      description += " (\(attributes.joined(separator: ", ")))"
+    }
+    description += ":"
+    if let productName {
+      description += "\n  Product name: \(productName)"
+    }
+    description += "\n  Model: "
+    if modelNumber == kDisplayProductIDGeneric {
+      description += "generic"
+    } else if modelNumber == 0xFFFFFFFF {
+      description += "no monitor associated with display"
+    } else {
+      description += "\(modelNumber)"
+    }
+    description += "\n  Vendor: "
+    if vendorNumber == kDisplayVendorIDUnknown {
+      description += "unknown"
+    } else if vendorNumber == 0xFFFFFFFF {
+      description += "no monitor associated with display"
+    } else {
+      description += "\(vendorNumber)"
+    }
+    description += "\n  Bounds: \(CGDisplayBounds(displayId))"
+    if let displayBacklight {
+      description += "\n  Display luminance: \(displayBacklight) nits"
+    }
+    if let nonReferencePeakHDRLuminance, let nonReferencePeakSDRLuminance {
+      description += """
+        \n  Peak non-reference luminance: HDR \(nonReferencePeakHDRLuminance) nits, \
+        SDR \(nonReferencePeakSDRLuminance) nits
+        """
+    }
+    if let referencePeakHDRLuminance, let referencePeakSDRLuminance {
+      description += """
+        \n  Peak reference luminance: HDR \(referencePeakHDRLuminance) nits, \
+        SDR \(referencePeakSDRLuminance) nits
+        """
+    }
+    if let mode = CGDisplayCopyDisplayMode(displayId) {
+      description += "\n  Mode: \(mode.shortDescription)"
+    }
+    let modes = displayModes.reduce("", { result, displayMode in
+      result + "\n    " + displayMode.shortDescription })
+    description += "\n  Native modes:"
+    description += modes
+    return description
+  }
+
+  // Luminance of non-XDR displays.
+  let displayBacklight: Int?
+
+  let displayId: CGDirectDisplayID
+
+  /// Native modes supported by the display.
+  let displayModes: [CGDisplayMode]
+
+  /// Whether the display is built-in, such as the internal display in portable systems.
+  let isBuiltin: Bool
+
+  /// The model number of the display's monitor.
+  let modelNumber: UInt32
+
+  /// XDR display luminance.
+  let nonReferencePeakHDRLuminance: Int?
+  let nonReferencePeakSDRLuminance: Int?
+
+  /// Product name of the display in English..
+  let productName: String?
+
+  /// XDR display luminance.
+  let referencePeakHDRLuminance: Int?
+  let referencePeakSDRLuminance: Int?
+
+  /// The vendor number of the display’s monitor.
+  let vendorNumber: UInt32
+
+  /// Create a `Display` object for the display with the given ID.
+  /// - Parameter displayId: The
+  ///     [CGDirectDisplayID](https://developer.apple.com/documentation/coregraphics/cgdirectdisplayid)
+  ///     that identifies the display to create a `Display` object for.
+  init(_ displayId: CGDirectDisplayID) {
+    self.displayId = displayId
+    isBuiltin = CGDisplayIsBuiltin(displayId) != 0
+    modelNumber = CGDisplayModelNumber(displayId)
+    vendorNumber = CGDisplayVendorNumber(displayId)
+
+    // Obtain all the available modes on the display and filter out all except the native modes.
+    // Native modes are of interest as IINA in the future might add support for matching the refresh
+    // rate of the display when in full screen mode.
+    let allDisplayModes = CGDisplayCopyAllDisplayModes(displayId, nil) as! [CGDisplayMode]
+    var usableDisplayModes = allDisplayModes
+    usableDisplayModes.removeAll(where: { !$0.isNative })
+    displayModes = usableDisplayModes
+
+    // Additional information has to be obtained from the display's info dictionary.
+    guard let info = CoreDisplay_DisplayCreateInfoDictionary(displayId)?.takeRetainedValue() as?
+            [String: AnyObject] else {
+      // Not expected to occur, but we don't want it to be a fatal error if it does occur.
+      Logger.log("Failed to create info dictionary for display \(displayId)", level: .error)
+      displayBacklight = nil
+      nonReferencePeakHDRLuminance = nil
+      nonReferencePeakSDRLuminance = nil
+      productName = nil
+      referencePeakHDRLuminance = nil
+      referencePeakSDRLuminance = nil
+      return
+    }
+    // It appears the luminance of non-XDR displays is reported using the key DisplayBacklight.
+    displayBacklight = info["DisplayBacklight"] as? Int
+    if let productName = info["DisplayProductName"] as? [String: String] {
+      // As the product name is only used in a log message we use the English name.
+      self.productName = productName["en_US"]
+    } else {
+      productName = nil
+    }
+    // These luminance keys were seen with XDR displays.
+    nonReferencePeakHDRLuminance = info["NonReferencePeakHDRLuminance"] as? Int
+    nonReferencePeakSDRLuminance = info["NonReferencePeakSDRLuminance"] as? Int
+    referencePeakHDRLuminance = info["ReferencePeakHDRLuminance"] as? Int
+    referencePeakSDRLuminance = info["ReferencePeakSDRLuminance"] as? Int
+  }
+}
+
+// MARK: - Rate Formatter
+
+/// A formatter for formatting display refresh rates in log messages.
+///
+/// The primary reason for this formatter is to avoid logging floating point numbers with a large number of fractional digits making log
+/// messages hard to read.
+private class RateFormatter: NumberFormatter, @unchecked Sendable {
+
+  override init() {
+    super.init()
+    maximumFractionDigits = 3
+    numberStyle = .decimal
+    roundingMode = .down
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  func string(for rate: Double) -> String {
+    super.string(for: rate)! + " Hz"
+  }
+}
+
+// MARK: - Extensions
+
+extension CGDisplayMode {
+  var isNative: Bool { (ioFlags & UInt32(kDisplayModeNativeFlag)) != 0 }
+
+  var shortDescription: String { "\(width)x\(height) @ \(rateFormatter.string(for: refreshRate))" }
+}

--- a/iina/DisplayController.swift
+++ b/iina/DisplayController.swift
@@ -1,0 +1,106 @@
+//
+//  DisplayController.swift
+//  iina
+//
+//  Created by low-batt on 9/5/25.
+//  Copyright © 2025 lhc. All rights reserved.
+//
+
+import Foundation
+
+/// Controller that keeps track of displays discovered using
+/// [CGGetActiveDisplayList](https://developer.apple.com/documentation/coregraphics/cggetactivedisplaylist(_:_:_:)).
+class DisplayController {
+  /// The `DisplayController` singleton object.
+  static let shared = DisplayController()
+
+  /// Known displays.
+  private var displays: [CGDirectDisplayID: Display] = [:]
+
+  /// Calls
+  /// [CGGetActiveDisplayList](https://developer.apple.com/documentation/coregraphics/cggetactivedisplaylist(_:_:_:))
+  /// and records any previously unknown displays.
+  ///
+  /// The details of any newly discovered displays will be logged.
+  func addNewDisplays() {
+    // Get the number of displays.
+    var maxDisplays: CGDisplayCount = 0
+    var result = CGGetOnlineDisplayList(0, nil, &maxDisplays)
+    guard checkResult(result, "CGGetOnlineDisplayList") else { return }
+
+    // If there are no new displays there is nothing to do.
+    guard maxDisplays != displays.count else { return }
+
+    // Now that we know the number of displays we can allocate the appropriate sized array.
+    var displayCount: CGDisplayCount = 0
+    var onlineDisplays = [CGDirectDisplayID](repeating: 0, count: Int(maxDisplays))
+    result = CGGetOnlineDisplayList(maxDisplays, &onlineDisplays, &displayCount)
+    guard checkResult(result, "CGGetOnlineDisplayList") else { return }
+
+    // Go through the list and add any newly discovered displays to our display dictionary.
+    for displayId in onlineDisplays {
+      guard !displays.keys.contains(displayId) else { continue }
+      let display = Display(displayId)
+      displays[displayId] = display
+      // Log the details of the newly discovered display.
+      Logger.log(display.description)
+    }
+  }
+
+  private init() {}
+
+  // MARK: - Error Checking
+
+  /// Check the result of calling a [Core Graphics](https://developer.apple.com/documentation/coregraphics) method.
+  /// 
+  /// If the result code is not [success](https://developer.apple.com/documentation/coregraphics/cgerror/success)
+  /// then an error message will be logged and `false` will be returned.
+  /// - Parameters:
+  ///   - result: The [CGError](https://developer.apple.com/documentation/coregraphics/cgerror) result
+  ///             code returned by the core graphics method.
+  ///   - method: The core graphics method that returned the result code.
+  /// - Returns: `True` if the call was successful; `false` otherwise.
+  private func checkResult(_ result: CGError, _ method: String) -> Bool {
+    guard result != .success else { return true }
+    Logger.log("Core graphics method \(method) failed: \(result) (\(result.rawValue))", level: .error)
+    return false
+  }
+}
+
+// MARK: - Extensions
+
+/// A uniform type for result codes returned by functions in Core Graphics.
+extension CGError: @retroactive CustomStringConvertible {
+
+  /// A description of what the error code indicates.
+  ///
+  /// See the Apple [CGError](https://developer.apple.com/documentation/coregraphics/cgerror) documentation.
+  public var description: String {
+    switch self {
+    case .cannotComplete:
+      "The requested operation is inappropriate for the parameters passed in, or the current system state"
+    case .failure:
+      "A general failure occurred"
+    case .illegalArgument:
+      "One or more of the parameters passed to a function are invalid. Check for NULL pointers"
+    case .invalidConnection:
+      "The parameter representing a connection to the window server is invalid"
+    case .invalidContext:
+      "The CPSProcessSerNum or context identifier parameter is not valid"
+    case .invalidOperation:
+      "The requested operation is not valid for the parameters passed in, or the current system state"
+    case .noneAvailable:
+      "The requested operation could not be completed as the indicated resources were not found"
+    case .notImplemented:
+      "Return value from obsolete function stubs present for binary compatibility, but not typically called"
+    case .rangeCheck:
+      "A parameter passed in has a value that is inappropriate, or which does not map to a useful operation or value"
+    case .success:
+      "The requested operation was completed successfully"
+    case .typeCheck:
+      "A data type or token was encountered that did not match the expected type or token"
+    @unknown default:
+      "Unrecognized core graphics return code"
+    }
+  }
+}

--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -787,10 +787,42 @@ extension NSScreen {
       Logger.log("\(label): nil", level: .warning, subsystem: subsystem)
       return
     }
-    // Unfortunately localizedName is not available until macOS Catalina.
+    var message = "\(label), \(screen.localizedName)"
+    if screen == NSScreen.main {
+      message += " (main screen)"
+    }
+    let screenNumberKey = NSDeviceDescriptionKey(rawValue: "NSScreenNumber")
+    if let displayId = screen.deviceDescription[screenNumberKey] as? CGDirectDisplayID {
+      message += ", on display \(displayId)"
+    }
+    message += ":"
+    message += "\n  Frame: \(screen.frame), visible \(screen.visibleFrame)"
+    message += "\n  \(formEDRMessage(screen))"
+    Logger.log(message, subsystem: subsystem)
+  }
+
+  /// Log EDR aspects of the given `NSScreen` object.
+  /// - parameter screen: The `NSScreen` object to log EDR aspects of.
+  static func logEDR(_ label: String, _ screen: NSScreen?, subsystem: Logger.Subsystem = .general) {
+    guard let screen = screen else {
+      Logger.log("\(label): nil", level: .warning, subsystem: subsystem)
+      return
+    }
+    var message = "\(label), \(screen.localizedName):"
+    message += "\n  \(formEDRMessage(screen))"
+    Logger.log(message, subsystem: subsystem)
+  }
+
+  /// Return a string describing EDR aspects of the given screen.
+  /// - Parameter screen: The `NSScreen` object to form EDR aspects of.
+  /// - Returns: A string with EDR related details of the given screen for use in a log message.
+  private static func formEDRMessage(_ screen: NSScreen) -> String {
     let maxPossibleEDR = screen.maximumPotentialExtendedDynamicRangeColorComponentValue
     let canEnableEDR = maxPossibleEDR > 1.0
-    Logger.log("\(label): \"\(screen.localizedName)\" visible frame \(screen.visibleFrame) EDR: {supports=\(canEnableEDR) maxPotential=\(maxPossibleEDR) maxCurrent=\(screen.maximumExtendedDynamicRangeColorComponentValue)}", subsystem: subsystem)
+    return """
+      EDR: \(canEnableEDR ? "Supported" : "Not supported"), max potential \(maxPossibleEDR), \
+      max current \(screen.maximumExtendedDynamicRangeColorComponentValue)
+      """
   }
 }
 

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -653,6 +653,7 @@ class MainWindowController: PlayerWindowController {
       // Update the cached value
       cachedScreenCount = screenCount
       videoView.updateDisplayLink()
+      DisplayController.shared.addNewDisplays()
       // In normal full screen mode AppKit will automatically adjust the window frame if the window
       // is moved to a new screen such as when the window is on an external display and that display
       // is disconnected. In legacy full screen mode IINA is responsible for adjusting the window's
@@ -694,9 +695,10 @@ class MainWindowController: PlayerWindowController {
 
     // As there have been issues in this area, log details about the screen selection process.
     NSScreen.log("window.screen", window.screen)
-    NSScreen.log("NSScreen.main", NSScreen.main)
     NSScreen.screens.enumerated().forEach { screen in
-      NSScreen.log("NSScreen.screens[\(screen.offset)]" , screen.element)
+      if screen.element != window.screen {
+        NSScreen.log("NSScreen.screens[\(screen.offset)]" , screen.element)
+      }
     }
 
     // If a video is not actively playing then the initial drawing of the view needs to be forced.

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -417,8 +417,8 @@ extension VideoView {
   func refreshEdrMode() {
     guard player.mainWindow.loaded, player.info.state.loaded, let displayId = currentDisplay else { return }
     if let screen = self.window?.screen {
-      NSScreen.log("Refreshing HDR for \(player.subsystem.rawValue) @ display\(displayId)", screen,
-                   subsystem: hdrSubsystem)
+      NSScreen.logEDR("Refreshing HDR for \(player.subsystem.rawValue) on display\(displayId)",
+                      screen, subsystem: hdrSubsystem)
     }
     let edrEnabled = requestEdrMode()
     let edrAvailable = edrEnabled != false


### PR DESCRIPTION
This commit will:
- Add a new `Display` struct that holds information about a physical display attached to the Mac
- Add a new `DisplayController` class that discovers and remembers displays attached to the Mac
- Add a new method `logScreenDetails` to `AppDelegate` that logs information about the attached displays and available screens at startup
- Change `AppDelegate.logPlatformDetails` to log the amount of physical memory the Mac has as well as the thermal state and whether low power mode is enabled
- Change the `NSScreen.log` extension to log more details about the screen
- Add a `logEDR` method to the NSScreen` extension that limits the information logged to EDR details
- Change `VideoView` to use the new `logEDR` method

These changes improve diagnostic logging to provide more insight to the hardware and state of the Mac IINA is running on.

In a future PR, VideoView.requestEdrMode should be able to be changed to use DisplayController for display information instead of obtaining that information itself.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
