### PR TITLE
Fix OSC top layout is misaligned, #5715

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -30,7 +30,7 @@ fileprivate let TitleBarHeightNormal: CGFloat = {
 }()
 fileprivate let TitleBarHeightWithOSC: CGFloat = TitleBarHeightNormal + 24 + 10
 fileprivate let TitleBarHeightWithOSCInFullScreen: CGFloat = 24 + 10
-fileprivate let OSCTopMainViewMarginTop: CGFloat = 26
+fileprivate let OSCTopMainViewMarginTop: CGFloat = TitleBarHeightNormal + 4
 fileprivate let OSCTopMainViewMarginTopInFullScreen: CGFloat = 6
 
 fileprivate let SettingsWidth: CGFloat = 360


### PR DESCRIPTION
This commit will change `OSCTopMainViewMarginTop` in `MainWindowController` to take into account the height of the title bar.

In macOS Big Sur Apple increased the title bar height causing the OSC to be slightly miss-aligned. In macOS Tahoe Apple has increased the title bar height even more making the miss-alignment obvious. This fix corrects the alignment when running on macOS Big Sur and later versions.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5715.

---

**Description:**
