### PR TITLE
Font Picker window improvements and bug fixes

### DIFF
--- a/iina/AppData.swift
+++ b/iina/AppData.swift
@@ -82,6 +82,7 @@ struct Constants {
     static let dot = "●"
     static let blackRightPointingTriangle = "▶︎"
     static let blackLeftPointingTriangle = "◀"
+    static let mpvDefaultFont = "sans-serif"
     static let videoTimePlaceholder = "--:--:--"
     static let trackNone = NSLocalizedString("track.none", comment: "<None>")
     static let chapter = "Chapter"

--- a/iina/Base.lproj/FontPickerWindowController.xib
+++ b/iina/Base.lproj/FontPickerWindowController.xib
@@ -191,7 +191,7 @@ Gw
                     </textField>
                     <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Qur-08-eHn">
                         <rect key="frame" x="12" y="52" width="434" height="24"/>
-                        <textFieldCell key="cell" controlSize="large" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="sans-serif" drawsBackground="YES" id="Kt3-me-43R">
+                        <textFieldCell key="cell" controlSize="large" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" drawsBackground="YES" id="Kt3-me-43R">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>

--- a/iina/Base.lproj/FontPickerWindowController.xib
+++ b/iina/Base.lproj/FontPickerWindowController.xib
@@ -6,7 +6,7 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <customObject id="-2" userLabel="File's Owner" customClass="FontPickerWindowController" customModule="IINA_Advance" customModuleProvider="target">
+        <customObject id="-2" userLabel="File's Owner" customClass="FontPickerWindowController" customModule="IINA" customModuleProvider="target">
             <connections>
                 <outlet property="faceTableView" destination="igd-1P-vQT" id="vk2-bn-1ZM"/>
                 <outlet property="familyTableView" destination="av5-Km-BXV" id="Ttw-xq-6IC"/>

--- a/iina/Base.lproj/FontPickerWindowController.xib
+++ b/iina/Base.lproj/FontPickerWindowController.xib
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="14313.18" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="14313.18"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
-        <customObject id="-2" userLabel="File's Owner" customClass="FontPickerWindowController" customModule="IINA" customModuleProvider="target">
+        <customObject id="-2" userLabel="File's Owner" customClass="FontPickerWindowController" customModule="IINA_Advance" customModuleProvider="target">
             <connections>
                 <outlet property="faceTableView" destination="igd-1P-vQT" id="vk2-bn-1ZM"/>
                 <outlet property="familyTableView" destination="av5-Km-BXV" id="Ttw-xq-6IC"/>
@@ -22,27 +22,26 @@
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="458" height="524"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1496" height="937"/>
             <view key="contentView" wantsLayer="YES" id="se5-gp-TjO">
-                <rect key="frame" x="0.0" y="0.0" width="458" height="502"/>
+                <rect key="frame" x="0.0" y="0.0" width="458" height="496"/>
                 <autoresizingMask key="autoresizingMask"/>
                 <subviews>
                     <scrollView focusRingType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Wus-vA-7bo">
-                        <rect key="frame" x="12" y="167" width="218" height="268"/>
+                        <rect key="frame" x="12" y="160" width="218" height="268"/>
                         <clipView key="contentView" focusRingType="none" id="Zfn-kp-cP8">
-                            <rect key="frame" x="1" y="0.0" width="216" height="267"/>
+                            <rect key="frame" x="1" y="1" width="216" height="266"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
-                                <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" headerView="hpt-ox-hcu" id="av5-Km-BXV">
-                                    <rect key="frame" x="0.0" y="0.0" width="216" height="244"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="none" columnReordering="NO" multipleSelection="NO" autosaveColumns="NO" headerView="hpt-ox-hcu" id="av5-Km-BXV">
+                                    <rect key="frame" x="0.0" y="0.0" width="220" height="243"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <size key="intercellSpacing" width="3" height="2"/>
                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                     <tableColumns>
-                                        <tableColumn editable="NO" width="213" minWidth="40" maxWidth="1000" id="2Ld-md-U2v">
+                                        <tableColumn editable="NO" width="200" minWidth="200" maxWidth="200" id="2Ld-md-U2v">
                                             <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Family">
-                                                <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
@@ -51,7 +50,7 @@
                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
-                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
                                         </tableColumn>
                                     </tableColumns>
                                 </tableView>
@@ -60,35 +59,34 @@
                         <constraints>
                             <constraint firstAttribute="height" constant="268" id="03m-Ug-zYu"/>
                         </constraints>
-                        <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="x8g-DZ-V9f">
-                            <rect key="frame" x="1" y="251" width="208" height="16"/>
+                        <scroller key="horizontalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="x8g-DZ-V9f">
+                            <rect key="frame" x="1" y="250" width="216" height="17"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
                         <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="biG-DG-2Qv">
                             <rect key="frame" x="-15" y="0.0" width="16" height="0.0"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
-                        <tableHeaderView key="headerView" id="hpt-ox-hcu">
-                            <rect key="frame" x="0.0" y="0.0" width="216" height="23"/>
+                        <tableHeaderView key="headerView" wantsLayer="YES" id="hpt-ox-hcu">
+                            <rect key="frame" x="0.0" y="0.0" width="220" height="23"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </tableHeaderView>
                     </scrollView>
                     <scrollView focusRingType="none" autohidesScrollers="YES" horizontalLineScroll="19" horizontalPageScroll="10" verticalLineScroll="19" verticalPageScroll="10" usesPredominantAxisScrolling="NO" translatesAutoresizingMaskIntoConstraints="NO" id="Smi-Ny-cCV">
-                        <rect key="frame" x="229" y="167" width="217" height="268"/>
+                        <rect key="frame" x="229" y="160" width="217" height="268"/>
                         <clipView key="contentView" focusRingType="none" id="2NA-x9-5pt">
-                            <rect key="frame" x="1" y="0.0" width="215" height="267"/>
+                            <rect key="frame" x="1" y="1" width="215" height="266"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
-                                <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="lastColumnOnly" columnReordering="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" headerView="qva-E8-4Pz" id="igd-1P-vQT">
-                                    <rect key="frame" x="0.0" y="0.0" width="215" height="244"/>
-                                    <autoresizingMask key="autoresizingMask"/>
+                                <tableView focusRingType="none" verticalHuggingPriority="750" allowsExpansionToolTips="YES" columnAutoresizingStyle="none" columnReordering="NO" multipleSelection="NO" emptySelection="NO" autosaveColumns="NO" headerView="qva-E8-4Pz" id="igd-1P-vQT">
+                                    <rect key="frame" x="0.0" y="0.0" width="220" height="243"/>
+                                    <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                                     <size key="intercellSpacing" width="3" height="2"/>
                                     <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                     <color key="gridColor" name="gridColor" catalog="System" colorSpace="catalog"/>
                                     <tableColumns>
-                                        <tableColumn editable="NO" width="212" minWidth="40" maxWidth="1000" id="fez-Z3-dnL">
+                                        <tableColumn editable="NO" width="200" minWidth="200" maxWidth="200" id="fez-Z3-dnL">
                                             <tableHeaderCell key="headerCell" lineBreakMode="truncatingTail" borderStyle="border" title="Typeface">
-                                                <font key="font" metaFont="smallSystem"/>
                                                 <color key="textColor" name="headerTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="headerColor" catalog="System" colorSpace="catalog"/>
                                             </tableHeaderCell>
@@ -97,38 +95,38 @@
                                                 <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlBackgroundColor" catalog="System" colorSpace="catalog"/>
                                             </textFieldCell>
-                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES" userResizable="YES"/>
+                                            <tableColumnResizingMask key="resizingMask" resizeWithTable="YES"/>
                                         </tableColumn>
                                     </tableColumns>
                                 </tableView>
                             </subviews>
                         </clipView>
-                        <scroller key="horizontalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="kUQ-Ph-Xwm">
-                            <rect key="frame" x="1" y="-16" width="0.0" height="16"/>
+                        <scroller key="horizontalScroller" wantsLayer="YES" verticalHuggingPriority="750" horizontal="YES" id="kUQ-Ph-Xwm">
+                            <rect key="frame" x="1" y="250" width="215" height="17"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
                         <scroller key="verticalScroller" hidden="YES" wantsLayer="YES" verticalHuggingPriority="750" horizontal="NO" id="F8i-dx-nrp">
                             <rect key="frame" x="-15" y="0.0" width="16" height="0.0"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </scroller>
-                        <tableHeaderView key="headerView" id="qva-E8-4Pz">
-                            <rect key="frame" x="0.0" y="0.0" width="215" height="23"/>
+                        <tableHeaderView key="headerView" wantsLayer="YES" id="qva-E8-4Pz">
+                            <rect key="frame" x="0.0" y="0.0" width="220" height="23"/>
                             <autoresizingMask key="autoresizingMask"/>
                         </tableHeaderView>
                     </scrollView>
-                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ikb-4c-nqb">
-                        <rect key="frame" x="12" y="125" width="434" height="34"/>
-                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="center" title="Test" drawsBackground="YES" id="qwM-r2-9ki">
+                    <textField focusRingType="none" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="ikb-4c-nqb">
+                        <rect key="frame" x="12" y="112" width="434" height="40"/>
+                        <constraints>
+                            <constraint firstAttribute="height" constant="40" id="Ome-pP-G3g"/>
+                        </constraints>
+                        <textFieldCell key="cell" controlSize="large" lineBreakMode="truncatingTail" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" alignment="center" title="Test" drawsBackground="YES" id="qwM-r2-9ki">
                             <font key="font" metaFont="system" size="24"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="JCC-UN-o4K">
-                        <rect key="frame" x="360" y="5" width="92" height="32"/>
-                        <constraints>
-                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="80" id="1sn-dR-xoe"/>
-                        </constraints>
+                        <rect key="frame" x="366" y="12" width="80" height="24"/>
                         <buttonCell key="cell" type="push" title="OK" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="S5m-SJ-Ggp">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -136,34 +134,31 @@
 DQ
 </string>
                         </buttonCell>
+                        <constraints>
+                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="80" id="1sn-dR-xoe"/>
+                        </constraints>
                         <connections>
                             <action selector="okBtnPressed:" target="-2" id="87E-0I-sF9"/>
                         </connections>
                     </button>
-                    <textField verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BPS-z6-4UH">
-                        <rect key="frame" x="12" y="443" width="434" height="22"/>
-                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Type to filter..." bezelStyle="round" id="DwS-ve-MLJ">
+                    <textField focusRingType="none" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BPS-z6-4UH">
+                        <rect key="frame" x="12" y="436" width="434" height="24"/>
+                        <textFieldCell key="cell" controlSize="large" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="Type to filter..." bezelStyle="round" id="DwS-ve-MLJ">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qRK-T8-QYd">
-                        <rect key="frame" x="18" y="141" width="46" height="14"/>
+                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qRK-T8-QYd">
+                        <rect key="frame" x="18" y="134" width="46" height="14"/>
                         <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Preview" id="XsF-e7-fXF">
                             <font key="font" metaFont="smallSystem"/>
                             <color key="textColor" name="tertiaryLabelColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="Fvr-Hf-cNO">
-                        <rect key="frame" x="0.0" y="106" width="458" height="5"/>
-                    </box>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="WAf-Zm-Nth">
-                        <rect key="frame" x="268" y="5" width="92" height="32"/>
-                        <constraints>
-                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="80" id="a8s-gx-BFx"/>
-                        </constraints>
+                        <rect key="frame" x="274" y="12" width="80" height="24"/>
                         <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Ihd-HK-wsv">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -171,29 +166,32 @@ DQ
 Gw
 </string>
                         </buttonCell>
+                        <constraints>
+                            <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="80" id="a8s-gx-BFx"/>
+                        </constraints>
                         <connections>
                             <action selector="cancelBtnPressed:" target="-2" id="bX2-tH-ayQ"/>
                         </connections>
                     </button>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lDI-0O-kbm">
-                        <rect key="frame" x="10" y="473" width="93" height="17"/>
+                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="lDI-0O-kbm">
+                        <rect key="frame" x="10" y="468" width="93" height="16"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" title="Choose a font:" id="TSI-Wt-Edx">
                             <font key="font" usesAppearanceFont="YES"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Lci-WK-6mm">
-                        <rect key="frame" x="10" y="79" width="146" height="17"/>
+                    <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Lci-WK-6mm">
+                        <rect key="frame" x="10" y="84" width="146" height="16"/>
                         <textFieldCell key="cell" lineBreakMode="clipping" title="Or enter the font name:" id="waR-LB-484">
                             <font key="font" usesAppearanceFont="YES"/>
                             <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                         </textFieldCell>
                     </textField>
-                    <textField verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Qur-08-eHn">
-                        <rect key="frame" x="12" y="49" width="434" height="22"/>
-                        <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="sans-serif" drawsBackground="YES" id="Kt3-me-43R">
+                    <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Qur-08-eHn">
+                        <rect key="frame" x="12" y="52" width="434" height="24"/>
+                        <textFieldCell key="cell" controlSize="large" scrollable="YES" lineBreakMode="clipping" selectable="YES" editable="YES" sendsActionOnEndEditing="YES" state="on" borderStyle="bezel" placeholderString="sans-serif" drawsBackground="YES" id="Kt3-me-43R">
                             <font key="font" metaFont="system"/>
                             <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
@@ -205,9 +203,7 @@ Gw
                     <constraint firstItem="Qur-08-eHn" firstAttribute="top" secondItem="Lci-WK-6mm" secondAttribute="bottom" constant="8" id="26h-9w-fst"/>
                     <constraint firstAttribute="trailing" secondItem="JCC-UN-o4K" secondAttribute="trailing" constant="12" id="2d2-lV-TZi"/>
                     <constraint firstItem="lDI-0O-kbm" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" constant="12" id="7xZ-CE-ayR"/>
-                    <constraint firstAttribute="trailing" secondItem="Fvr-Hf-cNO" secondAttribute="trailing" id="95M-0T-Nbk"/>
                     <constraint firstItem="BPS-z6-4UH" firstAttribute="top" secondItem="lDI-0O-kbm" secondAttribute="bottom" constant="8" id="9Wu-ek-bSW"/>
-                    <constraint firstItem="Lci-WK-6mm" firstAttribute="top" secondItem="Fvr-Hf-cNO" secondAttribute="bottom" constant="12" id="E8G-3Q-321"/>
                     <constraint firstItem="ikb-4c-nqb" firstAttribute="top" secondItem="Wus-vA-7bo" secondAttribute="bottom" constant="8" id="I1y-v2-32Q"/>
                     <constraint firstItem="qRK-T8-QYd" firstAttribute="top" secondItem="Wus-vA-7bo" secondAttribute="bottom" constant="12" id="I6H-ah-G4W"/>
                     <constraint firstItem="Wus-vA-7bo" firstAttribute="top" secondItem="BPS-z6-4UH" secondAttribute="bottom" constant="8" id="IYV-dp-2uX"/>
@@ -218,11 +214,11 @@ Gw
                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="Lci-WK-6mm" secondAttribute="trailing" constant="12" id="Tzv-cK-MX9"/>
                     <constraint firstItem="Wus-vA-7bo" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" constant="12" id="XqO-7j-13d"/>
                     <constraint firstItem="lDI-0O-kbm" firstAttribute="top" secondItem="se5-gp-TjO" secondAttribute="top" constant="12" id="Z9a-k5-kny"/>
+                    <constraint firstItem="Lci-WK-6mm" firstAttribute="top" secondItem="ikb-4c-nqb" secondAttribute="bottom" constant="12" id="ZF9-gF-LyM"/>
                     <constraint firstItem="Smi-Ny-cCV" firstAttribute="centerY" secondItem="Wus-vA-7bo" secondAttribute="centerY" id="ZMe-mC-Y62"/>
                     <constraint firstItem="JCC-UN-o4K" firstAttribute="baseline" secondItem="WAf-Zm-Nth" secondAttribute="baseline" id="a4p-TV-u3y"/>
                     <constraint firstItem="BPS-z6-4UH" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" constant="12" id="dQm-b6-OE7"/>
                     <constraint firstItem="Smi-Ny-cCV" firstAttribute="width" secondItem="Wus-vA-7bo" secondAttribute="width" id="dVt-g0-nYL"/>
-                    <constraint firstItem="Fvr-Hf-cNO" firstAttribute="top" secondItem="ikb-4c-nqb" secondAttribute="bottom" constant="16" id="db7-TB-R9r"/>
                     <constraint firstItem="Lci-WK-6mm" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" constant="12" id="fWP-Iu-eR5"/>
                     <constraint firstItem="Smi-Ny-cCV" firstAttribute="leading" secondItem="Wus-vA-7bo" secondAttribute="trailing" constant="-1" id="fqm-CI-J7U"/>
                     <constraint firstAttribute="trailing" secondItem="Smi-Ny-cCV" secondAttribute="trailing" constant="12" id="fx4-Fa-2yE"/>
@@ -231,7 +227,6 @@ Gw
                     <constraint firstItem="Smi-Ny-cCV" firstAttribute="height" secondItem="Wus-vA-7bo" secondAttribute="height" id="lL9-7L-rKv"/>
                     <constraint firstAttribute="trailing" secondItem="Qur-08-eHn" secondAttribute="trailing" constant="12" id="lXy-4i-gM2"/>
                     <constraint firstItem="Qur-08-eHn" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" constant="12" id="let-JF-n1I"/>
-                    <constraint firstItem="Fvr-Hf-cNO" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" id="mJx-PP-2Mr"/>
                     <constraint firstItem="qRK-T8-QYd" firstAttribute="leading" secondItem="se5-gp-TjO" secondAttribute="leading" constant="20" id="nbB-8x-tMW"/>
                     <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="qRK-T8-QYd" secondAttribute="trailing" constant="20" id="sIc-1a-cXv"/>
                     <constraint firstAttribute="bottom" secondItem="JCC-UN-o4K" secondAttribute="bottom" constant="12" id="tSp-3q-Qgx"/>

--- a/iina/FontPickerWindowController.swift
+++ b/iina/FontPickerWindowController.swift
@@ -40,7 +40,7 @@ class FontPickerWindowController: NSWindowController, NSTableViewDelegate, NSTab
     return ""
   }
 
-  var finishedPicking: ((String?) -> Void)?
+  var finishedPicking: ((String) -> Void)?
 
   private var enableSelectionChangeListener = true
 
@@ -71,6 +71,7 @@ class FontPickerWindowController: NSWindowController, NSTableViewDelegate, NSTab
       tv.dataSource = self
       tv.delegate = self
     }
+    otherField.placeholderString = Constants.String.mpvDefaultFont
     searchField.delegate = self
     faceTableView.doubleAction = #selector(okBtnPressed)
     Logger.log("FontPickerWindow init done")
@@ -79,7 +80,7 @@ class FontPickerWindowController: NSWindowController, NSTableViewDelegate, NSTab
   func select(_ fontString: String ) {
     Logger.log("FontPickerWindow selecting \(fontString.quoted) (searching=\(isSearching))")
 
-    otherField.stringValue = fontString
+    otherField.stringValue = fontString == Constants.String.mpvDefaultFont ? "" : fontString
 
     updateTablesFromOtherFieldValue()
   }
@@ -87,6 +88,12 @@ class FontPickerWindowController: NSWindowController, NSTableViewDelegate, NSTab
   /// Updates all other UI state from the `otherField` value (i.e., the manually entered typeface name).
   private func updateTablesFromOtherFieldValue() {
     let selectedFace = otherField.stringValue
+    guard !selectedFace.isEmpty else {
+      // Deselect any previous table selections
+      familyTableView.selectRowIndexes(IndexSet(), byExtendingSelection: false)
+      faceTableView.selectRowIndexes(IndexSet(), byExtendingSelection: false)
+      return
+    }
 
     // Search for font. Unfortunately this requires checking all typefaces in the system.
     // But it's still quite fast.
@@ -151,7 +158,7 @@ class FontPickerWindowController: NSWindowController, NSTableViewDelegate, NSTab
 
   // - MARK: NSTextField delegate
 
-  // Type-to-filter updates
+  /// Type-to-filter updates
   func controlTextDidChange(_ notification: Notification) {
     familyTableView.deselectAll(searchField)
     let str = searchField.stringValue
@@ -171,11 +178,7 @@ class FontPickerWindowController: NSWindowController, NSTableViewDelegate, NSTab
   @IBAction func okBtnPressed(_ sender: AnyObject) {
     if let block = finishedPicking {
       let otherString = otherField.stringValue
-      if otherString.isEmpty {
-        block(chosenFace)
-      } else {
-        block(otherString)
-      }
+      block(otherString)
       // remove the listener
       finishedPicking = nil
     }

--- a/iina/FontPickerWindowController.swift
+++ b/iina/FontPickerWindowController.swift
@@ -176,11 +176,12 @@ class FontPickerWindowController: NSWindowController, NSTableViewDelegate, NSTab
   }
 
   @IBAction func okBtnPressed(_ sender: AnyObject) {
-    if let block = finishedPicking {
+    if let finishedPicking {
       let otherString = otherField.stringValue
-      block(otherString)
+      let selectedFont = otherString.isEmpty ? Constants.String.mpvDefaultFont : otherString
+      finishedPicking(selectedFont)
       // remove the listener
-      finishedPicking = nil
+      self.finishedPicking = nil
     }
     self.close()
   }

--- a/iina/FontPickerWindowController.swift
+++ b/iina/FontPickerWindowController.swift
@@ -26,9 +26,19 @@ class FontPickerWindowController: NSWindowController, NSTableViewDelegate, NSTab
   var fontNames: [FontInfo] = []
   var filteredFontNames: [FontInfo] = []
   var isSearching = false
-  var chosenFontMembers: [[Any]]?
-  var chosenFamily: FontInfo?
-  var chosenFace: String
+
+  private var chosenFontMembers: [[Any]] {
+    guard familyTableView.selectedRow >= 0 else { return [] }
+    let chosenFamily = isSearching ? filteredFontNames[familyTableView.selectedRow] : fontNames[familyTableView.selectedRow]
+    return FixedFontManager.typefaces(forFontFamily: chosenFamily.name) as? [[Any]] ?? []
+  }
+  private var chosenFace: String {
+    let typefaceIndex = faceTableView.selectedRow
+    if typefaceIndex >= 0, let face = chosenFontMembers[faceTableView.selectedRow][0] as? String {
+      return face
+    }
+    return ""
+  }
 
   var finishedPicking: ((String?) -> Void)?
 
@@ -41,7 +51,6 @@ class FontPickerWindowController: NSWindowController, NSTableViewDelegate, NSTab
   }
 
   init() {
-    self.chosenFace = ""
     super.init(window: nil)
   }
 
@@ -78,30 +87,27 @@ class FontPickerWindowController: NSWindowController, NSTableViewDelegate, NSTab
   /// Updates all other UI state from the `otherField` value (i.e., the manually entered typeface name).
   private func updateTablesFromOtherFieldValue() {
     let selectedFace = otherField.stringValue
-    chosenFace = selectedFace
 
     // Search for font. Unfortunately this requires checking all typefaces in the system.
     // But it's still quite fast.
     // If there is a filter string already set don't try to change it, even if this means not finding a match.
     let fontNamesDisplayed = isSearching ? filteredFontNames : fontNames
     for (familyIndex, family) in fontNamesDisplayed.enumerated() {
-      if let typefaces = FixedFontManager.typefaces(forFontFamily: family.name) as? [[Any]] {
-        for (typefaceIndex, typeface) in typefaces.enumerated() {
-          if let faceName = typeface[0] as? String, faceName == selectedFace {
-            enableSelectionChangeListener = false
+      guard let typefaces = FixedFontManager.typefaces(forFontFamily: family.name) as? [[Any]] else { continue }
+      for (typefaceIndex, typeface) in typefaces.enumerated() {
+        guard let faceName = typeface[0] as? String, faceName == selectedFace else { continue }
+        enableSelectionChangeListener = false
 
-            chosenFamily = family
-            chosenFontMembers = typefaces
-            familyTableView.selectRowIndexes(IndexSet(integer: familyIndex), byExtendingSelection: false)
-            familyTableView.scrollRowToVisible(familyIndex)
-            faceTableView.selectRowIndexes(IndexSet(integer: typefaceIndex), byExtendingSelection: false)
-            faceTableView.scrollRowToVisible(typefaceIndex)
+        familyTableView.selectRowIndexes(IndexSet(integer: familyIndex), byExtendingSelection: false)
+        familyTableView.scrollRowToVisible(familyIndex)
 
-            enableSelectionChangeListener = true
-            updatePreview()
-            return
-          }
-        }
+        faceTableView.reloadData()
+        faceTableView.selectRowIndexes(IndexSet(integer: typefaceIndex), byExtendingSelection: false)
+        faceTableView.scrollRowToVisible(typefaceIndex)
+
+        enableSelectionChangeListener = true
+        updatePreview()
+        return
       }
     }
   }
@@ -112,7 +118,7 @@ class FontPickerWindowController: NSWindowController, NSTableViewDelegate, NSTab
     if tableView == familyTableView {
       return isSearching ? filteredFontNames.count : fontNames.count
     } else if tableView == faceTableView {
-      return chosenFontMembers?.count ?? 0
+      return chosenFontMembers.count
     } else {
       return 0
     }
@@ -122,8 +128,8 @@ class FontPickerWindowController: NSWindowController, NSTableViewDelegate, NSTab
     if tableView == familyTableView {
       return isSearching ? filteredFontNames[row].localizedName : fontNames[row].localizedName
     } else if tableView == faceTableView {
-      let face = chosenFontMembers?[row]
-      return face?[1]
+      let face = chosenFontMembers[row]
+      return face[1]
     } else {
       return 0
     }
@@ -133,16 +139,10 @@ class FontPickerWindowController: NSWindowController, NSTableViewDelegate, NSTab
     guard enableSelectionChangeListener else { return }
     guard let activeTv = notification.object as? NSTableView else { return }
     if activeTv == familyTableView {
-      guard familyTableView.selectedRow >= 0 else { return }
-      chosenFamily = isSearching ? filteredFontNames[familyTableView.selectedRow] : fontNames[familyTableView.selectedRow]
-      guard let chosenFamily else { return }
-      chosenFontMembers = FixedFontManager.typefaces(forFontFamily: chosenFamily.name) as? [[Any]]
       faceTableView.reloadData()
       faceTableView.selectRowIndexes(IndexSet(integer: 0), byExtendingSelection: false)
     }
 
-    guard let chosenFontMembers else { return }
-    chosenFace = (chosenFontMembers[faceTableView.selectedRow][0] as? String) ?? ""
     if !chosenFace.isEmpty {
       otherField.stringValue = chosenFace
     }
@@ -162,10 +162,10 @@ class FontPickerWindowController: NSWindowController, NSTableViewDelegate, NSTab
     } else {
       isSearching = true
       filteredFontNames = fontNames.filter { $0.localizedName.lowercased().contains(str.lowercased()) }
-      chosenFontMembers = nil
       familyTableView.reloadData()
       faceTableView.reloadData()
     }
+    updateTablesFromOtherFieldValue()
   }
 
   @IBAction func okBtnPressed(_ sender: AnyObject) {
@@ -190,10 +190,12 @@ class FontPickerWindowController: NSWindowController, NSTableViewDelegate, NSTab
   // - MARK: Utils
 
   private func updatePreview() {
-    guard let chosenFontMembers else { return }
-    chosenFace = (chosenFontMembers[faceTableView.selectedRow][0] as? String) ?? ""
-    Logger.log("Previewing chosen typeface (\(faceTableView.selectedRow) / \(chosenFontMembers.count)): \(chosenFace)")
-    previewField.font = NSFont(name: chosenFace, size: 24) ?? NSFont.systemFont(ofSize: 24)
+    let chosenFont = NSFont(name: chosenFace, size: 24)
+    if let chosenFont {
+      Logger.log("Previewing chosen typeface: \(chosenFont.fontName)")
+    }
+    let font = chosenFont ?? NSFont.systemFont(ofSize: 24)
+    previewField.font = font
   }
 
   private func withAllTableViews (_ block: (NSTableView) -> Void) {

--- a/iina/FontPickerWindowController.swift
+++ b/iina/FontPickerWindowController.swift
@@ -18,7 +18,9 @@ class FontPickerWindowController: NSWindowController, NSTableViewDelegate, NSTab
   @IBOutlet weak var familyTableView: NSTableView!
   @IBOutlet weak var faceTableView: NSTableView!
   @IBOutlet weak var previewField: NSTextField!
+  /// "Type to filter"
   @IBOutlet weak var searchField: NSTextField!
+  /// Font name manual entry
   @IBOutlet weak var otherField: NSTextField!
 
   var fontNames: [FontInfo] = []
@@ -26,14 +28,25 @@ class FontPickerWindowController: NSWindowController, NSTableViewDelegate, NSTab
   var isSearching = false
   var chosenFontMembers: [[Any]]?
   var chosenFamily: FontInfo?
-  var chosenFace: String?
+  var chosenFace: String
 
   var finishedPicking: ((String?) -> Void)?
+
+  private var enableSelectionChangeListener = true
 
   override var windowNibName: NSNib.Name {
     get {
       return NSNib.Name("FontPickerWindowController")
     }
+  }
+
+  init() {
+    self.chosenFace = ""
+    super.init(window: nil)
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
   }
 
   override func windowDidLoad() {
@@ -50,6 +63,47 @@ class FontPickerWindowController: NSWindowController, NSTableViewDelegate, NSTab
       tv.delegate = self
     }
     searchField.delegate = self
+    faceTableView.doubleAction = #selector(okBtnPressed)
+    Logger.log("FontPickerWindow init done")
+  }
+
+  func select(_ fontString: String ) {
+    Logger.log("FontPickerWindow selecting \(fontString.quoted) (searching=\(isSearching))")
+
+    otherField.stringValue = fontString
+
+    updateTablesFromOtherFieldValue()
+  }
+
+  /// Updates all other UI state from the `otherField` value (i.e., the manually entered typeface name).
+  private func updateTablesFromOtherFieldValue() {
+    let selectedFace = otherField.stringValue
+    chosenFace = selectedFace
+
+    // Search for font. Unfortunately this requires checking all typefaces in the system.
+    // But it's still quite fast.
+    // If there is a filter string already set don't try to change it, even if this means not finding a match.
+    let fontNamesDisplayed = isSearching ? filteredFontNames : fontNames
+    for (familyIndex, family) in fontNamesDisplayed.enumerated() {
+      if let typefaces = FixedFontManager.typefaces(forFontFamily: family.name) as? [[Any]] {
+        for (typefaceIndex, typeface) in typefaces.enumerated() {
+          if let faceName = typeface[0] as? String, faceName == selectedFace {
+            enableSelectionChangeListener = false
+
+            chosenFamily = family
+            chosenFontMembers = typefaces
+            familyTableView.selectRowIndexes(IndexSet(integer: familyIndex), byExtendingSelection: false)
+            familyTableView.scrollRowToVisible(familyIndex)
+            faceTableView.selectRowIndexes(IndexSet(integer: typefaceIndex), byExtendingSelection: false)
+            faceTableView.scrollRowToVisible(typefaceIndex)
+
+            enableSelectionChangeListener = true
+            updatePreview()
+            return
+          }
+        }
+      }
+    }
   }
 
   // - MARK: NSTableView delegate and data source
@@ -76,24 +130,29 @@ class FontPickerWindowController: NSWindowController, NSTableViewDelegate, NSTab
   }
 
   func tableViewSelectionDidChange(_ notification: Notification) {
+    guard enableSelectionChangeListener else { return }
     guard let activeTv = notification.object as? NSTableView else { return }
     if activeTv == familyTableView {
       guard familyTableView.selectedRow >= 0 else { return }
       chosenFamily = isSearching ? filteredFontNames[familyTableView.selectedRow] : fontNames[familyTableView.selectedRow]
-      if chosenFamily != nil {
-        chosenFontMembers = FixedFontManager.typefaces(forFontFamily: chosenFamily!.name) as? [[Any]]
-        faceTableView.reloadData()
-        faceTableView.selectRowIndexes(IndexSet(integer: 0), byExtendingSelection: false)
-        updatePreview()
-      }
-    } else if activeTv == faceTableView {
-      updatePreview()
+      guard let chosenFamily else { return }
+      chosenFontMembers = FixedFontManager.typefaces(forFontFamily: chosenFamily.name) as? [[Any]]
+      faceTableView.reloadData()
+      faceTableView.selectRowIndexes(IndexSet(integer: 0), byExtendingSelection: false)
     }
+
+    guard let chosenFontMembers else { return }
+    chosenFace = (chosenFontMembers[faceTableView.selectedRow][0] as? String) ?? ""
+    if !chosenFace.isEmpty {
+      otherField.stringValue = chosenFace
+    }
+    updatePreview()
   }
 
   // - MARK: NSTextField delegate
 
-  func controlTextDidChange(_ obj: Notification) {
+  // Type-to-filter updates
+  func controlTextDidChange(_ notification: Notification) {
     familyTableView.deselectAll(searchField)
     let str = searchField.stringValue
     if str.isEmpty {
@@ -131,9 +190,10 @@ class FontPickerWindowController: NSWindowController, NSTableViewDelegate, NSTab
   // - MARK: Utils
 
   private func updatePreview() {
-    guard chosenFontMembers != nil else { return }
-    chosenFace = (chosenFontMembers![faceTableView.selectedRow][0] as? String) ?? ""
-    previewField.font = NSFont(name: chosenFace!, size: 24) ?? NSFont.systemFont(ofSize: 24)
+    guard let chosenFontMembers else { return }
+    chosenFace = (chosenFontMembers[faceTableView.selectedRow][0] as? String) ?? ""
+    Logger.log("Previewing chosen typeface (\(faceTableView.selectedRow) / \(chosenFontMembers.count)): \(chosenFace)")
+    previewField.font = NSFont(name: chosenFace, size: 24) ?? NSFont.systemFont(ofSize: 24)
   }
 
   private func withAllTableViews (_ block: (NSTableView) -> Void) {

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -396,9 +396,7 @@ extension MainMenuActionHandler {
   }
 
   @objc func menuSubFont(_ sender: NSMenuItem) {
-    Utility.quickFontPickerWindow() {
-      self.player.setSubFont($0 ?? "")
-    }
+    player.chooseSubFont()
   }
 
   @objc func menuFindOnlineSub(_ sender: NSMenuItem) {

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1328,7 +1328,7 @@ class PlayerCore: NSObject {
     guard info.state.active else { return }
     let subFont = mpv.getString(MPVOption.Subtitles.subFont)
     Utility.quickFontPickerWindow(selecting: subFont) { [self] result in
-      setSubFont(result ?? "")
+      setSubFont(result)
     }
   }
 

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1323,6 +1323,15 @@ class PlayerCore: NSObject {
     }
   }
 
+  /// Shows the Font Chooser window to select a new font for the player
+  func chooseSubFont() {
+    guard info.state.active else { return }
+    let subFont = mpv.getString(MPVOption.Subtitles.subFont)
+    Utility.quickFontPickerWindow(selecting: subFont) { [self] result in
+      setSubFont(result ?? "")
+    }
+  }
+
   func toggleSubVisibility(_ set: Bool? = nil) {
     let newState = set ?? !info.isSubVisible
     mpv.setFlag(MPVOption.Subtitles.subVisibility, newState)

--- a/iina/PrefSubViewController.swift
+++ b/iina/PrefSubViewController.swift
@@ -87,9 +87,8 @@ class PrefSubViewController: PreferenceViewController, PreferenceWindowEmbeddabl
   }
 
   @IBAction func chooseSubFontAction(_ sender: AnyObject) {
-    Utility.quickFontPickerWindow { font in
+    Utility.quickFontPickerWindow(selecting: Preference.string(for: .subTextFont) ?? "sans-serif") { font in
       Preference.set(font ?? "sans-serif", for: .subTextFont)
-      UserDefaults.standard.synchronize()
     }
   }
 

--- a/iina/PrefSubViewController.swift
+++ b/iina/PrefSubViewController.swift
@@ -87,8 +87,9 @@ class PrefSubViewController: PreferenceViewController, PreferenceWindowEmbeddabl
   }
 
   @IBAction func chooseSubFontAction(_ sender: AnyObject) {
-    Utility.quickFontPickerWindow(selecting: Preference.string(for: .subTextFont) ?? "sans-serif") { font in
-      Preference.set(font ?? "sans-serif", for: .subTextFont)
+    let subFont = Preference.string(for: .subTextFont)
+    Utility.quickFontPickerWindow(selecting: subFont) { font in
+      Preference.set(font, for: .subTextFont)
     }
   }
 

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -932,7 +932,7 @@ struct Preference {
     .ignoreAssStyles: false,
     .subOverrideLevel: SubOverrideLevel.scale.rawValue,
     .secondarySubOverrideLevel: SubOverrideLevel.scale.rawValue,
-    .subTextFont: "sans-serif",
+    .subTextFont: Constants.String.mpvDefaultFont,
     .subTextSize: Float(55),
     .subTextColorString: NSColor.white.usingColorSpace(.deviceRGB)!.mpvColorString,
     .subBgColorString: NSColor.clear.usingColorSpace(.deviceRGB)!.mpvColorString,

--- a/iina/QuickSettingViewController.swift
+++ b/iina/QuickSettingViewController.swift
@@ -1052,9 +1052,7 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
   }
 
   @IBAction func subFontAction(_ sender: AnyObject) {
-    Utility.quickFontPickerWindow() {
-      self.player.setSubFont($0 ?? "")
-    }
+    player.chooseSubFont()
   }
 
 }

--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -377,7 +377,7 @@ class Utility {
    - parameters:
      - callback: A closure accepting the font name.
    */
-  static func quickFontPickerWindow(selecting initialSelection: String?, callback: @escaping (String?) -> Void) {
+  static func quickFontPickerWindow(selecting initialSelection: String?, callback: @escaping (String) -> Void) {
     let fontPicker = AppDelegate.shared.fontPicker
     let _ = fontPicker.window  // load if not loaded
     fontPicker.finishedPicking = callback

--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -377,10 +377,14 @@ class Utility {
    - parameters:
      - callback: A closure accepting the font name.
    */
-  static func quickFontPickerWindow(callback: @escaping (String?) -> Void) {
-    let appDelegate = AppDelegate.shared
-    appDelegate.fontPicker.finishedPicking = callback
-    appDelegate.fontPicker.showWindow(self)
+  static func quickFontPickerWindow(selecting initialSelection: String?, callback: @escaping (String?) -> Void) {
+    let fontPicker = AppDelegate.shared.fontPicker
+    let _ = fontPicker.window  // load if not loaded
+    fontPicker.finishedPicking = callback
+    if let initialSelection {
+      fontPicker.select(initialSelection)
+    }
+    fontPicker.showWindow(self)
   }
 
   // MARK: - App functions


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**

- Update UI on window open to select current family & face. This requires a search through all fonts & typefaces, but in practice this is nearly instantaneous. And it should be much more useful/intuitive to the user to see the existing selection. Obviously if the current font is not found in the list, it is simply not selected in the tables, and will be shown in the manual font entry at the bottom.
- Update manual font entry text when font selected in table by user. (This should be much more intuitive to the user when selecting fonts. Though currently the updates still do not go in the opposite direction - i.e., typing the font name does not select it in the table in real time).
- Fix layout so that changing the preview font doesn't result in a change to window height
- Minor changes to modernize layout (got rid of a horizontal line...)
