### PR TITLE
feat(browser): add keyboard shortcut support to Firefox extension

### DIFF
--- a/browser/Firefox_Open_In_IINA/manifest.json
+++ b/browser/Firefox_Open_In_IINA/manifest.json
@@ -18,6 +18,11 @@
     "default_icon": "icon.png",
     "default_title": "Open In IINA"
   },
+  "commands": {
+    "_execute_browser_action": {
+      "description": "Open current page in IINA"
+    }
+  },
   "permissions": [
     "tabs",
     "activeTab",


### PR DESCRIPTION
## Summary
- Add `commands` manifest key with `_execute_browser_action` to the Firefox extension
- Enables users to assign a custom keyboard shortcut via Firefox's "Manage Extension Shortcuts" settings

## Note
It would probably make sense to also add keyboard shortcut support to the Chrome extension using `_execute_action` (Manifest V3 equivalent).

## Test plan
- [ ] Install the Firefox extension
- [ ] Go to `about:addons` → gear icon → "Manage Extension Shortcuts"
- [ ] Verify "Open In IINA" appears with "Open current page in IINA" action
- [ ] Assign a keyboard shortcut and verify it triggers the extension

🤖 Generated with [Claude Code](https://claude.com/claude-code)