### PR TITLE
Fix miss-spellings detected by typos

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -14,6 +14,8 @@ extend-ignore-re = [
     'apiKey = "[^"]+"',
     "V\\[alue\\]",
     "ba!",
+    # Ignore the token declaration in AssrtSubtitle.
+    "5IzWrb.*"
 ]
 
 [default.extend-words]

--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ IINA is always looking for contributions, whether it's through bug reports, code
 - **Clickable Subtitles** (`kerim/iina-clickable-subtitles`) - Click subtitles to define words (macOS Look Up).
 - **Jump to Frame** (`bbeny123/iina-jump-to-frame`) - Navigate video by specific frame number.
 - **recorder** (`5thDimensionalVader/recorder-iina`) - to clip a video using ffmpeg.
-- **Multple Clips** (`karthisnk/multi-cutter-iina`) - multiple clip of a video using ffmpeg, with Batch Clipping, Vertical Clip, Format Selection, Preview Clip.
+- **Multiple Clips** (`karthisnk/multi-cutter-iina`) - multiple clip of a video using ffmpeg, with Batch Clipping, Vertical Clip, Format Selection, Preview Clip.
 
 > 💡 **Want to build your own plugin?**
 > 

--- a/iina/AboutWindowController.swift
+++ b/iina/AboutWindowController.swift
@@ -97,8 +97,8 @@ class AboutWindowController: NSWindowController {
       break
     }
 
-    if let contrubutionFile = Bundle.main.path(forResource: "Contribution", ofType: "rtf") {
-      detailTextView.readRTFD(fromFile: contrubutionFile)
+    if let contributionFile = Bundle.main.path(forResource: "Contribution", ofType: "rtf") {
+      detailTextView.readRTFD(fromFile: contributionFile)
       detailTextView.textColor = NSColor.secondaryLabelColor
     }
 


### PR DESCRIPTION
This commit will:
- Correct the spelling of multiple in READ.ME
- Correct the spelling of contribution in `AboutWindowController`
- Change .typos.toml to not report the token assignment in `AssrtSubtitle`

These changes correct miss-spellings now being detected by the latest version of typos.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
