### PR TITLE
chore: Update outdated GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
             deployment_target: ""
     runs-on:  macos-26
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Install dependencies
         run: ./other/download_libs.sh
@@ -29,7 +29,7 @@ jobs:
         run: tar cvJf ~/iina.tar.xz -C /Users/runner/Library/Developer/Xcode/DerivedData/iina-csbkugdtxazzqogjnydbothqrvib/Build/Products/Nightly IINA.app 
 
       - name: Save artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: IINA
           path: ~/iina.tar.xz

--- a/.github/workflows/spelling.yml
+++ b/.github/workflows/spelling.yml
@@ -10,6 +10,6 @@ jobs:
   typos:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: crate-ci/typos@master


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)

**Description:**  
This PR updates outdated GitHub Action versions.  
- Updated `actions/upload-artifact` from `v4` to `v6` in `.github/workflows/ci.yml`  
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/spelling.yml`  
- Updated `actions/checkout` from `v4` to `v6` in `.github/workflows/ci.yml`