### PR TITLE
Fix OSC button for increasing speed does not work, #5768

### DIFF
--- a/iina/PlaySlider.swift
+++ b/iina/PlaySlider.swift
@@ -95,6 +95,17 @@ final class PlaySlider: NSSlider {
 
   // MARK: - Mouse / Trackpad events
 
+  /// Informs the receiver that the user has pressed the left mouse button.
+  ///
+  /// This is a workaround for IINA issue #5768 where starting with macOS Tahoe AppKit is miss-handling mouse events in certain
+  /// circumstances. Merely adding this function solved the problem. Maybe the presence of this function prevents the use of some sort
+  /// of faulty optimization?
+  /// - Important: _DO NOT REMOVE_ this function thinking it is not needed. Read issue #5768.
+  /// - Parameter event: An object encapsulating information about the mouse-down event.
+  override func mouseDown(with event: NSEvent) {
+    super.mouseDown(with: event)
+  }
+
   /// The user is scrolling while the cursor is within the slider.
   ///
   /// With certain kinds of input devices, such as a mouse with a scroll wheel that spins freely, it is easy to accidentally move the cursor

--- a/iina/TimeLabelOverflowedStackView.swift
+++ b/iina/TimeLabelOverflowedStackView.swift
@@ -14,4 +14,14 @@ class TimeLabelOverflowedStackView: NSStackView {
     return NSEdgeInsets(top: 6, left: 0, bottom: 0, right: 0)
   }
 
+  /// Informs the receiver that the user has pressed the left mouse button.
+  ///
+  /// This is a workaround for IINA issue #5768 where starting with macOS Tahoe AppKit is miss-handling mouse events in certain
+  /// circumstances. Merely adding this function solved the problem. Maybe the presence of this function prevents the use of some sort
+  /// of faulty optimization?
+  /// - Important: _DO NOT REMOVE_ this function thinking it is not needed. Read issue #5768.
+  /// - Parameter event: An object encapsulating information about the mouse-down event.
+  override func mouseDown(with event: NSEvent) {
+    super.mouseDown(with: event)
+  }
 }


### PR DESCRIPTION
This commit will add a `mouseDown` function to the `PlaySlider` and `TimeLabelOverflowedStackView` classes that merely calls the parent class's method.

This is a workaround for an AppKit problem in macOS Tahoe related to mouse events. We do not know why this workaround works. See the issue for more discussion.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5768.

---

**Description:**
