### PR TITLE
Change getTrackInfo to use getNode

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -1042,6 +1042,18 @@ class MPVController: NSObject {
     MPVNode.free(node)
   }
 
+  /// Returns the given node map value as an `Int`.
+  ///
+  /// This method is intended to be used when extracting values from a `MPV_FORMAT_NODE_MAP` `mpv_node` that contains
+  /// mixed types.
+  /// - Note: Zero is returned for `nil` values to match the behavior of `getInt`.
+  /// - Parameter value:Value from a mpv node map.
+  /// - Returns: The given value converted to an `Int`.
+  static func nodeValueAsInt(_ value: Any?) -> Int {
+    guard let asInt64 = value as? Int64 else { return 0 }
+    return Int(asInt64)
+  }
+
   // MARK: - Hooks
 
   func addHook(_ name: MPVHook, priority: Int32 = 0, hook: MPVHookValue) {

--- a/iina/MPVTrack.swift
+++ b/iina/MPVTrack.swift
@@ -133,6 +133,36 @@ class MPVTrack: NSObject {
     self.isExternal = isExternal
   }
 
+  /// Returns a `MVPTrack` object or `nil` if initialization fails..
+  /// - Note: Failure of this initializer occurs if the given dictionary is missing required properties.
+  /// - Parameter dict: A dictionary containing the properties of the track.
+  convenience init?(_ dict: [String: Any]) {
+    guard let idAsNodeValue = dict["id"], let typeAsString = dict["type"] as? String,
+          let type =  MPVTrack.TrackType(rawValue: typeAsString),
+          let isDefault = dict["default"] as? Bool, let isForced = dict["forced"] as? Bool,
+          let isImage = dict["image"] as? Bool, let isSelected = dict["selected"] as? Bool,
+          let isExternal = dict["external"] as? Bool else {
+      // Internal error, should not occur.
+      return nil
+    }
+    let id = MPVController.nodeValueAsInt(idAsNodeValue)
+    self.init(id: id, type: type, isDefault: isDefault, isForced: isForced, isImage: isImage,
+              isSelected: isSelected, isExternal: isExternal)
+    srcId = MPVController.nodeValueAsInt(dict["src-id"])
+    title = dict["title"] as? String
+    lang = dict["lang"] as? String
+    codec = dict["codec"] as? String
+    externalFilename = dict["external-filename"] as? String
+    isAlbumart = dict["albumart"] as? Bool ?? false
+    decoderDesc = dict["decoder-desc"] as? String
+    demuxW = MPVController.nodeValueAsInt(dict["demux-w"])
+    demuxH = MPVController.nodeValueAsInt(dict["demux-h"])
+    demuxFps = dict["demux-fps"] as? Double
+    demuxChannelCount = MPVController.nodeValueAsInt(dict["demux-channel-count"])
+    demuxChannels = dict["demux-channels"] as? String
+    demuxSamplerate = MPVController.nodeValueAsInt(dict["demux-samplerate"])
+  }
+
   // Utils
 
   var isImageSub: Bool {

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -2818,36 +2818,16 @@ class PlayerCore: NSObject {
       let raw = mpv.getNode(MPVProperty.trackList)
       guard let list = raw as? [[String: Any]] else {
         // Internal error, should not occur.
-        log("Cast of mpv node failed: \(String(describing: raw))", level: .error)
+        log("Cast of mpv node failed while getting track list: \(String(describing: raw))",
+            level: .error)
         return
       }
       for dict in list {
-        guard let type = dict["type"] as? String else { continue }
-        guard let isDefault = dict["default"] as? Bool, let isForced = dict["forced"] as? Bool,
-              let isImage = dict["image"] as? Bool, let isSelected = dict["selected"] as? Bool,
-              let isExternal = dict["external"] as? Bool else {
+        guard let track = MPVTrack(dict) else {
           // Internal error, should not occur.
           log("Unable to construct MPVTrack from mpv node map: \(dict)", level: .error)
           continue
         }
-        let id = MPVController.nodeValueAsInt(dict["id"])
-        let track = MPVTrack(id: id, type: MPVTrack.TrackType(rawValue: type)!,
-                             isDefault: isDefault, isForced: isForced, isImage: isImage,
-                             isSelected: isSelected, isExternal: isExternal)
-        track.srcId = MPVController.nodeValueAsInt(dict["src-id"])
-        track.title = dict["title"] as? String
-        track.lang = dict["lang"] as? String
-        track.codec = dict["codec"] as? String
-        track.externalFilename = dict["external-filename"] as? String
-        track.isAlbumart = dict["albumart"] as? Bool ?? false
-        track.decoderDesc = dict["decoder-desc"] as? String
-        track.demuxW = MPVController.nodeValueAsInt(dict["demux-w"])
-        track.demuxH = MPVController.nodeValueAsInt(dict["demux-h"])
-        track.demuxFps = dict["demux-fps"] as? Double
-        track.demuxChannelCount = MPVController.nodeValueAsInt(dict["demux-channel-count"])
-        track.demuxChannels = dict["demux-channels"] as? String
-        track.demuxSamplerate = MPVController.nodeValueAsInt(dict["demux-samplerate"])
-
         // add to lists
         switch track.type {
         case .audio:

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -2815,30 +2815,38 @@ class PlayerCore: NSObject {
     info.videoTracks.removeAll(keepingCapacity: true)
     info.$subTracks.withLock {
       $0.removeAll(keepingCapacity: true)
-      let trackCount = mpv.getInt(MPVProperty.trackListCount)
-      for index in 0..<trackCount {
-        // get info for each track
-        guard let trackType = mpv.getString(MPVProperty.trackListNType(index)) else { continue }
-        let track = MPVTrack(id: mpv.getInt(MPVProperty.trackListNId(index)),
-                             type: MPVTrack.TrackType(rawValue: trackType)!,
-                             isDefault: mpv.getFlag(MPVProperty.trackListNDefault(index)),
-                             isForced: mpv.getFlag(MPVProperty.trackListNForced(index)),
-                             isImage: mpv.getFlag(MPVProperty.trackListNImage(index)),
-                             isSelected: mpv.getFlag(MPVProperty.trackListNSelected(index)),
-                             isExternal: mpv.getFlag(MPVProperty.trackListNExternal(index)))
-        track.srcId = mpv.getInt(MPVProperty.trackListNSrcId(index))
-        track.title = mpv.getString(MPVProperty.trackListNTitle(index))
-        track.lang = mpv.getString(MPVProperty.trackListNLang(index))
-        track.codec = mpv.getString(MPVProperty.trackListNCodec(index))
-        track.externalFilename = mpv.getString(MPVProperty.trackListNExternalFilename(index))
-        track.isAlbumart = mpv.getString(MPVProperty.trackListNAlbumart(index)) == "yes"
-        track.decoderDesc = mpv.getString(MPVProperty.trackListNDecoderDesc(index))
-        track.demuxW = mpv.getInt(MPVProperty.trackListNDemuxW(index))
-        track.demuxH = mpv.getInt(MPVProperty.trackListNDemuxH(index))
-        track.demuxFps = mpv.getDouble(MPVProperty.trackListNDemuxFps(index))
-        track.demuxChannelCount = mpv.getInt(MPVProperty.trackListNDemuxChannelCount(index))
-        track.demuxChannels = mpv.getString(MPVProperty.trackListNDemuxChannels(index))
-        track.demuxSamplerate = mpv.getInt(MPVProperty.trackListNDemuxSamplerate(index))
+      let raw = mpv.getNode(MPVProperty.trackList)
+      guard let list = raw as? [[String: Any]] else {
+        // Internal error, should not occur.
+        log("Cast of mpv node failed: \(String(describing: raw))", level: .error)
+        return
+      }
+      for dict in list {
+        guard let type = dict["type"] as? String else { continue }
+        guard let isDefault = dict["default"] as? Bool, let isForced = dict["forced"] as? Bool,
+              let isImage = dict["image"] as? Bool, let isSelected = dict["selected"] as? Bool,
+              let isExternal = dict["external"] as? Bool else {
+          // Internal error, should not occur.
+          log("Unable to construct MPVTrack from mpv node map: \(dict)", level: .error)
+          continue
+        }
+        let id = MPVController.nodeValueAsInt(dict["id"])
+        let track = MPVTrack(id: id, type: MPVTrack.TrackType(rawValue: type)!,
+                             isDefault: isDefault, isForced: isForced, isImage: isImage,
+                             isSelected: isSelected, isExternal: isExternal)
+        track.srcId = MPVController.nodeValueAsInt(dict["src-id"])
+        track.title = dict["title"] as? String
+        track.lang = dict["lang"] as? String
+        track.codec = dict["codec"] as? String
+        track.externalFilename = dict["external-filename"] as? String
+        track.isAlbumart = dict["albumart"] as? Bool ?? false
+        track.decoderDesc = dict["decoder-desc"] as? String
+        track.demuxW = MPVController.nodeValueAsInt(dict["demux-w"])
+        track.demuxH = MPVController.nodeValueAsInt(dict["demux-h"])
+        track.demuxFps = dict["demux-fps"] as? Double
+        track.demuxChannelCount = MPVController.nodeValueAsInt(dict["demux-channel-count"])
+        track.demuxChannels = dict["demux-channels"] as? String
+        track.demuxSamplerate = MPVController.nodeValueAsInt(dict["demux-samplerate"])
 
         // add to lists
         switch track.type {


### PR DESCRIPTION
This commit will:
- Change the `getTrackInfo` method in the `PlayerCore` class to get all tracks at once using `getNode`
- Add a `nodeValueAsInt` method to `MPVController` for extracting an integer from a node map

Instruments identified `getTrackInfo` as sometimes being responsible for short hangs. This is because `mpv_get_property` sometimes has to wait to acquire a mpv lock. The current `getTrackInfo` implementation makes 20 calls to `mpv_get_property` for each track. By changing `getTrackInfo` to make one call to `getNode`, obtaining the entire list in a single call to `mpv_get_property`, the time waiting for `mpv_get_property` is reduced.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
