### PR TITLE
player,ui: Option+scroll 0.25x speed step; add OSC speed chip

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -347,6 +347,7 @@
 		E34EAA83251A36CE00057F27 /* JavascriptAPIFile.swift in Sources */ = {isa = PBXBuildFile; fileRef = E34EAA82251A36CE00057F27 /* JavascriptAPIFile.swift */; };
 		E3513AF820EF79C500F8C347 /* PreferenceWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3513AF620EF79C500F8C347 /* PreferenceWindowController.swift */; };
 		E3513AFB20F120F600F8C347 /* PreferenceViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3513AFA20F120F600F8C347 /* PreferenceViewController.swift */; };
+		51F0AAAB2F00000100AAAAAA /* PlaybackSpeedStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F0AAAA2F00000100AAAAAA /* PlaybackSpeedStep.swift */; };
 		E35306EF2147A8CE008FE492 /* JavascriptPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = E35306EE2147A8CE008FE492 /* JavascriptPlugin.swift */; };
 		E35306F42147F78D008FE492 /* JavascriptAPICore.swift in Sources */ = {isa = PBXBuildFile; fileRef = E35306F32147F78D008FE492 /* JavascriptAPICore.swift */; };
 		E35306F62147F7AF008FE492 /* JavascriptAPIMpv.swift in Sources */ = {isa = PBXBuildFile; fileRef = E35306F52147F7AF008FE492 /* JavascriptAPIMpv.swift */; };
@@ -1199,6 +1200,7 @@
 		51165FBB2E1D91290060B817 /* ReadWriteAtomic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadWriteAtomic.swift; sourceTree = "<group>"; };
 		51165FBF2E1D91940060B817 /* ReadWriteLock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadWriteLock.swift; sourceTree = "<group>"; };
 		511BF43B2E12FF8800E9721E /* VolumeSlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VolumeSlider.swift; sourceTree = "<group>"; };
+		51F0AAAA2F00000100AAAAAA /* PlaybackSpeedStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaybackSpeedStep.swift; sourceTree = "<group>"; };
 		511BF43D2E1305C800E9721E /* MiniPlaySlider.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlaySlider.swift; sourceTree = "<group>"; };
 		5125117C2E89B2ED00CDAE9F /* Display.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Display.swift; sourceTree = "<group>"; };
 		512B8FDC2BC2376E00AF41BF /* OutlineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OutlineView.swift; sourceTree = "<group>"; };
@@ -2464,6 +2466,7 @@
 				51DE55C82A6646710050AD06 /* Sysctl.swift */,
 				519CCABC2BFFAEF10079DCAF /* HardwareDecodeCapabilities.swift */,
 				51165FBB2E1D91290060B817 /* ReadWriteAtomic.swift */,
+				51F0AAAA2F00000100AAAAAA /* PlaybackSpeedStep.swift */,
 			);
 			name = Utils;
 			sourceTree = "<group>";
@@ -3290,6 +3293,7 @@
 				84F5D4A01E44F9DB0060A838 /* KeyBindingItem.swift in Sources */,
 				84E5221323FF3D080006FDA1 /* JavascriptAPIPlaylist.swift in Sources */,
 				84A0BA991D2FAAA700BC8DA1 /* MPVController.swift in Sources */,
+				51F0AAAB2F00000100AAAAAA /* PlaybackSpeedStep.swift in Sources */,
 				847557161F406D360006B0FF /* MiniPlayerWindowMenuActions.swift in Sources */,
 				842F55A51EA17E7E0081D475 /* IINACommand.swift in Sources */,
 				840D47981DFEEE6A000D9A64 /* KeyMapping.swift in Sources */,

--- a/iina/Base.lproj/MainWindowController.xib
+++ b/iina/Base.lproj/MainWindowController.xib
@@ -50,6 +50,7 @@
                 <outlet property="playSlider" destination="eBP-6g-bAT" id="lGv-18-YeQ"/>
                 <outlet property="rightArrowButton" destination="EIi-qd-glM" id="U46-Gl-e8D"/>
                 <outlet property="rightArrowLabel" destination="QTI-wi-oyB" id="icX-KI-Muj"/>
+                <outlet property="oscSpeedChipLabel" destination="SpD-lb-LBL" id="spd-outlet-1"/>
                 <outlet property="rightLabel" destination="GgV-Cc-sk0" id="fnx-gO-YPl"/>
                 <outlet property="sideBarRightConstraint" destination="PAj-s6-32e" id="DOs-2k-JEG"/>
                 <outlet property="sideBarView" destination="epo-S6-QVB" id="5eE-aM-VUd"/>
@@ -487,6 +488,14 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
+                <textField horizontalHuggingPriority="260" verticalHuggingPriority="750" alphaValue="0.6" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="SpD-lb-LBL" userLabel="Speed Chip Label">
+                    <rect key="frame" x="224" y="15" width="60" height="12"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" refusesFirstResponder="YES" sendsActionOnEndEditing="YES" alignment="center" title="" id="SpD-lb-CEL">
+                        <font key="font" metaFont="system" size="10"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
             </subviews>
             <constraints>
                 <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="150" id="E6z-SF-UDn"/>
@@ -496,9 +505,13 @@
                 <constraint firstItem="eBP-6g-bAT" firstAttribute="centerY" secondItem="NBD-MV-OuG" secondAttribute="centerY" id="dX4-4l-aJM"/>
                 <constraint firstItem="NBD-MV-OuG" firstAttribute="leading" secondItem="BE1-yC-oJL" secondAttribute="leading" constant="2" id="fcm-ao-T7h"/>
                 <constraint firstItem="eBP-6g-bAT" firstAttribute="top" secondItem="BE1-yC-oJL" secondAttribute="top" constant="6" id="oEb-w7-DDS"/>
-                <constraint firstAttribute="trailing" secondItem="GgV-Cc-sk0" secondAttribute="trailing" constant="2" id="plE-qU-XZt"/>
+                <constraint firstAttribute="trailing" secondItem="SpD-lb-LBL" secondAttribute="trailing" constant="2" id="plE-qU-XZt"/>
                 <constraint firstItem="eBP-6g-bAT" firstAttribute="leading" secondItem="NBD-MV-OuG" secondAttribute="trailing" constant="2" id="uHE-D2-HgP"/>
                 <constraint firstItem="GgV-Cc-sk0" firstAttribute="leading" secondItem="eBP-6g-bAT" secondAttribute="trailing" constant="2" id="vzW-0s-yR6"/>
+                <constraint firstItem="SpD-lb-LBL" firstAttribute="centerY" secondItem="NBD-MV-OuG" secondAttribute="centerY" id="spd-cy-1"/>
+                <constraint firstItem="SpD-lb-LBL" firstAttribute="leading" secondItem="GgV-Cc-sk0" secondAttribute="trailing" constant="6" id="spd-lr-1"/>
+                <constraint firstItem="SpD-lb-LBL" firstAttribute="width" relation="greaterThanOrEqual" constant="30" id="spd-w-4b"/>
+                <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="30" id="spd-w-4"/>
             </constraints>
             <point key="canvasLocation" x="236" y="506"/>
         </customView>

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -488,6 +488,7 @@ class MainWindowController: PlayerWindowController {
 
   @IBOutlet weak var leftArrowLabel: NSTextField!
   @IBOutlet weak var rightArrowLabel: NSTextField!
+  @IBOutlet weak var oscSpeedChipLabel: NSTextField!
 
   @IBOutlet weak var osdVisualEffectView: NSVisualEffectView!
   @IBOutlet weak var osdStackView: NSStackView!
@@ -600,6 +601,9 @@ class MainWindowController: PlayerWindowController {
     }
 
     player.initVideo()
+
+    // Hide speed chip by default; it will appear when speed != 1.00x
+    oscSpeedChipLabel?.isHidden = true
 
     // init quick setting view now
     let _ = quickSettingView
@@ -839,6 +843,10 @@ class MainWindowController: PlayerWindowController {
       oscTopMainView.setVisibilityPriority(.mustHold, for: fragSliderView)
       oscTopMainView.setVisibilityPriority(.detachEarly, for: fragVolumeView)
       oscTopMainView.setVisibilityPriority(.detachEarlier, for: fragToolbarView)
+      // Ensure uniform spacing after the time/slider row (only if arranged)
+      if #available(macOS 10.12, *), oscTopMainView.arrangedSubviews.contains(fragSliderView!) {
+        oscTopMainView.setCustomSpacing(6, after: fragSliderView)
+      }
     case .bottom:
       currentControlBar = controlBarBottom
       fragControlView.setVisibilityPriority(.notVisible, for: fragControlViewLeftView)
@@ -851,6 +859,9 @@ class MainWindowController: PlayerWindowController {
       oscBottomMainView.setVisibilityPriority(.mustHold, for: fragSliderView)
       oscBottomMainView.setVisibilityPriority(.detachEarly, for: fragVolumeView)
       oscBottomMainView.setVisibilityPriority(.detachEarlier, for: fragToolbarView)
+      if #available(macOS 10.12, *), oscBottomMainView.arrangedSubviews.contains(fragSliderView!) {
+        oscBottomMainView.setCustomSpacing(6, after: fragSliderView)
+      }
     }
 
     if currentControlBar != nil {
@@ -872,6 +883,9 @@ class MainWindowController: PlayerWindowController {
         oscFloatingLeadingTrailingConstraint = nil
       }
     }
+
+    // Ensure speed indicators reflect current layout immediately after switching
+    updateSpeedLabel(speed: player.info.playSpeed)
   }
 
   // MARK: - Mouse / Trackpad events
@@ -2997,20 +3011,35 @@ class MainWindowController: PlayerWindowController {
   }
 
   func updateSpeedLabel(speed: Double) {
-    if (speed == 1) {
+    let isFloating = (oscPosition == .floating)
+
+    // Arrow-side speed labels are used only in Floating layout
+    if isFloating {
+      if speed == 1 {
+        leftArrowLabel.isHidden = true
+        rightArrowLabel.isHidden = true
+      } else if speed < 1 {
+        leftArrowLabel.isHidden = false
+        rightArrowLabel.isHidden = true
+        leftArrowLabel.stringValue = String(format: "%.2fx", speed)
+      } else { // speed > 1
+        leftArrowLabel.isHidden = true
+        rightArrowLabel.isHidden = false
+        rightArrowLabel.stringValue = String(format: "%.2fx", speed)
+      }
+    } else {
       leftArrowLabel.isHidden = true
       rightArrowLabel.isHidden = true
-    } else if speed < 1 {
-      leftArrowLabel.isHidden = false
-      rightArrowLabel.isHidden = true
-      leftArrowLabel.stringValue = String(format: "%.2fx", speed)
-    } else if speed > 1 {
-      leftArrowLabel.isHidden = true
-      rightArrowLabel.isHidden = false
-      let fmt = NumberFormatter()
-      fmt.numberStyle = .decimal
-      fmt.maximumSignificantDigits = 3
-      rightArrowLabel.stringValue = fmt.string(for: speed)! + "x"
+    }
+
+    // Compact OSC speed chip: shown only for Top/Bottom, hidden for Floating; also hide at exactly 1.00x
+    if let chip = oscSpeedChipLabel {
+      if isFloating || speed == 1 {
+        chip.isHidden = true
+      } else {
+        chip.isHidden = false
+        chip.stringValue = String(format: "%.2fx", speed)
+      }
     }
   }
 

--- a/iina/PlaybackSpeedStep.swift
+++ b/iina/PlaybackSpeedStep.swift
@@ -1,0 +1,68 @@
+//
+//  PlaybackSpeedStep.swift
+//  IINA
+//
+//  Discrete 0.25x stepping logic used when the user holds a modifier
+//  while scrolling to change playback speed. Kept pure for unit testing.
+//
+
+import Foundation
+
+enum PlaybackSpeedStep {
+
+  private static let eps: Double = 1e-6
+
+  /// Build a 0.25x grid between 0.25 and `max`, inclusive.
+  /// - Parameter max: upper bound (e.g., 4.0). Must be >= 0.25.
+  private static func grid(max: Double) -> [Double] {
+    let upper = max < 0.25 ? 0.25 : max
+    let steps = Int((upper / 0.25).rounded(.down))
+    return (1...steps).map { Double($0) * 0.25 }
+  }
+
+  /// Clamp a value to the 0.25-grid range [0.25, max].
+  static func clampToGridRange(_ value: Double, max: Double) -> Double {
+    if value < 0.25 { return 0.25 }
+    if value > max { return max }
+    return value
+  }
+
+  /// Return the next allowed value strictly greater than `current` within [0.25, max].
+  private static func nextUp(from current: Double, max: Double) -> Double {
+    let c = current
+    for v in grid(max: max) {
+      if v - c > eps { return v }
+    }
+    return max
+  }
+
+  /// Return the next allowed value strictly less than `current` within [0.25, max].
+  private static func nextDown(from current: Double, max: Double) -> Double {
+    let c = current
+    for v in grid(max: max).reversed() {
+      if c - v > eps { return v }
+    }
+    return 0.25
+  }
+
+  /// Snap to the nearest 0.25 multiple within [0.25, max].
+  static func snap(_ value: Double, max: Double) -> Double {
+    let clamped = clampToGridRange(value, max: max)
+    let quantized = (clamped / 0.25).rounded() * 0.25
+    return clampToGridRange(quantized, max: max)
+  }
+
+  /// Step from `current` by one grid unit (0.25) up (+1) or down (-1), within [0.25, max].
+  /// Out-of-range handling:
+  ///  - Above `max`: up → max; down → max - 0.25
+  ///  - Below 0.25: up/down → 0.25 (lowest allowed when Option is held)
+  static func step(from current: Double, direction: Int, max: Double) -> Double {
+    let dir = direction == 0 ? 0 : (direction > 0 ? 1 : -1)
+    guard dir != 0 else { return snap(current, max: max) }
+
+    if current > max { return dir > 0 ? max : max - 0.25 }
+    if current < 0.25 { return 0.25 }
+
+    return dir > 0 ? nextUp(from: current, max: max) : nextDown(from: current, max: max)
+  }
+}

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -27,6 +27,10 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
   
   let subsystem: Logger.Subsystem
 
+  /// Upper bound for scroll-driven playback speed adjustments used by both
+  /// proportional and Option+scroll paths. Keep in one place for consistency.
+  static let playbackSpeedScrollUpperBound: Double = 4.0
+
   init(playerCore: PlayerCore) {
     self.player = playerCore
     subsystem = Logger.makeSubsystem("window\(player.playerNumber)")
@@ -155,6 +159,10 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
   }
 
   internal var scrollDirection: ScrollDirection?
+
+  /// Accumulator for precise scrolling when using Option-key stepping for playback speed.
+  /// Values of absolute magnitude >= 1.0 trigger a single step and decrease the accumulator accordingly.
+  internal var playbackSpeedOptionAccumulator: Double = 0
 
   /** We need to pause the video when a user starts seeking by scrolling.
    This property records whether the video is paused initially so we can
@@ -455,16 +463,26 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
       scrollDirection = nil
     }
 
+    // detect modifier keys once
+    let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
+    let optDown = flags.contains(.option)
+
     let scrollAction: Preference.ScrollAction
     if seekOverride {
       scrollAction = .seek
     } else if volumeOverride {
       scrollAction = .volume
     } else {
-      scrollAction = scrollDirection == .horizontal ? horizontalScrollAction : verticalScrollAction
-      // show volume popover when volume seek begins and hide on end
-      if let miniPlayer = self as? MiniPlayerWindowController, scrollAction == .volume {
-        miniPlayer.handleVolumePopover(isTrackpadBegan, isTrackpadEnd, isMouse)
+      // Option-key override: adjust playback speed regardless of user mapping
+      // (but do not override when over seek/volume specific views)
+      if optDown {
+        scrollAction = .playbackSpeed
+      } else {
+        scrollAction = scrollDirection == .horizontal ? horizontalScrollAction : verticalScrollAction
+        // show volume popover when volume seek begins and hide on end
+        if let miniPlayer = self as? MiniPlayerWindowController, scrollAction == .volume {
+          miniPlayer.handleVolumePopover(isTrackpadBegan, isTrackpadEnd, isMouse)
+        }
       }
     }
 
@@ -514,10 +532,28 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
       player.setVolume(newVolume)
       volumeSlider.doubleValue = newVolume
     case .playbackSpeed:
-      let min = 0.05
-      let max = 4.0
-      let newSpeed = round(1000 * (player.info.playSpeed + (player.info.playSpeed * AppData.playbackSpeedMap[playbackSpeedScrollAmount] * delta)).clamped(to: min...max)) / 1000
-      player.setSpeed(newSpeed)
+      if optDown {
+        // Option-key: step through 0.25x increments.
+        // For mouse wheels, treat each notch as 1 unit. For precise deltas (trackpad), accumulate until |accum| >= 1.
+        let contribution = isPrecise ? delta : (delta == 0 ? 0 : (delta > 0 ? 1 : -1))
+        if isTrackpadBegan { playbackSpeedOptionAccumulator = 0 }
+        playbackSpeedOptionAccumulator += contribution
+        let proportionalMax = Self.playbackSpeedScrollUpperBound
+        while abs(playbackSpeedOptionAccumulator) >= 1 {
+          let direction = playbackSpeedOptionAccumulator > 0 ? 1 : -1
+          let current = player.info.playSpeed
+          let stepped = PlaybackSpeedStep.step(from: current, direction: direction, max: proportionalMax)
+          player.setSpeed(stepped)
+          playbackSpeedOptionAccumulator -= Double(direction)
+        }
+        if isTrackpadEnd { playbackSpeedOptionAccumulator = 0 }
+      } else {
+        // Default proportional behavior (unchanged)
+        let min = 0.05
+        let max = Self.playbackSpeedScrollUpperBound
+        let newSpeed = round(1000 * (player.info.playSpeed + (player.info.playSpeed * AppData.playbackSpeedMap[playbackSpeedScrollAmount] * delta)).clamped(to: min...max)) / 1000
+        player.setSpeed(newSpeed)
+      }
     default:
       break
     }


### PR DESCRIPTION
Add a keyboard modifier-based playback speed adjustment. Default proportional scroll behavior remains unchanged; the discrete stepping path is active only while the Option key is held.

This allows the user to quickly change the playback speed multiplier to [0.25x, 0.5x ... 3.75x, 4.0x] inclusive. The user can now quickly switch between standard playback speeds without excessive scrolling.

[Example gif](https://imgur.com/a/5d87Zqw) showing the behavior when the Option key is held down while scrolling.

  - Add 0.25x stepping for playback speed when holding Option while scrolling. Mouse wheel notches step ±0.25x per notch; trackpad precise scrolling accumulates until a full step is reached.
  - Keep proportional scroll behavior unchanged when no modifier is pressed.
  - Show a compact speed "chip" in Top/Bottom OSC layouts when speed != 1.00x; hide it at exactly 1.00x. Floating layout continues to use the left/right arrow labels.
  - Centralize the scroll upper bound via PlayerWindowController.playbackSpeedScrollUpperBound (4.0) so both paths stay consistent.
  - Add PlaybackSpeedStep.swift with pure 0.25x stepping helpers (clamp, snap, step) for reuse and testability.
  - Wire up oscSpeedChipLabel in MainWindowController.xib and update label visibility when layout changes.

  UI/XIB: update Base.lproj/MainWindowController.xib; no new localizable strings.

- [X] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)