### PR TITLE
Reset Scroll on Switching Tabs in Settings

### DIFF
--- a/iina/PreferenceWindowController.swift
+++ b/iina/PreferenceWindowController.swift
@@ -303,6 +303,11 @@ class PreferenceWindowController: NSWindowController {
     detailViewBottomConstraint?.isActive = !isScrollable
     prefDetailScrollView.verticalScrollElasticity = .none
 
+    // Reset scroll position to top when switching tabs
+    if let documentView = prefDetailScrollView.documentView {
+      documentView.scroll(NSPoint(x: 0, y: documentView.bounds.maxY))
+    }
+
     // find label
     if let title = title, let label = findLabel(titled: title, in: vc.view) {
       maskView.perform(#selector(maskView.highlight(_:)), with: label, afterDelay: 0.25)

--- a/iina/PreferenceWindowController.swift
+++ b/iina/PreferenceWindowController.swift
@@ -305,7 +305,7 @@ class PreferenceWindowController: NSWindowController {
 
     // Reset scroll position to top when switching tabs
     if let documentView = prefDetailScrollView.documentView {
-      documentView.scroll(NSPoint(x: 0, y: documentView.bounds.maxY))
+      documentView.scroll(NSPoint(x: 0, y: 0))
     }
 
     // find label


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
- I noticed an issue where the tab switching in the settings page doesn't reset the scroll we do in other tabs
- Added a reset to make sure this would be good UX