### PR TITLE
Fix StatusAPI position frozen when OSC hidden, #5941

### DIFF
--- a/iina/JavascriptAPICore.swift
+++ b/iina/JavascriptAPICore.swift
@@ -320,8 +320,11 @@ fileprivate class StatusAPI: JavascriptAPI, CoreSubAPIExportable {
     case "idle":
       return player!.info.state == .idle
     case "position":
+      player!.syncPositionIfNeeded()
       return player!.info.videoPosition?.second ?? NSNull()
     case "duration":
+      // When streaming the duration changes. Syncing the position will also update the duration.
+      player!.syncPositionIfNeeded()
       return player!.info.videoDuration?.second ?? NSNull()
     case "speed":
       return player!.info.playSpeed

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -134,7 +134,7 @@ extension MainMenuActionHandler {
 
   @objc func menuJumpTo(_ sender: NSMenuItem) {
     // Make certain the cached video position in the playback info is up to date.
-    player.syncUI(.time)
+    player.syncPositionIfNeeded()
     Utility.quickPromptPanel("jump_to", inputValue: self.player.info.videoPosition?.stringRepresentationWithPrecision(3)) { input in
       if let vt = VideoTime(input) {
         self.player.seek(absoluteSecond: vt.second)

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -441,7 +441,8 @@ class MenuController: NSObject, NSMenuDelegate {
 
   private func updateChapterList() {
     chapterMenu.removeAllItems()
-    let info = PlayerCore.active.info
+    let player = PlayerCore.active
+    let info = player.info
     let chapters = info.chapters
     let padder = { (time: String) -> String in
       let standard = (chapters.last?.time.stringRepresentation ?? "").reversed()
@@ -449,6 +450,7 @@ class MenuController: NSObject, NSMenuDelegate {
         $0 == ":" ? ":" : "0"
       }).reversed())
     }
+    player.syncPositionIfNeeded()
     for (index, chapter) in chapters.enumerated() {
       let menuTitle = "\(padder(chapter.time.stringRepresentation)) – \(chapter.title)"
       let nextChapterTime = chapters[at: index+1]?.time ?? Constants.Time.infinite

--- a/iina/NowPlayingInfoManager.swift
+++ b/iina/NowPlayingInfoManager.swift
@@ -166,6 +166,7 @@ class NowPlayingInfoManager {
       info[MPNowPlayingInfoPropertyChapterNumber] = player.info.chapter
     }
 
+    player.syncPositionIfNeeded()
     let duration = player.info.videoDuration?.second ?? 0
     let time = player.info.videoPosition?.second ?? 0
 

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -2493,6 +2493,39 @@ class PlayerCore: NSObject {
     }
   }
 
+  /// Synchronize the video position cached in the `info.videoPosition` property.
+  ///
+  /// This method updates the `PlaybackInfo.videoPosition` property.  If the video is being streamed `videoDuration` will
+  /// also be updated.
+  /// - Important: When the end of a video file is reached mpv does not update the value of the property
+  ///     [time-pos](https://mpv.io/manual/stable/#command-interface-time-pos), leaving it reflecting the position
+  ///     of the last frame of the video. This is especially noticeable if the onscreen controller time labels are configured to show
+  ///     milliseconds. Due to this behavior of the `time-pos` property, this method checks to see of the end of the video has been
+  ///     reached and if so, sets `videoPosition` to match `videoDuration`.
+  private func syncPosition() {
+    if info.isNetworkResource {
+      info.videoDuration?.second = mpv.getDouble(MPVProperty.duration)
+    }
+    let eofReached = mpv.getFlag(MPVProperty.eofReached)
+    if eofReached, let duration = info.videoDuration?.second {
+      info.videoPosition?.second = duration
+    } else {
+      info.videoPosition?.second = mpv.getDouble(MPVProperty.timePos)
+    }
+    info.constrainVideoPosition()
+  }
+
+  /// Synchronize the cached video position if the timer that updates the cache is not running.
+  ///
+  /// When portions of the UI that need the video position are visible (OSC, OSD), `syncUITimer` keeps the
+  /// `info.videoPosition` property synchronized with mpv. Code outside of the UI needs to call this method before accessing
+  /// the position to ensure the cache is up to date when the timer is not running..
+  func syncPositionIfNeeded() {
+    if let syncUITimer, syncUITimer.isValid { return }
+    guard info.state.active else { return }
+    syncPosition()
+  }
+
   // difficult to use option set
   enum SyncUIOption {
     case time
@@ -2523,20 +2556,7 @@ class PlayerCore: NSObject {
 
     case .time:
       let isNetworkStream = info.isNetworkResource
-      if isNetworkStream {
-        info.videoDuration?.second = mpv.getDouble(MPVProperty.duration)
-      }
-      // When the end of a video file is reached mpv does not update the value of the property
-      // time-pos, leaving it reflecting the position of the last frame of the video. This is
-      // especially noticeable if the onscreen controller time labels are configured to show
-      // milliseconds. Adjust the position if the end of the file has been reached.
-      let eofReached = mpv.getFlag(MPVProperty.eofReached)
-      if eofReached, let duration = info.videoDuration?.second {
-        info.videoPosition?.second = duration
-      } else {
-        info.videoPosition?.second = mpv.getDouble(MPVProperty.timePos)
-      }
-      info.constrainVideoPosition()
+      syncPosition()
       info.videoRemaining?.second = Preference.bool(for: .scaleRemainingTime) ?
         mpv.getDouble(MPVProperty.playtimeRemainingFull) :
         mpv.getDouble(MPVProperty.timeRemainingFull)


### PR DESCRIPTION
This commit will:
- Move code in `PlayerCore` for synchronizing videoPosition out of `syncUI` and into a new `syncPosition` method to allow shared use
- Add a new `syncPositionIfNeeded` method that will update `videoPosition` if the `syncUITimer` is not running
- Change `JavascriptAPICore` to call `syncPositionIfNeeded` before accessing `videoPosition`
- Change `MainMenuActions.menuJumpTo`, `MenuController.updateChapterList` and `NowPlayingInfoManager.updateInfo` to also call `syncPositionIfNeeded` before accessing `videoPosition`

This will correct problems due to a stale `videoPosition` value being used because the UI elements that ensure the position is synchronized with mpv are hidden and therefore the synchronization timer that updates `videoPosition` is not running to avoid needless energy use. The fix changes the code outside of the UI that needs access to `videoPosition` to first synchronize the cache, if the timer is not running, before accessing the value.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5941.

---

**Description:**
