### PR TITLE
RFC. Command (allow to assign a hotkey) for toggling auto-hiding of On Screen Controller

### DIFF
--- a/iina/Base.lproj/KeyBinding.strings
+++ b/iina/Base.lproj/KeyBinding.strings
@@ -39,6 +39,7 @@
 
 "iina.toggle-pip" = "Toggle Picture-in-Picture";
 "iina.toggle-music-mode" = "Toggle Music Mode";
+"iina.toggle-control-bar-auto-hide" = "Toggle On Screen Controller auto-hiding";
 "iina.open-file" = "Open file";
 "iina.open-url" = "Open URL";
 "iina.video-panel" = "Video panel";

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -141,7 +141,8 @@
 "osd.file_loop" = "Loop Single File";
 "osd.playlist_loop" = "Loop Playlist";
 "osd.no_loop" = "Disable Looping";
-"osd.control_bar_auto_hide" = "On Screen Controller auto-hide: %@";
+"osd.control_bar_auto_hide_enabled" = "Auto-hiding On Screen Controller";
+"osd.control_bar_auto_hide_disabled" = "On Screen Controller always visible";
 
 "preference.title" = "Settings";
 "preference.general" = "General";

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -141,6 +141,7 @@
 "osd.file_loop" = "Loop Single File";
 "osd.playlist_loop" = "Loop Playlist";
 "osd.no_loop" = "Disable Looping";
+"osd.control_bar_auto_hide" = "On Screen Controller auto-hide: %@";
 
 "preference.title" = "Settings";
 "preference.general" = "General";

--- a/iina/IINACommand.swift
+++ b/iina/IINACommand.swift
@@ -37,4 +37,6 @@ enum IINACommand: String {
   case findOnlineSubs = "find-online-subs"
   case saveDownloadedSub = "save-downloaded-sub"
 
+  case toggleControlBarAutoHide = "toggle-control-bar-auto-hide"
+
 }

--- a/iina/KeyBindingDataLoader.swift
+++ b/iina/KeyBindingDataLoader.swift
@@ -54,6 +54,9 @@ class KeyBindingDataLoader {
     KBI("playlist-panel", type: .iinaCmd),
     KBI("chapter-panel", type: .iinaCmd),
     KBI.separator(),
+    KBI("toggle-control-bar-auto-hide", type: .iinaCmd),
+    KBI.separator(),
+
     KBI("open-file", type: .iinaCmd),
     KBI("open-url", type: .iinaCmd),
     KBI("save-playlist", type: .iinaCmd),

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -627,7 +627,7 @@ class MainWindowController: PlayerWindowController {
     timePreviewWhenSeek.isHidden = true
     bottomView.isHidden = true
     pipOverlayView.isHidden = true
-    
+
     if player.disableUI { hideUI() }
 
     // add user default observers

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1854,7 +1854,7 @@ class MainWindowController: PlayerWindowController {
     }
   }
 
-  private func showUI() {
+  func showUI() {
     if player.disableUI { return }
     animationState = .willShow
     fadeableViews.forEach { (v) in
@@ -1882,7 +1882,7 @@ class MainWindowController: PlayerWindowController {
 
   // MARK: - UI: Show / Hide Timer
 
-  private func updateTimer() {
+  func updateTimer() {
     destroyTimer()
     createTimer()
   }

--- a/iina/OSDMessage.swift
+++ b/iina/OSDMessage.swift
@@ -337,12 +337,13 @@ enum OSDMessage {
     case .clearPlaylist:
       return (NSLocalizedString("osd.clear_playlist", comment: "Cleared Playlist"), .normal)
 
-    case .controlBarAutoHide(let enabled):
-      let status = enabled ? NSLocalizedString("general.on", comment: "On") : NSLocalizedString("general.off", comment: "Off")
-      return (
-        String(format: NSLocalizedString("osd.control_bar_auto_hide", comment: "On Screen Controller auto-hide: %@"), status),
-        .normal
-      )
+    case .controlBarAutoHide(let isHiding):
+      let text = if isHiding {
+        NSLocalizedString("osd.control_bar_auto_hide_enabled", comment: "Auto-hiding On Screen Controller")
+      } else {
+        NSLocalizedString("osd.control_bar_auto_hide_disabled", comment: "On Screen Controller always visible")
+      }
+      return (text, .normal)
 
     case .contrast(let value):
       return (

--- a/iina/OSDMessage.swift
+++ b/iina/OSDMessage.swift
@@ -63,6 +63,7 @@ enum OSDMessage {
   case track(MPVTrack)
   case addToPlaylist(Int)
   case clearPlaylist
+  case controlBarAutoHide(Bool)
 
   case contrast(Int)
   case hue(Int)
@@ -335,6 +336,13 @@ enum OSDMessage {
 
     case .clearPlaylist:
       return (NSLocalizedString("osd.clear_playlist", comment: "Cleared Playlist"), .normal)
+
+    case .controlBarAutoHide(let enabled):
+      let status = enabled ? NSLocalizedString("general.on", comment: "On") : NSLocalizedString("general.off", comment: "Off")
+      return (
+        String(format: NSLocalizedString("osd.control_bar_auto_hide", comment: "On Screen Controller auto-hide: %@"), status),
+        .normal
+      )
 
     case .contrast(let value):
       return (

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -688,8 +688,16 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
   }
 
   private func toggleControlBarAutoHide() {
-    let previous = Preference.bool(for: .enableControlBarAutoHide)
-    Preference.set(!previous, for: .enableControlBarAutoHide)
+    let isHiding = !Preference.bool(for: .enableControlBarAutoHide) // toggle the current setting
+    Preference.set(isHiding, for: .enableControlBarAutoHide)
+
+    if isHiding {
+      // For auto-hiding to work, need to update the timer.
+      player.mainWindow.updateTimer()
+    } else {
+      // The user wants the UI to be always visible, need to show it explicitly.
+      player.mainWindow.showUI()
+    }
   }
 
   internal func handleIINACommand(_ cmd: IINACommand) {

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -687,6 +687,11 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
     player.seek(percent: percentage, forceExact: !followGlobalSeekTypeWhenAdjustSlider)
   }
 
+  private func toggleControlBarAutoHide() {
+    let previous = Preference.bool(for: .enableControlBarAutoHide)
+    Preference.set(!previous, for: .enableControlBarAutoHide)
+  }
+
   internal func handleIINACommand(_ cmd: IINACommand) {
     switch cmd {
     case .openFile:
@@ -697,6 +702,8 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
       menuActionHandler.menuDeleteCurrentFile(.dummy)
     case .deleteCurrentFileHard:
       menuActionHandler.menuDeleteCurrentFileHard(.dummy)
+    case .toggleControlBarAutoHide:
+      toggleControlBarAutoHide()
     default:
       break
     }

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -691,6 +691,8 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
     let isHiding = !Preference.bool(for: .enableControlBarAutoHide) // toggle the current setting
     Preference.set(isHiding, for: .enableControlBarAutoHide)
 
+    player.sendOSD(.controlBarAutoHide(isHiding))
+
     if isHiding {
       // For auto-hiding to work, need to update the timer.
       player.mainWindow.updateTimer()

--- a/iina/en.lproj/KeyBinding.strings
+++ b/iina/en.lproj/KeyBinding.strings
@@ -39,6 +39,7 @@
 
 "iina.toggle-pip" = "Toggle Picture-in-Picture";
 "iina.toggle-music-mode" = "Toggle Music Mode";
+"iina.toggle-control-bar-auto-hide" = "Toggle On Screen Controller auto-hiding";
 "iina.open-file" = "Open file";
 "iina.open-url" = "Open URL";
 "iina.video-panel" = "Video panel";

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -141,7 +141,8 @@
 "osd.file_loop" = "Loop Single File";
 "osd.playlist_loop" = "Loop Playlist";
 "osd.no_loop" = "Disable Looping";
-"osd.control_bar_auto_hide" = "On Screen Controller auto-hide: %@";
+"osd.control_bar_auto_hide_enabled" = "Auto-hiding On Screen Controller";
+"osd.control_bar_auto_hide_disabled" = "On Screen Controller always visible";
 
 "preference.title" = "Settings";
 "preference.general" = "General";

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -141,6 +141,7 @@
 "osd.file_loop" = "Loop Single File";
 "osd.playlist_loop" = "Loop Playlist";
 "osd.no_loop" = "Disable Looping";
+"osd.control_bar_auto_hide" = "On Screen Controller auto-hide: %@";
 
 "preference.title" = "Settings";
 "preference.general" = "General";


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5566 (somewhat)

---

**Description:**
There was an [idea to add a hotkey](https://github.com/iina/iina/issues/5566) to briefly show the UI (without the need to move the mouse, for example). But perhaps it would be also nice to have a hotkey to enable-disable the UI auto-hiding itself. The screenshot below shows the setting that we toggle via a hotkey basically.

<img width="964" height="531" alt="Screenshot of Iina app settings view, with an arrow pointing at the checkbox next to the “Auto hide after” setting" src="https://github.com/user-attachments/assets/8ea6d321-1cb2-4e9d-b022-63cb76cb4ee0" />

Here’s a screenshot of a debug build of the implementation:
<img width="932" height="784" alt="Screenshot of Iina keyboard shortcuts settings, show adding a new shortcut with a “Toggle On Screen Controller auto-hiding” option highlighted" src="https://github.com/user-attachments/assets/ca25eb99-5a6a-4566-b436-7abf0714463d" />

<details><summary>Screenshots of the player window with OSD messages</summary>
<img width="1136" height="688" alt="Screenshot of Iina player window with an on-screen alert message saying “On Screen Controller always visible”" src="https://github.com/user-attachments/assets/5f109075-355e-47b0-95b3-6d7dcc198768" />

<img width="1136" height="688" alt="Screenshot of Iina player window with an on-screen alert message saying “Auto-hiding On Screen Controller”" src="https://github.com/user-attachments/assets/f72995c7-a58a-48ba-a644-f4bb565fc0e1" />

</details>

This PR is just a suggestion (hence titled as an “RFC”), feel free to close or to request style changes. Thank you! 🙏 

> [!warning]
> This is an AI-assisted work 🤷‍♂️