### PR TITLE
Fix binding tab key to show playlist panel, #5905

### DIFF
--- a/iina/KeyCodeHelper.swift
+++ b/iina/KeyCodeHelper.swift
@@ -152,6 +152,7 @@ class KeyCodeHelper {
       "DOWN": NSDownArrowFunctionKey,
       "BS": NSBackspaceCharacter,
       "KP_DEL": NSDeleteCharacter,
+      "TAB": NSTabCharacter,
       "DEL": NSDeleteCharacter,
       "KP_INS": NSInsertFunctionKey,
       "INS": NSInsertFunctionKey,

--- a/iina/KeyMapping.swift
+++ b/iina/KeyMapping.swift
@@ -8,7 +8,8 @@
 
 import Foundation
 
-fileprivate let IINA_PREFIX = "#@iina"
+fileprivate let IINA_PREFIX = "@iina"
+fileprivate let IINA_PREFIX_IN_FILE = "#" + IINA_PREFIX
 
 class KeyMapping: NSObject {
 
@@ -102,7 +103,7 @@ class KeyMapping: NSObject {
 
   var confFileFormat: String {
     get {
-      let iinaCommandString = isIINACommand ? "\(IINA_PREFIX) " : ""
+      let iinaCommandString = isIINACommand ? "\(IINA_PREFIX_IN_FILE) " : ""
       let commentString = (comment == nil || comment!.isEmpty) ? "" : "   #\(comment!)"
       return "\(iinaCommandString)\(rawKey) \(action.joined(separator: " "))\(commentString)"
     }
@@ -134,10 +135,10 @@ class KeyMapping: NSObject {
       if line.trimmingCharacters(in: .whitespaces).isEmpty {
         continue
       } else if line.hasPrefix("#") {
-        if line.hasPrefix(IINA_PREFIX) {
+        if line.hasPrefix(IINA_PREFIX_IN_FILE) {
           // extended syntax
           isIINACommand = true
-          line = String(line[line.index(line.startIndex, offsetBy: IINA_PREFIX.count)...])
+          line = String(line[line.index(line.startIndex, offsetBy: IINA_PREFIX_IN_FILE.count)...])
         } else {
           // ignore comment line
           continue


### PR DESCRIPTION
This commit will:
- Add a new `IINA_PREFIX_IN_FILE` constant to `KeyMapping`
- Change `IINA_PREFIX` to just be "@iina"
- Change `confFileFormat` and `parseInputConf` to use `IINA_PREFIX_IN_FILE`
- Add `NSTabCharacter` to `mpvSymbolToKeyChar` in `KeyCodeHelper`

The changes in this commit add support for binding the TAB character to an IINA command such as `playlist-panel`. They also correct a regression where the UI was inconsistently using "#@iina" as the prefix for an IINA command instead of "@iina" as in older versions of IINA.

This commit is a spot fix that only addresses the specific problems uncovered by the cited issue. The support for `NSTabCharacter` was ported from the enhanced fork belonging to @svob. Quickly comparing sources with that fork indicates there are other similar key binding problems. This needs to be explored further in an IINA release that allows for extensive changes.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5905.

---

**Description:**
