### PR TITLE
Log plugin name and version at startup

### DIFF
--- a/iina/JavascriptPlugin.swift
+++ b/iina/JavascriptPlugin.swift
@@ -428,6 +428,7 @@ class JavascriptPlugin: NSObject {
     if (enabled) {
       registerSubProviders()
     }
+    Logger.log("Loaded JS plugin: \(name) \(version)\(enabled ? "" : " (disabled)")")
   }
 
   func registerSubProviders() {


### PR DESCRIPTION
This commit will change the `init` method in the `JavascriptPlugin` class to emit a log message when a plugin is successfully loaded giving the name and version of the plugin as well as an indication if the plugin is disabled.

The version of the plugin currently installed is critical information when investigating a problem as the user may not be using the latest version of the plugin.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
