### PR TITLE
Fix crashes with custom mpv OSD settings, #5727

### DIFF
--- a/iina/EventController.swift
+++ b/iina/EventController.swift
@@ -46,7 +46,7 @@ class EventController {
     static let fileLoaded = Name("iina.file-loaded")
     static let fileStarted = Name("iina.file-started")
     
-    static let mpvInitialized = Name("iina.mpv-inititalized")
+    static let mpvInitialized = Name("iina.mpv-initialized")
     static let thumbnailsReady = Name("iina.thumbnails-ready")
     static let pluginOverlayLoaded = Name("iina.plugin-overlay-loaded")
   }

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -485,6 +485,13 @@ class PlayerCore: NSObject {
       mainWindow.videoView.displayActive()
     }
 
+    // If this mpv core is being reused icc-profile-auto may have been left set to true. This option
+    // MUST be reset to false to avoid a crash that occurs if the mpv OSD is being used. Another way
+    // to fix this would be to add this option to the mpv reset-on-next-file option. However the
+    // user might override IINA and set that option themselves and not include icc-profile-auto.
+    // Better to directly reset icc-profile-auto. See issue #5727 for details.
+    mpv.setFlag(MPVOption.GPURendererOptions.iccProfileAuto, false)
+
     // Send load file command
     info.justOpenedFile = true
     info.state = .loading

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -317,8 +317,10 @@ class VideoView: NSView {
     } else if let screenColorSpace {
       let name = screenColorSpace.localizedName ?? "unnamed"
       logHDR("Using the ICC profile of the color space \(name)")
-      player.mpv.setFlag(MPVOption.GPURendererOptions.iccProfileAuto, true)
+      // Set MPV_RENDER_PARAM_ICC_PROFILE before enabling icc-profile-auto to true as mpv requires
+      // that parameter be set in the render context when icc-profile-auto is in use.
       videoLayer.setRenderICCProfile(screenColorSpace)
+      player.mpv.setFlag(MPVOption.GPURendererOptions.iccProfileAuto, true)
     }
 
     let sdrColorSpace = screenColorSpace?.cgColorSpace ?? VideoView.SRGB


### PR DESCRIPTION
This commit will change `PlayerCore.openMainWindow` to reset the mpv `icc-profile-auto` option to `false` before loading a file.

This corrects a crash that occurs when IINA is configured to display the mpv OSD.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5727.

---

**Description:**
