### PR TITLE
Fix typo in JavaScript api error.

### DIFF
--- a/iina/JavascriptAPIFile.swift
+++ b/iina/JavascriptAPIFile.swift
@@ -146,7 +146,7 @@ class JavascriptAPIFile: JavascriptAPI, JavascriptAPIFileExportable {
     case "write":
       handleMode = .write
     default:
-      throwError(withMessage: "file.handle: moude should be \"read\" or \"write\".")
+      throwError(withMessage: "file.handle: mode should be \"read\" or \"write\".")
       return nil
     }
     if let handle = JavascriptFileHandle(url: URL(fileURLWithPath: filePath), mode: handleMode) {


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)

**Description:**
Fixes typo I found playing around with the extensions.

`moude` => `mode`