### PR TITLE
Auto load timecoded lyrics from LRC or metadata

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -317,6 +317,7 @@
 		B4E446F725CB54EF0069F06E /* Mustache in Frameworks */ = {isa = PBXBuildFile; productRef = B4E446F625CB54EF0069F06E /* Mustache */; };
 		B4E4470125CE3F930069F06E /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = B4E4470025CE3F930069F06E /* Sparkle */; };
 		C789872F1E34EF170005769F /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = C78987311E34EF170005769F /* InfoPlist.strings */; };
+		CE9628082EB3985000FF6CBF /* LyricsManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE9628072EB3985000FF6CBF /* LyricsManager.swift */; };
 		D17504A82918F13E005C3DD0 /* OSCToolbarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17504A72918F13E005C3DD0 /* OSCToolbarButton.swift */; };
 		D17B857B2C94C8B5002A8EDE /* movist-v2-default-input.conf in Copy Configs */ = {isa = PBXBuildFile; fileRef = D1F68E742C6ABC22003D1208 /* movist-v2-default-input.conf */; };
 		D1A4D98A2B1495270009AB4E /* LegacyMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A4D9892B1495270009AB4E /* LegacyMigration.swift */; };
@@ -1781,6 +1782,7 @@
 		C7DBA5EB1F07C5FD00C2B416 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/InitialWindowController.strings; sourceTree = "<group>"; };
 		C7DC79CE1EC63821002DE23B /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/HistoryWindowController.strings; sourceTree = "<group>"; };
 		C7E90B522087EC5700A58B6B /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/SubChooseViewController.strings; sourceTree = "<group>"; };
+		CE9628072EB3985000FF6CBF /* LyricsManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LyricsManager.swift; sourceTree = "<group>"; };
 		D17504A72918F13E005C3DD0 /* OSCToolbarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSCToolbarButton.swift; sourceTree = "<group>"; };
 		D1A4D9892B1495270009AB4E /* LegacyMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyMigration.swift; sourceTree = "<group>"; };
 		D1B4E24D2A3AFC9100E36F1D /* MiniPlayerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerWindow.swift; sourceTree = "<group>"; };
@@ -2472,6 +2474,7 @@
 				348F71952DE2A814006C587D /* MPVCommandWrappers.swift */,
 				84C6D3611EAF8D63009BF721 /* HistoryController.swift */,
 				84FBCB361EEACDDD0076C77C /* FFmpegController.h */,
+				CE9628072EB3985000FF6CBF /* LyricsManager.swift */,
 				84FBCB371EEACDDD0076C77C /* FFmpegController.m */,
 				842904E11F0EC01600478376 /* AutoFileMatcher.swift */,
 				846121BC1F35FCA500ABB39C /* DraggingDetect.swift */,
@@ -3224,6 +3227,7 @@
 				84AABE941DBFAF1A00D138FD /* FontPickerWindowController.swift in Sources */,
 				844C59E71F7C143D008D1B00 /* CacheManager.swift in Sources */,
 				E34EAA83251A36CE00057F27 /* JavascriptAPIFile.swift in Sources */,
+				CE9628082EB3985000FF6CBF /* LyricsManager.swift in Sources */,
 				E32712B024EAA14500359DAB /* ScreenshootOSDView.swift in Sources */,
 				E3BA79EE2131443A00529D99 /* OpenURLWindowController.swift in Sources */,
 				E3FF5AC02938582F0019CE45 /* JavascriptDevTool.swift in Sources */,

--- a/iina/FFmpegController.h
+++ b/iina/FFmpegController.h
@@ -66,4 +66,11 @@
 
 + (nullable NSDictionary *)probeVideoInfoForFile:(nonnull NSString *)file;
 
+/// Extract lyrics from media file metadata.
+///
+/// This method will open the file and search for lyrics in the metadata.
+/// - Parameter url: URL of the file to extract lyrics from.
+/// - Returns: The lyrics as a string, or null if no lyrics were found.
++ (nullable NSString *)extractLyricsFromURL:(nonnull NSURL *)url;
+
 @end

--- a/iina/FFmpegController.m
+++ b/iina/FFmpegController.m
@@ -809,4 +809,36 @@ return -1;\
 }
 #endif
 
+// MARK: - Extracting Lyrics
+
++ (NSString *)extractLyricsFromURL:(nonnull NSURL *)url
+{
+  AVFormatContext *pFormatCtx = NULL;
+
+  @try {
+    int ret = avformat_open_input(&pFormatCtx, url.fileSystemRepresentation, NULL, NULL);
+    if (ret < 0) {
+      LOG_ERROR(@"Failed to open file %@ when searching for lyrics: %s (%d)", url, av_err2str(ret), ret);
+      return NULL;
+    }
+
+    AVDictionary *metadata = pFormatCtx->metadata;
+    
+    AVDictionaryEntry *tag = av_dict_get(metadata, "lyrics", NULL, AV_DICT_IGNORE_SUFFIX);
+    if (tag && tag->value && strlen(tag->value) > 0) {
+      NSString *lyrics = [NSString stringWithCString:tag->value encoding:NSUTF8StringEncoding];
+      if (lyrics && lyrics.length > 0) {
+        LOG_DEBUG(@"Found lyrics in metadata tag '%s' for file: %@", tag->key, url);
+        return lyrics;
+      }
+    }
+
+    LOG_DEBUG(@"No lyrics found in metadata for file: %@", url);
+    return NULL;
+  }
+  @finally {
+    avformat_close_input(&pFormatCtx);
+  }
+}
+
 @end

--- a/iina/LyricsManager.swift
+++ b/iina/LyricsManager.swift
@@ -1,0 +1,105 @@
+//
+//  LyricsManager.swift
+//  iina
+//
+//  Copyright © 2025 lhc. All rights reserved.
+//
+
+import Foundation
+
+/// Manager for handling automatic loading of lyrics from various sources
+class LyricsManager {
+  
+  private weak var player: PlayerCore?
+  
+  init(player: PlayerCore) {
+    self.player = player
+  }
+  
+  /// Attempts to automatically load lyrics for the current media file
+  /// - Parameter url: The URL of the media file
+  func autoLoadLyrics(for url: URL) {
+    guard url.isFileURL else { return }
+    
+    let pathWithoutExtension = url.deletingPathExtension().path
+    
+    // First, try to load .lrc file with the same name
+    let lrcPath = pathWithoutExtension + ".lrc"
+    if FileManager.default.fileExists(atPath: lrcPath) {
+      Logger.log("Found LRC file: \(lrcPath)", subsystem: player?.subsystem ?? Logger.Subsystem(rawValue: "lyrics"))
+      loadLRCFile(at: URL(fileURLWithPath: lrcPath))
+      return
+    }
+    
+    // If no .lrc file found, try to extract lyrics from metadata
+    extractAndLoadLyricsFromMetadata(for: url)
+  }
+  
+  /// Loads an external .lrc file as subtitles
+  /// - Parameter url: The URL of the .lrc file
+  private func loadLRCFile(at url: URL) {
+    guard let player = player else { return }
+    
+    Logger.log("Loading LRC file as subtitles: \(url.path)", subsystem: player.subsystem)
+    player.loadExternalSubFile(url)
+  }
+  
+  /// Extracts lyrics from metadata and loads them as subtitles
+  /// - Parameter url: The URL of the media file
+  private func extractAndLoadLyricsFromMetadata(for url: URL) {
+    guard let player = player else { return }
+    
+    guard let lyrics = FFmpegController.extractLyrics(from: url) else {
+      Logger.log("No lyrics found in metadata for: \(url.path)", level: .verbose, subsystem: player.subsystem)
+      return
+    }
+    
+    guard isValidLRC(lyrics) else {
+      Logger.log("Extracted lyrics are not in valid LRC format", level: .warning, subsystem: player.subsystem)
+      return
+    }
+    
+    Logger.log("Found valid lyrics in metadata, creating temporary LRC file", subsystem: player.subsystem)
+    
+    let tempDir = Utility.tempDirURL
+    let tempFileName = url.deletingPathExtension().lastPathComponent + ".lrc"
+    let tempLRCURL = tempDir.appendingPathComponent(tempFileName)
+    
+    do {
+      try lyrics.write(to: tempLRCURL, atomically: true, encoding: .utf8)
+      Logger.log("Created temporary LRC file: \(tempLRCURL.path)", subsystem: player.subsystem)
+    } catch {
+      Logger.log("Failed to create temporary LRC file: \(error.localizedDescription)", level: .error, subsystem: player.subsystem)
+    }
+    
+    loadLRCFile(at: tempLRCURL)
+    
+    do {
+      try FileManager.default.removeItem(at: tempLRCURL)
+      Logger.log("Cleaned up temporary LRC file", level: .verbose, subsystem: player.subsystem)
+    } catch {
+      Logger.log("Failed to create temporary LRC file: \(error.localizedDescription)", level: .error, subsystem: player.subsystem)
+    }
+  }
+
+  /// Validates if the provided string is in valid LRC format according to MPV
+  /// - Parameter content: The string content to validate
+  /// - Returns: True if the content contains valid LRC timestamps
+  private func isValidLRC(_ content: String) -> Bool {
+    // Empty lines are skipped by MPV, but whitespace is not
+    guard let firstLine = content.split(separator: "\n", omittingEmptySubsequences: true).first else {
+      return false
+    }
+    
+    // [mm:ss.xx] or [mm:ss.xxx] or [mm:ss]
+    let timestampPattern = #"^\[\d{1,2}:\d{2}(?:\.\d{2,3})?\]"#
+    // [tag:data]
+    let tagPattern = #"^\[[^:\]]+:[^\]]*\]"#
+    
+    let isTimestamp = firstLine.range(of: timestampPattern, options: .regularExpression) != nil
+    let isTag = firstLine.range(of: tagPattern, options: .regularExpression) != nil
+
+    // As long as the first line is valid, MPV won't complain and simply ignore further invalid lines
+    return isTimestamp || isTag
+  }
+}

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -204,6 +204,8 @@ class PlayerCore: NSObject {
     return controller
   }()
 
+  lazy var lyricsManager: LyricsManager = LyricsManager(player: self)
+
   lazy var info: PlaybackInfo = PlaybackInfo(self)
 
   var syncUITimer: Timer?
@@ -2042,6 +2044,9 @@ class PlayerCore: NSObject {
       if Preference.bool(for: .recordRecentFiles) && Preference.bool(for: .trackAllFilesInRecentOpenMenu) {
         AppDelegate.shared.noteNewRecentDocumentURL(url)
       }
+      
+      // Auto-load lyrics if available
+      lyricsManager.autoLoadLyrics(for: url)
     }
     postNotification(.iinaFileLoaded)
     events.emit(.fileLoaded, data: info.currentURL?.absoluteString ?? "")


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #2658, #2383, #1138, #4317, #4599.

---

**Description:**

MPV and IINA already support LRC timecoded lyrics, but you need to manually load them from `Subtitles > Load External Subtitle...` for each audio file. This PR makes a few improvements on that front:
- Auto load `.lrc` files if they have the same name as the input file
- Parse out `lyrics` metadata from audio files and if it matches LRC format (it is timecoded), load it as such

There is one minor issue with the current implementation - if the subtitles are extracted from metadata, they are saved to a temporary `.lrc` file so it can be loaded with mpv command. The file is immediately deleted after. I couldn't find a way to load from memory, but if there is, please let me know.

The lyrics code currently runs on any input file, including video, but it causes no issues if it doesn't find LRC file or relevant metadata. If this is unwanted for videos, please let me know how to refactor it.

I tested MP3 and M4A (AAC) with embedded lyrics as well as the same files with external LRC lyrics. All scenarios worked for me. If anybody wants to test without compiling, I am uploading a build here:

https://files.catbox.moe/3c2iin.zip
