### PR TITLE
Change get/setFlag to use Int32 for MPV_FORMAT_FLAG

### DIFF
--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -843,7 +843,7 @@ class MPVController: NSObject {
   // Set property
   func setFlag(_ name: String, _ flag: Bool, level: Logger.Level = .debug) {
     log("Set property: \(name)=\(flag)", level: level)
-    var data: Int = flag ? 1 : 0
+    var data: Int32 = flag ? 1 : 0
     mpv_set_property(mpv, name, MPV_FORMAT_FLAG, &data)
   }
 
@@ -885,7 +885,7 @@ class MPVController: NSObject {
   }
 
   func getFlag(_ name: String) -> Bool {
-    var data = Int64()
+    var data = Int32()
     mpv_get_property(mpv, name, MPV_FORMAT_FLAG, &data)
     return data > 0
   }


### PR DESCRIPTION
This commit will:
- Change `MPVController.getFlag` to use `Int32` instead of `Int64` when calling `mpv_get_property`
- Change `MPVController.setFlag` to use `Int32` instead of `Int` when calling `mpv_set_property`

Using 64 bit integers is working, but is not technically correct. A `MPV_FORMAT_FLAG` is a 32 bit integer. `MPVController` correctly uses `Int32` for other `libmpv` client APIs that use 32 bit integers. These changes align these two methods with that convention.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
