### PR TITLE
fix: strip quarantine xattr in handleOpenFile to prevent repeated Gatekeeper verification on Open With

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -768,6 +768,17 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
       return
     }
 
+    // Remove com.apple.quarantine xattr from local files so macOS Gatekeeper does not
+    // show a "Verifying..." dialog on every subsequent "Open With" invocation.
+    // When a file is opened via drag-and-drop, Launch Services is bypassed and the
+    // quarantine check never fires. Via "Open With", Launch Services re-checks the
+    // xattr on every open if it has not been cleared. Stripping it here ensures the
+    // dialog only appears at most once — on the very first open — when macOS itself
+    // triggers the initial Gatekeeper scan before calling this callback.
+    for filename in pendingFilesForOpenFile {
+      removexattr((filename as NSString).fileSystemRepresentation, "com.apple.quarantine", 0)
+    }
+
     // open pending files
     pendingFilesForOpenFile.removeAll()
     if PlayerCore.openURLs(urls) == 0 {


### PR DESCRIPTION
## Summary

Fixes #5624 — Repeated "Verifying..." Gatekeeper dialog when opening files via **Open With → IINA**.

## Root Cause

macOS Launch Services checks the `com.apple.quarantine` extended attribute on every file that is opened through an "Open With" action. If the attribute is present, Gatekeeper shows its "Verifying..." dialog before handing the file to the app. This check **does not fire** for drag-and-drop because that path bypasses Launch Services entirely — the file path comes directly from `NSPasteboard`.

After the user explicitly selects IINA to open a file, the quarantine check is redundant. macOS would normally clear the attribute itself after a successful first-time scan, but failures to reach Apple's servers or read-only filesystem edge-cases can leave it set, causing the dialog to reappear on every open.

## Fix

In `handleOpenFile()` — the handler called by `application(_:openFile:)` — call `removexattr()` to strip `com.apple.quarantine` from each received file path before opening it. `removexattr` is a best-effort call; a non-zero return (attribute absent, file on read-only volume, etc.) is silently ignored.

```swift
for filename in pendingFilesForOpenFile {
  removexattr((filename as NSString).fileSystemRepresentation, "com.apple.quarantine", 0)
}
```

## Testing

1. Download an MP4 (so it acquires the quarantine xattr).
2. Confirm the xattr is present: `xattr -l /path/to/file.mp4` should show `com.apple.quarantine`.
3. Right-click → Open With → IINA → observe "Verifying..." on first open (expected — Gatekeeper runs before the callback fires).
4. Open the same file again via Open With — **no dialog should appear**.

Without the fix, step 4 shows the dialog every time.