### PR TITLE
Fix wrong History table header color in MacOS Tahoe's dark mode

### DIFF
--- a/iina/Base.lproj/HistoryWindowController.xib
+++ b/iina/Base.lproj/HistoryWindowController.xib
@@ -97,7 +97,7 @@
                                     <rect key="frame" x="0.0" y="0.0" width="606" height="243"/>
                                     <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <size key="intercellSpacing" width="8" height="2"/>
-                                    <color key="backgroundColor" white="1" alpha="0.0" colorSpace="deviceWhite"/>
+                                    <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                     <tableColumns>
                                         <tableColumn identifier="Filename" editable="NO" width="408" minWidth="200" maxWidth="5000" id="DIC-tR-R2F" userLabel="File Column">
@@ -262,6 +262,7 @@
                                     </connections>
                                 </outlineView>
                             </subviews>
+                            <nil key="backgroundColor"/>
                         </clipView>
                         <scroller key="horizontalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="Hfw-fb-gd5">
                             <rect key="frame" x="1" y="251" width="598" height="16"/>


### PR DESCRIPTION
- [xj] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
Looks like MacOS Tahoe's `NSOutlineView` adds improved support for custom background color, but this revealed that the background color was set incorrectly. It's not clear why only the table header was drawn with the wrong color (and not the remaining rows).

This patch changes the table's background to the default color.

Before:
<img width="389" height="150" alt="Before" src="https://github.com/user-attachments/assets/130bd5d3-e65f-4ec7-87df-08a7306e264f" />

After:
<img width="402" height="156" alt="After" src="https://github.com/user-attachments/assets/aac5c4b8-dff8-4baf-bf51-240a22e4f3ae" />

