### PR TITLE
RFC. Zoom in full screen!

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -174,6 +174,15 @@ class MainWindowController: PlayerWindowController {
 
   var lastMagnification: CGFloat = 0.0
   var frameWhenStartedPinching = NSRect()
+  var pinchOriginInWindow: NSPoint?
+  var pinchOriginInVideo: NSPoint?
+  var pinchOriginInVideoUnit: NSPoint?
+  var pinchScale: CGFloat = 1.0
+  var pinchInitialZoom: Double = 1.0
+  private let pinchZoomMultiplier: Double = 1.0
+  private let pinchMinZoom: Double = 1.0
+  private let pinchMaxZoom: Double = 4.5
+  private let pinchMaxPan: Double = 1.0
 
   /** Views that will show/hide when cursor moving in/out the window. */
   var fadeableViews: [NSView] = []
@@ -584,7 +593,7 @@ class MainWindowController: PlayerWindowController {
     addVideoViewToWindow()
 
     // gesture recognizer
-    cv.addGestureRecognizer(magnificationGestureRecognizer)
+    videoView.addGestureRecognizer(magnificationGestureRecognizer)
 
     // Work around a bug in macOS Ventura where HDR content becomes dimmed when playing in full
     // screen mode once overlaying views are fully hidden (issue #3844). After applying this
@@ -1173,6 +1182,7 @@ class MainWindowController: PlayerWindowController {
   @objc func handleMagnifyGesture(recognizer: NSMagnificationGestureRecognizer) {
     guard pinchAction != .none else { return }
     guard !isInInteractiveMode, let window = window, let screenFrame = NSScreen.main?.visibleFrame else { return }
+    let isFullscreen = fsState.isFullscreen
 
     switch pinchAction {
     case .none:
@@ -1187,32 +1197,114 @@ class MainWindowController: PlayerWindowController {
         }
       }
     case .windowSize:
-      if fsState.isFullscreen { return }
-
-      // adjust window size
-      if recognizer.state == .began {
-        // began
-        lastMagnification = recognizer.magnification
-        videoView.videoLayer.inLiveResize = true
-        frameWhenStartedPinching = window.frame
-      } else if recognizer.state == .changed {
-        // changed
-        let offset = recognizer.magnification - lastMagnification + 1.0;
-        let newWidth = window.frame.width * offset
-        let newHeight = newWidth / window.aspectRatio.aspect
-
-        //Check against max & min threshold
-        if newHeight < screenFrame.height && newHeight > minSize.height && newWidth > minSize.width {
-          let newSize = NSSize(width: newWidth, height: newHeight);
-          window.setFrame(frameWhenStartedPinching.centeredResize(to: newSize), display: true)
+      if isFullscreen {
+        // Fullscreen: pinch to zoom video around the pinch origin.
+        if recognizer.state == .began {
+          lastMagnification = recognizer.magnification
+          pinchScale = 1.0
+          videoView.videoLayer.inLiveResize = true
+          frameWhenStartedPinching = window.frame
+          let currentZoom = player.mpv.getDouble(MPVOption.Video.videoZoom)
+          pinchInitialZoom = max(pinchMinZoom, 1.0 + currentZoom)
+          // Only update the pinch origin if starting from baseline; otherwise keep the prior origin to reduce jumps.
+          if pinchInitialZoom <= pinchMinZoom {
+            pinchOriginInWindow = recognizer.location(in: window.contentView)
+            pinchOriginInVideo = clampedVideoPoint(fromWindowPoint: pinchOriginInWindow ?? .zero)
+            pinchOriginInVideoUnit = normalizedVideoPoint(fromWindowPoint: pinchOriginInWindow ?? .zero)
+          }
+        } else if recognizer.state == .changed {
+          pinchScale = recognizer.magnification + 1.0
+          applyVideoZoom(scaleMultiplier: pinchScale)
+          lastMagnification = recognizer.magnification
+        } else if recognizer.state == .ended {
+          applyVideoZoom(scaleMultiplier: pinchScale)
+          videoView.videoLayer.inLiveResize = false
         }
+      } else {
+        // Windowed: resize the window as before.
+        if recognizer.state == .began {
+          lastMagnification = recognizer.magnification
+          videoView.videoLayer.inLiveResize = true
+          frameWhenStartedPinching = window.frame
+        } else if recognizer.state == .changed {
+          let offset = recognizer.magnification - lastMagnification + 1.0
+          let newWidth = window.frame.width * offset
+          let newHeight = newWidth / window.aspectRatio.aspect
 
-        lastMagnification = recognizer.magnification
-      } else if recognizer.state == .ended {
-        updateWindowParametersForMPV()
-        videoView.videoLayer.inLiveResize = false
+          if newHeight < screenFrame.height && newHeight > minSize.height && newWidth > minSize.width {
+            let newSize = NSSize(width: newWidth, height: newHeight)
+            window.setFrame(frameWhenStartedPinching.centeredResize(to: newSize), display: true)
+          }
+
+          lastMagnification = recognizer.magnification
+        } else if recognizer.state == .ended {
+          updateWindowParametersForMPV()
+          videoView.videoLayer.inLiveResize = false
+        }
       }
     }
+  }
+
+  private func clampedVideoPoint(fromWindowPoint point: NSPoint) -> NSPoint {
+    let viewPoint = videoView.convert(point, from: window?.contentView)
+    let bounds = videoView.bounds
+    guard bounds.width > 0, bounds.height > 0 else { return .zero }
+
+    let (videoWidth, videoHeight) = player.videoSizeForDisplay
+    let videoSize = NSSize(width: CGFloat(videoWidth), height: CGFloat(videoHeight))
+    let fitSize = videoSize.shrink(toSize: bounds.size)
+    let videoRect = fitSize.centeredRect(in: bounds)
+
+    guard videoRect.width > 0, videoRect.height > 0 else { return .zero }
+
+    let clampedX = max(videoRect.minX, min(videoRect.maxX - 1, viewPoint.x))
+    let clampedY = max(videoRect.minY, min(videoRect.maxY - 1, viewPoint.y))
+
+    return NSPoint(x: clampedX - videoRect.minX, y: clampedY - videoRect.minY)
+  }
+
+  private func normalizedVideoPoint(fromWindowPoint point: NSPoint) -> NSPoint? {
+    guard let rect = videoRectInView() else { return nil }
+    let clamped = clampedVideoPoint(fromWindowPoint: point)
+    guard rect.width > 0, rect.height > 0 else { return nil }
+    return NSPoint(x: clamped.x / rect.width, y: clamped.y / rect.height)
+  }
+
+  private func videoRectInView() -> NSRect? {
+    let bounds = videoView.bounds
+    guard bounds.width > 0, bounds.height > 0 else { return nil }
+    let (videoWidth, videoHeight) = player.videoSizeForDisplay
+    let videoSize = NSSize(width: CGFloat(videoWidth), height: CGFloat(videoHeight))
+    let fitSize = videoSize.shrink(toSize: bounds.size)
+    return fitSize.centeredRect(in: bounds)
+  }
+
+  private func applyVideoZoom(scaleMultiplier: CGFloat) {
+    let s0 = pinchInitialZoom
+    let s1 = min(pinchMaxZoom, max(pinchMinZoom, s0 * Double(scaleMultiplier) * pinchZoomMultiplier))
+    let zoomProp = s1 - 1.0
+
+    let origin = pinchOriginInVideoUnit ?? NSPoint(x: 0.5, y: 0.5)
+    // Adjust pan to keep the pinch origin under the cursor relative to the current zoom.
+    // mpv pan semantics: positive pan-x moves video right; positive pan-y moves video down.
+    let invScale = 1.0 / s1
+    let newPanX = clampPan(Double(0.5 - origin.x) * (1.0 - invScale))
+    let newPanY = clampPan(Double(origin.y - 0.5) * (1.0 - invScale))
+
+    player.mpv.setDouble(MPVOption.Video.videoZoom, zoomProp, level: .verbose)
+    player.mpv.setDouble(MPVOption.Video.videoPanX, newPanX, level: .verbose)
+    player.mpv.setDouble(MPVOption.Video.videoPanY, newPanY, level: .verbose)
+
+    // If we're effectively back to 1x, forget the stored origin so a new pinch can pick a fresh focal point.
+    if s1 <= pinchMinZoom + 0.0001 {
+      pinchOriginInWindow = nil
+      pinchOriginInVideo = nil
+      pinchOriginInVideoUnit = nil
+    }
+  }
+
+  private func clampPan(_ value: Double) -> Double {
+    return min(pinchMaxPan, max(-pinchMaxPan, value))
   }
 
   // MARK: - Window delegate: Open / Close

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -182,7 +182,6 @@ class MainWindowController: PlayerWindowController {
   private let pinchZoomMultiplier: Double = 1.0
   private let pinchMinZoom: Double = 1.0
   private let pinchMaxZoom: Double = 4.5
-  private let pinchMaxPan: Double = 1.0
 
   /** Views that will show/hide when cursor moving in/out the window. */
   var fadeableViews: [NSView] = []
@@ -1084,6 +1083,9 @@ class MainWindowController: PlayerWindowController {
       // ignore delta caused by abrupt momentum phases
       return
     }
+    if handlePanGesture(with: event) {
+      return
+    }
     /**
      reference: https://developer.apple.com/library/archive/documentation/Cocoa/Conceptual/EventOverview/HandlingTouchEvents/HandlingTouchEvents.html#//apple_ref/doc/uid/10000060i-CH13
 
@@ -1205,7 +1207,7 @@ class MainWindowController: PlayerWindowController {
           videoView.videoLayer.inLiveResize = true
           frameWhenStartedPinching = window.frame
           let currentZoom = player.mpv.getDouble(MPVOption.Video.videoZoom)
-          pinchInitialZoom = max(pinchMinZoom, 1.0 + currentZoom)
+          pinchInitialZoom = max(pinchMinZoom, mpvScale(fromZoom: currentZoom))
           // Only update the pinch origin if starting from baseline; otherwise keep the prior origin to reduce jumps.
           if pinchInitialZoom <= pinchMinZoom {
             pinchOriginInWindow = recognizer.location(in: window.contentView)
@@ -1279,17 +1281,25 @@ class MainWindowController: PlayerWindowController {
     return fitSize.centeredRect(in: bounds)
   }
 
+  private enum PanAxis {
+    case x
+    case y
+  }
+
   private func applyVideoZoom(scaleMultiplier: CGFloat) {
     let s0 = pinchInitialZoom
     let s1 = min(pinchMaxZoom, max(pinchMinZoom, s0 * Double(scaleMultiplier) * pinchZoomMultiplier))
-    let zoomProp = s1 - 1.0
+    let zoomProp = mpvZoom(fromScale: s1)
+    let bounds = videoView.bounds
+    let rect = videoRectInView() ?? bounds
 
     let origin = pinchOriginInVideoUnit ?? NSPoint(x: 0.5, y: 0.5)
     // Adjust pan to keep the pinch origin under the cursor relative to the current zoom.
     // mpv pan semantics: positive pan-x moves video right; positive pan-y moves video down.
-    let invScale = 1.0 / s1
-    let newPanX = clampPan(Double(0.5 - origin.x) * (1.0 - invScale))
-    let newPanY = clampPan(Double(origin.y - 0.5) * (1.0 - invScale))
+    let marginX = panMargin(forScale: s1, rect: rect, bounds: bounds, axis: .x)
+    let marginY = panMargin(forScale: s1, rect: rect, bounds: bounds, axis: .y)
+    let newPanX = clampPan(Double(0.5 - origin.x), reach: marginX)
+    let newPanY = clampPan(Double(origin.y - 0.5), reach: marginY)
 
     player.mpv.setDouble(MPVOption.Video.videoZoom, zoomProp, level: .verbose)
     player.mpv.setDouble(MPVOption.Video.videoPanX, newPanX, level: .verbose)
@@ -1303,8 +1313,96 @@ class MainWindowController: PlayerWindowController {
     }
   }
 
-  private func clampPan(_ value: Double) -> Double {
-    return min(pinchMaxPan, max(-pinchMaxPan, value))
+  private func clampPan(_ value: Double, reach: Double) -> Double {
+    let limit = 0.5 - reach
+    guard limit > 0 else { return 0 }
+    return min(limit, max(-limit, value))
+  }
+
+  private func clampedNormalizedCenter(_ value: Double, reach: Double) -> Double {
+    return min(1.0 - reach, max(reach, value))
+  }
+
+  private func panMargin(forScale scale: Double, rect: NSRect, bounds: NSRect, axis: PanAxis) -> Double {
+    guard scale > 1.0 else { return 0.5 }
+    guard rect.width > 0, rect.height > 0, bounds.width > 0, bounds.height > 0 else { return 0.5 / scale }
+
+    let aspectVideo = rect.width / rect.height
+    let aspectView = bounds.width / bounds.height
+    let fillX: Double
+    let fillY: Double
+    if aspectVideo > aspectView {
+      fillX = 1.0
+      fillY = aspectView / aspectVideo
+    } else {
+      fillX = aspectVideo / aspectView
+      fillY = 1.0
+    }
+
+    let fill = (axis == .x) ? fillX : fillY
+    let reach = 0.5 / (scale * fill)
+    return min(0.5, max(0.0, reach))
+  }
+
+  private func mpvScale(fromZoom zoom: Double) -> Double {
+    return pow(2.0, zoom)
+  }
+
+  private func mpvZoom(fromScale scale: Double) -> Double {
+    return log2(scale)
+  }
+
+  private func handlePanGesture(with event: NSEvent) -> Bool {
+    guard fsState.isFullscreen else { return false }
+    guard !isInInteractiveMode else { return false }
+    guard event.hasPreciseScrollingDeltas else { return false }
+    guard event.momentumPhase.isEmpty else { return true }
+
+    let currentZoom = player.mpv.getDouble(MPVOption.Video.videoZoom)
+    let currentScale = max(pinchMinZoom, mpvScale(fromZoom: currentZoom))
+    guard currentScale > pinchMinZoom + 0.0001 else { return false }
+
+    guard let rect = videoRectInView(), rect.width > 0, rect.height > 0 else { return false }
+    let bounds = videoView.bounds
+    guard !isMouseEvent(event, inAnyOf: [sideBarView, titleBarView, subPopoverView, currentControlBar, fragSliderView, fragVolumeView]) else { return false }
+
+    var deltaX = event.scrollingDeltaX
+    var deltaY = event.scrollingDeltaY
+
+    if event.isDirectionInvertedFromDevice {
+      deltaX = -deltaX
+      deltaY = -deltaY
+    }
+
+    let panSpeed: Double = 2.3
+    let normalizedDeltaX = Double(deltaX) * panSpeed / (Double(rect.width) * currentScale)
+    let normalizedDeltaY = -Double(deltaY) * panSpeed / (Double(rect.height) * currentScale)
+
+    if abs(normalizedDeltaX) < 0.000001 && abs(normalizedDeltaY) < 0.000001 {
+      return true
+    }
+
+    let currentPanX = player.mpv.getDouble(MPVOption.Video.videoPanX)
+    let currentPanY = player.mpv.getDouble(MPVOption.Video.videoPanY)
+
+    let marginX = panMargin(forScale: currentScale, rect: rect, bounds: bounds, axis: .x)
+    let marginY = panMargin(forScale: currentScale, rect: rect, bounds: bounds, axis: .y)
+
+    let currentCenterX = 0.5 - currentPanX
+    let currentCenterY = 0.5 + currentPanY
+
+    let newCenterX = clampedNormalizedCenter(currentCenterX + normalizedDeltaX, reach: marginX)
+    let newCenterY = clampedNormalizedCenter(currentCenterY + normalizedDeltaY, reach: marginY)
+
+    let newPanX = clampPan(0.5 - newCenterX, reach: marginX)
+    let newPanY = clampPan(newCenterY - 0.5, reach: marginY)
+
+    player.mpv.setDouble(MPVOption.Video.videoPanX, newPanX, level: .verbose)
+    player.mpv.setDouble(MPVOption.Video.videoPanY, newPanY, level: .verbose)
+
+    pinchOriginInVideoUnit = NSPoint(x: newCenterX, y: newCenterY)
+
+    return true
   }
 
   // MARK: - Window delegate: Open / Close


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4487

---

**Description:**

A suggestion and a conversation-starter. An AI-assisted work again 🤖, so the code might need some love.

* Zoom works when the setting `Control → Pinch to` is set to _“Adjust window size“_.  (Maybe a new setting could be introduced to keep legacy behavior if many users wish so)
* If we are not zoomed-in (so the size is 100%), the zoom starts around the cursor position (clamping to the nearest point in the video when the cursor is outside of the video)
* If we zoom several times (“consecutive zooms”), zooming still happens around the point where we started when we were at 100%. This avoids “jumps” that naïve panning would cause in such a case. And it feels natural anyway
* But perhaps a more easing-in mode of panning for consecutive zooms and zooms after panning (see below) could be introduced 
* Only when zoom is above 100%, we can pan (with two fingers on a touchpad, for example). After we have panned, zoom happens around the center of the screen. (This could be a little confusing if your cursor is far from the center. But if we zoom around the cursor again, that would cause a “jump“ of fast panning as well; see above.)
* Panning seems to play along fine with the `Control → Scroll vertically to` and `Scroll horizontally to` actions. When we are zoomed above 100%, we get panning, at 100% we get our configured actions
* Max zoom level is hardcoded in the code
* The behavior of the zoom in windowed mode should not be affected
* If `General → Resume last playback position` setting is enabled, zoom and pan state is also remembered. I think that‘s fine
