### PR TITLE
Fix malformed URL loading panel, #5718

### DIFF
--- a/iina/OpenURLWindowController.swift
+++ b/iina/OpenURLWindowController.swift
@@ -48,6 +48,8 @@ class OpenURLWindowController: NSWindowController, NSTextFieldDelegate, NSContro
   func showLoadingScreen(playerCore: PlayerCore) {
     _ = window
     overlayView.isHidden = false
+    // Must not leave the focus in the username or password text fields.
+    window?.makeFirstResponder(nil)
     self.playerCore = playerCore
     loadingURL = playerCore.info.currentURL?.absoluteString
     if #available(macOS 14, *) {
@@ -115,6 +117,8 @@ class OpenURLWindowController: NSWindowController, NSTextFieldDelegate, NSContro
                                   port: url.port)
       }
       overlayView.isHidden = false
+      // Must not leave the focus in the username or password text fields.
+      window?.makeFirstResponder(nil)
       playerCore = PlayerCore.activeOrNewForMenuAction(isAlternative: isAlternativeAction)
       playerCore!.openURL(url)
     } else {


### PR DESCRIPTION
This commit will change the `openBtnAction` and `showLoadingScreen` methods in the `OpenURLWindowController` class to set the first responder to `nil` when showing the loading media throbber.

This change ensures the focus is not left in the username  or password text fields after loading has started.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5718.

---

**Description:**
