### PR TITLE
Log settings changed from their defaults

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -233,6 +233,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     logBuildDetails()
     logPlatformDetails()
     logScreenDetails()
+    Preference.logSettings()
 
     Logger.log("App will launch")
 

--- a/iina/InitialWindowController.swift
+++ b/iina/InitialWindowController.swift
@@ -211,7 +211,7 @@ class InitialWindowController: NSWindowController {
     recentDocuments = makeRecentDocumentsList()
     recentFilesTableView.reloadData()
 
-    if Logger.enabled && Logger.Level.preferred >= .verbose {
+    if Logger.isEmitting(.verbose) {
       let last = lastPlaybackURL.flatMap { $0.resolvingSymlinksInPath().path } ?? "<none>"
       Logger.log("InitialWindow.reloadData(): LastPlaybackURL: \(last)", level: .verbose)
 

--- a/iina/Logger.swift
+++ b/iina/Logger.swift
@@ -76,17 +76,18 @@ class Logger: NSObject {
   }
 
   enum Level: Int, Comparable, CustomStringConvertible, CaseIterable, InitializingFromKey {
-    init?(key: Preference.Key) {
-      self.init(rawValue: Preference.integer(for: key))
-    }
 
-    static var defaultValue: Logger.Level = .debug
-    
+    static var defaultValue = Level.debug
+
     static func < (lhs: Level, rhs: Level) -> Bool {
       return lhs.rawValue < rhs.rawValue
     }
 
     static var preferred: Level = Level(rawValue: Preference.integer(for: .logLevel).clamped(to: 0...3))!
+
+    init?(key: Preference.Key) {
+      self.init(rawValue: Preference.integer(for: key))
+    }
 
     case verbose = 0
     case debug
@@ -94,6 +95,15 @@ class Logger: NSObject {
     case error
 
     var description: String {
+      switch self {
+      case .verbose: return "verbose"
+      case .debug: return "debug"
+      case .warning: return "warning"
+      case .error: return "error"
+      }
+    }
+
+    var shortForm: String {
       switch self {
       case .verbose: return "v"
       case .debug: return "d"
@@ -196,7 +206,17 @@ class Logger: NSObject {
   private static func formatMessage(_ message: String, _ level: Level, _ subsystem: Subsystem,
                                     _ appendNewlineAtTheEnd: Bool, _ date: Date = Date()) -> String {
     let time = dateFormatter.string(from: date)
-    return "\(time) [\(subsystem.rawValue)][\(level.description)] \(message)\(appendNewlineAtTheEnd ? "\n" : "")"
+    return "\(time) [\(subsystem.rawValue)][\(level.shortForm)] \(message)\(appendNewlineAtTheEnd ? "\n" : "")"
+  }
+
+  /// Whether the logger is emitting messages at the given level.
+  /// - Parameter level: The log level to check.
+  /// - Returns: `true` if messages at the given level will be emitted; `false` if the logger is suppressing messages at this level.
+  static func isEmitting(_ level: Level) -> Bool {
+    #if !DEBUG
+    guard enabled else { return  false }
+    #endif
+    return Level.preferred <= level
   }
 
   /// Log a message.

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -360,15 +360,14 @@ class MPVController: NSObject {
 
     setUserOption(PK.screenshotFormat, type: .other, forName: MPVOption.Screenshot.screenshotFormat,
                   verboseIfDefault: true) { key in
-      let v = Preference.integer(for: key)
-      let format = Preference.ScreenshotFormat(rawValue: v)
+      let format: Preference.ScreenshotFormat = Preference.enum(for: key)
       // Workaround for mpv issue  #15107, HDR screenshots are unimplemented (gpu/gpu-next).
       // If the screenshot format is set to JPEG XL then set the screenshot-sw option to yes. This
       // causes the screenshot to be rendered by software instead of the VO. If a HDR video is being
       // displayed in HDR then the resulting screenshot will be HDR.
       self.chkErr(self.setOptionFlag(MPVOption.Screenshot.screenshotSw, format == .jxl,
                                      verboseIfDefault: true))
-      return format?.string
+      return String(describing: format)
     }
 
     setUserOption(PK.screenshotTemplate, type: .string,
@@ -410,8 +409,7 @@ class MPVController: NSObject {
 
     setUserOption(PK.hardwareDecoder, type: .other, forName: MPVOption.Video.hwdec,
                   verboseIfDefault: true) { key in
-      let value = Preference.integer(for: key)
-      return Preference.HardwareDecoderOption(rawValue: value)?.mpvString ?? "auto"
+      return String(describing: Preference.enum(for: key) as Preference.HardwareDecoderOption)
     }
 
     setUserOption(PK.audioLanguage, type: .string, forName: MPVOption.TrackSelection.alang,
@@ -430,8 +428,7 @@ class MPVController: NSObject {
 
     setUserOption(PK.replayGain, type: .other, forName: MPVOption.Audio.replaygain,
                   verboseIfDefault: true) { key in
-      let value = Preference.integer(for: key)
-      return Preference.ReplayGainOption(rawValue: value)?.mpvString ?? "no"
+      return String(describing: Preference.enum(for: key) as Preference.ReplayGainOption)
     }
     setUserOption(PK.replayGainPreamp, type: .float, forName: MPVOption.Audio.replaygainPreamp,
                   verboseIfDefault: true)
@@ -442,8 +439,7 @@ class MPVController: NSObject {
 
     setUserOption(PK.gaplessAudio, type: .other, forName: MPVOption.Audio.gaplessAudio,
                   verboseIfDefault: true) { key in
-      let value = Preference.integer(for: key)
-      return Preference.GaplessAudioOption(rawValue: value)?.mpvString ?? "weak"
+      return String(describing: Preference.enum(for: key) as Preference.GaplessAudioOption)
     }
 
     // - Sub
@@ -454,7 +450,7 @@ class MPVController: NSObject {
     player.info.subEncoding = Preference.string(for: .defaultEncoding)
 
     let subOverrideHandler: OptionObserverInfo.Transformer = { key in
-      (Preference.enum(for: key) as Preference.SubOverrideLevel).string
+      String(describing: Preference.enum(for: key) as Preference.SubOverrideLevel)
     }
     setUserOption(PK.subOverrideLevel, type: .other, forName: MPVOption.Subtitles.subAssOverride,
                   verboseIfDefault: true, transformer: subOverrideHandler)
@@ -494,14 +490,12 @@ class MPVController: NSObject {
 
     setUserOption(PK.subAlignX, type: .other, forName: MPVOption.Subtitles.subAlignX,
                   verboseIfDefault: true) { key in
-      let v = Preference.integer(for: key)
-      return Preference.SubAlign(rawValue: v)?.stringForX
+      return String(describing: Preference.enum(for: key) as Preference.SubAlignX)
     }
 
     setUserOption(PK.subAlignY, type: .other, forName: MPVOption.Subtitles.subAlignY,
                   verboseIfDefault: true) { key in
-      let v = Preference.integer(for: key)
-      return Preference.SubAlign(rawValue: v)?.stringForY
+      return String(describing: Preference.enum(for: key) as Preference.SubAlignY)
     }
 
     setUserOption(PK.subMarginX, type: .int, forName: MPVOption.Subtitles.subMarginX,
@@ -542,8 +536,8 @@ class MPVController: NSObject {
 
     setUserOption(PK.transportRTSPThrough, type: .other, forName: MPVOption.Network.rtspTransport,
                   verboseIfDefault: true) { key in
-      let v: Preference.RTSPTransportation = Preference.enum(for: .transportRTSPThrough)
-      return v.string
+      return String(describing: Preference.enum(for: .transportRTSPThrough) as
+                    Preference.RTSPTransportation)
     }
 
     setUserOption(PK.ytdlEnabled, type: .other, forName: MPVOption.ProgramBehavior.ytdl,

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -925,7 +925,7 @@ class MainWindowController: PlayerWindowController {
   }
 
   override func mouseDown(with event: NSEvent) {
-    if Logger.enabled && Logger.Level.preferred >= .verbose {
+    if Logger.isEmitting(.verbose) {
       log("MainWindow mouseDown @ \(event.locationInWindow)", level: .verbose)
     }
     workaroundCursorDefect()
@@ -972,7 +972,7 @@ class MainWindowController: PlayerWindowController {
           if mousePosRelatedToWindow.distance(to: event.locationInWindow) <= minimumInitialDragDistance {
             return
           }
-          if Logger.enabled && Logger.Level.preferred >= .verbose {
+          if Logger.isEmitting(.verbose) {
             log("MainWindow mouseDrag: minimum dragging distance was met", level: .verbose)
           }
           isDragging = true
@@ -984,7 +984,7 @@ class MainWindowController: PlayerWindowController {
   }
 
   override func mouseUp(with event: NSEvent) {
-    if Logger.enabled && Logger.Level.preferred >= .verbose {
+    if Logger.isEmitting(.verbose) {
       log("MainWindow mouseUp @ \(event.locationInWindow), isDragging: \(isDragging), isResizingSidebar: \(isResizingSidebar), clickCount: \(event.clickCount)",
                  level: .verbose)
     }

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -127,7 +127,7 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     controlView.alphaValue = 0
     
     // tool tips
-    togglePlaylistButton.toolTip = Preference.ToolBarButton.playlist.description()
+    togglePlaylistButton.toolTip = Preference.ToolBarButton.playlist.localizedDescription()
     toggleAlbumArtButton.toolTip = NSLocalizedString("mini_player.album_art", comment: "album_art")
     volumeButton.toolTip = NSLocalizedString("mini_player.volume", comment: "volume")
     closeButtonVE.toolTip = NSLocalizedString("mini_player.close", comment: "close")

--- a/iina/OSCToolbarButton.swift
+++ b/iina/OSCToolbarButton.swift
@@ -20,7 +20,7 @@ class OSCToolbarButton {
     toolbarButton.isBordered = false
     toolbarButton.tag = buttonType.rawValue
     toolbarButton.refusesFirstResponder = true
-    toolbarButton.toolTip = buttonType.description()
+    toolbarButton.toolTip = buttonType.localizedDescription()
     let buttonHeight = Preference.ToolBarButton.frameSize
     let buttonWidth = reducedWidth ? Preference.ToolBarButton.compactFrameWidth : Preference.ToolBarButton.frameSize
     Utility.quickConstraints(["H:[btn(\(buttonWidth))]", "V:[btn(\(buttonHeight))]"], ["btn": toolbarButton])

--- a/iina/Pages/SettingsPageGeneral.swift
+++ b/iina/Pages/SettingsPageGeneral.swift
@@ -197,5 +197,14 @@ fileprivate extension Preference {
     init?(key: Preference.Key) {
       self.init(rawValue: Preference.integer(for: key))
     }
+
+    var description: String {
+      switch self {
+      case .hourly: "hourly"
+      case .daily: "daily"
+      case .weekly: "weekly"
+      case .monthly: "monthly"
+      }
+    }
   }
 }

--- a/iina/Pages/SettingsPageSubtitles.swift
+++ b/iina/Pages/SettingsPageSubtitles.swift
@@ -396,7 +396,8 @@ fileprivate class SubtitlesAlignView: SettingsAccessory.Base {
   }
 
   private func makePopUp(_ key: Preference.Key) -> NSPopUpButton {
-    let allValues = Preference.SubAlign.self.allCases.map { $0.rawValue }
+    let allValues = key == .subAlignX ? Preference.SubAlignX.self.allCases.map { $0.rawValue } :
+      Preference.SubAlignY.self.allCases.map { $0.rawValue }
     let popupButton = NSPopUpButton()
     popupButton.bezelStyle = .toolbar
 

--- a/iina/Pages/SettingsPageVideoAudio.swift
+++ b/iina/Pages/SettingsPageVideoAudio.swift
@@ -177,6 +177,13 @@ fileprivate enum AudioDriver: Int, InitializingFromKey, CaseIterable {
   init?(key: Preference.Key) {
     self.init(rawValue: Preference.integer(for: key))
   }
+
+  var description: String {
+    switch self {
+    case .coreAudio: "coreAudio"
+    case .avFoundation: "avFoundation"
+    }
+  }
 }
 
 

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1327,7 +1327,8 @@ class PlayerCore: NSObject {
   }
 
   func toggleHardwareDecoding(_ enable: Bool) {
-    let value = Preference.HardwareDecoderOption(rawValue: Preference.integer(for: .hardwareDecoder))?.mpvString ?? "auto"
+    let value = String(describing: Preference.enum(for: .hardwareDecoder) as
+                       Preference.HardwareDecoderOption)
     mpv.setString(MPVOption.Video.hwdec, enable ? value : "no")
   }
 
@@ -2554,7 +2555,7 @@ class PlayerCore: NSObject {
       }
     }
 
-    if Logger.enabled && Logger.Level.preferred >= .verbose {
+    if Logger.isEmitting(.verbose) {
       var summary = wasTimerRunning ? (useTimer ? "restarting" : "didStop") : (useTimer ? "starting" : "notNeeded")
       if summary != "notNeeded" {  // too many calls; try not to flood the log
         if useTimer {

--- a/iina/PrefOSCToolbarDraggingItemViewController.swift
+++ b/iina/PrefOSCToolbarDraggingItemViewController.swift
@@ -37,7 +37,7 @@ class PrefOSCToolbarDraggingItemViewController: NSViewController, NSPasteboardWr
     // Button is actually disabled so that its mouseDown goes to its superview instead. But don't gray it out.
     (toolbarButton.cell! as! NSButtonCell).imageDimsWhenDisabled = false
 
-    descriptionLabel.stringValue = buttonType.description()
+    descriptionLabel.stringValue = buttonType.localizedDescription()
   }
 
   func writableTypes(for pasteboard: NSPasteboard) -> [NSPasteboard.PasteboardType] {

--- a/iina/PrefSubViewController.swift
+++ b/iina/PrefSubViewController.swift
@@ -202,7 +202,7 @@ class ASSOverrideLevelTransformer: ValueTransformer {
   override func transformedValue(_ value: Any?) -> Any? {
     guard let num = value as? NSNumber,
           let level = Preference.SubOverrideLevel(rawValue: num.intValue) else { return nil }
-    return level.string
+    return String(describing: level)
   }
 }
 

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -8,12 +8,11 @@
 
 import Cocoa
 
-protocol InitializingFromKey {
+protocol InitializingFromKey: CustomStringConvertible {
 
   static var defaultValue: Self { get }
 
   init?(key: Preference.Key)
-
 }
 
 struct Preference {
@@ -363,6 +362,14 @@ struct Preference {
     init?(key: Key) {
       self.init(rawValue: Preference.integer(for: key))
     }
+
+    var description: String {
+      switch self {
+      case .welcomeWindow: "welcomeWindow"
+      case .openPanel: "openPanel"
+      case .none: "none"
+      }
+    }
   }
 
   enum ArrowButtonAction: Int, InitializingFromKey, CaseIterable {
@@ -374,6 +381,14 @@ struct Preference {
 
     init?(key: Key) {
       self.init(rawValue: Preference.integer(for: key))
+    }
+
+    var description: String {
+      switch self {
+      case .speed: "speed"
+      case .playlist: "playlist"
+      case .seek: "seek"
+      }
     }
   }
 
@@ -393,6 +408,14 @@ struct Preference {
       }
       self.init(rawValue: Preference.integer(for: key))
     }
+
+    var description: String {
+      switch self {
+      case .dark: "dark"
+      case .light: "light"
+      case .system: "system"
+      }
+    }
   }
 
   enum OSCPosition: Int, InitializingFromKey {
@@ -405,6 +428,14 @@ struct Preference {
     init?(key: Key) {
       self.init(rawValue: Preference.integer(for: key))
     }
+
+    var description: String {
+      switch self {
+      case .floating: "floating"
+      case .top: "top"
+      case .bottom: "bottom"
+      }
+    }
   }
 
   enum SeekOption: Int, InitializingFromKey, CaseIterable {
@@ -416,6 +447,14 @@ struct Preference {
 
     init?(key: Key) {
       self.init(rawValue: Preference.integer(for: key))
+    }
+
+    var description: String {
+      switch self {
+      case .relative: "relative"
+      case .exact: "exact"
+      case .auto: "auto"
+      }
     }
   }
 
@@ -433,6 +472,18 @@ struct Preference {
     init?(key: Key) {
       self.init(rawValue: Preference.integer(for: key))
     }
+
+    var description: String {
+      switch self {
+      case .none: "none"
+      case .fullscreen: "fullscreen"
+      case .pause: "pause"
+      case .hideOSC: "hideOSC"
+      case .togglePIP: "togglePIP"
+      case .abLoop: "abLoop"
+      case .resetSpeed: "resetSpeed"
+      }
+    }
   }
 
   enum ScrollAction: Int, InitializingFromKey, CaseIterable {
@@ -447,6 +498,15 @@ struct Preference {
     init?(key: Key) {
       self.init(rawValue: Preference.integer(for: key))
     }
+
+    var description: String {
+      switch self {
+      case .volume: "volume"
+      case .seek: "seek"
+      case .none: "none"
+      case .playbackSpeed: "playbackSpeed"
+      }
+    }
   }
 
   enum PinchAction: Int, InitializingFromKey, CaseIterable {
@@ -458,6 +518,14 @@ struct Preference {
 
     init?(key: Key) {
       self.init(rawValue: Preference.integer(for: key))
+    }
+
+    var description: String {
+      switch self {
+      case .windowSize: "windowSize"
+      case .fullscreen: "fullscreen"
+      case .none: "none"
+      }
     }
   }
 
@@ -479,6 +547,14 @@ struct Preference {
     func shouldLoadSubsMatchedByIINA() -> Bool {
       return self == .iina
     }
+
+    var description: String {
+      switch self {
+      case .disabled: "disabled"
+      case .mpvFuzzy: "mpvFuzzy"
+      case .iina: "iina"
+      }
+    }
   }
 
   enum AutoLoadAction: Int, InitializingFromKey {
@@ -493,14 +569,12 @@ struct Preference {
       self.init(rawValue: Preference.integer(for: key))
     }
 
-    var string: String {
-      get {
-        switch self {
-        case .no: return "no"
-        case .exact: return "exact"
-        case .fuzzy: return "fuzzy"
-        case .all: return "all"
-        }
+    var description: String {
+      switch self {
+      case .no: "no"
+      case .exact: "exact"
+      case .fuzzy: "fuzzy"
+      case .all: "all"
       }
     }
   }
@@ -523,47 +597,53 @@ struct Preference {
       self.init(rawValue: Preference.integer(for: key))
     }
 
-    var string: String {
-      get {
-        switch self {
-        case .yes: return "yes"
-        case .force : return "force"
-        case .strip: return "strip"
-        case .scale: return "scale"
-        case .no: return "no"
-        }
+    var description: String {
+      switch self {
+      case .yes: "yes"
+      case .force : "force"
+      case .strip: "strip"
+      case .scale: "scale"
+      case .no: "no"
       }
     }
   }
 
-  enum SubAlign: Int, InitializingFromKey, CaseIterable {
-    case top = 0  // left
+  enum SubAlignX: Int, InitializingFromKey, CaseIterable {
+    case left = 0
     case center
-    case bottom  // right
+    case right
 
-    static var defaultValue = SubAlign.center
+    static var defaultValue = SubAlignX.center
 
     init?(key: Key) {
       self.init(rawValue: Preference.integer(for: key))
     }
 
-    var stringForX: String {
-      get {
-        switch self {
-        case .top: return "left"
-        case .center: return "center"
-        case .bottom: return "right"
-        }
+    var description: String {
+      switch self {
+      case .left: "left"
+      case .center: "center"
+      case .right: "right"
       }
     }
+  }
 
-    var stringForY: String {
-      get {
-        switch self {
-        case .top: return "top"
-        case .center: return "center"
-        case .bottom: return "bottom"
-        }
+  enum SubAlignY: Int, InitializingFromKey, CaseIterable {
+    case top = 0
+    case center
+    case bottom
+
+    static var defaultValue = SubAlignY.bottom
+
+    init?(key: Key) {
+      self.init(rawValue: Preference.integer(for: key))
+    }
+
+    var description: String {
+      switch self {
+      case .top: "top"
+      case .center: "center"
+      case .bottom: "bottom"
       }
     }
   }
@@ -580,14 +660,12 @@ struct Preference {
       self.init(rawValue: Preference.integer(for: key))
     }
 
-    var string: String {
-      get {
-        switch self {
-        case .lavf: return "lavf"
-        case .tcp: return "tcp"
-        case .udp: return "udp"
-        case .http: return "http"
-        }
+    var description: String {
+      switch self {
+      case .lavf: "lavf"
+      case .tcp: "tcp"
+      case .udp: "udp"
+      case .http: "http"
       }
     }
   }
@@ -605,15 +683,13 @@ struct Preference {
       self.init(rawValue: Preference.integer(for: key))
     }
 
-    var string: String {
-      get {
-        switch self {
-        case .png: return "png"
-        case .jpg: return "jpg"
-        case .jpeg: return "jpeg"
-        case .webp: return "webp"
-        case .jxl: return "jxl"
-        }
+    var description: String {
+      switch self {
+      case .png: "png"
+      case .jpg: "jpg"
+      case .jpeg: "jpeg"
+      case .webp: "webp"
+      case .jxl: "jxl"
       }
     }
   }
@@ -629,16 +705,16 @@ struct Preference {
       self.init(rawValue: Preference.integer(for: key))
     }
 
-    var mpvString: String {
+    var description: String {
       switch self {
-      case .disabled: return "no"
-      case .auto: return "auto"
-      case .autoCopy: return "auto-copy"
+      case .disabled: "no"
+      case .auto: "auto"
+      case .autoCopy: "auto-copy"
       }
     }
 
     var localizedDescription: String {
-      return NSLocalizedString("hwdec." + mpvString, comment: mpvString)
+      NSLocalizedString("hwdec." + description, comment: description)
     }
   }
 
@@ -658,16 +734,16 @@ struct Preference {
       self.init(rawValue: Preference.integer(for: key))
     }
 
-    var mpvString: String {
+    var description: String {
       switch self {
-      case .auto: return "auto"
-      case .clip: return "clip"
-      case .mobius: return "mobius"
-      case .reinhard: return "reinhard"
-      case .hable: return "hable"
-      case .bt_2390: return "bt.2390"
-      case .gamma: return "gamma"
-      case .linear: return "linear"
+      case .auto: "auto"
+      case .clip: "clip"
+      case .mobius: "mobius"
+      case .reinhard: "reinhard"
+      case .hable: "hable"
+      case .bt_2390: "bt.2390"
+      case .gamma: "gamma"
+      case .linear: "linear"
       }
     }
   }
@@ -681,6 +757,14 @@ struct Preference {
 
     init?(key: Key) {
       self.init(rawValue: Preference.integer(for: key))
+    }
+
+    var description: String {
+      switch self {
+      case .always: "always"
+      case .onlyWhenOpen: "onlyWhenOpen"
+      case .never: "never"
+      }
     }
   }
 
@@ -699,13 +783,15 @@ struct Preference {
 
     var ratio: Double {
       switch self {
-      case .fitScreen: return -1
-      case .videoSize05: return 0.5
-      case .videoSize10: return 1
-      case .videoSize15: return 1.5
-      case .videoSize20: return 2
+      case .fitScreen: -1
+      case .videoSize05: 0.5
+      case .videoSize10: 1
+      case .videoSize15: 1.5
+      case .videoSize20: 2
       }
     }
+
+    var description: String { String(ratio) }
   }
 
   enum WindowBehaviorWhenPip: Int, InitializingFromKey, CaseIterable {
@@ -718,9 +804,17 @@ struct Preference {
     init?(key: Key) {
       self.init(rawValue: Preference.integer(for: key))
     }
+
+    var description: String {
+      switch self {
+      case .doNothing: "doNothing"
+      case .hide: "hide"
+      case .minimize: "minimize"
+      }
+    }
   }
 
-  enum ToolBarButton: Int {
+  enum ToolBarButton: Int, CustomStringConvertible {
     case settings = 0
     case playlist
     case pip
@@ -729,6 +823,19 @@ struct Preference {
     case subTrack
     case screenshot
     case plugins
+
+    var description: String {
+      switch self {
+      case .settings: "settings"
+      case .playlist: "playlist"
+      case .pip: "pip"
+      case .fullScreen: "fullScreen"
+      case .musicMode: "musicMode"
+      case .subTrack: "subTrack"
+      case .screenshot: "screenshot"
+      case .plugins: "plugins"
+      }
+    }
 
     func image() -> NSImage {
       func makeSymbol(_ names: [String], _ fallbackImage: NSImage.Name) -> NSImage {
@@ -748,7 +855,7 @@ struct Preference {
       }
     }
 
-    func description() -> String {
+    func localizedDescription() -> String {
       let key: String
       switch self {
       case .settings: key = "settings"
@@ -781,13 +888,11 @@ struct Preference {
       self.init(rawValue: Preference.integer(for: key))
     }
 
-    var mpvString: String {
-      get {
-        switch self {
-        case .no: return "no"
-        case .track : return "track"
-        case .album: return "album"
-        }
+    var description: String {
+      switch self {
+      case .no: "no"
+      case .track : "track"
+      case .album: "album"
       }
     }
   }
@@ -804,28 +909,33 @@ struct Preference {
     }
 
     var localizedDescription: String {
-      return NSLocalizedString("gaplessAudio." + mpvString, comment: mpvString)
+      NSLocalizedString("gaplessAudio." + description, comment: description)
     }
 
-    var mpvString: String {
-      get {
-        switch self {
-        case .disabled: return "no"
-        case .weak : return "weak"
-        case .strong: return "yes"
-        }
+    var description: String {
+      switch self {
+      case .disabled: "no"
+      case .weak : "weak"
+      case .strong: "yes"
       }
     }
   }
 
   enum DefaultRepeatMode: Int, InitializingFromKey, CaseIterable {
-    static var defaultValue = DefaultRepeatMode.playlist
-
     case playlist = 0
     case file
 
+    static var defaultValue = DefaultRepeatMode.playlist
+
     init?(key: Key) {
       self.init(rawValue: Preference.integer(for: key))
+    }
+
+    var description: String {
+      switch self {
+      case .playlist: "playlist"
+      case .file : "file"
+      }
     }
   }
 
@@ -918,7 +1028,7 @@ struct Preference {
     .enableHdrSupport: true,
     .enableToneMapping: false,
     .toneMappingTargetPeak: 0,
-    .toneMappingAlgorithm: "auto",
+    .toneMappingAlgorithm: ToneMappingAlgorithmOption.defaultValue.rawValue,
     .audioDriverEnableAVFoundation: false,
     .audioThreads: 0,
     .audioLanguage: "",
@@ -954,8 +1064,8 @@ struct Preference {
     .subBorderColorString: NSColor.black.usingColorSpace(.deviceRGB)!.mpvColorString,
     .subShadowSize: Float(0),
     .subShadowColorString: NSColor.clear.usingColorSpace(.deviceRGB)!.mpvColorString,
-    .subAlignX: SubAlign.center.rawValue,
-    .subAlignY: SubAlign.bottom.rawValue,
+    .subAlignX: SubAlignX.center.rawValue,
+    .subAlignY: SubAlignY.bottom.rawValue,
     .subMarginX: Float(25),
     .subMarginY: Float(22),
     .subPos: Float(100),
@@ -1037,84 +1147,396 @@ struct Preference {
 
   static private let ud = UserDefaults.standard
 
-  static func object(for key: Key) -> Any? {
-    return ud.object(forKey: key.rawValue)
-  }
+  static func object(for key: Key) -> Any? { ud.object(forKey: key.rawValue) }
 
-  static func array(for key: Key) -> [Any]? {
-    return ud.array(forKey: key.rawValue)
-  }
+  static func array(for key: Key) -> [Any]? { ud.array(forKey: key.rawValue) }
 
-  static func url(for key: Key) -> URL? {
-    return ud.url(forKey: key.rawValue)
-  }
+  static func url(for key: Key) -> URL? { ud.url(forKey: key.rawValue) }
 
-  static func dictionary(for key: Key) -> [String : Any]? {
-    return ud.dictionary(forKey: key.rawValue)
-  }
+  static func dictionary(for key: Key) -> [String : Any]? { ud.dictionary(forKey: key.rawValue) }
 
-  static func string(for key: Key) -> String? {
-    return ud.string(forKey: key.rawValue)
-  }
+  static func string(for key: Key) -> String? { ud.string(forKey: key.rawValue) }
 
-  static func stringArray(for key: Key) -> [String]? {
-    return ud.stringArray(forKey: key.rawValue)
-  }
+  static func stringArray(for key: Key) -> [String]? { ud.stringArray(forKey: key.rawValue) }
 
-  static func data(for key: Key) -> Data? {
-    return ud.data(forKey: key.rawValue)
-  }
+  static func data(for key: Key) -> Data? { ud.data(forKey: key.rawValue) }
 
-  static func bool(for key: Key) -> Bool {
-    return ud.bool(forKey: key.rawValue)
-  }
+  static func bool(for key: Key) -> Bool { ud.bool(forKey: key.rawValue) }
 
-  static func integer(for key: Key) -> Int {
-    return ud.integer(forKey: key.rawValue)
-  }
+  static func integer(for key: Key) -> Int { ud.integer(forKey: key.rawValue) }
 
-  static func float(for key: Key) -> Float {
-    return ud.float(forKey: key.rawValue)
-  }
+  static func float(for key: Key) -> Float { ud.float(forKey: key.rawValue) }
 
-  static func double(for key: Key) -> Double {
-    return ud.double(forKey: key.rawValue)
-  }
+  static func double(for key: Key) -> Double { ud.double(forKey: key.rawValue) }
 
-  static func value(for key: Key) -> Any? {
-    return ud.value(forKey: key.rawValue)
-  }
+  static func value(for key: Key) -> Any? { ud.value(forKey: key.rawValue) }
 
-  static func set(_ value: Bool, for key: Key) {
-    ud.set(value, forKey: key.rawValue)
-  }
+  static func set(_ value: Bool, for key: Key) { ud.set(value, forKey: key.rawValue) }
 
-  static func set(_ value: Int, for key: Key) {
-    ud.set(value, forKey: key.rawValue)
-  }
+  static func set(_ value: Int, for key: Key) { ud.set(value, forKey: key.rawValue) }
 
-  static func set(_ value: String, for key: Key) {
-    ud.set(value, forKey: key.rawValue)
-  }
+  static func set(_ value: String, for key: Key) { ud.set(value, forKey: key.rawValue) }
 
-  static func set(_ value: Float, for key: Key) {
-    ud.set(value, forKey: key.rawValue)
-  }
+  static func set(_ value: Float, for key: Key) { ud.set(value, forKey: key.rawValue) }
 
-  static func set(_ value: Double, for key: Key) {
-    ud.set(value, forKey: key.rawValue)
-  }
+  static func set(_ value: Double, for key: Key) { ud.set(value, forKey: key.rawValue) }
 
-  static func set(_ value: URL, for key: Key) {
-    ud.set(value, forKey: key.rawValue)
-  }
+  static func set(_ value: URL, for key: Key) { ud.set(value, forKey: key.rawValue) }
 
-  static func set(_ value: Any?, for key: Key) {
-    ud.set(value, forKey: key.rawValue)
-  }
+  static func set(_ value: Any?, for key: Key) { ud.set(value, forKey: key.rawValue) }
 
   static func `enum`<T: InitializingFromKey>(for key: Key) -> T {
-    return T.init(key: key) ?? T.defaultValue
+    T.init(key: key) ?? T.defaultValue
   }
 
+  // MARK: - Logging
+
+  /// Log the value of settings that have been changed from their default value.
+  ///
+  /// These log messages are intended to be used by developers, not the user, so not all settings that have been changed are logged,
+  /// ones not of interest to developers are not logged:
+  /// - assrtToken Sensitive information
+  /// - controlBarPositionHorizontal Not of interest, frequently changed
+  /// - controlBarPositionVertical Not of interest, frequently changed
+  /// - musicModeShowAlbumArt Not of interest
+  /// - musicModeShowPlaylist Not of interest
+  /// - openSubUsername Sensitive information
+  /// - playlistWidth Not of interest
+  /// - recentDocuments Sensitive information, not of interest, maybe large
+  /// - savedAudioFilters Not of interest, maybe large
+  /// - savedVideoFilters Not of interest, maybe large
+  /// - softVolume Not of interest, frequently changed
+  /// - watchProperties Not of interest, maybe large
+  ///
+  /// Although some values of settings can be determined from log messages emitted by `MPVController` it is easier for
+  /// developers to have a concentrated list logged at startup.
+  /// - Important: To determine if a setting has changed this method converts the current value of the setting as well as the default
+  ///     value for the setting to [AnyHashable](https://developer.apple.com/documentation/swift/anyhashable)
+  ///     and then compares the hash values. This filters out many settings that are still set to their default values. _However_ the
+  ///     hash values can differ even when the setting is set to the default value. For example, if the user directly sets an IINA setting
+  ///     using the [defaults](https://support.apple.com/guide/terminal/edit-property-lists-apda49a1bb2-577e-4721-8f25-ffc0836f6997/mac)
+  ///     command like so:
+  ///     ```bash
+  ///     defaults write com.colliderli.iina enableNowPlayingArtwork true
+  ///     ```
+  ///     Instead of:
+  ///     ```bash
+  ///     defaults write com.colliderli.iina enableNowPlayingArtwork -bool true
+  ///     ```
+  ///     The type of the value will be `NSTaggedPointerString` instead of `__NSCFBoolean` and the hash values will differ
+  ///     even when set to the default value. For this reason there is an additional check once the value has been converted to the
+  ///     appropriate type and can be directly compared to the default value.
+  static func logSettings() {
+    guard Logger.isEmitting(.debug) else { return }
+    // See the list in this method's documentation comment for why these settings are not logged.
+    let doNotLog: [Key] = [.assrtToken, .controlBarPositionHorizontal, .controlBarPositionVertical,
+      .musicModeShowAlbumArt, .musicModeShowPlaylist, .openSubUsername, .playlistWidth,
+      .recentDocuments, .savedAudioFilters, .savedVideoFilters, .softVolume, .watchProperties]
+    // There isn't an enumeration of the settings, so we use the keys in the dictionary containing
+    // the defaults. Filter the list to remove the keys we do not want to log and then sort the keys
+    // so the log messages are ordered for easier reading.
+    let keys = Preference.defaultPreference.keys.filter( { !doNotLog.contains($0) } )
+      .sorted(by: { $0.rawValue < $1.rawValue })
+    log("Partial list of settings changed from their default values:")
+    for key in keys {
+      guard let defaultValue = Preference.defaultPreference[key] else {
+        // Internal error. Nil is not a valid default value.
+        log("Default for \(key) is nil", level: .error)
+        continue
+      }
+      guard let value = Preference.value(for: key) else {
+        // Internal error. All settings must have defaults.
+        log("Value for \(key) is nil", level: .error)
+        continue
+      }
+      // Only the value of recentDocuments which is of type Array<Any> cannot be cast to
+      // AnyHashable. As that setting is not logged we do not bother to exclude that key.
+      guard let hashableDefault = defaultValue as? AnyHashable else {
+        log("Default for \(key) is of type \(type(of: defaultValue)) and cannot be cast to AnyHashable",
+            level: .error)
+        continue
+      }
+      guard let hashableValue = value as? AnyHashable else {
+        log("Value for \(key) is of type \(type(of: value)) and cannot be cast to AnyHashable",
+            level: .error)
+        continue
+      }
+      // NOTE that if the hash does not match may not mean the setting is not set to the default.
+      // See the discussion in this method's documentation comment. This check is still useful as it
+      // avoids the work to convert the value and its default to their respective type and then into
+      // a string.
+      guard hashableValue.hashValue != hashableDefault.hashValue else { continue }
+      // The values of many settings are not stored in a human friendly representation. The values
+      // must be converted to their respective types and then converted to a string.
+      let defaultAsString: String
+      let valueAsString: String
+      // Other than the first entry the cases in the switch are ordered based on the name of the
+      // type of the value.
+      switch key {
+      case .assrtToken, .openSubUsername:
+        // These keys should have been filtered above, so this code should never be executed. This
+        // code makes sure that if a change to the code causes these keys to be logged the value
+        // will be hidden.
+        defaultAsString = ""
+        valueAsString = "<private>"
+      case .actionAfterLaunch:
+        defaultAsString = String(describing: ActionAfterLaunch.defaultValue)
+        valueAsString = String(describing: Preference.enum(for: key) as ActionAfterLaunch)
+      case .arrowButtonAction:
+        defaultAsString = String(describing: ArrowButtonAction.defaultValue)
+        valueAsString = String(describing: Preference.enum(for: key) as ArrowButtonAction)
+      case .allowScreenSaverForAudio,
+           .alwaysFloatOnTop,
+           .alwaysOpenInNewWindow,
+           .alwaysShowOnTopIcon,
+           .audioDriverEnableAVFoundation,
+           .autoRepeat,
+           .autoSearchOnlineSub,
+           .autoSwitchToMusicMode,
+           .blackOutMonitor,
+           .controlBarStickToCenter,
+           .disableAnimations,
+           .disableOSDFileStartMsg,
+           .disableOSDPauseResumeMsgs,
+           .disableOSDSeekMsg,
+           .disableOSDSpeedMsg,
+           .disablePlaySliderScrolling,
+           .disableVolumeSliderScrolling,
+           .displayInLetterBox,
+           .displayKeyBindingRawValues,
+           .displayTimeAndBatteryInFullScreen,
+           .enableAdvancedSettings,
+           .enableCache,
+           .enableCmdN,
+           .enableControlBarAutoHide,
+           .enableDisplayIdle,
+           .enableFFmpegImageDecoder,
+           .enableHdrSupport,
+           .enableHdrWorkaround,
+           .enableInitialVolume,
+           .enableLogging,
+           .enableNowPlayingArtwork,
+           .enableOSD,
+           .enableRecentDocumentsWorkaround,
+           .enableThumbnailForRemoteFiles,
+           .enableThumbnailPreview,
+           .enableToneMapping,
+           .enableWrongScreenWorkaround,
+           .followGlobalSeekTypeWhenAdjustSlider,
+           .forceDedicatedGPU,
+           .fullScreenWhenOpen,
+           .ignoreAssStyles,
+           .iinaEnablePluginSystem,
+           .keepOpenOnFileEnd,
+           .loadIccProfile,
+           .musicModeShowAlbumArt,
+           .musicModeShowPlaylist,
+           .pauseWhenGoesToSleep,
+           .pauseWhenInactive,
+           .pauseWhenLeavingFullScreen,
+           .pauseWhenMinimized,
+           .pauseWhenOpen,
+           .pauseWhenPip,
+           .playlistAutoAdd,
+           .playlistAutoPlayNext,
+           .playlistShowMetadata,
+           .playlistShowMetadataInMusicMode,
+           .playWhenEnteringFullScreen,
+           .prefetchPlaylistVideoDuration,
+           .preventScreenSaver,
+           .quitWhenNoOpenedWindow,
+           .receiveBetaUpdate,
+           .recordPlaybackHistory,
+           .recordRecentFiles,
+           .replayGainClip,
+           .resumeLastPosition,
+           .scaleRemainingTime,
+           .screenshotCopyToClipboard,
+           .screenshotIncludeSubtitle,
+           .screenshotSaveToFile,
+           .screenshotShowPreview,
+           .showBufferingThrobber,
+           .showChapterPos,
+           .showRemainingTime,
+           .showSeekingThrobber,
+           .spdifAC3,
+           .spdifDTS,
+           .spdifDTSHD,
+           .subBold,
+           .subItalic,
+           .subScaleWithWindow,
+           .togglePipByMinimizingWindow,
+           .togglePipByMinimizingWindowForVideoOnly,
+           .touchbarShowRemainingTime,
+           .trackAllFilesInRecentOpenMenu,
+           .useAppleRemote,
+           .useLegacyFullScreen,
+           .useMediaKeys,
+           .useMpvOsd,
+           .usePhysicalResolution,
+           .useUserDefinedConfDir,
+           .videoViewAcceptsFirstMouse,
+           .ytdlEnabled:
+        guard let defaultAsBool = defaultValue as? Bool else {
+          // Should not occur. Internal error.
+          log("Default for \(key) is of type \(type(of: value)) and cannot be cast to Bool",
+              level: .error)
+          continue
+        }
+        defaultAsString = String(defaultAsBool)
+        valueAsString = String(Preference.bool(for: key))
+      case .defaultRepeatMode:
+        defaultAsString = String(describing: DefaultRepeatMode.defaultValue)
+        valueAsString = String(describing: Preference.enum(for: key) as DefaultRepeatMode)
+      case .controlBarAutoHideTimeout,
+           .controlBarPositionHorizontal,
+           .controlBarPositionVertical,
+           .osdAutoHideTimeout,
+           .osdTextSize,
+           .subBlur,
+           .subBorderSize,
+           .subMarginX,
+           .subMarginY,
+           .subPos,
+           .subShadowSize,
+           .subSpacing,
+           .subTextSize:
+        guard let defaultAsFloat = defaultValue as? Float else {
+          // Should not occur. Internal error.
+          log("Default for \(key) is of type \(type(of: value)) and cannot be cast to Float",
+              level: .error)
+          continue
+        }
+        defaultAsString = String(defaultAsFloat)
+        valueAsString = String(Preference.float(for: key))
+      case .gaplessAudio:
+        defaultAsString = String(describing: GaplessAudioOption.defaultValue)
+        valueAsString = String(describing: Preference.enum(for: key) as GaplessAudioOption)
+      case .hardwareDecoder:
+        defaultAsString = String(describing: HardwareDecoderOption.defaultValue)
+        valueAsString = String(describing: Preference.enum(for: key) as HardwareDecoderOption)
+      case .subAutoLoadIINA:
+        defaultAsString = String(describing: IINAAutoLoadAction.defaultValue)
+        valueAsString = String(describing: Preference.enum(for: key) as IINAAutoLoadAction)
+      case .logLevel:
+        defaultAsString = String(describing: Logger.Level.defaultValue)
+        valueAsString = String(describing: Preference.enum(for: key) as Logger.Level)
+      case .doubleClickAction,
+           .forceTouchAction,
+           .middleClickAction,
+           .rightClickAction,
+           .singleClickAction:
+        defaultAsString = String(describing: MouseClickAction.defaultValue)
+        valueAsString = String(describing: Preference.enum(for: key) as MouseClickAction)
+      case .oscPosition:
+        defaultAsString = String(describing: OSCPosition.defaultValue)
+        valueAsString = String(describing: Preference.enum(for: key) as OSCPosition)
+      case .pinchAction:
+        defaultAsString = String(describing: PinchAction.defaultValue)
+        valueAsString = String(describing: Preference.enum(for: key) as PinchAction)
+      case .replayGain:
+        defaultAsString = String(describing: ReplayGainOption.defaultValue)
+        valueAsString = String(describing: Preference.enum(for: key) as ReplayGainOption)
+      case .resizeWindowOption:
+        defaultAsString = String(describing: ResizeWindowOption.defaultValue)
+        valueAsString = String(describing: Preference.enum(for: key) as ResizeWindowOption)
+      case .resizeWindowTiming:
+        defaultAsString = String(describing: ResizeWindowTiming.defaultValue)
+        valueAsString = String(describing: Preference.enum(for: key) as ResizeWindowTiming)
+      case .transportRTSPThrough:
+        defaultAsString = String(describing: RTSPTransportation.defaultValue)
+        valueAsString = String(describing: Preference.enum(for: key) as RTSPTransportation)
+      case .screenshotFormat:
+        defaultAsString = String(describing: ScreenshotFormat.defaultValue)
+        valueAsString = String(describing: Preference.enum(for: key) as ScreenshotFormat)
+      case .horizontalScrollAction, .verticalScrollAction:
+        defaultAsString = String(describing: ScrollAction.defaultValue)
+        valueAsString = String(describing: Preference.enum(for: key) as ScrollAction)
+      case .useExactSeek:
+        defaultAsString = String(describing: SeekOption.defaultValue)
+        valueAsString = String(describing: Preference.enum(for: key) as SeekOption)
+      case.userOptions:
+        defaultAsString = "[]"
+        guard let valueAsArray = value as? [[String]] else {
+          // Should not occur. Internal error.
+          log("Default for \(key) is of type \(type(of: value)) and cannot be cast to [[String]]",
+              level: .error)
+          continue
+        }
+        valueAsString = valueAsArray.reduce("[", { $0 + $1.joined(separator: " = ") }) + "]"
+      case .subAlignX:
+        defaultAsString = String(describing: SubAlignX.defaultValue)
+        valueAsString = String(describing: Preference.enum(for: key) as SubAlignX)
+      case .subAlignY:
+        defaultAsString = String(describing: SubAlignY.defaultValue)
+        valueAsString = String(describing: Preference.enum(for: key) as SubAlignY)
+      case .secondarySubOverrideLevel, .subOverrideLevel:
+        defaultAsString = String(describing: SubOverrideLevel.defaultValue)
+        valueAsString = String(describing: Preference.enum(for: key) as SubOverrideLevel)
+      case .themeMaterial:
+        defaultAsString = String(describing: Theme.defaultValue)
+        valueAsString = String(describing: Preference.enum(for: key) as Theme)
+      case .toneMappingAlgorithm:
+        defaultAsString = String(describing: ToneMappingAlgorithmOption.defaultValue)
+        valueAsString = String(describing: Preference.enum(for: key) as ToneMappingAlgorithmOption)
+      case .controlBarToolbarButtons:
+        // The value is an array of ToolBarButton enum values stored as integers.
+        guard let defaultAsArray = defaultValue as? [Int] else {
+          // Should not occur. Internal error.
+          log("Default for \(key) is of type \(type(of: value)) and cannot be cast to [Int]",
+              level: .error)
+          continue
+        }
+        defaultAsString = "[" + defaultAsArray.compactMap({
+          guard let button = ToolBarButton.init(rawValue: $0) else { return "unknown(\($0))" }
+          return String(describing: button)
+        }).joined(separator: ", ") + "]"
+        guard let valueAsArray = value as? [Int] else {
+          // Should not occur. Internal error.
+          log("Value for \(key) is of type \(type(of: value)) and cannot be cast to [Int]",
+              level: .error)
+          continue
+        }
+        valueAsString = "[" + valueAsArray.compactMap({
+          guard let button = ToolBarButton.init(rawValue: $0) else { return "unknown(\($0))" }
+          return String(describing: button)
+        }).joined(separator: ", ") + "]"
+      case .windowBehaviorWhenPip:
+        defaultAsString = String(describing: WindowBehaviorWhenPip.defaultValue)
+        valueAsString = String(describing: Preference.enum(for: key) as WindowBehaviorWhenPip)
+      default:
+        // The remaining settings have values that are integers or strings and can be directly
+        // converted to strings.
+        defaultAsString = String(describing: defaultValue)
+        valueAsString = String(describing: value)
+      }
+      // Now that the value and the default have both been converted to their human readable form
+      // we can deterministically check if the setting has been changed from its default.
+      guard valueAsString != defaultAsString else { continue }
+      // To make the output easier to read we don't include the default value of boolean settings as
+      // it is obviously the opposite of the current value of the setting. Defaults that are empty
+      // strings or arrays are also not included to reduce clutter.
+      switch defaultAsString {
+      case "", "false", "true", "[]":
+        log("\(key.rawValue) = \(valueAsString)")
+      default:
+        log("\(key.rawValue) = \(valueAsString) (default: \(defaultAsString))")
+      }
+    }
+  }
+
+  /// Log a message using the `settings` logger subsystem.
+  ///
+  /// This is a wrapper function that merely avoids the need to include the `settings` subsystem in calls to the logger.
+  /// - Important: As settings control the logger use of logging by this class _must not_ occur during class initialization.
+  /// - Parameters:
+  ///   - message: A closure that when executed gives the message to log.
+  ///   - level: The log level of the message.
+  private static func log(_ message: @autoclosure () -> String, level: Logger.Level = .debug) {
+    Logger.log(message, level: level, subsystem: Logger.Sub.settings)
+  }
+}
+
+extension Logger.Sub {
+  static let settings = Logger.makeSubsystem("settings")
 }

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -498,9 +498,8 @@ extension VideoView {
           targetPeak = 400
         }
       }
-      let algorithm = Preference.ToneMappingAlgorithmOption(rawValue: Preference.integer(for: .toneMappingAlgorithm))?.mpvString
-        ?? Preference.ToneMappingAlgorithmOption.defaultValue.mpvString
-
+      let algorithm = String(describing: Preference.enum(for: .toneMappingAlgorithm) as
+                             Preference.ToneMappingAlgorithmOption)
       logHDR("Will enable tone mapping: target-peak=\(targetPeak) algorithm=\(algorithm)")
       mpv.setInt(MPVOption.GPURendererOptions.targetPeak, targetPeak)
       mpv.setString(MPVOption.GPURendererOptions.toneMapping, algorithm)


### PR DESCRIPTION
This commit will:
- Add a `logSettings` method to the `Preference` class
- Change `AppDelegate.applicationWillFinishLaunching` to call `Preference.logSettings`
- Change `Preference.InitializingFromKey` to implement `CustomStringConvertible`
- Refactor enums in `Preference` to have a `description` property as required by `CustomStringConvertible`
- Rename the `ToolBarButton.description` method to `localizedDescription` to not conflict with the `description` property required by `CustomStringConvertible`
- Change code converting these enums to string to use `String(describing:)` as recommended by `CustomStringConvertible`
- Change code using setting that are enums to get the value using `Preference.enum`
- Split the `Preference.SubAlign` enum into `SubAlignX` and `SubAlignY` enums and adjust code referencing `SubAlign`
- Change `Logger.Level` to implement `CustomStringConvertible`
- Rename the existing `Level.description` property to be `shortForm` and update code referencing it
- Add a new `Level.description` property that provides the full name of the levels
- Add a new `isEmitting` method to `Logger`
- Change code testing to see if the logger is configured to emit a certain level to use `isEmitting`

The changes in this commit will cause IINA to at startup log a partial list of settings that have been changed from their defaults. This list allows developers to see how the user has configured IINA, which can be important when trying to reproduce user reported problems. This also alerts developers when they have forgotten to restore setting after changing them when trying to reproduce a problem.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
