### PR TITLE
Correct force drawing

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1632,9 +1632,9 @@ class MainWindowController: PlayerWindowController {
     guard let window = window else { return }
     
     if case .animating(_, _, _) = fsState {
-      forceDraw("window entered full screen animation while paused")
+      forceDraw("window resized during animated enter or exit full screen")
     } else if !videoView.videoLayer.inLiveResize {
-      forceDraw("window resized while paused")
+      forceDraw("window resized")
     }
 
     // interactive mode

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1988,7 +1988,7 @@ class PlayerCore: NSObject {
     // Must force drawing to cover the case where this player was previously used to play a video
     // and is now playing an audio file without an album cover and without using music mode.
     // See issue #5403.
-    mainWindow.forceDraw("file loaded")
+    mainWindow.forceDraw("file loaded", always: true)
 
     // Get video size and set the initial window size
     let width = mpv.getInt(MPVProperty.width)

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -655,10 +655,15 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
   /// If a video is actively being played then there is no need to force a draw as the view is actively being drawn. Otherwise the view
   /// must be drawn. Video tracks can be images or cover art. Even when there isn't a video track drawing sometimes must be forced
   /// to clear a previous image, such as when an audio only file is played in the main window after it was used to play a video.
-  func forceDraw(_ reason: String) {
+  /// - Parameters:
+  ///   - reason: Reason for forcing drawing.
+  ///   - always: Draw even when playback is in progress and there isn't a video track. Used to clear any previous image.
+  func forceDraw(_ reason: String, always: Bool = false) {
     guard player.info.state.active else { return }
-    let notVideo = player.info.currentTrack(.video)?.isImage ?? true
-    guard player.info.state == .paused || notVideo else { return }
+    if !always {
+      let notVideo = player.info.currentTrack(.video)?.isImage ?? true
+      guard player.info.state == .paused || notVideo else { return }
+    }
     log("Forcing drawing, \(reason)")
     videoView.videoLayer.update(force: true)
   }


### PR DESCRIPTION
This commit will:
- Add a new always parameter to `PlayerWindowController.forceDraw` method
- Change `PlayerCore.fileLoaded` to pass the always parameter when calling `forceDraw`
- Correct some of the force drawing log messages

This fixes a problem where the call to `forceDraw` from `fileLoaded` did not force a draw when it was needed to erase the image from the previous media.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
