### PR TITLE
Fix osd-status-msg rendering in lower resolution, #5782

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1627,8 +1627,10 @@ class MainWindowController: PlayerWindowController {
   func windowDidResize(_ notification: Notification) {
     guard let window = window else { return }
     
-    if case .animating(_, _, _) = fsState, player.info.state == .paused {
-      forceDraw("Window entered full screen animation while paused")
+    if case .animating(_, _, _) = fsState {
+      forceDraw("window entered full screen animation while paused")
+    } else if !videoView.videoLayer.inLiveResize {
+      forceDraw("window resized while paused")
     }
 
     // interactive mode


### PR DESCRIPTION
This commit will change `MainWindowController.windowDidResize` to force a drawing of the window unless a live resize operation is in progress.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5782.

---

**Description:**
