### PR TITLE
feat: show current timestamp and progress bar on 'O' key press

### DIFF
--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -283,6 +283,10 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
       case MPVCommand.screenshot.rawValue:
         return player.screenshot(fromKeyBinding: keyBinding)
         
+      case MPVCommand.showProgress.rawValue:
+        showTimestampWithPosition()
+        returnValue = 0
+        
       default:
         returnValue = player.mpv.command(rawString: keyBinding.rawAction)
       }
@@ -700,6 +704,15 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
     default:
       break
     }
+  }
+
+  internal func showTimestampWithPosition() {
+    guard player.info.state.loaded else { return }
+    let osdText = (player.info.videoPosition?.stringRepresentation ?? Constants.String.videoTimePlaceholder) + " / " +
+    (player.info.videoDuration?.stringRepresentation ?? Constants.String.videoTimePlaceholder)
+    let percentage = (player.info.videoPosition / player.info.videoDuration) ?? 0
+    
+    player.sendOSD(.seek(osdText, percentage))
   }
 
   internal func isMouseEvent(_ event: NSEvent, inAnyOf views: [NSView?]) -> Bool {

--- a/iina/config/iina-default-input.conf
+++ b/iina/config/iina-default-input.conf
@@ -84,6 +84,7 @@ ENTER set fullscreen yes
 q quit
 
 p cycle pause                          # toggle pause/playback mode
+o show-progress                        # show playback progress with position bar
 
 . frame-step                           # advance one frame and pause
 , frame-back-step                      # go back by one frame and pause

--- a/iina/config/input.conf
+++ b/iina/config/input.conf
@@ -92,7 +92,7 @@ SPACE cycle pause                      # toggle pause/playback mode
 ENTER playlist-next                    # skip to the next file
 < playlist-prev                        # skip to the previous file
 O no-osd cycle-values osd-level 3 1    # toggle displaying the OSD on user interaction or always
-o show-progress                        # show playback progress
+o show-progress                        # show playback progress with position bar
 P show-progress                        # show playback progress
 i script-binding stats/display-stats   # display information and statistics
 I script-binding stats/display-stats-toggle # toggle displaying information and statistics


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5694 .
.

---

**Description:**
when you press the O key, it shows the current timestamp and progress bar on the screen.
changes in the input.conf by adding the o keybinding
