### PR TITLE
Fix playlist wrongly displays folded common prefix, #5879

### DIFF
--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -561,6 +561,7 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
           cellView.setPrefix(prefix)
           cellView.setTitle(String(filename[filename.index(filename.startIndex, offsetBy: prefix.count)...]))
         } else {
+          cellView.setPrefix(nil)
           cellView.setTitle(filename)
         }
         // playback progress and duration


### PR DESCRIPTION
This commit will change `PlaylistTrackCellView.tableView` to clear a table cell's folded common prefix when it is not needed.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5879.

---

**Description:**
