### PR TITLE
(Fix) Fix subtitle color controls in Quick Settings side panel

### DIFF
--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -423,9 +423,17 @@ extension FloatingPoint {
 
 extension NSColor {
   var mpvColorString: String {
-    get {
-      return "\(self.redComponent)/\(self.greenComponent)/\(self.blueComponent)/\(self.alphaComponent)"
-    }
+    // Normalize to sRGB before extracting cmponents
+    let rgb = self.usingColorSpace(.sRGB) ?? self
+
+    var red: CGFloat = 0
+    var green: CGFloat = 0
+    var blue: CGFloat = 0
+    var alpha: CGFloat = 0
+
+    rgb.getRed(&red, green: &green, blue: &blue, alpha: &alpha)
+    
+    return "\(red)/\(green)/\(blue)/\(alpha)"
   }
 
   convenience init?(mpvColorString: String) {

--- a/iina/QuickSettingViewController.swift
+++ b/iina/QuickSettingViewController.swift
@@ -246,6 +246,17 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
       Utility.quickConstraints(["H:|[v]|", "V:|[v]|"], ["v": well])
     }
     
+    // Wire color wells to IBAction handlers
+    subTextColorWell.target = self
+    subTextColorWell.action = #selector(subTextColorAction(_:))
+
+    subTextBgColorWell.target = self
+    subTextBgColorWell.action = #selector(subTextBgColorAction(_:))
+
+    subTextBorderColorWell.target = self
+    subTextBorderColorWell.action = #selector(subTextBorderColorAction(_:))
+    
+    
     if #available(macOS 26, *) {
       subtitleSwitch.controlSize = .small
       secondarySubtitleSwitch.controlSize = .small


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5866 

---

**Description:**
This fixes a regression where subtitle color controls in the Quick Settings side panel appeared to change, but did not actually apply to the subtitles.

Root cause: the subtitle color wells were changed from Interface Builder–owned outlets to programmatically created views, and the target/action wiring was not re-added. 

This PR restores the wiring so color changes are applied immediately again. It also adds a small safety fix to correctly handle non-RGB color selections (such as grayscale colors) when formatting colors for mpv.
