### PR TITLE
Add support for disabling title bar animation

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1832,7 +1832,7 @@ class MainWindowController: PlayerWindowController {
       v.isHidden = false
     }
     NSAnimationContext.runAnimationGroup({ (context) in
-      context.duration = UIAnimationDuration
+      context.duration = AccessibilityPreferences.adjustedDuration(UIAnimationDuration)
       fadeableViews.forEach { (v) in
         v.animator().alphaValue = 0
       }
@@ -1865,7 +1865,7 @@ class MainWindowController: PlayerWindowController {
     player.refreshSyncUITimer()
     standardWindowButtons.forEach { $0.isEnabled = true }
     NSAnimationContext.runAnimationGroup({ (context) in
-      context.duration = UIAnimationDuration
+      context.duration = AccessibilityPreferences.adjustedDuration(UIAnimationDuration)
       fadeableViews.forEach { (v) in
         v.animator().alphaValue = 1
       }


### PR DESCRIPTION
This commit will change the `MainWindowController` methods `showUI` and `hideUI` to use the `AccessibilityPreferences.adjustedDuration` method to suppress animations if the user has enabled the `Disable animation` setting found on the `UI` tab of IINA's settings.

In macOS Sequoia and earlier versions of macOS, when IINA shows and hides the OSC and the title bar, the bar fades into and out of view. In macOS Tahoe the behavior of the title bar animation changed. The buttons and title in the tile bar now slide out of the bar while fading away. Sliding is one of the kinds of animations that make some people physically uncomfortable and thus title bar animation should now be included in the animations controlled by the `Disable animation` setting.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
