### PR TITLE
Proof-of-concept-ish Vapoursynth Support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,7 +114,7 @@ browser/Firefox_Open_In_IINA/*
 *.xcarchive
 /.vscode
 
-deps/include
-deps/lib
-deps/executable
-deps/plugins
+deps/
+.home/
+.spm/
+.tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ Temporary Items
 build/
 DerivedData/
 
+## nix build result symlink
+result
+
 ## Xcode generated
 */project.xcworkspace/xcshareddata/
 
@@ -113,4 +116,3 @@ browser/Firefox_Open_In_IINA/*
 
 deps/executable/youtube-dl
 deps/plugins
-

--- a/.gitignore
+++ b/.gitignore
@@ -114,5 +114,7 @@ browser/Firefox_Open_In_IINA/*
 *.xcarchive
 /.vscode
 
-deps/executable/youtube-dl
+deps/include
+deps/lib
+deps/executable
 deps/plugins

--- a/Configs/iina.xcconfig
+++ b/Configs/iina.xcconfig
@@ -22,7 +22,7 @@ LIBRARY_SEARCH_PATHS = $(inherited) $(SRCROOT)/deps/lib
 // The following libraries are not needed for arm64, so they are not universal libraries. To avoid
 // triggering build warnings they are not included in the Link Binary With Libraries phase. Instead
 // they are added here where we can add them only for the x86_64 build.
-OTHER_LDFLAGS[arch=x86_64] = $(inherited) -l gcc_s.1.1 -l stdc++.6
+OTHER_LDFLAGS[arch=x86_64] = $(inherited)
 PRODUCT_BUNDLE_IDENTIFIER = com.colliderli.$(TARGET_NAME)
 PRODUCT_NAME = IINA
 SWIFT_EMIT_LOC_STRINGS = YES

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1759439645,
+        "narHash": "sha256-oiAyQaRilPk525Z5aTtTNWNzSrcdJ7IXM0/PL3CGlbI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "879bd460b3d3e8571354ce172128fbcbac1ed633",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.05",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1759439645,
-        "narHash": "sha256-oiAyQaRilPk525Z5aTtTNWNzSrcdJ7IXM0/PL3CGlbI=",
+        "lastModified": 1763049705,
+        "narHash": "sha256-A5LS0AJZ1yDPTa2fHxufZN++n8MCmtgrJDtxFxrH4S8=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "879bd460b3d3e8571354ce172128fbcbac1ed633",
+        "rev": "3acb677ea67d4c6218f33de0db0955f116b7588c",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -19,7 +19,7 @@
           pkgs = import nixpkgs { inherit system; };
 
           # Pull system's xcode in
-          xcode = pkgs.runCommandNoCC "system-xcode" { } ''
+          xcode = pkgs.runCommand "system-xcode" { } ''
             mkdir -p $out/bin
             ln -sf /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild $out/bin/xcodebuild
           '';
@@ -146,6 +146,7 @@
                   pkgs.libass
                   pkgs.libb2
                   pkgs.libbluray
+                  pkgs.libbs2b
                   pkgs.libidn2
                   pkgs.libjpeg_turbo
                   pkgs.libjxl
@@ -661,7 +662,7 @@
 
               # Rewrite SwiftPM workspace-state.json to fix absolute paths
               if [ -f .spm/workspace-state.json ]; then
-                old_prefix=$(grep -Eo "/tmp/nix-build-[^/]+/source" .spm/workspace-state.json | head -n1)
+                old_prefix=$(grep -Eo "/nix/var/nix/builds/nix-[^/]+/source" .spm/workspace-state.json | head -n1)
                 echo "Patching workspace-state.json: replacing $old_prefix → $PWD"
                 sed -i -E "s|$old_prefix|$PWD|g" .spm/workspace-state.json
               fi

--- a/flake.nix
+++ b/flake.nix
@@ -419,50 +419,74 @@
                 done
               }
 
+              declare -Ag BUNDLED_DEPS=()
+
               bundle_dep() {
-                local dep="$1"
-                local depbase
-                depbase=$(basename "$dep")
-                local dest="$frameworks/$depbase"
+                local dep="$1"   # path as found in otool -L (may be libbs2b.0.dylib)
 
-                if [ -f "$dest" ]; then
-                  echo "✅ Already bundled: $depbase"
+                # Canonical path for cycle detection
+                local dep_real
+                dep_real=$(realpath "$dep" 2>/dev/null || echo "$dep")
+
+                # Break cycles by *real* path
+                if [[ -n "''${BUNDLED_DEPS["$dep_real"]:-}" ]]; then
+                  echo "🔁 Already processed dep: $dep_real"
+                  return
+                fi
+                BUNDLED_DEPS["$dep_real"]=1
+
+                local request_base
+                request_base=$(basename "$dep")
+                local real_base
+                real_base=$(basename "$dep_real")
+                local dest="$frameworks/$request_base"
+
+                if [[ "$dep_real" == /usr/lib/* ]] || [[ "$dep_real" == /System/* ]] || [[ "$real_base" == libffi-trampoline.dylib ]]; then
+                  echo "🚫 Skipping system/non-target dep: $dep_real"
                   return
                 fi
 
-                if [[ "$dep" == /usr/lib/* ]] || [[ "$dep" == /System/* ]] || [[ "$depbase" == libffi-trampoline.dylib ]]; then
-                  echo "🚫 Skipping system/non-target dep: $dep"
+                if [ ! -f "$dep_real" ]; then
+                  echo "⚠️  Dep missing on disk, skipping: $dep_real"
                   return
                 fi
 
-                if [ ! -f "$dep" ]; then
-                  echo "⚠️  Dep missing on disk, skipping: $dep"
+                # Ensure the real payload file exists in Frameworks under some canonical name
+                local canonical="$frameworks/$real_base"
+                if [ ! -f "$canonical" ]; then
+                  echo "📥 Copying dep → Frameworks: $dep_real → $canonical"
+                  cp -L -p "$dep_real" "$canonical" || { echo "❌ Copy failed for $dep_real"; return; }
+                fi
+
+                # Ensure the *requested* name exists and points to the payload
+                if [ ! -e "$dest" ]; then
+                  echo "🔗 Copying $canonical → $dest"
+                  cp -L -p "$canonical" "$dest"
+                else
+                  echo "✏️ Normalizing already-bundled dep alias: $request_base"
+                fi
+
+                ensure_writable "$canonical"
+
+                if ! is_macho "$canonical"; then
+                  echo "🧾 Non-Mach-O dep (no patching): $real_base"
                   return
                 fi
 
-                echo "📥 Copying dep → Frameworks: $dep → $dest"
-                cp -L -p "$dep" "$dest" || { echo "❌ Copy failed for $dep"; return; }
-                ensure_writable "$dest"
+                echo "✏️ Setting install_name id on $real_base"
+                install_name_tool -id "@rpath/$request_base" "$canonical" || true
 
-                if ! is_macho "$dest"; then
-                  echo "🧾 Copied non-Mach-O dep (no patching): $depbase"
-                  return
-                fi
+                ensure_rpath "$canonical"
+                rewrite_deps_to_rpath "$canonical"
 
-                echo "✏️ Setting install_name id on $depbase"
-                install_name_tool -id "@rpath/$depbase" "$dest" || true
-
-                ensure_rpath "$dest"
-                rewrite_deps_to_rpath "$dest"
-
-                # Recurse into transitive deps
-                otool -L "$dest" | awk 'NF && $1 !~ /:$/ {print $1}' | while read -r sub; do
+                # Recurse into transitive deps based on their /nix/store path
+                otool -L "$canonical" | awk 'NF && $1 !~ /:$/ {print $1}' | while read -r sub; do
                   case "$sub" in
                     /nix/store/*)
                       local subbase
                       subbase=$(basename "$sub")
-                      echo "  🔗 Repointing subdep for $depbase: $sub → @rpath/$subbase"
-                      install_name_tool -change "$sub" "@rpath/$subbase" "$dest" || true
+                      echo "  🔗 Repointing subdep for $real_base: $sub → @rpath/$subbase"
+                      install_name_tool -change "$sub" "@rpath/$subbase" "$canonical" || true
                       bundle_dep "$sub"
                       ;;
                     *) : ;;

--- a/flake.nix
+++ b/flake.nix
@@ -632,15 +632,6 @@
               cp -RL ${depsLib}/.               deps/lib
               cp -RL ${depsExecutable}/.        deps/executable/
 
-              echo "🔃 Fixing compatibility"
-              cp deps/executable/yt-dlp             deps/executable/youtube-dl
-              cp deps/lib/librubberband.3.dylib     deps/lib/librubberband.2.dylib
-              cp deps/lib/libplacebo.349.dylib      deps/lib/libplacebo.338.dylib
-              cp deps/lib/libjpeg.62.dylib          deps/lib/libjpeg.8.dylib
-              cp deps/lib/libjxl_cms.0.11.dylib     deps/lib/libjxl_cms.0.10.dylib
-              cp deps/lib/libjxl_threads.0.11.dylib deps/lib/libjxl_threads.0.10.dylib
-              cp deps/lib/libjxl.0.11.dylib         deps/lib/libjxl.0.10.dylib
-
               echo "✏️ Rewriting install names to use @rpath"
               find deps/lib -type f \( -perm -111 -o -name "*.dylib" -o -name "*.so" \) | while read -r dep; do
                 echo "✏️ Patching install names in $dep"

--- a/flake.nix
+++ b/flake.nix
@@ -27,8 +27,15 @@
           # Override ffmpeg to use our version of libs
           ffmpeg = pkgs.ffmpeg_7.override {
             withSoxr = true;
+            soxr = pkgs.soxr;
+
+            withRubberband = true;
             rubberband = pkgs.rubberband;
+
+            withPlacebo = true;
             libplacebo = pkgs.libplacebo;
+
+            withJxl = true;
             libjxl = pkgs.libjxl;
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -270,7 +270,11 @@
                 )
                 [
                   ffmpeg
-                  mpv
+                  # Grab the real mpv binary instead of the /bin wrapper script
+                  (pkgs.runCommand "iina-mpv-executable" { } ''
+                    mkdir -p $out/bin
+                    cp -p ${mpv}/Applications/mpv.app/Contents/MacOS/mpv $out/bin/mpv
+                  '')
                   pkgs.vapoursynth
                   pkgs.python3
                   pkgs.yt-dlp

--- a/flake.nix
+++ b/flake.nix
@@ -29,6 +29,9 @@
             withSoxr = true;
             soxr = pkgs.soxr;
 
+            withBs2b = true;
+            libbs2b = pkgs.libbs2b;
+
             withRubberband = true;
             rubberband = pkgs.rubberband;
 

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,862 @@
+{
+  description = "IINA – The modern video player for macOS.";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-25.05";
+
+  outputs =
+    { self, nixpkgs }:
+    {
+      systems = [
+        "aarch64-darwin"
+        "x86_64-darwin"
+      ];
+
+      archApps = builtins.map (system: self.packages.${system}.iina) self.systems;
+
+      packages = nixpkgs.lib.genAttrs self.systems (
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+
+          # Pull system's xcode in
+          xcode = pkgs.runCommandNoCC "system-xcode" { } ''
+            mkdir -p $out/bin
+            ln -sf /Applications/Xcode.app/Contents/Developer/usr/bin/xcodebuild $out/bin/xcodebuild
+          '';
+
+          # Override ffmpeg to use our version of libs
+          ffmpeg = pkgs.ffmpeg_7.override {
+            withSoxr = true;
+            rubberband = pkgs.rubberband;
+            libplacebo = pkgs.libplacebo;
+            libjxl = pkgs.libjxl;
+          };
+
+          # Override mpv with vapoursynth support
+          mpv = pkgs.mpv-unwrapped.override {
+            ffmpeg = ffmpeg;
+            lua = pkgs.luajit;
+            vapoursynth = pkgs.vapoursynth;
+
+            # enable features we want
+            vapoursynthSupport = true;
+            javascriptSupport = true;
+            cmsSupport = true;
+            rubberbandSupport = true;
+            archiveSupport = true;
+            bluraySupport = true;
+            openalSupport = true;
+            vulkanSupport = true;
+            zimgSupport = true;
+
+            # disable linux-only bits
+            alsaSupport = false;
+            jackaudioSupport = false;
+            pipewireSupport = false;
+            x11Support = false;
+            waylandSupport = false;
+            vaapiSupport = false;
+            vdpauSupport = false;
+            sdl2Support = false;
+            cddaSupport = false;
+            dvbinSupport = false;
+            sixelSupport = false;
+          };
+
+          # Collect include deps as per readme.md
+          depsInc = pkgs.linkFarm "iina-deps-inc" [
+            {
+              name = "mpv";
+              path = "${pkgs.lib.getDev mpv}/include/mpv";
+            }
+            {
+              name = "libavcodec";
+              path = "${pkgs.lib.getDev ffmpeg}/include/libavcodec";
+            }
+            {
+              name = "libavdevice";
+              path = "${pkgs.lib.getDev ffmpeg}/include/libavdevice";
+            }
+            {
+              name = "libavfilter";
+              path = "${pkgs.lib.getDev ffmpeg}/include/libavfilter";
+            }
+            {
+              name = "libavformat";
+              path = "${pkgs.lib.getDev ffmpeg}/include/libavformat";
+            }
+            {
+              name = "libavutil";
+              path = "${pkgs.lib.getDev ffmpeg}/include/libavutil";
+            }
+            {
+              name = "libpostproc";
+              path = "${pkgs.lib.getDev ffmpeg}/include/libpostproc";
+            }
+            {
+              name = "libswresample";
+              path = "${pkgs.lib.getDev ffmpeg}/include/libswresample";
+            }
+            {
+              name = "libswscale";
+              path = "${pkgs.lib.getDev ffmpeg}/include/libswscale";
+            }
+          ];
+
+          # Collect lib deps as per readme.md
+          depsLib = pkgs.linkFarm "iina-deps-lib" (
+            pkgs.lib.flatten (
+              map
+                (
+                  pkg:
+                  let
+                    libdir = "${pkgs.lib.getLib pkg}/lib";
+                  in
+                  builtins.map (file: {
+                    name = baseNameOf file;
+                    path = "${libdir}/${file}";
+                  }) (builtins.attrNames (builtins.readDir libdir))
+                )
+                [
+                  ffmpeg
+                  mpv
+                  (pkgs.libhwy.overrideAttrs (old: {
+                    cmakeFlags = (old.cmakeFlags or [ ]) ++ [ "-DBUILD_SHARED_LIBS=ON" ];
+                  }))
+                  pkgs.brotli
+                  pkgs.dav1d
+                  pkgs.fontconfig
+                  pkgs.freetype
+                  pkgs.fribidi
+                  pkgs.gettext
+                  pkgs.glib
+                  pkgs.gmp
+                  pkgs.gnutls
+                  pkgs.graphite2
+                  pkgs.harfbuzz
+                  pkgs.lcms2
+                  pkgs.libarchive
+                  pkgs.libass
+                  pkgs.libb2
+                  pkgs.libbluray
+                  pkgs.libidn2
+                  pkgs.libjpeg_turbo
+                  pkgs.libjxl
+                  pkgs.libplacebo
+                  pkgs.libpng
+                  pkgs.libsamplerate
+                  pkgs.libsodium
+                  pkgs.libtasn1
+                  pkgs.libuchardet
+                  pkgs.libunibreak
+                  pkgs.libunistring
+                  pkgs.libwebp
+                  pkgs.luajit
+                  pkgs.lz4
+                  pkgs.mujs
+                  pkgs.nettle
+                  pkgs.p11-kit
+                  pkgs.pcre2
+                  pkgs.python3
+                  pkgs.rubberband
+                  pkgs.shaderc
+                  pkgs.snappy
+                  pkgs.soxr
+                  pkgs.speex
+                  pkgs.vapoursynth
+                  pkgs.vid-stab
+                  pkgs.vulkan-loader
+                  pkgs.xorg.libX11
+                  pkgs.xorg.libXau
+                  pkgs.xorg.libxcb
+                  pkgs.xorg.libXdmcp
+                  pkgs.xz
+                  pkgs.zeromq
+                  pkgs.zimg
+                  pkgs.zstd
+                ]
+            )
+          );
+
+          # Collect indirect deps
+          depsIndirect = pkgs.linkFarm "iina-deps-indirect" (
+            pkgs.lib.flatten (
+              map
+                (
+                  pkg:
+                  let
+                    libdir = "${pkgs.lib.getLib pkg}/lib";
+                    files = builtins.attrNames (builtins.readDir libdir);
+                  in
+                  pkgs.lib.concatMap (
+                    file:
+                    if pkgs.lib.hasSuffix ".dylib" file then
+                      [
+                        {
+                          name = file;
+                          path = "${libdir}/${file}";
+                        }
+                      ]
+                    else
+                      [ ]
+                  ) files
+                )
+                [
+                  pkgs.bzip2
+                  pkgs.expat
+                  pkgs.lame
+                  pkgs.libaom
+                  pkgs.libcaca
+                  pkgs.libcxx
+                  pkgs.libdovi
+                  pkgs.libdvdcss
+                  pkgs.libdvdnav
+                  pkgs.libffi
+                  pkgs.libjxl
+                  pkgs.libogg
+                  pkgs.libopenmpt
+                  pkgs.libopus
+                  pkgs.libplacebo
+                  pkgs.librist
+                  pkgs.libssh
+                  pkgs.libtheora
+                  pkgs.libvdpau
+                  pkgs.libvmaf
+                  pkgs.libvorbis
+                  pkgs.libxml2
+                  pkgs.llvmPackages.openmp
+                  pkgs.ocl-icd
+                  pkgs.openal
+                  pkgs.openjpeg
+                  pkgs.rubberband
+                  pkgs.SDL2
+                  pkgs.sdl3
+                  pkgs.srt
+                  pkgs.svt-av1
+                  pkgs.vapoursynth
+                  pkgs.x264
+                  pkgs.x265
+                  pkgs.zlib
+                  pkgs.zstd.out
+                  pkgs.zvbi
+                ]
+            )
+          );
+
+          # Collect executables to expose them for plugins
+          depsExecutable = pkgs.linkFarm "iina-deps-executable" (
+            pkgs.lib.flatten (
+              map
+                (
+                  pkg:
+                  let
+                    bindir = "${pkgs.lib.getBin pkg}/bin";
+                  in
+                  builtins.map (file: {
+                    name = baseNameOf file;
+                    path = "${bindir}/${file}";
+                  }) (builtins.attrNames (builtins.readDir bindir))
+                )
+                [
+                  ffmpeg
+                  mpv
+                  pkgs.vapoursynth
+                  pkgs.python3
+                  pkgs.yt-dlp
+                ]
+            )
+          );
+
+          # Collect SwiftPM deps as separate derivation for them to be cached
+          spmDeps = pkgs.stdenv.mkDerivation {
+            pname = "iina-spm-deps";
+            version = if self ? rev then builtins.substring 0 8 self.rev else "dev";
+
+            # Only include SwiftPM-related files as input
+            src = pkgs.lib.cleanSourceWith {
+              src = ./.;
+              filter =
+                path: type:
+                let
+                  relPath = pkgs.lib.removePrefix (toString ./. + "/") (toString path);
+                in
+                pkgs.lib.hasSuffix "Package.resolved" relPath
+                || pkgs.lib.hasSuffix "Package.swift" relPath
+                || pkgs.lib.hasPrefix "iina.xcodeproj" relPath;
+            };
+
+            dontFixup = true;
+
+            nativeBuildInputs = [
+              xcode
+              pkgs.git
+              pkgs.gnused
+              pkgs.unzip
+              pkgs.zip
+            ];
+
+            buildPhase = ''
+              export HOME=$PWD/.home
+              export CFFIXED_USER_HOME="$HOME"
+              export __XPC_CFFIXED_USER_HOME="$HOME"
+              export TMPDIR="$PWD/.tmp"; mkdir -p "$TMPDIR"
+              export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+
+              APPLE_BIN="$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/bin"
+              export PATH="$APPLE_BIN:$DEVELOPER_DIR/usr/bin:/usr/bin:/bin"
+
+              export TOOLCHAINS=XcodeDefault
+              export SDKROOT=macosx
+
+              mkdir -p .spm .spm-cache build
+
+              xcodebuild \
+                -workspace iina.xcodeproj/project.xcworkspace \
+                -scheme iina \
+                -resolvePackageDependencies \
+                -derivedDataPath "$PWD/build" \
+                -clonedSourcePackagesDirPath "$PWD/.spm" \
+                -packageCachePath "$PWD/.spm-cache" \
+                -disablePackageRepositoryCache \
+                -IDEPackageSupportDisableManifestSandbox=YES \
+                -IDEPackageSupportDisablePluginExecutionSandbox=YES \
+                ARCHS="$(uname -m)" ONLY_ACTIVE_ARCH=YES \
+                SWIFT_ENABLE_EXPLICIT_MODULES=NO
+            '';
+
+            # Copy everything — keep full structure (SPM state, caches, workspace, etc.)
+            installPhase = ''
+              mkdir -p $out
+              cp -R . $out/
+            '';
+          };
+
+          # hared normalizer script
+          normalizer = pkgs.writeShellApplication {
+            name = "iina-normalize-app";
+            runtimeInputs = [
+              pkgs.coreutils
+              pkgs.findutils
+              pkgs.gawk
+              pkgs.gnugrep
+              pkgs.file
+            ];
+            text = ''
+              set -euo pipefail
+
+              if [[ $# -lt 1 ]]; then
+                echo "usage: iina-normalize-app /path/to/IINA.app" >&2
+                exit 2
+              fi
+
+              app="$1"
+              frameworks="$app/Contents/Frameworks"
+
+              echo "🔧 iina-normalize-app: normalizing $app"
+              mkdir -p "$frameworks"
+
+              echo "📝 Making app contents writable"
+              find "$app" -type d -exec chmod u+rwx {} \;
+              find "$app" -type f -exec chmod u+rw  {} \;
+
+              # ✏️ Helpers
+              is_macho() {
+                # true for thin/fat Mach-O; false for scripts/text
+                file -b "$1" 2>/dev/null | grep -Eq 'Mach-O (universal binary|64-bit|arm64|x86_64)'
+              }
+
+              ensure_writable() { chmod u+rw "$1" 2>/dev/null || true; }
+
+              ensure_rpath() {
+                local f="$1"
+
+                if ! is_macho "$f"; then
+                  echo "🧾 Non-Mach-O, skipping rpath: $f"
+                  return
+                fi
+
+                if otool -l "$f" | grep -q '@executable_path/../Frameworks'; then
+                  echo "✅ LC_RPATH present → $f"
+                  return
+                fi
+                
+                echo "➕ LC_RPATH @executable_path/../Frameworks → $f"
+                install_name_tool -add_rpath "@executable_path/../Frameworks" "$f" || true
+              }
+
+              rewrite_deps_to_rpath() {
+                local bin="$1"
+
+                if ! is_macho "$bin"; then
+                  echo "🧾 Non-Mach-O, skipping dep rewrite: $bin"
+                  return
+                fi
+
+                echo "✏️ Rewriting deps → @rpath for: $bin"
+
+                # /nix/store/* → @rpath/<basename>
+                otool -L "$bin" | awk '/\/nix\/store/ && $1 !~ /:$/ {print $1}' | while read -r abs; do
+                  local base
+                  base=$(basename "$abs")
+                  echo "  🔁 /nix/store → @rpath: $abs → @rpath/$base"
+                  install_name_tool -change "$abs" "@rpath/$base" "$bin" || true
+                done
+
+                # bare dylibs (no /, no @) → @rpath/<basename>
+                otool -L "$bin" | awk 'NF && $1 !~ /:$/ && $1 ~ /^[^/@][^/]*\.dylib$/ {print $1}' | while read -r bare; do
+                  local base
+                  base=$(basename "$bare")
+                  echo "  🔁 bare → @rpath: $bare → @rpath/$base"
+                  install_name_tool -change "$bare" "@rpath/$base" "$bin" || true
+                done
+              }
+
+              bundle_dep() {
+                local dep="$1"
+                local depbase
+                depbase=$(basename "$dep")
+                local dest="$frameworks/$depbase"
+
+                if [ -f "$dest" ]; then
+                  echo "✅ Already bundled: $depbase"
+                  return
+                fi
+
+                if [[ "$dep" == /usr/lib/* ]] || [[ "$dep" == /System/* ]] || [[ "$depbase" == libffi-trampoline.dylib ]]; then
+                  echo "🚫 Skipping system/non-target dep: $dep"
+                  return
+                fi
+
+                if [ ! -f "$dep" ]; then
+                  echo "⚠️  Dep missing on disk, skipping: $dep"
+                  return
+                fi
+
+                echo "📥 Copying dep → Frameworks: $dep → $dest"
+                cp -L -p "$dep" "$dest" || { echo "❌ Copy failed for $dep"; return; }
+                ensure_writable "$dest"
+
+                if ! is_macho "$dest"; then
+                  echo "🧾 Copied non-Mach-O dep (no patching): $depbase"
+                  return
+                fi
+
+                echo "✏️ Setting install_name id on $depbase"
+                install_name_tool -id "@rpath/$depbase" "$dest" || true
+
+                ensure_rpath "$dest"
+                rewrite_deps_to_rpath "$dest"
+
+                # Recurse into transitive deps
+                otool -L "$dest" | awk 'NF && $1 !~ /:$/ {print $1}' | while read -r sub; do
+                  case "$sub" in
+                    /nix/store/*)
+                      local subbase
+                      subbase=$(basename "$sub")
+                      echo "  🔗 Repointing subdep for $depbase: $sub → @rpath/$subbase"
+                      install_name_tool -change "$sub" "@rpath/$subbase" "$dest" || true
+                      bundle_dep "$sub"
+                      ;;
+                    *) : ;;
+                  esac
+                done
+              }
+
+              export -f ensure_writable ensure_rpath rewrite_deps_to_rpath bundle_dep
+
+              echo "🔍 Scanning app for dylib + executable dependencies…"
+
+              # executables + loadable libs
+              find "$app" -type f \( -perm -111 -o -name "*.dylib" -o -name "*.so" \) | while read -r bin; do
+                echo "———"
+                echo "🔍 Inspecting: $bin"
+                ensure_writable "$bin"
+                ensure_rpath "$bin"
+
+                if ! is_macho "$bin"; then
+                  echo "🧾 Non-Mach-O target has no dylib deps to bundle"
+                  continue
+                fi
+
+                # bundle remaining absolute /nix/store deps
+                otool -L "$bin" | awk 'NF && $1 !~ /:$/ {print $1}' | while read -r dep; do
+                  case "$dep" in
+                    /nix/store/*)
+                      echo "  📦 Bundling needed dep for $bin: $dep"
+                      bundle_dep "$dep"
+                      ;;
+                    *) : ;;
+                  esac
+                done
+
+                rewrite_deps_to_rpath "$bin"
+              done
+
+              echo "✅ Normalization complete"
+            '';
+          };
+
+          canonicalizeLibGroups = pkgs.writeShellApplication {
+            name = "iina-canonicalize-lib-groups";
+            runtimeInputs = [
+              pkgs.findutils
+              pkgs.coreutils
+              pkgs.gawk
+            ];
+            text = ''
+              set -euo pipefail
+
+              frameworks="$1/Contents/Frameworks"
+
+              # Build the index in memory: each line is "STEM \t VERSION \t BASENAME"
+              lines="$(
+                find "$frameworks" -maxdepth 1 \( -type f -o -type l \) -name 'lib*.dylib' | while read -r dep; do
+                  base="$(basename "$dep")"
+                  if [[ "$base" =~ ^(lib[^.]+)\.([0-9]+(\.[0-9]+)*)\.dylib$ ]]; then
+                    printf '%s\t%s\t%s\n' "''${BASH_REMATCH[1]}" "''${BASH_REMATCH[2]}" "$base"
+                  elif [[ "$base" =~ ^(lib[^.]+)\.dylib$ ]]; then
+                    printf '%s\tUNVER\t%s\n' "''${BASH_REMATCH[1]}" "$base"
+                  fi
+                done
+              )"
+
+              # For each STEM, pick highest VERSION as canonical; relink others to it
+              printf '%s\n' "$lines" | cut -f1 | sort -u | while read -r stem; do
+                canon="$(
+                  printf '%s\n' "$lines" | awk -F'\t' -v s="$stem" '$1==s && $2!="UNVER"{print $2"\t"$3}' \
+                    | ${pkgs.coreutils}/bin/sort -V | tail -n1 | cut -f2
+                )"
+
+                # If no versioned file exists, fall back to unversioned
+                if [ -z "$canon" ]; then
+                  canon="$(printf '%s\n' "$lines" | awk -F'\t' -v s="$stem" '$1==s && $2=="UNVER"{print $3}' | head -n1)"
+                fi
+                [ -n "$canon" ] || continue
+
+                # Relink every other alias in the group to canonical (relative link)
+                (
+                  cd "$frameworks"
+                  printf '%s\n' "$lines" | awk -F'\t' -v s="$stem" '$1==s{print $3}' | while read -r alias; do
+                    [ "$alias" = "$canon" ] && continue
+                    rm -f -- "$alias"
+                    ln -s -- "$canon" "$alias"
+                  done
+                )
+              done
+
+              echo "✅ Canonicalized lib groups under $frameworks"
+            '';
+          };
+
+          resign = pkgs.writeShellApplication {
+            name = "iina-resign";
+            runtimeInputs = [
+              pkgs.findutils
+              pkgs.coreutils
+            ];
+            text = ''
+              set -euo pipefail
+              app="$1"
+
+              # Make sure everything we might sign is writable
+              find "$app" -type d -exec chmod u+rwx {} \;
+              find "$app" -type f -exec chmod u+rw  {} \;
+
+              # (optionally re-mark executables executable, in case)
+              find "$app/Contents/MacOS" -type f -perm -111 -exec chmod u+rw {} \;
+
+              /usr/bin/codesign --force --deep --sign - "$app"
+            '';
+          };
+        in
+        {
+          iina = pkgs.stdenv.mkDerivation {
+            pname = "iina";
+            version = if self ? rev then builtins.substring 0 8 self.rev else "dev";
+
+            src = pkgs.nix-gitignore.gitignoreSource [ "flake.nix" "flake.lock" ] ./.;
+
+            strictDeps = true;
+
+            nativeBuildInputs = [
+              pkgs.coreutils
+              xcode
+              pkgs.rsync
+              pkgs.git
+              pkgs.gnused
+              pkgs.unzip
+              pkgs.zip
+            ];
+
+            buildInputs = [
+              spmDeps
+              pkgs.yt-dlp
+            ];
+
+            buildPhase = ''
+              echo "🔧 Setting up build environment"
+              export HOME=$PWD/.home
+              export CFFIXED_USER_HOME="$HOME"
+              export __XPC_CFFIXED_USER_HOME="$HOME"
+              export TMPDIR="$PWD/.tmp"; mkdir -p "$TMPDIR"
+              export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+
+              APPLE_BIN="$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/bin"
+              export PATH="$APPLE_BIN:$DEVELOPER_DIR/usr/bin:/usr/bin:/bin"
+
+              unset CC CXX LD AR RANLIB NM STRIP OBJCOPY \
+                CFLAGS CXXFLAGS LDFLAGS SDKROOT CPATH C_INCLUDE_PATH CPLUS_INCLUDE_PATH LIBRARY_PATH \
+                NIX_CFLAGS_COMPILE NIX_CFLAGS_LINK PKG_CONFIG_PATH
+
+              export TOOLCHAINS=XcodeDefault
+              export SDKROOT=macosx
+
+              echo "Using $TOOLCHAINS toolchain"
+              echo "Using $SDKROOT sdk"
+
+              echo "📦 Copying external deps"
+              mkdir -p deps
+              rm -rf deps/include deps/lib
+
+              mkdir -p deps/include deps/lib deps/executable
+
+              cp -RL ${depsInc}/.               deps/include
+              cp -RL ${depsLib}/.               deps/lib
+              cp -RL ${depsExecutable}/.        deps/executable/
+
+              echo "🔃 Fixing compatibility"
+              cp deps/executable/yt-dlp             deps/executable/youtube-dl
+              cp deps/lib/librubberband.3.dylib     deps/lib/librubberband.2.dylib
+              cp deps/lib/libplacebo.349.dylib      deps/lib/libplacebo.338.dylib
+              cp deps/lib/libjpeg.62.dylib          deps/lib/libjpeg.8.dylib
+              cp deps/lib/libjxl_cms.0.11.dylib     deps/lib/libjxl_cms.0.10.dylib
+              cp deps/lib/libjxl_threads.0.11.dylib deps/lib/libjxl_threads.0.10.dylib
+              cp deps/lib/libjxl.0.11.dylib         deps/lib/libjxl.0.10.dylib
+
+              echo "✏️ Rewriting install names to use @rpath"
+              find deps/lib -type f \( -perm -111 -o -name "*.dylib" -o -name "*.so" \) | while read -r dep; do
+                echo "✏️ Patching install names in $dep"
+                chmod +w "$dep"
+
+                # Change its ID to @rpath/<filename>
+                install_name_tool -id "@rpath/$(basename "$dep")" "$dep" || true
+
+                # Rewrite dependencies that still point to /nix/store
+                otool -L "$dep" | awk '/\/nix\/store/ && $1 !~ /:$/ {print $1}' | while read -r nixdep; do
+                  base=$(basename "$nixdep")
+                  install_name_tool -change "$nixdep" "@rpath/$base" "$dep" || true
+                done
+              done
+
+              echo "📦 Copying SPM deps"
+              rsync -a ${spmDeps}/ ./
+              chmod -R u+rwx,g+rx,o+rx .
+
+              # Rewrite SwiftPM workspace-state.json to fix absolute paths
+              if [ -f .spm/workspace-state.json ]; then
+                old_prefix=$(grep -Eo "/tmp/nix-build-[^/]+/source" .spm/workspace-state.json | head -n1)
+                echo "Patching workspace-state.json: replacing $old_prefix → $PWD"
+                sed -i -E "s|$old_prefix|$PWD|g" .spm/workspace-state.json
+              fi
+
+              # Build IINA
+              echo "🔨 Building IINA"
+              xcodebuild \
+                -workspace iina.xcodeproj/project.xcworkspace \
+                -scheme iina \
+                -configuration Release \
+                -sdk macosx \
+                -skipPackagePluginValidation \
+                -derivedDataPath "$PWD/build" \
+                -clonedSourcePackagesDirPath "$PWD/.spm" \
+                -packageCachePath "$PWD/.spm-cache" \
+                -disablePackageRepositoryCache \
+                -disableAutomaticPackageResolution \
+                -onlyUsePackageVersionsFromResolvedFile \
+                -IDEPackageSupportDisableManifestSandbox=YES \
+                -IDEPackageSupportDisablePluginExecutionSandbox=YES \
+                ARCHS="$(uname -m)" ONLY_ACTIVE_ARCH=YES \
+                SWIFT_ENABLE_EXPLICIT_MODULES=NO \
+                CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
+            '';
+
+            installPhase = ''
+              mkdir -p $out/Applications
+              cp -R build/Build/Products/Release/IINA.app $out/Applications/
+            '';
+
+            preFixup = ''
+              export PATH=${pkgs.coreutils}/bin:$PATH
+            '';
+
+            postFixup = ''
+              app="$out/Applications/IINA.app"
+              macos="$app/Contents/MacOS"
+              frameworks="$app/Contents/Frameworks"
+              resources="$app/Contents/Resources"
+              plist="$app/Contents/Info.plist"
+
+              mkdir -p "$frameworks"
+              mkdir -p "$resources"
+
+              echo "📦 Bundling ${depsIndirect} into IINA.app"
+              cp -RL ${depsIndirect}/. "$frameworks/"
+
+              echo "📦 Bundling ${depsExecutable} into IINA.app"
+              cp -RL ${depsExecutable}/. "$macos/"
+
+              echo "🐍 Bundling ${pkgs.python3} into IINA.app"
+
+              # Pick the single pythonX.Y dir from Nix’s python3
+              python_src_dir=$(echo ${pkgs.python3}/lib/python* | awk '{print $1}')
+              python_basename="$(basename "$python_src_dir")"
+              python_site="$resources/Python/lib/$python_basename/site-packages"
+              vapoursynth_site_src=$(echo ${pkgs.vapoursynth}/lib/python*/site-packages | awk '{print $1}')
+
+              mkdir -p "$resources/Python/lib"
+              mkdir -p "$python_site"
+
+              # Copy Python's stdlib
+              cp -RL "$python_src_dir" "$resources/Python/lib/"
+
+              # Copy VapourSynth’s Python package
+              cp -RL "$vapoursynth_site_src"/. "$python_site/"
+
+              echo "📦 Deep-bundling dynamic dependencies into IINA.app"
+              ${normalizer}/bin/iina-normalize-app "$app"
+
+              echo "✏️ Canonicalize Lib Groups"
+              ${canonicalizeLibGroups}/bin/iina-canonicalize-lib-groups "$app"
+
+              echo "✏️ Setting up environment variables"
+
+              /usr/libexec/PlistBuddy -c 'Add :LSEnvironment dict'                                                                             "$plist" 2>/dev/null || true
+              /usr/libexec/PlistBuddy -c 'Add :LSEnvironment:PYTHONHOME          string "@executable_path/../Resources/Python"'                "$plist" 2>/dev/null || true
+              /usr/libexec/PlistBuddy -c 'Set :LSEnvironment:PYTHONHOME                 "@executable_path/../Resources/Python"'                "$plist"
+              /usr/libexec/PlistBuddy -c 'Add :LSEnvironment:PYTHONNOUSERSITE    string "1"'                                                   "$plist" 2>/dev/null || true
+              /usr/libexec/PlistBuddy -c 'Set :LSEnvironment:PYTHONNOUSERSITE           "1"'                                                   "$plist"
+              /usr/libexec/PlistBuddy -c 'Add :LSEnvironment:VAPOURSYNTH_LIBRARY string "@executable_path/../Frameworks/libvapoursynth.dylib"' "$plist" 2>/dev/null || true
+              /usr/libexec/PlistBuddy -c 'Set :LSEnvironment:VAPOURSYNTH_LIBRARY        "@executable_path/../Frameworks/libvapoursynth.dylib"' "$plist"
+              /usr/libexec/PlistBuddy -c 'Add :LSEnvironment:IINA_EXECUTABLE    string "@executable_path"'                                    "$plist" 2>/dev/null || true
+              /usr/libexec/PlistBuddy -c 'Set :LSEnvironment:IINA_EXECUTABLE           "@executable_path"'                                    "$plist"
+
+              echo "🔏 Re-signing IINA.app..."
+              ${resign}/bin/iina-resign "$app"
+            '';
+          };
+
+          iina-universal = pkgs.stdenv.mkDerivation {
+            pname = "iina-universal";
+            version = if self ? rev then builtins.substring 0 8 self.rev else "dev";
+
+            nativeBuildInputs = [
+              pkgs.rsync
+              pkgs.coreutils
+            ];
+
+            buildCommand = ''
+              app="$out/Applications/IINA.app"
+              frameworks="$app/Contents/Frameworks"
+
+              export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+              APPLE_BIN="$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/bin"
+              export PATH="$APPLE_BIN:$DEVELOPER_DIR/usr/bin:/usr/bin:/bin"
+
+              echo "📦 Combining universal IINA.app"
+
+              mkdir -p "$out/Applications"
+              # copy the contents of the source app into the target dir
+              ${pkgs.rsync}/bin/rsync -a ${builtins.elemAt self.archApps 0}/Applications/IINA.app/ "$app/"
+              chmod -R u+w "$app"
+
+              echo "🔍 Merging binaries across architectures"
+              find "$app" -type f \( -perm -111 -o -name "*.dylib" -o -name "*.so" \) | while read -r dep; do
+                if [[ -L "$dep" ]] || [[ ! -f "$dep" ]]; then
+                  echo "✅ Skipping non-file $dep"
+                  continue
+                fi
+
+                if ! file -b "$dep" | grep -qi 'Mach-O'; then
+                  echo "✅ Skipping non-Mach-O $dep"
+                  continue
+                fi
+
+                relpath=$(${pkgs.coreutils}/bin/realpath --relative-to="$app" "$dep")
+
+                # collect candidate files from each arch build
+                inputs=""
+                for archroot in ${
+                  builtins.concatStringsSep " " (map (a: "\"${a}/Applications/IINA.app\"") self.archApps)
+                }; do
+                  candidate="$archroot/$relpath"
+                  if [ -f "$candidate" ]; then
+                    inputs="$inputs $candidate"
+                  fi
+                done
+
+                # pick at most one file per arch to avoid duplicates
+                arm64=""
+                x86_64=""
+                for f in $inputs; do
+                  info=$(lipo -info "$f" 2>/dev/null || true)
+
+                  if echo "$info" | grep -qw arm64 && [ -z "$arm64" ]; then
+                    arm64="$f"
+                  fi
+
+                  if echo "$info" | grep -qw x86_64 && [ -z "$x86_64" ]; then
+                    x86_64="$f"
+                  fi
+
+                  # if we ever see a fat that already has both, just use it as-is
+                  if echo "$info" | grep -q 'Architectures in the fat file' && \
+                     echo "$info" | grep -qw arm64 && echo "$info" | grep -qw x86_64; then
+                    arm64="$f"; x86_64="$f"; break
+                  fi
+                done
+
+                # if only one arch available, leave it alone
+                if [ -z "$arm64" ] || [ -z "$x86_64" ]; then
+                  echo "✅ Skipping single-arch $dep"
+                  continue
+                fi
+
+                echo "🔨 Merging $relpath"
+                tmp="$dep.universal.$$"
+
+                # Ensure we can replace the file
+                chmod u+w "$dep" 2>/dev/null || true
+
+                # Guard against already universal binaries
+                if [ "$arm64" = "$x86_64" ]; then
+                  cp -p "$arm64" "$tmp"
+                else
+                  lipo -create -arch arm64 "$arm64" -arch x86_64 "$x86_64" -output "$tmp"
+                fi
+                
+                # Preserve mode if possible (GNU coreutils); fall back to +x
+                ${pkgs.coreutils}/bin/chmod --reference="$dep" "$tmp" 2>/dev/null || chmod +x "$tmp"
+
+                mv -f "$tmp" "$dep"
+              done
+
+              echo "📦 Deep-bundling dynamic dependencies into IINA.app"
+              ${normalizer}/bin/iina-normalize-app "$app"
+
+              echo "✏️ Canonicalize Lib Groups"
+              ${canonicalizeLibGroups}/bin/iina-canonicalize-lib-groups "$app"
+
+              echo "🔏 Re-signing IINA.app..."
+              ${resign}/bin/iina-resign "$app"
+            '';
+
+            preFixup = ''
+              export PATH=${pkgs.coreutils}/bin:$PATH
+            '';
+          };
+
+          default = self.packages.${system}.iina-universal;
+        }
+      );
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -5,18 +5,22 @@
 
   outputs =
     { self, nixpkgs }:
-    {
+    let
       systems = [
         "aarch64-darwin"
         "x86_64-darwin"
       ];
 
-      archApps = builtins.map (system: self.packages.${system}.iina) self.systems;
-
-      packages = nixpkgs.lib.genAttrs self.systems (
+      perSystem = nixpkgs.lib.genAttrs systems (
         system:
         let
           pkgs = import nixpkgs { inherit system; };
+
+          scripts = {
+            normalizer = import ./nix/scripts/normalizer.nix { inherit pkgs; };
+            canonicalizeLibGroups = import ./nix/scripts/canonicalize-lib-groups.nix { inherit pkgs; };
+            resign = import ./nix/scripts/resign.nix { inherit pkgs; };
+          };
 
           # Pull system's xcode in
           xcode = pkgs.runCommand "system-xcode" { } ''
@@ -346,547 +350,349 @@
             '';
           };
 
-          # hared normalizer script
-          normalizer = pkgs.writeShellApplication {
-            name = "iina-normalize-app";
-            runtimeInputs = [
-              pkgs.coreutils
-              pkgs.findutils
-              pkgs.gawk
-              pkgs.gnugrep
-              pkgs.file
-            ];
-            text = ''
-              set -euo pipefail
+          # Package Python resources (stdlib + VapourSynth) for reuse in builds and dev shells
+          depsResources = pkgs.runCommand "iina-deps-resources" { } ''
+            set -euo pipefail
 
-              if [[ $# -lt 1 ]]; then
-                echo "usage: iina-normalize-app /path/to/IINA.app" >&2
-                exit 2
-              fi
+            mkdir -p "$out/Python/lib"
+            python_src=$(echo ${pkgs.python3}/lib/python* | awk '{print $1}')
+            python_basename="$(basename "$python_src")"
+            cp -rL --no-preserve=mode,ownership "$python_src" "$out/Python/lib/"
 
-              app="$1"
-              frameworks="$app/Contents/Frameworks"
+            python_target="$out/Python/lib/$python_basename"
+            chmod -R u+w "$python_target"
+            mkdir -p "$python_target/site-packages"
 
-              echo "🔧 iina-normalize-app: normalizing $app"
-              mkdir -p "$frameworks"
-
-              echo "📝 Making app contents writable"
-              find "$app" -type d -exec chmod u+rwx {} \;
-              find "$app" -type f -exec chmod u+rw  {} \;
-
-              # ✏️ Helpers
-              is_macho() {
-                # true for thin/fat Mach-O; false for scripts/text
-                file -b "$1" 2>/dev/null | grep -Eq 'Mach-O (universal binary|64-bit|arm64|x86_64)'
-              }
-
-              ensure_writable() { chmod u+rw "$1" 2>/dev/null || true; }
-
-              ensure_rpath() {
-                local f="$1"
-
-                if ! is_macho "$f"; then
-                  echo "🧾 Non-Mach-O, skipping rpath: $f"
-                  return
-                fi
-
-                if otool -l "$f" | grep -q '@executable_path/../Frameworks'; then
-                  echo "✅ LC_RPATH present → $f"
-                  return
-                fi
-                
-                echo "➕ LC_RPATH @executable_path/../Frameworks → $f"
-                install_name_tool -add_rpath "@executable_path/../Frameworks" "$f" || true
-              }
-
-              rewrite_deps_to_rpath() {
-                local bin="$1"
-
-                if ! is_macho "$bin"; then
-                  echo "🧾 Non-Mach-O, skipping dep rewrite: $bin"
-                  return
-                fi
-
-                echo "✏️ Rewriting deps → @rpath for: $bin"
-
-                # /nix/store/* → @rpath/<basename>
-                otool -L "$bin" | awk '/\/nix\/store/ && $1 !~ /:$/ {print $1}' | while read -r abs; do
-                  local base
-                  base=$(basename "$abs")
-                  echo "  🔁 /nix/store → @rpath: $abs → @rpath/$base"
-                  install_name_tool -change "$abs" "@rpath/$base" "$bin" || true
-                done
-
-                # bare dylibs (no /, no @) → @rpath/<basename>
-                otool -L "$bin" | awk 'NF && $1 !~ /:$/ && $1 ~ /^[^/@][^/]*\.dylib$/ {print $1}' | while read -r bare; do
-                  local base
-                  base=$(basename "$bare")
-                  echo "  🔁 bare → @rpath: $bare → @rpath/$base"
-                  install_name_tool -change "$bare" "@rpath/$base" "$bin" || true
-                done
-              }
-
-              declare -Ag BUNDLED_DEPS=()
-
-              bundle_dep() {
-                local dep="$1"   # path as found in otool -L (may be libbs2b.0.dylib)
-
-                # Canonical path for cycle detection
-                local dep_real
-                dep_real=$(realpath "$dep" 2>/dev/null || echo "$dep")
-
-                # Break cycles by *real* path
-                if [[ -n "''${BUNDLED_DEPS["$dep_real"]:-}" ]]; then
-                  echo "🔁 Already processed dep: $dep_real"
-                  return
-                fi
-                BUNDLED_DEPS["$dep_real"]=1
-
-                local request_base
-                request_base=$(basename "$dep")
-                local real_base
-                real_base=$(basename "$dep_real")
-                local dest="$frameworks/$request_base"
-
-                if [[ "$dep_real" == /usr/lib/* ]] || [[ "$dep_real" == /System/* ]] || [[ "$real_base" == libffi-trampoline.dylib ]]; then
-                  echo "🚫 Skipping system/non-target dep: $dep_real"
-                  return
-                fi
-
-                if [ ! -f "$dep_real" ]; then
-                  echo "⚠️  Dep missing on disk, skipping: $dep_real"
-                  return
-                fi
-
-                # Ensure the real payload file exists in Frameworks under some canonical name
-                local canonical="$frameworks/$real_base"
-                if [ ! -f "$canonical" ]; then
-                  echo "📥 Copying dep → Frameworks: $dep_real → $canonical"
-                  cp -L -p "$dep_real" "$canonical" || { echo "❌ Copy failed for $dep_real"; return; }
-                fi
-
-                # Ensure the *requested* name exists and points to the payload
-                if [ ! -e "$dest" ]; then
-                  echo "🔗 Copying $canonical → $dest"
-                  cp -L -p "$canonical" "$dest"
-                else
-                  echo "✏️ Normalizing already-bundled dep alias: $request_base"
-                fi
-
-                ensure_writable "$canonical"
-
-                if ! is_macho "$canonical"; then
-                  echo "🧾 Non-Mach-O dep (no patching): $real_base"
-                  return
-                fi
-
-                echo "✏️ Setting install_name id on $real_base"
-                install_name_tool -id "@rpath/$request_base" "$canonical" || true
-
-                ensure_rpath "$canonical"
-                rewrite_deps_to_rpath "$canonical"
-
-                # Recurse into transitive deps based on their /nix/store path
-                otool -L "$canonical" | awk 'NF && $1 !~ /:$/ {print $1}' | while read -r sub; do
-                  case "$sub" in
-                    /nix/store/*)
-                      local subbase
-                      subbase=$(basename "$sub")
-                      echo "  🔗 Repointing subdep for $real_base: $sub → @rpath/$subbase"
-                      install_name_tool -change "$sub" "@rpath/$subbase" "$canonical" || true
-                      bundle_dep "$sub"
-                      ;;
-                    *) : ;;
-                  esac
-                done
-              }
-
-              export -f ensure_writable ensure_rpath rewrite_deps_to_rpath bundle_dep
-
-              echo "🔍 Scanning app for dylib + executable dependencies…"
-
-              # executables + loadable libs
-              find "$app" -type f \( -perm -111 -o -name "*.dylib" -o -name "*.so" \) | while read -r bin; do
-                echo "———"
-                echo "🔍 Inspecting: $bin"
-                ensure_writable "$bin"
-                ensure_rpath "$bin"
-
-                if ! is_macho "$bin"; then
-                  echo "🧾 Non-Mach-O target has no dylib deps to bundle"
-                  continue
-                fi
-
-                # bundle remaining absolute /nix/store deps
-                otool -L "$bin" | awk 'NF && $1 !~ /:$/ {print $1}' | while read -r dep; do
-                  case "$dep" in
-                    /nix/store/*)
-                      echo "  📦 Bundling needed dep for $bin: $dep"
-                      bundle_dep "$dep"
-                      ;;
-                    *) : ;;
-                  esac
-                done
-
-                rewrite_deps_to_rpath "$bin"
-              done
-
-              echo "✅ Normalization complete"
-            '';
-          };
-
-          canonicalizeLibGroups = pkgs.writeShellApplication {
-            name = "iina-canonicalize-lib-groups";
-            runtimeInputs = [
-              pkgs.findutils
-              pkgs.coreutils
-              pkgs.gawk
-            ];
-            text = ''
-              set -euo pipefail
-
-              frameworks="$1/Contents/Frameworks"
-
-              # Build the index in memory: each line is "STEM \t VERSION \t BASENAME"
-              lines="$(
-                find "$frameworks" -maxdepth 1 \( -type f -o -type l \) -name 'lib*.dylib' | while read -r dep; do
-                  base="$(basename "$dep")"
-                  if [[ "$base" =~ ^(lib[^.]+)\.([0-9]+(\.[0-9]+)*)\.dylib$ ]]; then
-                    printf '%s\t%s\t%s\n' "''${BASH_REMATCH[1]}" "''${BASH_REMATCH[2]}" "$base"
-                  elif [[ "$base" =~ ^(lib[^.]+)\.dylib$ ]]; then
-                    printf '%s\tUNVER\t%s\n' "''${BASH_REMATCH[1]}" "$base"
-                  fi
-                done
-              )"
-
-              # For each STEM, pick highest VERSION as canonical; relink others to it
-              printf '%s\n' "$lines" | cut -f1 | sort -u | while read -r stem; do
-                canon="$(
-                  printf '%s\n' "$lines" | awk -F'\t' -v s="$stem" '$1==s && $2!="UNVER"{print $2"\t"$3}' \
-                    | ${pkgs.coreutils}/bin/sort -V | tail -n1 | cut -f2
-                )"
-
-                # If no versioned file exists, fall back to unversioned
-                if [ -z "$canon" ]; then
-                  canon="$(printf '%s\n' "$lines" | awk -F'\t' -v s="$stem" '$1==s && $2=="UNVER"{print $3}' | head -n1)"
-                fi
-                [ -n "$canon" ] || continue
-
-                # Relink every other alias in the group to canonical (relative link)
-                (
-                  cd "$frameworks"
-                  printf '%s\n' "$lines" | awk -F'\t' -v s="$stem" '$1==s{print $3}' | while read -r alias; do
-                    [ "$alias" = "$canon" ] && continue
-                    rm -f -- "$alias"
-                    ln -s -- "$canon" "$alias"
-                  done
-                )
-              done
-
-              echo "✅ Canonicalized lib groups under $frameworks"
-            '';
-          };
-
-          resign = pkgs.writeShellApplication {
-            name = "iina-resign";
-            runtimeInputs = [
-              pkgs.findutils
-              pkgs.coreutils
-            ];
-            text = ''
-              set -euo pipefail
-              app="$1"
-
-              # Make sure everything we might sign is writable
-              find "$app" -type d -exec chmod u+rwx {} \;
-              find "$app" -type f -exec chmod u+rw  {} \;
-
-              # (optionally re-mark executables executable, in case)
-              find "$app/Contents/MacOS" -type f -perm -111 -exec chmod u+rw {} \;
-
-              /usr/bin/codesign --force --deep --sign - "$app"
-            '';
-          };
+            vapoursynth_site=$(echo ${pkgs.vapoursynth}/lib/python*/site-packages | awk '{print $1}')
+            cp -rL --no-preserve=mode,ownership "$vapoursynth_site"/. "$python_target/site-packages/"
+          '';
         in
-        {
-          iina = pkgs.stdenv.mkDerivation {
-            pname = "iina";
-            version = if self ? rev then builtins.substring 0 8 self.rev else "dev";
+        rec {
+          packages = rec {
+            iina = pkgs.stdenv.mkDerivation {
+              pname = "iina";
+              version = if self ? rev then builtins.substring 0 8 self.rev else "dev";
 
-            src = pkgs.nix-gitignore.gitignoreSource [ "flake.nix" "flake.lock" ] ./.;
+              src = pkgs.nix-gitignore.gitignoreSource [ "flake.nix" "flake.lock" ] ./.;
 
-            strictDeps = true;
+              strictDeps = true;
 
-            nativeBuildInputs = [
-              pkgs.coreutils
-              xcode
-              pkgs.rsync
-              pkgs.git
-              pkgs.gnused
-              pkgs.unzip
-              pkgs.zip
-            ];
+              nativeBuildInputs = [
+                pkgs.coreutils
+                xcode
+                pkgs.rsync
+                pkgs.git
+                pkgs.gnused
+                pkgs.unzip
+                pkgs.zip
+              ];
 
-            buildInputs = [
-              spmDeps
-              pkgs.yt-dlp
-            ];
+              buildInputs = [
+                spmDeps
+                pkgs.yt-dlp
+              ];
 
-            buildPhase = ''
-              echo "🔧 Setting up build environment"
-              export HOME=$PWD/.home
-              export CFFIXED_USER_HOME="$HOME"
-              export __XPC_CFFIXED_USER_HOME="$HOME"
-              export TMPDIR="$PWD/.tmp"; mkdir -p "$TMPDIR"
-              export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+              buildPhase = ''
+                echo "🔧 Setting up build environment"
+                export HOME=$PWD/.home
+                export CFFIXED_USER_HOME="$HOME"
+                export __XPC_CFFIXED_USER_HOME="$HOME"
+                export TMPDIR="$PWD/.tmp"; mkdir -p "$TMPDIR"
+                export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
 
-              APPLE_BIN="$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/bin"
-              export PATH="$APPLE_BIN:$DEVELOPER_DIR/usr/bin:/usr/bin:/bin"
+                APPLE_BIN="$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/bin"
+                export PATH="$APPLE_BIN:$DEVELOPER_DIR/usr/bin:/usr/bin:/bin"
 
-              unset CC CXX LD AR RANLIB NM STRIP OBJCOPY \
-                CFLAGS CXXFLAGS LDFLAGS SDKROOT CPATH C_INCLUDE_PATH CPLUS_INCLUDE_PATH LIBRARY_PATH \
-                NIX_CFLAGS_COMPILE NIX_CFLAGS_LINK PKG_CONFIG_PATH
+                unset CC CXX LD AR RANLIB NM STRIP OBJCOPY \
+                  CFLAGS CXXFLAGS LDFLAGS SDKROOT CPATH C_INCLUDE_PATH CPLUS_INCLUDE_PATH LIBRARY_PATH \
+                  NIX_CFLAGS_COMPILE NIX_CFLAGS_LINK PKG_CONFIG_PATH
 
-              export TOOLCHAINS=XcodeDefault
-              export SDKROOT=macosx
+                export TOOLCHAINS=XcodeDefault
+                export SDKROOT=macosx
 
-              echo "Using $TOOLCHAINS toolchain"
-              echo "Using $SDKROOT sdk"
+                echo "Using $TOOLCHAINS toolchain"
+                echo "Using $SDKROOT sdk"
 
-              echo "📦 Copying external deps"
-              mkdir -p deps
-              rm -rf deps/include deps/lib
+                echo "📦 Copying external deps"
+                mkdir -p deps
+                rm -rf deps/include deps/lib
 
-              mkdir -p deps/include deps/lib deps/executable
+                mkdir -p deps/include deps/lib deps/executable
 
-              cp -RL ${depsInc}/.               deps/include
-              cp -RL ${depsLib}/.               deps/lib
-              cp -RL ${depsExecutable}/.        deps/executable/
+                cp -RL ${depsInc}/.               deps/include
+                cp -RL ${depsLib}/.               deps/lib
+                cp -RL ${depsExecutable}/.        deps/executable/
 
-              echo "✏️ Rewriting install names to use @rpath"
-              find deps/lib -type f \( -perm -111 -o -name "*.dylib" -o -name "*.so" \) | while read -r dep; do
-                echo "✏️ Patching install names in $dep"
-                chmod +w "$dep"
+                echo "✏️ Rewriting install names to use @rpath"
+                find deps/lib -type f \( -perm -111 -o -name "*.dylib" -o -name "*.so" \) | while read -r dep; do
+                  echo "✏️ Patching install names in $dep"
+                  chmod +w "$dep"
 
-                # Change its ID to @rpath/<filename>
-                install_name_tool -id "@rpath/$(basename "$dep")" "$dep" || true
+                  # Change its ID to @rpath/<filename>
+                  install_name_tool -id "@rpath/$(basename "$dep")" "$dep" || true
 
-                # Rewrite dependencies that still point to /nix/store
-                otool -L "$dep" | awk '/\/nix\/store/ && $1 !~ /:$/ {print $1}' | while read -r nixdep; do
-                  base=$(basename "$nixdep")
-                  install_name_tool -change "$nixdep" "@rpath/$base" "$dep" || true
+                  # Rewrite dependencies that still point to /nix/store
+                  otool -L "$dep" | awk '/\/nix\/store/ && $1 !~ /:$/ {print $1}' | while read -r nixdep; do
+                    base=$(basename "$nixdep")
+                    install_name_tool -change "$nixdep" "@rpath/$base" "$dep" || true
+                  done
                 done
-              done
 
-              echo "📦 Copying SPM deps"
-              rsync -a ${spmDeps}/ ./
-              chmod -R u+rwx,g+rx,o+rx .
+                echo "📦 Copying SPM deps"
+                rsync -a ${spmDeps}/ ./
+                chmod -R u+rwx,g+rx,o+rx .
 
-              # Rewrite SwiftPM workspace-state.json to fix absolute paths
-              if [ -f .spm/workspace-state.json ]; then
-                old_prefix=$(grep -Eo "/nix/var/nix/builds/nix-[^/]+/source" .spm/workspace-state.json | head -n1)
-                echo "Patching workspace-state.json: replacing $old_prefix → $PWD"
-                sed -i -E "s|$old_prefix|$PWD|g" .spm/workspace-state.json
-              fi
+                # Rewrite SwiftPM workspace-state.json to fix absolute paths
+                if [ -f .spm/workspace-state.json ]; then
+                  old_prefix=$(grep -Eo "/nix/var/nix/builds/nix-[^/]+/source" .spm/workspace-state.json | head -n1)
+                  echo "Patching workspace-state.json: replacing $old_prefix → $PWD"
+                  sed -i -E "s|$old_prefix|$PWD|g" .spm/workspace-state.json
+                fi
 
-              # Build IINA
-              echo "🔨 Building IINA"
-              xcodebuild \
-                -workspace iina.xcodeproj/project.xcworkspace \
-                -scheme iina \
-                -configuration Release \
-                -sdk macosx \
-                -skipPackagePluginValidation \
-                -derivedDataPath "$PWD/build" \
-                -clonedSourcePackagesDirPath "$PWD/.spm" \
-                -packageCachePath "$PWD/.spm-cache" \
-                -disablePackageRepositoryCache \
-                -disableAutomaticPackageResolution \
-                -onlyUsePackageVersionsFromResolvedFile \
-                -IDEPackageSupportDisableManifestSandbox=YES \
-                -IDEPackageSupportDisablePluginExecutionSandbox=YES \
-                ARCHS="$(uname -m)" ONLY_ACTIVE_ARCH=YES \
-                SWIFT_ENABLE_EXPLICIT_MODULES=NO \
-                CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
-            '';
+                # Build IINA
+                echo "🔨 Building IINA"
+                xcodebuild \
+                  -workspace iina.xcodeproj/project.xcworkspace \
+                  -scheme iina \
+                  -configuration Release \
+                  -sdk macosx \
+                  -skipPackagePluginValidation \
+                  -derivedDataPath "$PWD/build" \
+                  -clonedSourcePackagesDirPath "$PWD/.spm" \
+                  -packageCachePath "$PWD/.spm-cache" \
+                  -disablePackageRepositoryCache \
+                  -disableAutomaticPackageResolution \
+                  -onlyUsePackageVersionsFromResolvedFile \
+                  -IDEPackageSupportDisableManifestSandbox=YES \
+                  -IDEPackageSupportDisablePluginExecutionSandbox=YES \
+                  ARCHS="$(uname -m)" ONLY_ACTIVE_ARCH=YES \
+                  SWIFT_ENABLE_EXPLICIT_MODULES=NO \
+                  CODE_SIGNING_ALLOWED=NO CODE_SIGNING_REQUIRED=NO CODE_SIGN_IDENTITY=""
+              '';
 
-            installPhase = ''
-              mkdir -p $out/Applications
-              cp -R build/Build/Products/Release/IINA.app $out/Applications/
-            '';
+              installPhase = ''
+                mkdir -p $out/Applications
+                cp -R build/Build/Products/Release/IINA.app $out/Applications/
+              '';
 
-            preFixup = ''
-              export PATH=${pkgs.coreutils}/bin:$PATH
-            '';
+              preFixup = ''
+                export PATH=${pkgs.coreutils}/bin:$PATH
+              '';
 
-            postFixup = ''
-              app="$out/Applications/IINA.app"
-              macos="$app/Contents/MacOS"
-              frameworks="$app/Contents/Frameworks"
-              resources="$app/Contents/Resources"
-              plist="$app/Contents/Info.plist"
+              postFixup = ''
+                app="$out/Applications/IINA.app"
+                macos="$app/Contents/MacOS"
+                frameworks="$app/Contents/Frameworks"
+                resources="$app/Contents/Resources"
+                plist="$app/Contents/Info.plist"
 
-              mkdir -p "$frameworks"
-              mkdir -p "$resources"
+                mkdir -p "$frameworks"
+                mkdir -p "$resources"
 
-              echo "📦 Bundling ${depsIndirect} into IINA.app"
-              cp -RL ${depsIndirect}/. "$frameworks/"
+                echo "📦 Bundling ${depsResources} into IINA.app"
+                cp -RL ${depsResources}/. "$resources/"
 
-              echo "📦 Bundling ${depsExecutable} into IINA.app"
-              cp -RL ${depsExecutable}/. "$macos/"
+                echo "📦 Bundling ${depsIndirect} into IINA.app"
+                cp -RL ${depsIndirect}/. "$frameworks/"
 
-              echo "🐍 Bundling ${pkgs.python3} into IINA.app"
+                echo "📦 Bundling ${depsExecutable} into IINA.app"
+                cp -RL ${depsExecutable}/. "$macos/"
 
-              # Pick the single pythonX.Y dir from Nix’s python3
-              python_src_dir=$(echo ${pkgs.python3}/lib/python* | awk '{print $1}')
-              python_basename="$(basename "$python_src_dir")"
-              python_site="$resources/Python/lib/$python_basename/site-packages"
-              vapoursynth_site_src=$(echo ${pkgs.vapoursynth}/lib/python*/site-packages | awk '{print $1}')
+                echo "📦 Deep-bundling dynamic dependencies into IINA.app"
+                ${scripts.normalizer}/bin/iina-normalize-app "$app"
 
-              mkdir -p "$resources/Python/lib"
-              mkdir -p "$python_site"
+                echo "✏️ Canonicalize Lib Groups"
+                ${scripts.canonicalizeLibGroups}/bin/iina-canonicalize-lib-groups "$app"
 
-              # Copy Python's stdlib
-              cp -RL "$python_src_dir" "$resources/Python/lib/"
+                echo "✏️ Setting up environment variables"
 
-              # Copy VapourSynth’s Python package
-              cp -RL "$vapoursynth_site_src"/. "$python_site/"
+                /usr/libexec/PlistBuddy -c 'Add :LSEnvironment dict'                                                                             "$plist" 2>/dev/null || true
+                /usr/libexec/PlistBuddy -c 'Add :LSEnvironment:PYTHONHOME          string "@executable_path/../Resources/Python"'                "$plist" 2>/dev/null || true
+                /usr/libexec/PlistBuddy -c 'Set :LSEnvironment:PYTHONHOME                 "@executable_path/../Resources/Python"'                "$plist"
+                /usr/libexec/PlistBuddy -c 'Add :LSEnvironment:PYTHONNOUSERSITE    string "1"'                                                   "$plist" 2>/dev/null || true
+                /usr/libexec/PlistBuddy -c 'Set :LSEnvironment:PYTHONNOUSERSITE           "1"'                                                   "$plist"
+                /usr/libexec/PlistBuddy -c 'Add :LSEnvironment:VAPOURSYNTH_LIBRARY string "@executable_path/../Frameworks/libvapoursynth.dylib"' "$plist" 2>/dev/null || true
+                /usr/libexec/PlistBuddy -c 'Set :LSEnvironment:VAPOURSYNTH_LIBRARY        "@executable_path/../Frameworks/libvapoursynth.dylib"' "$plist"
+                /usr/libexec/PlistBuddy -c 'Add :LSEnvironment:IINA_EXECUTABLE    string "@executable_path"'                                    "$plist" 2>/dev/null || true
+                /usr/libexec/PlistBuddy -c 'Set :LSEnvironment:IINA_EXECUTABLE           "@executable_path"'                                    "$plist"
 
-              echo "📦 Deep-bundling dynamic dependencies into IINA.app"
-              ${normalizer}/bin/iina-normalize-app "$app"
+                echo "🔏 Re-signing IINA.app..."
+                ${scripts.resign}/bin/iina-resign "$app"
+              '';
+            };
 
-              echo "✏️ Canonicalize Lib Groups"
-              ${canonicalizeLibGroups}/bin/iina-canonicalize-lib-groups "$app"
+            iina-universal = pkgs.stdenv.mkDerivation {
+              pname = "iina-universal";
+              version = if self ? rev then builtins.substring 0 8 self.rev else "dev";
 
-              echo "✏️ Setting up environment variables"
+              nativeBuildInputs = [
+                pkgs.rsync
+                pkgs.coreutils
+              ];
 
-              /usr/libexec/PlistBuddy -c 'Add :LSEnvironment dict'                                                                             "$plist" 2>/dev/null || true
-              /usr/libexec/PlistBuddy -c 'Add :LSEnvironment:PYTHONHOME          string "@executable_path/../Resources/Python"'                "$plist" 2>/dev/null || true
-              /usr/libexec/PlistBuddy -c 'Set :LSEnvironment:PYTHONHOME                 "@executable_path/../Resources/Python"'                "$plist"
-              /usr/libexec/PlistBuddy -c 'Add :LSEnvironment:PYTHONNOUSERSITE    string "1"'                                                   "$plist" 2>/dev/null || true
-              /usr/libexec/PlistBuddy -c 'Set :LSEnvironment:PYTHONNOUSERSITE           "1"'                                                   "$plist"
-              /usr/libexec/PlistBuddy -c 'Add :LSEnvironment:VAPOURSYNTH_LIBRARY string "@executable_path/../Frameworks/libvapoursynth.dylib"' "$plist" 2>/dev/null || true
-              /usr/libexec/PlistBuddy -c 'Set :LSEnvironment:VAPOURSYNTH_LIBRARY        "@executable_path/../Frameworks/libvapoursynth.dylib"' "$plist"
-              /usr/libexec/PlistBuddy -c 'Add :LSEnvironment:IINA_EXECUTABLE    string "@executable_path"'                                    "$plist" 2>/dev/null || true
-              /usr/libexec/PlistBuddy -c 'Set :LSEnvironment:IINA_EXECUTABLE           "@executable_path"'                                    "$plist"
+              buildCommand = ''
+                app="$out/Applications/IINA.app"
+                frameworks="$app/Contents/Frameworks"
 
-              echo "🔏 Re-signing IINA.app..."
-              ${resign}/bin/iina-resign "$app"
-            '';
+                export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
+                APPLE_BIN="$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/bin"
+                export PATH="$APPLE_BIN:$DEVELOPER_DIR/usr/bin:/usr/bin:/bin"
+
+                echo "📦 Combining universal IINA.app"
+
+                mkdir -p "$out/Applications"
+                # copy the contents of the source app into the target dir
+                ${pkgs.rsync}/bin/rsync -a ${builtins.elemAt self.archApps 0}/Applications/IINA.app/ "$app/"
+                chmod -R u+w "$app"
+
+                echo "🔍 Merging binaries across architectures"
+                find "$app" -type f \( -perm -111 -o -name "*.dylib" -o -name "*.so" \) | while read -r dep; do
+                  if [[ -L "$dep" ]] || [[ ! -f "$dep" ]]; then
+                    echo "✅ Skipping non-file $dep"
+                    continue
+                  fi
+
+                  if ! file -b "$dep" | grep -qi 'Mach-O'; then
+                    echo "✅ Skipping non-Mach-O $dep"
+                    continue
+                  fi
+
+                  relpath=$(${pkgs.coreutils}/bin/realpath --relative-to="$app" "$dep")
+
+                  # collect candidate files from each arch build
+                  inputs=""
+                  for archroot in ${
+                    builtins.concatStringsSep " " (map (a: "\"${a}/Applications/IINA.app\"") self.archApps)
+                  }; do
+                    candidate="$archroot/$relpath"
+                    if [ -f "$candidate" ]; then
+                      inputs="$inputs $candidate"
+                    fi
+                  done
+
+                  # pick at most one file per arch to avoid duplicates
+                  arm64=""
+                  x86_64=""
+                  for f in $inputs; do
+                    info=$(lipo -info "$f" 2>/dev/null || true)
+
+                    if echo "$info" | grep -qw arm64 && [ -z "$arm64" ]; then
+                      arm64="$f"
+                    fi
+
+                    if echo "$info" | grep -qw x86_64 && [ -z "$x86_64" ]; then
+                      x86_64="$f"
+                    fi
+
+                    # if we ever see a fat that already has both, just use it as-is
+                    if echo "$info" | grep -q 'Architectures in the fat file' && \
+                       echo "$info" | grep -qw arm64 && echo "$info" | grep -qw x86_64; then
+                      arm64="$f"; x86_64="$f"; break
+                    fi
+                  done
+
+                  # if only one arch available, leave it alone
+                  if [ -z "$arm64" ] || [ -z "$x86_64" ]; then
+                    echo "✅ Skipping single-arch $dep"
+                    continue
+                  fi
+
+                  echo "🔨 Merging $relpath"
+                  tmp="$dep.universal.$$"
+
+                  # Ensure we can replace the file
+                  chmod u+w "$dep" 2>/dev/null || true
+
+                  # Guard against already universal binaries
+                  if [ "$arm64" = "$x86_64" ]; then
+                    cp -p "$arm64" "$tmp"
+                  else
+                    lipo -create -arch arm64 "$arm64" -arch x86_64 "$x86_64" -output "$tmp"
+                  fi
+                  
+                  # Preserve mode if possible (GNU coreutils); fall back to +x
+                  ${pkgs.coreutils}/bin/chmod --reference="$dep" "$tmp" 2>/dev/null || chmod +x "$tmp"
+
+                  mv -f "$tmp" "$dep"
+                done
+
+                echo "📦 Deep-bundling dynamic dependencies into IINA.app"
+                ${scripts.normalizer}/bin/iina-normalize-app "$app"
+
+                echo "✏️ Canonicalize Lib Groups"
+                ${scripts.canonicalizeLibGroups}/bin/iina-canonicalize-lib-groups "$app"
+
+                echo "🔏 Re-signing IINA.app..."
+                ${scripts.resign}/bin/iina-resign "$app"
+              '';
+
+              preFixup = ''
+                export PATH=${pkgs.coreutils}/bin:$PATH
+              '';
+            };
+
+            default = iina-universal;
           };
 
-          iina-universal = pkgs.stdenv.mkDerivation {
-            pname = "iina-universal";
-            version = if self ? rev then builtins.substring 0 8 self.rev else "dev";
+          devShells = {
+            default = pkgs.mkShell {
+              packages = [
+                xcode
+                pkgs.rsync
+                pkgs.gnused
+                pkgs.gnugrep
+                pkgs.coreutils
+              ];
 
-            nativeBuildInputs = [
-              pkgs.rsync
-              pkgs.coreutils
-            ];
+              shellHook = ''
+                set -euo pipefail
 
-            buildCommand = ''
-              app="$out/Applications/IINA.app"
-              frameworks="$app/Contents/Frameworks"
+                export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
 
-              export DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer
-              APPLE_BIN="$DEVELOPER_DIR/Toolchains/XcodeDefault.xctoolchain/usr/bin"
-              export PATH="$APPLE_BIN:$DEVELOPER_DIR/usr/bin:/usr/bin:/bin"
+                deps_root="$PWD/deps"
+                mkdir -p "$deps_root"
 
-              echo "📦 Combining universal IINA.app"
+                link_tree() {
+                  local target="$1"
+                  local link="$2"
 
-              mkdir -p "$out/Applications"
-              # copy the contents of the source app into the target dir
-              ${pkgs.rsync}/bin/rsync -a ${builtins.elemAt self.archApps 0}/Applications/IINA.app/ "$app/"
-              chmod -R u+w "$app"
-
-              echo "🔍 Merging binaries across architectures"
-              find "$app" -type f \( -perm -111 -o -name "*.dylib" -o -name "*.so" \) | while read -r dep; do
-                if [[ -L "$dep" ]] || [[ ! -f "$dep" ]]; then
-                  echo "✅ Skipping non-file $dep"
-                  continue
-                fi
-
-                if ! file -b "$dep" | grep -qi 'Mach-O'; then
-                  echo "✅ Skipping non-Mach-O $dep"
-                  continue
-                fi
-
-                relpath=$(${pkgs.coreutils}/bin/realpath --relative-to="$app" "$dep")
-
-                # collect candidate files from each arch build
-                inputs=""
-                for archroot in ${
-                  builtins.concatStringsSep " " (map (a: "\"${a}/Applications/IINA.app\"") self.archApps)
-                }; do
-                  candidate="$archroot/$relpath"
-                  if [ -f "$candidate" ]; then
-                    inputs="$inputs $candidate"
-                  fi
-                done
-
-                # pick at most one file per arch to avoid duplicates
-                arm64=""
-                x86_64=""
-                for f in $inputs; do
-                  info=$(lipo -info "$f" 2>/dev/null || true)
-
-                  if echo "$info" | grep -qw arm64 && [ -z "$arm64" ]; then
-                    arm64="$f"
+                  if [ -e "$link" ] && [ ! -L "$link" ]; then
+                    echo "⚠️  $link exists and is not a symlink; leaving it untouched."
+                    return
                   fi
 
-                  if echo "$info" | grep -qw x86_64 && [ -z "$x86_64" ]; then
-                    x86_64="$f"
+                  ln -sfn "$target" "$link"
+                }
+
+                link_tree ${depsInc} "$deps_root/include"
+                link_tree ${depsLib} "$deps_root/lib"
+                link_tree ${depsExecutable} "$deps_root/executable"
+                link_tree ${depsIndirect} "$deps_root/indirect"
+                link_tree ${depsResources} "$deps_root/resources"
+
+                echo "📦 Syncing SwiftPM deps"
+                rsync -a --chmod=Du+rwx,Fu+rw ${spmDeps}/ ./
+
+                if [ -f .spm/workspace-state.json ]; then
+                  chmod u+w .spm/workspace-state.json 2>/dev/null || true
+                  old_prefix=$(grep -Eo "/nix/var/nix/builds/nix-[^/]+/source" .spm/workspace-state.json | head -n1)
+                  if [ -n "$old_prefix" ]; then
+                    sed -i -E "s|$old_prefix|$PWD|g" .spm/workspace-state.json
                   fi
-
-                  # if we ever see a fat that already has both, just use it as-is
-                  if echo "$info" | grep -q 'Architectures in the fat file' && \
-                     echo "$info" | grep -qw arm64 && echo "$info" | grep -qw x86_64; then
-                    arm64="$f"; x86_64="$f"; break
-                  fi
-                done
-
-                # if only one arch available, leave it alone
-                if [ -z "$arm64" ] || [ -z "$x86_64" ]; then
-                  echo "✅ Skipping single-arch $dep"
-                  continue
                 fi
-
-                echo "🔨 Merging $relpath"
-                tmp="$dep.universal.$$"
-
-                # Ensure we can replace the file
-                chmod u+w "$dep" 2>/dev/null || true
-
-                # Guard against already universal binaries
-                if [ "$arm64" = "$x86_64" ]; then
-                  cp -p "$arm64" "$tmp"
-                else
-                  lipo -create -arch arm64 "$arm64" -arch x86_64 "$x86_64" -output "$tmp"
-                fi
-                
-                # Preserve mode if possible (GNU coreutils); fall back to +x
-                ${pkgs.coreutils}/bin/chmod --reference="$dep" "$tmp" 2>/dev/null || chmod +x "$tmp"
-
-                mv -f "$tmp" "$dep"
-              done
-
-              echo "📦 Deep-bundling dynamic dependencies into IINA.app"
-              ${normalizer}/bin/iina-normalize-app "$app"
-
-              echo "✏️ Canonicalize Lib Groups"
-              ${canonicalizeLibGroups}/bin/iina-canonicalize-lib-groups "$app"
-
-              echo "🔏 Re-signing IINA.app..."
-              ${resign}/bin/iina-resign "$app"
-            '';
-
-            preFixup = ''
-              export PATH=${pkgs.coreutils}/bin:$PATH
-            '';
+              '';
+            };
           };
-
-          default = self.packages.${system}.iina-universal;
         }
       );
+    in
+    {
+      inherit systems;
+
+      packages = nixpkgs.lib.genAttrs systems (system: (perSystem.${system}).packages);
+
+      devShells = nixpkgs.lib.genAttrs systems (system: (perSystem.${system}).devShells);
+
+      archApps = builtins.map (system: self.packages.${system}.iina) systems;
     };
 }

--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -28,11 +28,10 @@
 		34ACAB802C142A0500F871A0 /* libfribidi.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB3B2C142A0300F871A0 /* libfribidi.0.dylib */; };
 		34ACAB812C142A0500F871A0 /* libvidstab.1.2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB3C2C142A0300F871A0 /* libvidstab.1.2.dylib */; };
 		34ACAB822C142A0500F871A0 /* libwebp.7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB3D2C142A0300F871A0 /* libwebp.7.dylib */; };
-		34ACAB832C142A0500F871A0 /* libjxl.0.10.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB3E2C142A0300F871A0 /* libjxl.0.10.dylib */; };
+		34ACAB832C142A0500F871A0 /* libjxl.0.11.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB3E2C142A0300F871A0 /* libjxl.0.11.dylib */; };
 		34ACAB842C142A0500F871A0 /* libXau.6.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB3F2C142A0300F871A0 /* libXau.6.dylib */; };
 		34ACAB852C142A0500F871A0 /* libdav1d.7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB402C142A0300F871A0 /* libdav1d.7.dylib */; };
 		34ACAB862C142A0500F871A0 /* libXdmcp.6.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB412C142A0300F871A0 /* libXdmcp.6.dylib */; };
-		34ACAB872C142A0500F871A0 /* libpostproc.58.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB422C142A0300F871A0 /* libpostproc.58.dylib */; };
 		34ACAB882C142A0500F871A0 /* libswscale.8.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB432C142A0300F871A0 /* libswscale.8.dylib */; };
 		34ACAB892C142A0500F871A0 /* libunibreak.6.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB442C142A0300F871A0 /* libunibreak.6.dylib */; };
 		34ACAB8A2C142A0500F871A0 /* libfontconfig.1.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB452C142A0300F871A0 /* libfontconfig.1.dylib */; };
@@ -48,7 +47,7 @@
 		34ACAB942C142A0500F871A0 /* libglib-2.0.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB4F2C142A0400F871A0 /* libglib-2.0.0.dylib */; };
 		34ACAB952C142A0500F871A0 /* libbrotlienc.1.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB502C142A0400F871A0 /* libbrotlienc.1.dylib */; };
 		34ACAB962C142A0500F871A0 /* libbrotlicommon.1.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB512C142A0400F871A0 /* libbrotlicommon.1.dylib */; };
-		34ACAB972C142A0500F871A0 /* libjxl_threads.0.10.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB522C142A0400F871A0 /* libjxl_threads.0.10.dylib */; };
+		34ACAB972C142A0500F871A0 /* libjxl_threads.0.11.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB522C142A0400F871A0 /* libjxl_threads.0.11.dylib */; };
 		34ACAB982C142A0500F871A0 /* libpng16.16.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB532C142A0400F871A0 /* libpng16.16.dylib */; };
 		34ACAB992C142A0500F871A0 /* libbluray.2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB542C142A0400F871A0 /* libbluray.2.dylib */; };
 		34ACAB9A2C142A0500F871A0 /* libuchardet.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB552C142A0400F871A0 /* libuchardet.0.dylib */; };
@@ -57,17 +56,17 @@
 		34ACAB9D2C142A0500F871A0 /* libavutil.59.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB582C142A0400F871A0 /* libavutil.59.dylib */; };
 		34ACAB9E2C142A0500F871A0 /* libarchive.13.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB592C142A0400F871A0 /* libarchive.13.dylib */; };
 		34ACAB9F2C142A0500F871A0 /* libidn2.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB5A2C142A0400F871A0 /* libidn2.0.dylib */; };
-		34ACABA02C142A0500F871A0 /* libplacebo.338.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB5B2C142A0400F871A0 /* libplacebo.338.dylib */; };
+		34ACABA02C142A0500F871A0 /* libplacebo.349.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB5B2C142A0400F871A0 /* libplacebo.349.dylib */; };
 		34ACABA12C142A0500F871A0 /* libX11.6.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB5C2C142A0400F871A0 /* libX11.6.dylib */; };
 		34ACABA22C142A0500F871A0 /* liblzma.5.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB5D2C142A0400F871A0 /* liblzma.5.dylib */; };
 		34ACABA32C142A0500F871A0 /* libsoxr.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB5E2C142A0400F871A0 /* libsoxr.0.dylib */; };
-		34ACABA42C142A0500F871A0 /* librubberband.2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB5F2C142A0400F871A0 /* librubberband.2.dylib */; };
+		34ACABA42C142A0500F871A0 /* librubberband.3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB5F2C142A0400F871A0 /* librubberband.3.dylib */; };
 		34ACABA52C142A0500F871A0 /* libavcodec.61.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB602C142A0400F871A0 /* libavcodec.61.dylib */; };
 		34ACABA62C142A0500F871A0 /* libhogweed.6.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB612C142A0400F871A0 /* libhogweed.6.dylib */; };
 		34ACABA72C142A0500F871A0 /* libsodium.26.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB622C142A0400F871A0 /* libsodium.26.dylib */; };
 		34ACABA82C142A0500F871A0 /* libsamplerate.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB632C142A0400F871A0 /* libsamplerate.0.dylib */; };
 		34ACABA92C142A0500F871A0 /* libxcb-shm.0.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB642C142A0400F871A0 /* libxcb-shm.0.dylib */; };
-		34ACABAA2C142A0500F871A0 /* libjpeg.8.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB652C142A0400F871A0 /* libjpeg.8.dylib */; };
+		34ACABAA2C142A0500F871A0 /* libjpeg.62.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB652C142A0400F871A0 /* libjpeg.62.dylib */; };
 		34ACABAB2C142A0500F871A0 /* libzimg.2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB662C142A0500F871A0 /* libzimg.2.dylib */; };
 		34ACABAC2C142A0500F871A0 /* libnettle.8.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB672C142A0500F871A0 /* libnettle.8.dylib */; };
 		34ACABAD2C142A0500F871A0 /* libavdevice.61.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB682C142A0500F871A0 /* libavdevice.61.dylib */; };
@@ -76,7 +75,7 @@
 		34ACABB02C142A0500F871A0 /* libgmp.10.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB6B2C142A0500F871A0 /* libgmp.10.dylib */; };
 		34ACABB12C142A0500F871A0 /* libswresample.5.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB6C2C142A0500F871A0 /* libswresample.5.dylib */; };
 		34ACABB22C142A0500F871A0 /* libfreetype.6.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB6D2C142A0500F871A0 /* libfreetype.6.dylib */; };
-		34ACABB32C142A0500F871A0 /* libjxl_cms.0.10.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB6E2C142A0500F871A0 /* libjxl_cms.0.10.dylib */; };
+		34ACABB32C142A0500F871A0 /* libjxl_cms.0.11.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB6E2C142A0500F871A0 /* libjxl_cms.0.11.dylib */; };
 		34ACABB42C142A0500F871A0 /* libmpv.2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB6F2C142A0500F871A0 /* libmpv.2.dylib */; };
 		34ACABB52C142A0500F871A0 /* libspeex.1.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB702C142A0500F871A0 /* libspeex.1.dylib */; };
 		34ACABB62C142A0500F871A0 /* libass.9.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB712C142A0500F871A0 /* libass.9.dylib */; };
@@ -105,10 +104,10 @@
 		34ACABCD2C142A0C00F871A0 /* libhwy.1.dylib in Copy Dylibs */ = {isa = PBXBuildFile; fileRef = 34ACAB692C142A0500F871A0 /* libhwy.1.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		34ACABCE2C142A0C00F871A0 /* libidn2.0.dylib in Copy Dylibs */ = {isa = PBXBuildFile; fileRef = 34ACAB5A2C142A0400F871A0 /* libidn2.0.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		34ACABCF2C142A0C00F871A0 /* libintl.8.dylib in Copy Dylibs */ = {isa = PBXBuildFile; fileRef = 34ACAB2D2C142A0300F871A0 /* libintl.8.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		34ACABD02C142A0C00F871A0 /* libjpeg.8.dylib in Copy Dylibs */ = {isa = PBXBuildFile; fileRef = 34ACAB652C142A0400F871A0 /* libjpeg.8.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		34ACABD12C142A0C00F871A0 /* libjxl_cms.0.10.dylib in Copy Dylibs */ = {isa = PBXBuildFile; fileRef = 34ACAB6E2C142A0500F871A0 /* libjxl_cms.0.10.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		34ACABD22C142A0C00F871A0 /* libjxl_threads.0.10.dylib in Copy Dylibs */ = {isa = PBXBuildFile; fileRef = 34ACAB522C142A0400F871A0 /* libjxl_threads.0.10.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		34ACABD32C142A0C00F871A0 /* libjxl.0.10.dylib in Copy Dylibs */ = {isa = PBXBuildFile; fileRef = 34ACAB3E2C142A0300F871A0 /* libjxl.0.10.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		34ACABD02C142A0C00F871A0 /* libjpeg.62.dylib in Copy Dylibs */ = {isa = PBXBuildFile; fileRef = 34ACAB652C142A0400F871A0 /* libjpeg.62.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		34ACABD12C142A0C00F871A0 /* libjxl_cms.0.11.dylib in Copy Dylibs */ = {isa = PBXBuildFile; fileRef = 34ACAB6E2C142A0500F871A0 /* libjxl_cms.0.11.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		34ACABD22C142A0C00F871A0 /* libjxl_threads.0.11.dylib in Copy Dylibs */ = {isa = PBXBuildFile; fileRef = 34ACAB522C142A0400F871A0 /* libjxl_threads.0.11.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		34ACABD32C142A0C00F871A0 /* libjxl.0.11.dylib in Copy Dylibs */ = {isa = PBXBuildFile; fileRef = 34ACAB3E2C142A0300F871A0 /* libjxl.0.11.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		34ACABD42C142A0C00F871A0 /* liblcms2.2.dylib in Copy Dylibs */ = {isa = PBXBuildFile; fileRef = 34ACAB2F2C142A0300F871A0 /* liblcms2.2.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		34ACABD52C142A0C00F871A0 /* libluajit-5.1.2.dylib in Copy Dylibs */ = {isa = PBXBuildFile; fileRef = 34ACAB3A2C142A0300F871A0 /* libluajit-5.1.2.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		34ACABD62C142A0C00F871A0 /* liblz4.1.dylib in Copy Dylibs */ = {isa = PBXBuildFile; fileRef = 34ACAB362C142A0300F871A0 /* liblz4.1.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
@@ -118,10 +117,9 @@
 		34ACABDA2C142A0C00F871A0 /* libnettle.8.dylib in Copy Dylibs */ = {isa = PBXBuildFile; fileRef = 34ACAB672C142A0500F871A0 /* libnettle.8.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		34ACABDB2C142A0C00F871A0 /* libp11-kit.0.dylib in Copy Dylibs */ = {isa = PBXBuildFile; fileRef = 34ACAB302C142A0300F871A0 /* libp11-kit.0.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		34ACABDC2C142A0C00F871A0 /* libpcre2-8.0.dylib in Copy Dylibs */ = {isa = PBXBuildFile; fileRef = 34ACAB4C2C142A0400F871A0 /* libpcre2-8.0.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		34ACABDD2C142A0C00F871A0 /* libplacebo.338.dylib in Copy Dylibs */ = {isa = PBXBuildFile; fileRef = 34ACAB5B2C142A0400F871A0 /* libplacebo.338.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		34ACABDD2C142A0C00F871A0 /* libplacebo.349.dylib in Copy Dylibs */ = {isa = PBXBuildFile; fileRef = 34ACAB5B2C142A0400F871A0 /* libplacebo.349.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		34ACABDE2C142A0C00F871A0 /* libpng16.16.dylib in Copy Dylibs */ = {isa = PBXBuildFile; fileRef = 34ACAB532C142A0400F871A0 /* libpng16.16.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		34ACABDF2C142A0C00F871A0 /* libpostproc.58.dylib in Copy Dylibs */ = {isa = PBXBuildFile; fileRef = 34ACAB422C142A0300F871A0 /* libpostproc.58.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		34ACABE02C142A0C00F871A0 /* librubberband.2.dylib in Copy Dylibs */ = {isa = PBXBuildFile; fileRef = 34ACAB5F2C142A0400F871A0 /* librubberband.2.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		34ACABE02C142A0C00F871A0 /* librubberband.3.dylib in Copy Dylibs */ = {isa = PBXBuildFile; fileRef = 34ACAB5F2C142A0400F871A0 /* librubberband.3.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		34ACABE12C142A0C00F871A0 /* libsamplerate.0.dylib in Copy Dylibs */ = {isa = PBXBuildFile; fileRef = 34ACAB632C142A0400F871A0 /* libsamplerate.0.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		34ACABE22C142A0C00F871A0 /* libshaderc_shared.1.dylib in Copy Dylibs */ = {isa = PBXBuildFile; fileRef = 34ACAB342C142A0300F871A0 /* libshaderc_shared.1.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		34ACABE32C142A0C00F871A0 /* libsharpyuv.0.dylib in Copy Dylibs */ = {isa = PBXBuildFile; fileRef = 34ACAB332C142A0300F871A0 /* libsharpyuv.0.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
@@ -229,7 +227,7 @@
 		845FB0C71D39462E00C011E0 /* ControlBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845FB0C61D39462E00C011E0 /* ControlBarView.swift */; };
 		8460FBA91D6497490081841B /* PlaylistViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8460FBA71D6497490081841B /* PlaylistViewController.swift */; };
 		846121BD1F35FCA500ABB39C /* DraggingDetect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846121BC1F35FCA500ABB39C /* DraggingDetect.swift */; };
-		8461BA681E4237C7008BB852 /* youtube-dl in Copy Executables */ = {isa = PBXBuildFile; fileRef = 8461BA671E4237C2008BB852 /* youtube-dl */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		8461BA681E4237C7008BB852 /* yt-dlp in Copy Executables */ = {isa = PBXBuildFile; fileRef = 8461BA671E4237C2008BB852 /* yt-dlp */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		8461C52E1D45FFF6006E91FF /* PlaySliderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8461C52D1D45FFF6006E91FF /* PlaySliderCell.swift */; };
 		8461C5301D462488006E91FF /* VideoTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8461C52F1D462488006E91FF /* VideoTime.swift */; };
 		846352581EEEE11A0043F0CC /* ThumbnailPeekView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846352571EEEE11A0043F0CC /* ThumbnailPeekView.swift */; };
@@ -441,7 +439,7 @@
 			files = (
 				E3DE8DD31FD848BA0021921C /* iina-cli in Copy Executables */,
 				515B5E5A2A579903001FCD49 /* iina-plugin in Copy Executables */,
-				8461BA681E4237C7008BB852 /* youtube-dl in Copy Executables */,
+				8461BA681E4237C7008BB852 /* yt-dlp in Copy Executables */,
 			);
 			name = "Copy Executables";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -477,10 +475,10 @@
 				34ACABCD2C142A0C00F871A0 /* libhwy.1.dylib in Copy Dylibs */,
 				34ACABCE2C142A0C00F871A0 /* libidn2.0.dylib in Copy Dylibs */,
 				34ACABCF2C142A0C00F871A0 /* libintl.8.dylib in Copy Dylibs */,
-				34ACABD02C142A0C00F871A0 /* libjpeg.8.dylib in Copy Dylibs */,
-				34ACABD12C142A0C00F871A0 /* libjxl_cms.0.10.dylib in Copy Dylibs */,
-				34ACABD22C142A0C00F871A0 /* libjxl_threads.0.10.dylib in Copy Dylibs */,
-				34ACABD32C142A0C00F871A0 /* libjxl.0.10.dylib in Copy Dylibs */,
+				34ACABD02C142A0C00F871A0 /* libjpeg.62.dylib in Copy Dylibs */,
+				34ACABD12C142A0C00F871A0 /* libjxl_cms.0.11.dylib in Copy Dylibs */,
+				34ACABD22C142A0C00F871A0 /* libjxl_threads.0.11.dylib in Copy Dylibs */,
+				34ACABD32C142A0C00F871A0 /* libjxl.0.11.dylib in Copy Dylibs */,
 				34ACABD42C142A0C00F871A0 /* liblcms2.2.dylib in Copy Dylibs */,
 				34ACABD52C142A0C00F871A0 /* libluajit-5.1.2.dylib in Copy Dylibs */,
 				34ACABD62C142A0C00F871A0 /* liblz4.1.dylib in Copy Dylibs */,
@@ -490,10 +488,9 @@
 				34ACABDA2C142A0C00F871A0 /* libnettle.8.dylib in Copy Dylibs */,
 				34ACABDB2C142A0C00F871A0 /* libp11-kit.0.dylib in Copy Dylibs */,
 				34ACABDC2C142A0C00F871A0 /* libpcre2-8.0.dylib in Copy Dylibs */,
-				34ACABDD2C142A0C00F871A0 /* libplacebo.338.dylib in Copy Dylibs */,
+				34ACABDD2C142A0C00F871A0 /* libplacebo.349.dylib in Copy Dylibs */,
 				34ACABDE2C142A0C00F871A0 /* libpng16.16.dylib in Copy Dylibs */,
-				34ACABDF2C142A0C00F871A0 /* libpostproc.58.dylib in Copy Dylibs */,
-				34ACABE02C142A0C00F871A0 /* librubberband.2.dylib in Copy Dylibs */,
+				34ACABE02C142A0C00F871A0 /* librubberband.3.dylib in Copy Dylibs */,
 				34ACABE12C142A0C00F871A0 /* libsamplerate.0.dylib in Copy Dylibs */,
 				34ACABE22C142A0C00F871A0 /* libshaderc_shared.1.dylib in Copy Dylibs */,
 				34ACABE32C142A0C00F871A0 /* libsharpyuv.0.dylib in Copy Dylibs */,
@@ -934,11 +931,10 @@
 		34ACAB3B2C142A0300F871A0 /* libfribidi.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libfribidi.0.dylib; path = deps/lib/libfribidi.0.dylib; sourceTree = "<group>"; };
 		34ACAB3C2C142A0300F871A0 /* libvidstab.1.2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libvidstab.1.2.dylib; path = deps/lib/libvidstab.1.2.dylib; sourceTree = "<group>"; };
 		34ACAB3D2C142A0300F871A0 /* libwebp.7.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libwebp.7.dylib; path = deps/lib/libwebp.7.dylib; sourceTree = "<group>"; };
-		34ACAB3E2C142A0300F871A0 /* libjxl.0.10.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libjxl.0.10.dylib; path = deps/lib/libjxl.0.10.dylib; sourceTree = "<group>"; };
+		34ACAB3E2C142A0300F871A0 /* libjxl.0.11.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libjxl.0.11.dylib; path = deps/lib/libjxl.0.11.dylib; sourceTree = "<group>"; };
 		34ACAB3F2C142A0300F871A0 /* libXau.6.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libXau.6.dylib; path = deps/lib/libXau.6.dylib; sourceTree = "<group>"; };
 		34ACAB402C142A0300F871A0 /* libdav1d.7.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libdav1d.7.dylib; path = deps/lib/libdav1d.7.dylib; sourceTree = "<group>"; };
 		34ACAB412C142A0300F871A0 /* libXdmcp.6.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libXdmcp.6.dylib; path = deps/lib/libXdmcp.6.dylib; sourceTree = "<group>"; };
-		34ACAB422C142A0300F871A0 /* libpostproc.58.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libpostproc.58.dylib; path = deps/lib/libpostproc.58.dylib; sourceTree = "<group>"; };
 		34ACAB432C142A0300F871A0 /* libswscale.8.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libswscale.8.dylib; path = deps/lib/libswscale.8.dylib; sourceTree = "<group>"; };
 		34ACAB442C142A0300F871A0 /* libunibreak.6.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libunibreak.6.dylib; path = deps/lib/libunibreak.6.dylib; sourceTree = "<group>"; };
 		34ACAB452C142A0300F871A0 /* libfontconfig.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libfontconfig.1.dylib; path = deps/lib/libfontconfig.1.dylib; sourceTree = "<group>"; };
@@ -954,7 +950,7 @@
 		34ACAB4F2C142A0400F871A0 /* libglib-2.0.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libglib-2.0.0.dylib"; path = "deps/lib/libglib-2.0.0.dylib"; sourceTree = "<group>"; };
 		34ACAB502C142A0400F871A0 /* libbrotlienc.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libbrotlienc.1.dylib; path = deps/lib/libbrotlienc.1.dylib; sourceTree = "<group>"; };
 		34ACAB512C142A0400F871A0 /* libbrotlicommon.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libbrotlicommon.1.dylib; path = deps/lib/libbrotlicommon.1.dylib; sourceTree = "<group>"; };
-		34ACAB522C142A0400F871A0 /* libjxl_threads.0.10.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libjxl_threads.0.10.dylib; path = deps/lib/libjxl_threads.0.10.dylib; sourceTree = "<group>"; };
+		34ACAB522C142A0400F871A0 /* libjxl_threads.0.11.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libjxl_threads.0.11.dylib; path = deps/lib/libjxl_threads.0.11.dylib; sourceTree = "<group>"; };
 		34ACAB532C142A0400F871A0 /* libpng16.16.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libpng16.16.dylib; path = deps/lib/libpng16.16.dylib; sourceTree = "<group>"; };
 		34ACAB542C142A0400F871A0 /* libbluray.2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libbluray.2.dylib; path = deps/lib/libbluray.2.dylib; sourceTree = "<group>"; };
 		34ACAB552C142A0400F871A0 /* libuchardet.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libuchardet.0.dylib; path = deps/lib/libuchardet.0.dylib; sourceTree = "<group>"; };
@@ -963,17 +959,17 @@
 		34ACAB582C142A0400F871A0 /* libavutil.59.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libavutil.59.dylib; path = deps/lib/libavutil.59.dylib; sourceTree = "<group>"; };
 		34ACAB592C142A0400F871A0 /* libarchive.13.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libarchive.13.dylib; path = deps/lib/libarchive.13.dylib; sourceTree = "<group>"; };
 		34ACAB5A2C142A0400F871A0 /* libidn2.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libidn2.0.dylib; path = deps/lib/libidn2.0.dylib; sourceTree = "<group>"; };
-		34ACAB5B2C142A0400F871A0 /* libplacebo.338.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libplacebo.338.dylib; path = deps/lib/libplacebo.338.dylib; sourceTree = "<group>"; };
+		34ACAB5B2C142A0400F871A0 /* libplacebo.349.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libplacebo.349.dylib; path = deps/lib/libplacebo.349.dylib; sourceTree = "<group>"; };
 		34ACAB5C2C142A0400F871A0 /* libX11.6.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libX11.6.dylib; path = deps/lib/libX11.6.dylib; sourceTree = "<group>"; };
 		34ACAB5D2C142A0400F871A0 /* liblzma.5.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = liblzma.5.dylib; path = deps/lib/liblzma.5.dylib; sourceTree = "<group>"; };
 		34ACAB5E2C142A0400F871A0 /* libsoxr.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libsoxr.0.dylib; path = deps/lib/libsoxr.0.dylib; sourceTree = "<group>"; };
-		34ACAB5F2C142A0400F871A0 /* librubberband.2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = librubberband.2.dylib; path = deps/lib/librubberband.2.dylib; sourceTree = "<group>"; };
+		34ACAB5F2C142A0400F871A0 /* librubberband.3.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = librubberband.3.dylib; path = deps/lib/librubberband.3.dylib; sourceTree = "<group>"; };
 		34ACAB602C142A0400F871A0 /* libavcodec.61.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libavcodec.61.dylib; path = deps/lib/libavcodec.61.dylib; sourceTree = "<group>"; };
 		34ACAB612C142A0400F871A0 /* libhogweed.6.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libhogweed.6.dylib; path = deps/lib/libhogweed.6.dylib; sourceTree = "<group>"; };
 		34ACAB622C142A0400F871A0 /* libsodium.26.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libsodium.26.dylib; path = deps/lib/libsodium.26.dylib; sourceTree = "<group>"; };
 		34ACAB632C142A0400F871A0 /* libsamplerate.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libsamplerate.0.dylib; path = deps/lib/libsamplerate.0.dylib; sourceTree = "<group>"; };
 		34ACAB642C142A0400F871A0 /* libxcb-shm.0.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libxcb-shm.0.dylib"; path = "deps/lib/libxcb-shm.0.dylib"; sourceTree = "<group>"; };
-		34ACAB652C142A0400F871A0 /* libjpeg.8.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libjpeg.8.dylib; path = deps/lib/libjpeg.8.dylib; sourceTree = "<group>"; };
+		34ACAB652C142A0400F871A0 /* libjpeg.62.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libjpeg.62.dylib; path = deps/lib/libjpeg.62.dylib; sourceTree = "<group>"; };
 		34ACAB662C142A0500F871A0 /* libzimg.2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libzimg.2.dylib; path = deps/lib/libzimg.2.dylib; sourceTree = "<group>"; };
 		34ACAB672C142A0500F871A0 /* libnettle.8.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libnettle.8.dylib; path = deps/lib/libnettle.8.dylib; sourceTree = "<group>"; };
 		34ACAB682C142A0500F871A0 /* libavdevice.61.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libavdevice.61.dylib; path = deps/lib/libavdevice.61.dylib; sourceTree = "<group>"; };
@@ -982,7 +978,7 @@
 		34ACAB6B2C142A0500F871A0 /* libgmp.10.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libgmp.10.dylib; path = deps/lib/libgmp.10.dylib; sourceTree = "<group>"; };
 		34ACAB6C2C142A0500F871A0 /* libswresample.5.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libswresample.5.dylib; path = deps/lib/libswresample.5.dylib; sourceTree = "<group>"; };
 		34ACAB6D2C142A0500F871A0 /* libfreetype.6.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libfreetype.6.dylib; path = deps/lib/libfreetype.6.dylib; sourceTree = "<group>"; };
-		34ACAB6E2C142A0500F871A0 /* libjxl_cms.0.10.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libjxl_cms.0.10.dylib; path = deps/lib/libjxl_cms.0.10.dylib; sourceTree = "<group>"; };
+		34ACAB6E2C142A0500F871A0 /* libjxl_cms.0.11.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libjxl_cms.0.11.dylib; path = deps/lib/libjxl_cms.0.11.dylib; sourceTree = "<group>"; };
 		34ACAB6F2C142A0500F871A0 /* libmpv.2.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libmpv.2.dylib; path = deps/lib/libmpv.2.dylib; sourceTree = "<group>"; };
 		34ACAB702C142A0500F871A0 /* libspeex.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libspeex.1.dylib; path = deps/lib/libspeex.1.dylib; sourceTree = "<group>"; };
 		34ACAB712C142A0500F871A0 /* libass.9.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libass.9.dylib; path = deps/lib/libass.9.dylib; sourceTree = "<group>"; };
@@ -1425,7 +1421,7 @@
 		845FB0C61D39462E00C011E0 /* ControlBarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ControlBarView.swift; sourceTree = "<group>"; };
 		8460FBA71D6497490081841B /* PlaylistViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaylistViewController.swift; sourceTree = "<group>"; };
 		846121BC1F35FCA500ABB39C /* DraggingDetect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraggingDetect.swift; sourceTree = "<group>"; };
-		8461BA671E4237C2008BB852 /* youtube-dl */ = {isa = PBXFileReference; lastKnownFileType = text; name = "youtube-dl"; path = "deps/executable/youtube-dl"; sourceTree = SOURCE_ROOT; };
+		8461BA671E4237C2008BB852 /* yt-dlp */ = {isa = PBXFileReference; lastKnownFileType = text; name = "yt-dlp"; path = "deps/executable/yt-dlp"; sourceTree = SOURCE_ROOT; };
 		8461C52D1D45FFF6006E91FF /* PlaySliderCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaySliderCell.swift; sourceTree = "<group>"; };
 		8461C52F1D462488006E91FF /* VideoTime.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoTime.swift; sourceTree = "<group>"; };
 		846352571EEEE11A0043F0CC /* ThumbnailPeekView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThumbnailPeekView.swift; sourceTree = "<group>"; };
@@ -2052,7 +2048,7 @@
 				34ACABA82C142A0500F871A0 /* libsamplerate.0.dylib in Frameworks */,
 				34ACAB892C142A0500F871A0 /* libunibreak.6.dylib in Frameworks */,
 				34ACAB792C142A0500F871A0 /* libshaderc_shared.1.dylib in Frameworks */,
-				34ACABA42C142A0500F871A0 /* librubberband.2.dylib in Frameworks */,
+				34ACABA42C142A0500F871A0 /* librubberband.3.dylib in Frameworks */,
 				34ACAB9E2C142A0500F871A0 /* libarchive.13.dylib in Frameworks */,
 				34ACAB862C142A0500F871A0 /* libXdmcp.6.dylib in Frameworks */,
 				34ACAB9A2C142A0500F871A0 /* libuchardet.0.dylib in Frameworks */,
@@ -2064,11 +2060,10 @@
 				34ACABAF2C142A0500F871A0 /* libb2.1.dylib in Frameworks */,
 				34ACABA22C142A0500F871A0 /* liblzma.5.dylib in Frameworks */,
 				34ACAB992C142A0500F871A0 /* libbluray.2.dylib in Frameworks */,
-				34ACAB872C142A0500F871A0 /* libpostproc.58.dylib in Frameworks */,
 				34ACAB952C142A0500F871A0 /* libbrotlienc.1.dylib in Frameworks */,
 				34ACAB8F2C142A0500F871A0 /* libbrotlidec.1.dylib in Frameworks */,
 				34ACAB8B2C142A0500F871A0 /* libsnappy.1.dylib in Frameworks */,
-				34ACABA02C142A0500F871A0 /* libplacebo.338.dylib in Frameworks */,
+				34ACABA02C142A0500F871A0 /* libplacebo.349.dylib in Frameworks */,
 				34ACAB7C2C142A0500F871A0 /* libwebpmux.3.dylib in Frameworks */,
 				34ACABB62C142A0500F871A0 /* libass.9.dylib in Frameworks */,
 				34ACAB7A2C142A0500F871A0 /* libunistring.5.dylib in Frameworks */,
@@ -2083,9 +2078,9 @@
 				34ACABB52C142A0500F871A0 /* libspeex.1.dylib in Frameworks */,
 				34ACAB912C142A0500F871A0 /* libpcre2-8.0.dylib in Frameworks */,
 				34ACAB882C142A0500F871A0 /* libswscale.8.dylib in Frameworks */,
-				34ACAB972C142A0500F871A0 /* libjxl_threads.0.10.dylib in Frameworks */,
+				34ACAB972C142A0500F871A0 /* libjxl_threads.0.11.dylib in Frameworks */,
 				34ACABAB2C142A0500F871A0 /* libzimg.2.dylib in Frameworks */,
-				34ACAB832C142A0500F871A0 /* libjxl.0.10.dylib in Frameworks */,
+				34ACAB832C142A0500F871A0 /* libjxl.0.11.dylib in Frameworks */,
 				34ACAB9F2C142A0500F871A0 /* libidn2.0.dylib in Frameworks */,
 				34ACAB9B2C142A0500F871A0 /* libmujs.dylib in Frameworks */,
 				34ACAB802C142A0500F871A0 /* libfribidi.0.dylib in Frameworks */,
@@ -2098,9 +2093,9 @@
 				34ACAB822C142A0500F871A0 /* libwebp.7.dylib in Frameworks */,
 				34ACAB9C2C142A0500F871A0 /* libavformat.61.dylib in Frameworks */,
 				34ACAB932C142A0500F871A0 /* libzstd.1.dylib in Frameworks */,
-				34ACABAA2C142A0500F871A0 /* libjpeg.8.dylib in Frameworks */,
+				34ACABAA2C142A0500F871A0 /* libjpeg.62.dylib in Frameworks */,
 				34ACABB42C142A0500F871A0 /* libmpv.2.dylib in Frameworks */,
-				34ACABB32C142A0500F871A0 /* libjxl_cms.0.10.dylib in Frameworks */,
+				34ACABB32C142A0500F871A0 /* libjxl_cms.0.11.dylib in Frameworks */,
 				34ACAB842C142A0500F871A0 /* libXau.6.dylib in Frameworks */,
 				34ACABB12C142A0500F871A0 /* libswresample.5.dylib in Frameworks */,
 				34ACABAD2C142A0500F871A0 /* libavdevice.61.dylib in Frameworks */,
@@ -2253,7 +2248,7 @@
 		8461BA641E42344D008BB852 /* Executables */ = {
 			isa = PBXGroup;
 			children = (
-				8461BA671E4237C2008BB852 /* youtube-dl */,
+				8461BA671E4237C2008BB852 /* yt-dlp */,
 			);
 			name = Executables;
 			path = iina;
@@ -2298,10 +2293,10 @@
 				34ACAB692C142A0500F871A0 /* libhwy.1.dylib */,
 				34ACAB5A2C142A0400F871A0 /* libidn2.0.dylib */,
 				34ACAB2D2C142A0300F871A0 /* libintl.8.dylib */,
-				34ACAB652C142A0400F871A0 /* libjpeg.8.dylib */,
-				34ACAB6E2C142A0500F871A0 /* libjxl_cms.0.10.dylib */,
-				34ACAB522C142A0400F871A0 /* libjxl_threads.0.10.dylib */,
-				34ACAB3E2C142A0300F871A0 /* libjxl.0.10.dylib */,
+				34ACAB652C142A0400F871A0 /* libjpeg.62.dylib */,
+				34ACAB6E2C142A0500F871A0 /* libjxl_cms.0.11.dylib */,
+				34ACAB522C142A0400F871A0 /* libjxl_threads.0.11.dylib */,
+				34ACAB3E2C142A0300F871A0 /* libjxl.0.11.dylib */,
 				34ACAB2F2C142A0300F871A0 /* liblcms2.2.dylib */,
 				34ACAB3A2C142A0300F871A0 /* libluajit-5.1.2.dylib */,
 				34ACAB362C142A0300F871A0 /* liblz4.1.dylib */,
@@ -2311,10 +2306,9 @@
 				34ACAB672C142A0500F871A0 /* libnettle.8.dylib */,
 				34ACAB302C142A0300F871A0 /* libp11-kit.0.dylib */,
 				34ACAB4C2C142A0400F871A0 /* libpcre2-8.0.dylib */,
-				34ACAB5B2C142A0400F871A0 /* libplacebo.338.dylib */,
+				34ACAB5B2C142A0400F871A0 /* libplacebo.349.dylib */,
 				34ACAB532C142A0400F871A0 /* libpng16.16.dylib */,
-				34ACAB422C142A0300F871A0 /* libpostproc.58.dylib */,
-				34ACAB5F2C142A0400F871A0 /* librubberband.2.dylib */,
+				34ACAB5F2C142A0400F871A0 /* librubberband.3.dylib */,
 				34ACAB632C142A0400F871A0 /* libsamplerate.0.dylib */,
 				34ACAB342C142A0300F871A0 /* libshaderc_shared.1.dylib */,
 				34ACAB332C142A0300F871A0 /* libsharpyuv.0.dylib */,
@@ -2518,7 +2512,7 @@
 			path = libavcodec;
 			sourceTree = "<group>";
 		};
-		84BC78661EEECBE30068BF17 /* libavformat */ = {
+		84BC78661EEECBE30068BF17 /* libavformat.61 */ = {
 			isa = PBXGroup;
 			children = (
 				34ACAC162C142C7100F871A0 /* avformat.h */,
@@ -2526,7 +2520,7 @@
 				34ACAC152C142C7100F871A0 /* version_major.h */,
 				34ACAC142C142C7100F871A0 /* version.h */,
 			);
-			path = libavformat;
+			path = libavformat.61;
 			sourceTree = "<group>";
 		};
 		84BC786D1EEECBE30068BF17 /* libavutil */ = {
@@ -2700,7 +2694,7 @@
 			isa = PBXGroup;
 			children = (
 				84BC784B1EEECBE30068BF17 /* libavcodec */,
-				84BC78661EEECBE30068BF17 /* libavformat */,
+				84BC78661EEECBE30068BF17 /* libavformat.61 */,
 				84BC786D1EEECBE30068BF17 /* libavutil */,
 				84BC78C01EEECBE30068BF17 /* libswscale */,
 				84FF846F1D2FF698001B318A /* mpv */,

--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -168,8 +168,6 @@
 		512B8FDD2BC2376E00AF41BF /* OutlineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 512B8FDC2BC2376E00AF41BF /* OutlineView.swift */; };
 		513A4FFA29B53F8100A8EA7D /* Atomic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 513A4FF929B53F8100A8EA7D /* Atomic.swift */; };
 		515B5E5A2A579903001FCD49 /* iina-plugin in Copy Executables */ = {isa = PBXBuildFile; fileRef = E38558872A484A2D0083772D /* iina-plugin */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		518376DD2C23DD2300574F00 /* libgcc_s.1.1.dylib in Copy Dylibs */ = {isa = PBXBuildFile; fileRef = 518376D92C23DB1400574F00 /* libgcc_s.1.1.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
-		518376DE2C23DD2300574F00 /* libstdc++.6.dylib in Copy Dylibs */ = {isa = PBXBuildFile; fileRef = 518376DB2C23DB2F00574F00 /* libstdc++.6.dylib */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		51854CDA2A1C489300C40B78 /* FFmpegLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51854CD92A1C489300C40B78 /* FFmpegLogger.swift */; };
 		5196819A29EC963F00B05D55 /* CoreDisplay.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5196819929EC963F00B05D55 /* CoreDisplay.framework */; };
 		519872FF26879B9B00F84BCC /* AccessibilityPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519872FE26879B9B00F84BCC /* AccessibilityPreferences.swift */; };
@@ -454,8 +452,6 @@
 			dstPath = "";
 			dstSubfolderSpec = 10;
 			files = (
-				518376DD2C23DD2300574F00 /* libgcc_s.1.1.dylib in Copy Dylibs */,
-				518376DE2C23DD2300574F00 /* libstdc++.6.dylib in Copy Dylibs */,
 				34ACABB72C142A0C00F871A0 /* libarchive.13.dylib in Copy Dylibs */,
 				34ACABB82C142A0C00F871A0 /* libass.9.dylib in Copy Dylibs */,
 				34ACABB92C142A0C00F871A0 /* libavcodec.61.dylib in Copy Dylibs */,
@@ -1202,8 +1198,6 @@
 		513A4FF929B53F8100A8EA7D /* Atomic.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Atomic.swift; sourceTree = "<group>"; };
 		51537C7229FA26DD00F9A472 /* Nightly.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Nightly.xcconfig; sourceTree = "<group>"; };
 		515B5E592A579782001FCD49 /* iina-plugin.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "iina-plugin.xcconfig"; sourceTree = "<group>"; };
-		518376D92C23DB1400574F00 /* libgcc_s.1.1.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libgcc_s.1.1.dylib; path = deps/lib/libgcc_s.1.1.dylib; sourceTree = "<group>"; };
-		518376DB2C23DB2F00574F00 /* libstdc++.6.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = "libstdc++.6.dylib"; path = "deps/lib/libstdc++.6.dylib"; sourceTree = "<group>"; };
 		51854CD92A1C489300C40B78 /* FFmpegLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FFmpegLogger.swift; sourceTree = "<group>"; };
 		5196819929EC963F00B05D55 /* CoreDisplay.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreDisplay.framework; path = /System/Library/Frameworks/CoreDisplay.framework; sourceTree = "<group>"; };
 		519872FE26879B9B00F84BCC /* AccessibilityPreferences.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AccessibilityPreferences.swift; sourceTree = "<group>"; };
@@ -2295,7 +2289,6 @@
 				34ACAB452C142A0300F871A0 /* libfontconfig.1.dylib */,
 				34ACAB6D2C142A0500F871A0 /* libfreetype.6.dylib */,
 				34ACAB3B2C142A0300F871A0 /* libfribidi.0.dylib */,
-				518376D92C23DB1400574F00 /* libgcc_s.1.1.dylib */,
 				34ACAB4F2C142A0400F871A0 /* libglib-2.0.0.dylib */,
 				34ACAB6B2C142A0500F871A0 /* libgmp.10.dylib */,
 				34ACAB312C142A0300F871A0 /* libgnutls.30.dylib */,
@@ -2329,7 +2322,6 @@
 				34ACAB622C142A0400F871A0 /* libsodium.26.dylib */,
 				34ACAB5E2C142A0400F871A0 /* libsoxr.0.dylib */,
 				34ACAB702C142A0500F871A0 /* libspeex.1.dylib */,
-				518376DB2C23DB2F00574F00 /* libstdc++.6.dylib */,
 				34ACAB6C2C142A0500F871A0 /* libswresample.5.dylib */,
 				34ACAB432C142A0300F871A0 /* libswscale.8.dylib */,
 				34ACAB4D2C142A0400F871A0 /* libtasn1.6.dylib */,

--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -173,6 +173,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
   // MARK: - App Delegate
 
   func applicationWillFinishLaunching(_ notification: Notification) {
+    // Must expand before mpv initialization since it may depend on proper paths in env vars
+    expandAppEnvironmentVariables()
+
     // Must setup preferences before logging so log level is set correctly.
     registerUserDefaultValues()
 
@@ -403,6 +406,27 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     NSApplication.shared.servicesProvider = self
 
     AppDelegate.shared.menuController?.updatePluginMenu()
+  }
+
+  func expandAppEnvironmentVariables() {
+    guard let executablePath = Bundle.main.executablePath else { return }
+    let executableDir = URL(fileURLWithPath: executablePath).deletingLastPathComponent()
+    let bundleDir = URL(fileURLWithPath: Bundle.main.bundlePath)
+    let contentsDir = bundleDir.appendingPathComponent("Contents")
+    let resourcesDir = Bundle.main.resourceURL!
+
+    for (key, value) in ProcessInfo.processInfo.environment {
+      setenv(
+        key,
+        value
+          .replacingOccurrences(of: "@executable_path", with: executableDir.path)
+          .replacingOccurrences(of: "@loader_path", with: executableDir.path)
+          .replacingOccurrences(of: "@bundle_path", with: bundleDir.path)
+          .replacingOccurrences(of: "@contents_path", with: contentsDir.path)
+          .replacingOccurrences(of: "@resources_path", with: resourcesDir.path),
+        1
+      )
+    }
   }
 
   /** Show welcome window if `application(_:openFile:)` wasn't called, i.e. launched normally. */

--- a/nix/scripts/canonicalize-lib-groups.nix
+++ b/nix/scripts/canonicalize-lib-groups.nix
@@ -1,0 +1,53 @@
+{ pkgs }:
+
+pkgs.writeShellApplication {
+  name = "iina-canonicalize-lib-groups";
+  runtimeInputs = [
+    pkgs.findutils
+    pkgs.coreutils
+    pkgs.gawk
+  ];
+  text = ''
+    set -euo pipefail
+
+    frameworks="$1/Contents/Frameworks"
+
+    # Build the index in memory: each line is "STEM \t VERSION \t BASENAME"
+    lines="$(
+      find "$frameworks" -maxdepth 1 \( -type f -o -type l \) -name 'lib*.dylib' | while read -r dep; do
+        base="$(basename "$dep")"
+        if [[ "$base" =~ ^(lib[^.]+)\.([0-9]+(\.[0-9]+)*)\.dylib$ ]]; then
+          printf '%s\t%s\t%s\n' "''${BASH_REMATCH[1]}" "''${BASH_REMATCH[2]}" "$base"
+        elif [[ "$base" =~ ^(lib[^.]+)\.dylib$ ]]; then
+          printf '%s\tUNVER\t%s\n' "''${BASH_REMATCH[1]}" "$base"
+        fi
+      done
+    )"
+
+    # For each STEM, pick highest VERSION as canonical; relink others to it
+    printf '%s\n' "$lines" | cut -f1 | sort -u | while read -r stem; do
+      canon="$(
+        printf '%s\n' "$lines" | awk -F'\t' -v s="$stem" '$1==s && $2!="UNVER"{print $2"\t"$3}' \
+          | ${pkgs.coreutils}/bin/sort -V | tail -n1 | cut -f2
+      )"
+
+      # If no versioned file exists, fall back to unversioned
+      if [ -z "$canon" ]; then
+        canon="$(printf '%s\n' "$lines" | awk -F'\t' -v s="$stem" '$1==s && $2=="UNVER"{print $3}' | head -n1)"
+      fi
+      [ -n "$canon" ] || continue
+
+      # Relink every other alias in the group to canonical (relative link)
+      (
+        cd "$frameworks"
+        printf '%s\n' "$lines" | awk -F'\t' -v s="$stem" '$1==s{print $3}' | while read -r alias; do
+          [ "$alias" = "$canon" ] && continue
+          rm -f -- "$alias"
+          ln -s -- "$canon" "$alias"
+        done
+      )
+    done
+
+    echo "✅ Canonicalized lib groups under $frameworks"
+  '';
+}

--- a/nix/scripts/normalizer.nix
+++ b/nix/scripts/normalizer.nix
@@ -1,0 +1,189 @@
+{ pkgs }:
+
+pkgs.writeShellApplication {
+  name = "iina-normalize-app";
+  runtimeInputs = [
+    pkgs.coreutils
+    pkgs.findutils
+    pkgs.gawk
+    pkgs.gnugrep
+    pkgs.file
+  ];
+  text = ''
+    set -euo pipefail
+
+    if [[ $# -lt 1 ]]; then
+      echo "usage: iina-normalize-app /path/to/IINA.app" >&2
+      exit 2
+    fi
+
+    app="$1"
+    frameworks="$app/Contents/Frameworks"
+
+    echo "🔧 iina-normalize-app: normalizing $app"
+    mkdir -p "$frameworks"
+
+    echo "📝 Making app contents writable"
+    find "$app" -type d -exec chmod u+rwx {} \;
+    find "$app" -type f -exec chmod u+rw  {} \;
+
+    # ✏️ Helpers
+    is_macho() {
+      # true for thin/fat Mach-O; false for scripts/text
+      file -b "$1" 2>/dev/null | grep -Eq 'Mach-O (universal binary|64-bit|arm64|x86_64)'
+    }
+
+    ensure_writable() { chmod u+rw "$1" 2>/dev/null || true; }
+
+    ensure_rpath() {
+      local f="$1"
+
+      if ! is_macho "$f"; then
+        echo "🧾 Non-Mach-O, skipping rpath: $f"
+        return
+      fi
+
+      if otool -l "$f" | grep -q '@executable_path/../Frameworks'; then
+        echo "✅ LC_RPATH present → $f"
+        return
+      fi
+      
+      echo "➕ LC_RPATH @executable_path/../Frameworks → $f"
+      install_name_tool -add_rpath "@executable_path/../Frameworks" "$f" || true
+    }
+
+    rewrite_deps_to_rpath() {
+      local bin="$1"
+
+      if ! is_macho "$bin"; then
+        echo "🧾 Non-Mach-O, skipping dep rewrite: $bin"
+        return
+      fi
+
+      echo "✏️ Rewriting deps → @rpath for: $bin"
+
+      # /nix/store/* → @rpath/<basename>
+      otool -L "$bin" | awk '/\/nix\/store/ && $1 !~ /:$/ {print $1}' | while read -r abs; do
+        local base
+        base=$(basename "$abs")
+        echo "  🔁 /nix/store → @rpath: $abs → @rpath/$base"
+        install_name_tool -change "$abs" "@rpath/$base" "$bin" || true
+      done
+
+      # bare dylibs (no /, no @) → @rpath/<basename>
+      otool -L "$bin" | awk 'NF && $1 !~ /:$/ && $1 ~ /^[^/@][^/]*\.dylib$/ {print $1}' | while read -r bare; do
+        local base
+        base=$(basename "$bare")
+        echo "  🔁 bare → @rpath: $bare → @rpath/$base"
+        install_name_tool -change "$bare" "@rpath/$base" "$bin" || true
+      done
+    }
+
+    declare -Ag BUNDLED_DEPS=()
+
+    bundle_dep() {
+      local dep="$1"   # path as found in otool -L (may be libbs2b.0.dylib)
+
+      # Canonical path for cycle detection
+      local dep_real
+      dep_real=$(realpath "$dep" 2>/dev/null || echo "$dep")
+
+      # Break cycles by *real* path
+      if [[ -n "''${BUNDLED_DEPS["$dep_real"]:-}" ]]; then
+        echo "🔁 Already processed dep: $dep_real"
+        return
+      fi
+      BUNDLED_DEPS["$dep_real"]=1
+
+      local request_base
+      request_base=$(basename "$dep")
+      local real_base
+      real_base=$(basename "$dep_real")
+      local dest="$frameworks/$request_base"
+
+      if [[ "$dep_real" == /usr/lib/* ]] || [[ "$dep_real" == /System/* ]] || [[ "$real_base" == libffi-trampoline.dylib ]]; then
+        echo "🚫 Skipping system/non-target dep: $dep_real"
+        return
+      fi
+
+      if [ ! -f "$dep_real" ]; then
+        echo "⚠️  Dep missing on disk, skipping: $dep_real"
+        return
+      fi
+
+      # Ensure the real payload file exists in Frameworks under some canonical name
+      local canonical="$frameworks/$real_base"
+      if [ ! -f "$canonical" ]; then
+        echo "📥 Copying dep → Frameworks: $dep_real → $canonical"
+        cp -L -p "$dep_real" "$canonical" || { echo "❌ Copy failed for $dep_real"; return; }
+      fi
+
+      # Ensure the *requested* name exists and points to the payload
+      if [ ! -e "$dest" ]; then
+        echo "🔗 Copying $canonical → $dest"
+        cp -L -p "$canonical" "$dest"
+      else
+        echo "✏️ Normalizing already-bundled dep alias: $request_base"
+      fi
+
+      ensure_writable "$canonical"
+
+      if ! is_macho "$canonical"; then
+        echo "🧾 Non-Mach-O dep (no patching): $real_base"
+        return
+      fi
+
+      echo "✏️ Setting install_name id on $real_base"
+      install_name_tool -id "@rpath/$request_base" "$canonical" || true
+
+      ensure_rpath "$canonical"
+      rewrite_deps_to_rpath "$canonical"
+
+      # Recurse into transitive deps based on their /nix/store path
+      otool -L "$canonical" | awk 'NF && $1 !~ /:$/ {print $1}' | while read -r sub; do
+        case "$sub" in
+          /nix/store/*)
+            local subbase
+            subbase=$(basename "$sub")
+            echo "  🔗 Repointing subdep for $real_base: $sub → @rpath/$subbase"
+            install_name_tool -change "$sub" "@rpath/$subbase" "$canonical" || true
+            bundle_dep "$sub"
+            ;;
+          *) : ;;
+        esac
+      done
+    }
+
+    export -f ensure_writable ensure_rpath rewrite_deps_to_rpath bundle_dep
+
+    echo "🔍 Scanning app for dylib + executable dependencies…"
+
+    # executables + loadable libs
+    find "$app" -type f \( -perm -111 -o -name "*.dylib" -o -name "*.so" \) | while read -r bin; do
+      echo "———"
+      echo "🔍 Inspecting: $bin"
+      ensure_writable "$bin"
+      ensure_rpath "$bin"
+
+      if ! is_macho "$bin"; then
+        echo "🧾 Non-Mach-O target has no dylib deps to bundle"
+        continue
+      fi
+
+      # bundle remaining absolute /nix/store deps
+      otool -L "$bin" | awk 'NF && $1 !~ /:$/ {print $1}' | while read -r dep; do
+        case "$dep" in
+          /nix/store/*)
+            echo "  📦 Bundling needed dep for $bin: $dep"
+            bundle_dep "$dep"
+            ;;
+          *) : ;;
+        esac
+      done
+
+      rewrite_deps_to_rpath "$bin"
+    done
+
+    echo "✅ Normalization complete"
+  '';
+}

--- a/nix/scripts/resign.nix
+++ b/nix/scripts/resign.nix
@@ -1,0 +1,16 @@
+{ pkgs }:
+
+pkgs.writeShellApplication {
+  name = "iina-resign";
+  runtimeInputs = [ pkgs.findutils pkgs.coreutils ];
+  text = ''
+    set -euo pipefail
+    app="$1"
+
+    find "$app" -type d -exec chmod u+rwx {} \;
+    find "$app" -type f -exec chmod u+rw  {} \;
+    find "$app/Contents/MacOS" -type f -perm -111 -exec chmod u+rw {} \;
+
+    /usr/bin/codesign --force --deep --sign - "$app"
+  '';
+}


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #3210 #5443.

---

**Description:**

This pull request implements new build process for the IINA using nix to achieve the following goals:

1. Add vapoursynth support – #3210
2. Enhance plugin development experience – #5443
3. Simplify the build process by describing it in a single `flake.nix` file
4. Make builds (semi-)reproducible by depending only on host's Xcode and commonly available libraries from `nixpkgs` rather than custom-managed IINA dependencies to simplify maintenance.
    Please note that overriding the dependencies to suite custom needs of IINA team that the PR's author wasn't aware of should be possible by modifying `flake.nix`
5. Keep to the macOS ideology of self-contained `.app`s

## General build strategy

To ease the review and (hopefully) further collaboration on this, I include this description of the build process:

For all supported systems (defined in `outputs.systems`):

1. Build custom `ffmpeg`
2. Build custom `mpv`
3. Gather the external dependencies in `depsInc`, `depsLib`, `depsIndirect`, `depsExecutable`
4. Fetch `SwiftPM` packages into seprate derivation to cache that step
5. Build `IINA.app` for that platform:
    1. Copy `depsInc` and `depsLib` as per readme.md
    2. Rewrite their rpaths for proper linkage
    3. Run `xcodebuild`
6. Patch the resulting `IINA.app` to:
    1. Include `depsIndirect`
    2. Copy recursively other dependencies from `/nix/store` that might be referenced 
    3. Package `python3` and `vapoursynth`'s `site-packages`
    4. Rewrite rpaths for proper loading at runtime so the `.app` remains self-contained
    5. Restore symlinks across `dylib`'s versions
    6. Add necessary environment variables as `LSEnvironment` entries into `Info.plist`
    7. Codesign the resulting `IINA.app`
8. Stich the builds for each platform into universal app using `lipo` and also
    1. Ensure rpaths for proper loading at runtime so the `.app` remains self-contained
    2. Restore symlinks across `dylib`'s versions
    3. Codesign the resulting `IINA.app`

## Testing

The resulting universal build was tested on:

1. M4 Max machine
2. M4 Pro machine
3. Intel-based machine

The testing strategy included the following:

1. Running `IINA.app`
2. Playing h264 and av1 videos as is.
3. Exposing `/tmp/iinasocket` to test SVP integration

While this strategy is very barebones, no issues were found.

## Running the build

To run the build:

1. Ensure `nix` is installed on your system
2. Run `nix build` in the repository root
3. This will produce symlinked `result` directory to the universal binary

## Vapoursynth support

As far as I understand from #3210 the main challenge of supporting `vapoursynth` was the packaging of `python3` as it is required by `vapoursynth`.

While solving it I've discovered that `vapoursynth` requires for some environment variables to be set to function properly. To do this at a packaging stage outside of Xcode the following solution was implemented:

1. Bundle everything using `nix`
2. Write the variables as `LSEnvironment` entries into `Info.plist`
3. Expand the paths on application start to keep the `.app` properly self-contained.

## Enhancing plugin development experience by bundling of `ffmpeg`, `mpv` and `python3` executables

While gathering information on `vapoursynth` support I've also came across #5443, and decided to implement it since the proposed solution already includes libraries required by these tools, so overall bundle size impact is negligible.

## Other modifications

While implementing it, I've disabled linking against `libgcc_s.1.1` and `libstdc++.6` on x86 platforms since it seems these are unnecessary.

## Other considerations

1. SVP Support – If we make `/tmp/iinasocket` available by default, IINA will support tools like SVP out-of-the box.
2. Build size – the build size was noticeably increased from ~160mb to ~500mb, as far as I understand major contributor to it might be ffmpeg, since I didn't strip it down as was mentioned in #5443. Do we need to address that?
3. `.xcconfig` support – currently the build is done using Release configuration. Should we expose it as a parameter?
4. Potential redundancy in the Xcode build pipeline – since the proposed solution does some of the dylib packaging by itself, do we need to keep copying from `deps/lib` in the Xcode build pipeline
5. Proper code signing support – We may want to implement non-adhoc codesigning to enable this solution to be used for releasing IINA to the AppStore.
6. Fixing compatibility step in the platform IINA build – I wasn't able to figure out why Xcode wants to link against these specific versions, since other packages shouldn't depend on it. As a workaround these libraries are simply copied.
7. `libc++` linkage – as far as I understand, `libc++` is provided by macOS, but I chose to link against `nix`-provided `libc++`. Do we need to link agains macOS-provided version explicitly

## Resulting build (not an official IINA build)

I would also like to include resulting build for those willing to try it.
Please understand this is **not an official build** done by IINA team.
If you encounter any problems, it is very likely IINA team has nothing to do with them, so please don't open issues in the IINA repo. If you would like to provide feedback, do it here as a comment.

Also note that the build needs to be signed on your machine to run: `sudo /usr/bin/codesign --force --deep --sign - path/to/IINA.app`.

[Download link](https://filebin.net/arx7us0fo5rduw0a)

PS

I'm not very familiar with the development of native macOS apps, so please consider this PR as a proof-of-concept rather than production-ready solution. I would very much like to collaborate on this with IINA team to achieve the goals stated at the beginning.