### PR TITLE
(re)name bundled `yt-dlp` as `iina-ytdl` instead of `youtube-dl`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,6 @@ browser/Firefox_Open_In_IINA/*
 *.xcarchive
 /.vscode
 
-deps/executable/youtube-dl
+deps/executable/iina-ytdl
 deps/plugins
 

--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -231,7 +231,7 @@
 		845FB0C71D39462E00C011E0 /* ControlBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845FB0C61D39462E00C011E0 /* ControlBarView.swift */; };
 		8460FBA91D6497490081841B /* PlaylistViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8460FBA71D6497490081841B /* PlaylistViewController.swift */; };
 		846121BD1F35FCA500ABB39C /* DraggingDetect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846121BC1F35FCA500ABB39C /* DraggingDetect.swift */; };
-		8461BA681E4237C7008BB852 /* youtube-dl in Copy Executables */ = {isa = PBXBuildFile; fileRef = 8461BA671E4237C2008BB852 /* youtube-dl */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
+		8461BA681E4237C7008BB852 /* iina-ytdl in Copy Executables */ = {isa = PBXBuildFile; fileRef = 8461BA671E4237C2008BB852 /* iina-ytdl */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		8461C52E1D45FFF6006E91FF /* PlaySliderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8461C52D1D45FFF6006E91FF /* PlaySliderCell.swift */; };
 		8461C5301D462488006E91FF /* VideoTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8461C52F1D462488006E91FF /* VideoTime.swift */; };
 		846352581EEEE11A0043F0CC /* ThumbnailPeekView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846352571EEEE11A0043F0CC /* ThumbnailPeekView.swift */; };
@@ -443,7 +443,7 @@
 			files = (
 				E3DE8DD31FD848BA0021921C /* iina-cli in Copy Executables */,
 				515B5E5A2A579903001FCD49 /* iina-plugin in Copy Executables */,
-				8461BA681E4237C7008BB852 /* youtube-dl in Copy Executables */,
+				8461BA681E4237C7008BB852 /* iina-ytdl in Copy Executables */,
 			);
 			name = "Copy Executables";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -1431,7 +1431,7 @@
 		845FB0C61D39462E00C011E0 /* ControlBarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ControlBarView.swift; sourceTree = "<group>"; };
 		8460FBA71D6497490081841B /* PlaylistViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaylistViewController.swift; sourceTree = "<group>"; };
 		846121BC1F35FCA500ABB39C /* DraggingDetect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraggingDetect.swift; sourceTree = "<group>"; };
-		8461BA671E4237C2008BB852 /* youtube-dl */ = {isa = PBXFileReference; lastKnownFileType = text; name = "youtube-dl"; path = "deps/executable/iina-ytdl"; sourceTree = SOURCE_ROOT; };
+		8461BA671E4237C2008BB852 /* iina-ytdl */ = {isa = PBXFileReference; lastKnownFileType = text; name = "iina-ytdl"; path = "deps/executable/iina-ytdl"; sourceTree = SOURCE_ROOT; };
 		8461C52D1D45FFF6006E91FF /* PlaySliderCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaySliderCell.swift; sourceTree = "<group>"; };
 		8461C52F1D462488006E91FF /* VideoTime.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoTime.swift; sourceTree = "<group>"; };
 		846352571EEEE11A0043F0CC /* ThumbnailPeekView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThumbnailPeekView.swift; sourceTree = "<group>"; };
@@ -2259,7 +2259,7 @@
 		8461BA641E42344D008BB852 /* Executables */ = {
 			isa = PBXGroup;
 			children = (
-				8461BA671E4237C2008BB852 /* youtube-dl */,
+				8461BA671E4237C2008BB852 /* iina-ytdl */,
 			);
 			name = Executables;
 			path = iina;

--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -1431,7 +1431,7 @@
 		845FB0C61D39462E00C011E0 /* ControlBarView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ControlBarView.swift; sourceTree = "<group>"; };
 		8460FBA71D6497490081841B /* PlaylistViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaylistViewController.swift; sourceTree = "<group>"; };
 		846121BC1F35FCA500ABB39C /* DraggingDetect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraggingDetect.swift; sourceTree = "<group>"; };
-		8461BA671E4237C2008BB852 /* youtube-dl */ = {isa = PBXFileReference; lastKnownFileType = text; name = "youtube-dl"; path = "deps/executable/youtube-dl"; sourceTree = SOURCE_ROOT; };
+		8461BA671E4237C2008BB852 /* youtube-dl */ = {isa = PBXFileReference; lastKnownFileType = text; name = "youtube-dl"; path = "deps/executable/iina-ytdl"; sourceTree = SOURCE_ROOT; };
 		8461C52D1D45FFF6006E91FF /* PlaySliderCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaySliderCell.swift; sourceTree = "<group>"; };
 		8461C52F1D462488006E91FF /* VideoTime.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoTime.swift; sourceTree = "<group>"; };
 		846352571EEEE11A0043F0CC /* ThumbnailPeekView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThumbnailPeekView.swift; sourceTree = "<group>"; };

--- a/iina/AppData.swift
+++ b/iina/AppData.swift
@@ -56,7 +56,7 @@ struct AppData {
   static let crowdinMembersLink = "https://crowdin.com/project/iina"
   static let wikiLink = "https://github.com/iina/iina/wiki"
   static let websiteLink = "https://iina.io"
-  static let ytdlHelpLink = "https://github.com/rg3/youtube-dl/blob/master/README.md#readme"
+  static let ytdlHelpLink = "https://github.com/yt-dlp/yt-dlp#usage-and-options"
   static let appcastLink = "https://www.iina.io/appcast.xml"
   static let appcastBetaLink = "https://www.iina.io/appcast-beta.xml"
   static let assrtRegisterLink = "https://secure.assrt.net/user/register.xml?redir=http%3A%2F%2Fassrt.net%2Fusercp.php"

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -176,7 +176,7 @@
 "preference.sub_override_level.descriptive_text.yes" = "Apply all the style settings in this section.";
 
 "preference.ytdl_plugin_not_installed" = "Install the Online Media plugin from \"Plugins > Install from GitHub\" to enjoy advanced features such and video downloading and auto yt-dlp updates.";
-"preference.ytdl_plugin_installed" = "The built-in youtube-dl support is disabled since you have the Online media plugin installed.";
+"preference.ytdl_plugin_installed" = "The built-in yt-dl support is disabled since you have the Online media plugin installed.";
 
 "menu.volume" = "Volume: %@";
 "menu.volume_muted" = "Volume: %@ (Muted)";

--- a/iina/Base.lproj/PrefNetworkViewController.xib
+++ b/iina/Base.lproj/PrefNetworkViewController.xib
@@ -303,12 +303,12 @@
             </constraints>
             <point key="canvasLocation" x="-385" y="470.5"/>
         </customView>
-        <customView translatesAutoresizingMaskIntoConstraints="NO" id="GHK-tq-Ssh" userLabel="Prefs &gt; Network &gt; youtube-dl">
+        <customView translatesAutoresizingMaskIntoConstraints="NO" id="GHK-tq-Ssh" userLabel="Prefs &gt; Network &gt; ytdl">
             <rect key="frame" x="0.0" y="0.0" width="480" height="152"/>
             <subviews>
                 <textField identifier="SectionTitleYtdl" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="mRg-vm-guk">
                     <rect key="frame" x="-2" y="128" width="80" height="16"/>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="youtube-dl:" id="1Ex-0X-pjo">
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="ytdl:" id="1Ex-0X-pjo">
                         <font key="font" metaFont="systemBold"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -335,7 +335,7 @@
                 </textField>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="iwI-aJ-5PQ">
                     <rect key="frame" x="118" y="127" width="137" height="18"/>
-                    <buttonCell key="cell" type="check" title="Enable youtube-dl" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="cyH-Md-FAD">
+                    <buttonCell key="cell" type="check" title="Enable ytdl" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="cyH-Md-FAD">
                         <behavior key="behavior" changeContents="YES" doesNotDimImage="YES" lightByContents="YES"/>
                         <font key="font" metaFont="system"/>
                     </buttonCell>
@@ -367,7 +367,7 @@
                 </textField>
                 <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="aSG-qR-qgc">
                     <rect key="frame" x="118" y="74" width="156" height="16"/>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Custom youtube-dl path:" id="2qf-cC-Lfi">
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Custom ytdl path:" id="2qf-cC-Lfi">
                         <font key="font" metaFont="system"/>
                         <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -398,7 +398,7 @@
                     <constraints>
                         <constraint firstAttribute="height" constant="14" id="74z-l3-NRT"/>
                     </constraints>
-                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="IINA will search youtube-dl in this folder. Restart needed." id="YqE-yV-BvQ">
+                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="IINA will search ytdl in this folder. Restart needed." id="YqE-yV-BvQ">
                         <font key="font" metaFont="message" size="11"/>
                         <color key="textColor" name="disabledControlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>

--- a/iina/Base.lproj/PrefUtilsViewController.xib
+++ b/iina/Base.lproj/PrefUtilsViewController.xib
@@ -285,7 +285,7 @@
                 </button>
                 <textField focusRingType="none" verticalHuggingPriority="750" horizontalCompressionResistancePriority="250" translatesAutoresizingMaskIntoConstraints="NO" id="DZn-sK-pTY">
                     <rect key="frame" x="-2" y="34" width="424" height="28"/>
-                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Open links or current webpage in IINA with one click. The website must be supported by youtube-dl." id="GAo-fx-NG0">
+                    <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Open links or current webpage in IINA with one click. The website must be supported by ytdl." id="GAo-fx-NG0">
                         <font key="font" metaFont="smallSystem"/>
                         <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -539,6 +539,7 @@ class MPVController: NSObject {
     }
     setUserOption(PK.ytdlRawOptions, type: .string, forName: MPVOption.ProgramBehavior.ytdlRawOptions,
                   verboseIfDefault: true)
+    chkErr(setOptionString(MPVOption.ProgramBehavior.scriptOpts, "ytdl_hook-ytdl_path=iina-ytdl", level: .verbose))
     chkErr(setOptionString(MPVOption.ProgramBehavior.resetOnNextFile,
             "\(MPVOption.PlaybackControl.abLoopA),\(MPVOption.PlaybackControl.abLoopB)", level: .verbose))
 

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -561,7 +561,7 @@ class PlayerCore: NSObject {
   }
 
   func startMPV() {
-    // set path for youtube-dl
+    // set path for ytdl
     let oldPath = String(cString: getenv("PATH")!)
     var path = Utility.exeDirURL.path + ":" + oldPath
     if let customYtdlPath = Preference.string(for: .ytdlSearchPath), !customYtdlPath.isEmpty {

--- a/other/download_libs.sh
+++ b/other/download_libs.sh
@@ -5,13 +5,10 @@ PROJECT_NAME='iina'
 # universal | arm64 | x86_64
 ARCH="universal"
 # github | iina (use iina to get the binary included in the latest release)
-YT_DLP_SOURCE="github"
-
-DYLIBS_DOWNLOAD_PATH="https://iina.io/dylibs/${ARCH}"
-YT_DLP_DOWNLOAD_PATH="https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos"
+YTDL_SOURCE="github"
 
 # Reset in case getopts has been used previously in the shell.
-if ! OPTS=$(getopt -o "h": --long "arch:,yt-dlp-src,help": -n 'parse-options' -- "$@"); then
+if ! OPTS=$(getopt -o "h": --long "arch:,ytdl-src,help": -n 'parse-options' -- "$@"); then
   echo "Failed parsing options." >&2
   exit 1
 fi
@@ -21,7 +18,7 @@ printUsageHelp() {
   echo "Usage:"
   echo "    $0 [-h|--help]:           Displays this help message"
   echo "    $0 [--arch] <ARCH>:       Architecture to download dylibs for: universal | arm64 | x86_64"
-  echo "    $0 [--yt-dlp-src] <SRC>:  Source to download youtube-dl from: github | iina"
+  echo "    $0 [--ytdl-src] <SRC>:  Source to download ytdl from: github | iina"
   echo
 }
 
@@ -53,13 +50,13 @@ while true; do
     ARCH=$2
     shift 2
     ;;
-  --yt-dlp-src)
+  --ytdl-src)
     if [[ -z "$2" ]]; then
-      echo "You need to specify a source when using --yt-dlp-src"
+      echo "You need to specify a source when using --ytdl-src"
       printUsageHelp
       exit 1
     fi
-    YT_DLP_SOURCE=$2
+    YTDL_SOURCE=$2
     shift 2
     ;;
   --)
@@ -70,15 +67,15 @@ while true; do
   esac
 done
 
-case $YT_DLP_SOURCE in
+case $YTDL_SOURCE in
 github)
-  YT_DLP_DOWNLOAD_PATH="https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos"
+  YTDL_DOWNLOAD_PATH="https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos"
   ;;
 iina)
-  YT_DLP_DOWNLOAD_PATH="https://iina.io/dylibs/youtube-dl"
+  YTDL_DOWNLOAD_PATH="https://iina.io/dylibs/youtube-dl"
   ;;
 *)
-  echo "Invalid youtube-dl source: $YT_DLP_SOURCE"
+  echo "Invalid ytdl source: $YTDL_SOURCE"
   printUsageHelp
   exit 1
   ;;
@@ -111,7 +108,7 @@ fi
 DEPS_PATH="$ROOT_PATH/deps"
 LIB_PATH="$DEPS_PATH/lib"
 EXEC_PATH="$DEPS_PATH/executable"
-YT_DLP_PATH="$EXEC_PATH/iina-ytdl"
+YTDL_PATH="$EXEC_PATH/iina-ytdl"
 
 IFS=$'\n' read -r -d '' -a files < <(curl "${DYLIBS_DOWNLOAD_PATH}/filelist.txt" && printf '\0')
 
@@ -124,5 +121,5 @@ for FILE in "${files[@]}"; do
 done
 
 mkdir -p "$EXEC_PATH"
-curl -L "$YT_DLP_DOWNLOAD_PATH" -o "$YT_DLP_PATH"
-chmod +x "$YT_DLP_PATH"
+curl -L "$YTDL_DOWNLOAD_PATH" -o "$YTDL_PATH"
+chmod +x "$YTDL_PATH"

--- a/other/download_libs.sh
+++ b/other/download_libs.sh
@@ -111,7 +111,7 @@ fi
 DEPS_PATH="$ROOT_PATH/deps"
 LIB_PATH="$DEPS_PATH/lib"
 EXEC_PATH="$DEPS_PATH/executable"
-YT_DLP_PATH="$EXEC_PATH/youtube-dl"
+YT_DLP_PATH="$EXEC_PATH/iina-ytdl"
 
 IFS=$'\n' read -r -d '' -a files < <(curl "${DYLIBS_DOWNLOAD_PATH}/filelist.txt" && printf '\0')
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
I am working on the official IINA plugin `Online Media` and found out that there's no way in the plugin API to distinguish between executables having the same name on the system `$PATH` and IINA's executable directory - in my case - it is `youtube-dl`.

The `JavascriptAPIUtils.findInPath` searches in, both, system `$PATH` and IINA's executable directory (`IINA.app/Contents/MacOS/`).

More than overcoming this limitation of the API, I think prefixing the executable name with "iina-" to give it a specialised name is a more appropriate solution.

NOTE: (I am forced to make this PR as I need this distinction for the plugin work I am doing) I don't know the Swift language, nor `libmpv`. This PR could be flat out wrong and broken, and I am extremely sorry for that if that's the case. Please bear with me.