### PR TITLE
Fix large files loaded in RAM, 86 GB in use by IINA, #5803

### DIFF
--- a/iina/FFmpegController.m
+++ b/iina/FFmpegController.m
@@ -750,6 +750,7 @@ return -1;\
     }
 
     // Search the streams for one that contains front cover artwork.
+    int index = 0;
     AVPacket* packet = NULL;
     for (int i = 0; i < pFormatCtx->nb_streams; i++) {
       AVStream* stream = pFormatCtx->streams[i];
@@ -766,6 +767,7 @@ return -1;\
       // types can be found here: https://id3.org/id3v2.3.0#Attached_picture
 
       // Found front cover artwork.
+      index = i;
       packet = &stream->attached_pic;
       break;
     }
@@ -775,6 +777,7 @@ return -1;\
     }
 
     // Form an image from the stream's data.
+    LOG_DEBUG(@"Creating an image from stream %d using %d bytes", index, packet->size);
     NSData *data = [[NSData alloc] initWithBytes:packet->data length:packet->size];
     NSImage *image = [[NSImage alloc] initWithData:data];
     if (!image) {

--- a/iina/NowPlayingInfoManager.swift
+++ b/iina/NowPlayingInfoManager.swift
@@ -255,8 +255,9 @@ class NowPlayingInfoManager {
       log("External artwork track is missing external-filename", url, level: .error)
       return nil
     }
+    log("Creating an image from external artwork file: \(filename)")
     guard let image = NSImage(contentsOfFile: filename) else {
-      log("Unable to create an image for external artwork file: \(filename)", level: .error)
+      log("Unable to create an image from external artwork file: \(filename)", level: .error)
       return nil
     }
     return image
@@ -437,8 +438,7 @@ class NowPlayingInfoManager {
   /// Search the given video tracks for front cover art.
   ///
   /// Container formats such as Matroska support embedding cover art. An external file can be specified as cover art using the mpv
-  /// option [cover-art-files](https://mpv.io/manual/stable/#options-cover-art-files). If the media being "played" is
-  /// an image file then it will be used as the artwork.
+  /// option [cover-art-files](https://mpv.io/manual/stable/#options-cover-art-files).
   /// - Parameters:
   ///   - player: The `PlayerCore` that is playing the media item.
   ///   - url: The URL of the media item.
@@ -450,18 +450,8 @@ class NowPlayingInfoManager {
     guard !tracks.isEmpty else { return false }
     log("Searching \(tracks.count) tracks for front cover artwork", url, level: .verbose)
     for track in tracks {
-      // Only interested in tracks representing an image.
-      guard track.isImage else { continue }
-      if track.isAlbumart {
-        guard let image = constructImage(url, track) else { continue }
-        foundFrontCoverArtwork(player, url, ticket, image)
-        return true
-      }
-      // The media item is an image.
-      guard let image = NSImage(contentsOf: url) else {
-        log("Unable to create an image from: \(url)", level: .error)
-        continue
-      }
+      // Only interested in tracks representing cover artwork.
+      guard track.isAlbumart, let image = constructImage(url, track) else { continue }
       foundFrontCoverArtwork(player, url, ticket, image)
       return true
     }


### PR DESCRIPTION
This commit will:
- Change the `searchTracksForArtwork` method in the `NowPlayingInfoManager` class to not support picture files
- Add additional logging in the constructImage method
- Add a log message to the `readArtworkFromURL` method in the `FFmpegController` class

It is difficult for `searchTracksForArtwork` to detect if the media being played is a picture. Instead for pictures `NowPlayingInfoManager` will rely upon `QLThumbnailGenerator` to generate artwork for the Now Playing module.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5803.

---

**Description:**
