### PR TITLE
Support External Subtitle Rendering for Audio-Only Files

### DIFF
--- a/iina/AutoFileMatcher.swift
+++ b/iina/AutoFileMatcher.swift
@@ -26,7 +26,7 @@ class AutoFileMatcher {
   private var subtitles: [FileInfo] = []
   private var subsGroupedBySeries: [String: [FileInfo]] = [:]
   private var unmatchedVideos: [FileInfo] = []
-  
+
   private let subsystem: Logger.Subsystem
 
   private func log(_ message: @autoclosure () -> String, level: Logger.Level = .debug) {
@@ -199,7 +199,8 @@ class AutoFileMatcher {
     let subAutoLoadOption: Preference.IINAAutoLoadAction = Preference.enum(for: .subAutoLoadIINA)
     guard subAutoLoadOption != .disabled else { return }
 
-    for video in filesGroupedByMediaType[.video]! {
+    let currentVideosInfo = filesGroupedByMediaType[.video]! + filesGroupedByMediaType[.audio]!
+    for video in currentVideosInfo {
       var matchedSubs = Set<FileInfo>()
       log("Matching for \(video.filename)")
 
@@ -314,7 +315,7 @@ class AutoFileMatcher {
           if dist < minDistToVideo { minDistToVideo = dist }
         }
         guard minDistToVideo != .max else { continue }
-        sub.minDist = filesGroupedByMediaType[.video]!.filter { sub.dist[$0] == minDistToVideo }
+        sub.minDist = (filesGroupedByMediaType[.video]! + filesGroupedByMediaType[.audio]!).filter { sub.dist[$0] == minDistToVideo }
       }
 
       // match them
@@ -355,7 +356,7 @@ class AutoFileMatcher {
 
       // group video and sub files
       log("Grouping video files...")
-      videosGroupedBySeries = FileGroup.group(files: filesGroupedByMediaType[.video]!).flatten()
+      videosGroupedBySeries = FileGroup.group(files: filesGroupedByMediaType[.video]! + filesGroupedByMediaType[.audio]!).flatten()
       log("Finished with \(videosGroupedBySeries.count) groups")
 
       log("Grouping sub files...")

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -142,6 +142,7 @@ class MPVController: NSObject {
     MPVOption.Subtitles.subPos: MPV_FORMAT_DOUBLE,
     MPVOption.Subtitles.subScale: MPV_FORMAT_DOUBLE,
     MPVOption.Subtitles.subVisibility: MPV_FORMAT_FLAG,
+    MPVProperty.subText: MPV_FORMAT_STRING,
     MPVOption.Equalizer.contrast: MPV_FORMAT_INT64,
     MPVOption.Equalizer.brightness: MPV_FORMAT_INT64,
     MPVOption.Equalizer.gamma: MPV_FORMAT_INT64,
@@ -1402,6 +1403,9 @@ class MPVController: NSObject {
         break
       }
       DispatchQueue.main.async { self.player.subPosChanged(data) }
+
+    case MPVProperty.subText:
+      DispatchQueue.main.async { self.player.subTextChanged() }
 
     case MPVOption.Equalizer.contrast:
       guard let data = UnsafePointer<Int64>(OpaquePointer(property.data))?.pointee else {

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -579,6 +579,10 @@ class MPVController: NSObject {
       }
     }
 
+    // Force mpv window creation. Required to render subtitles/OSD even for audio-only scenarios (e.g. mp3).
+    // Must be set BEFORE mpv_initialize(), since mpv_set_option_string only works pre-init.
+    chkErr(setOptionString(MPVOption.Window.forceWindow, "yes", level: .verbose))
+
     // Set user defined options.
     if Preference.bool(for: .enableAdvancedSettings) {
       if let userOptions = Preference.value(for: .userOptions) as? [[String]] {

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -332,12 +332,21 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     guard let window = window else { return }
     let w = player.info.displayWidth, h = player.info.displayHeight
 
-    // For audio-only files (no real video tracks), we want to keep 1:1 aspect
-    // even if a synthetic lavfi-complex track added a video.
+    // For audio-only files, use album art dimensions if available, otherwise 1:1.
     let hasRealVideoTrack = player.info.videoTracks.contains { !$0.isAlbumart }
     let isAudioOnly = player.info.videoTracks.isEmpty || !hasRealVideoTrack
 
-    let (width, height) = (w == 0 && h == 0) || isAudioOnly ? (1, 1) :  player.videoSizeForDisplay
+    let width, height: Int
+    if (w == 0 && h == 0) || isAudioOnly {
+      if let albumArt = player.info.videoTracks.first(where: { $0.isAlbumart }),
+         let artW = albumArt.demuxW, let artH = albumArt.demuxH, artW > 0, artH > 0 {
+        (width, height) = (artW, artH)
+      } else {
+        (width, height) = (1, 1)
+      }
+    } else {
+      (width, height) = player.videoSizeForDisplay
+    }
     let aspect = CGFloat(width) / CGFloat(height)
     let currentHeight = videoView.frame.height
     let newHeight = videoView.frame.width / aspect

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -51,9 +51,61 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
   @IBOutlet weak var defaultAlbumArt: NSView!
   @IBOutlet weak var togglePlaylistButton: NSButton!
   @IBOutlet weak var toggleAlbumArtButton: NSButton!
-  
+
   var isPlaylistVisible = false
   var isVideoVisible = true
+
+  /// Native subtitle text overlay for audio-only files in music mode.
+  /// Positioned at the bottom of the video wrapper view, on top of the album art.
+  lazy var subtitleLabel: NSTextField = {
+    let label = NSTextField(wrappingLabelWithString: "")
+    label.translatesAutoresizingMaskIntoConstraints = false
+    label.isEditable = false
+    label.isSelectable = false
+    label.isBezeled = false
+    label.drawsBackground = false
+    label.textColor = .white
+    label.font = NSFont.systemFont(ofSize: 20, weight: .medium)
+    label.alignment = .center
+    label.maximumNumberOfLines = 0
+    label.lineBreakMode = .byWordWrapping
+    label.cell?.truncatesLastVisibleLine = true
+    // Add shadow for readability over album art
+    let shadow = NSShadow()
+    shadow.shadowColor = NSColor.black.withAlphaComponent(0.9)
+    shadow.shadowBlurRadius = 4
+    shadow.shadowOffset = NSSize(width: 0, height: -1)
+    label.shadow = shadow
+    label.isHidden = true
+    return label
+  }()
+
+  /// Work item to hide the subtitle smoothly to prevent blinking during seeks
+  private var hideSubtitleWorkItem: DispatchWorkItem?
+
+  func updateSubtitleLabel(with text: String) {
+    if text.isEmpty {
+      // If already hidden, or already waiting to hide, do nothing.
+      if subtitleLabel.isHidden || hideSubtitleWorkItem != nil {
+        return
+      }
+
+      // Delay hiding to prevent blinking during seeks where subText is temporarily empty
+      let workItem = DispatchWorkItem { [weak self] in
+        self?.subtitleLabel.isHidden = true
+        self?.subtitleLabel.stringValue = ""
+        self?.hideSubtitleWorkItem = nil
+      }
+      hideSubtitleWorkItem = workItem
+      DispatchQueue.main.asyncAfter(deadline: .now() + 0.1, execute: workItem)
+    } else {
+      hideSubtitleWorkItem?.cancel()
+      hideSubtitleWorkItem = nil
+
+      subtitleLabel.stringValue = text
+      subtitleLabel.isHidden = false
+    }
+  }
 
   var videoViewAspectConstraint: NSLayoutConstraint?
 
@@ -121,7 +173,7 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     closeButtonBackgroundViewBox.isHidden = true
     closeButtonView.alphaValue = 0
     controlView.alphaValue = 0
-    
+
     // tool tips
     togglePlaylistButton.toolTip = Preference.ToolBarButton.playlist.description()
     toggleAlbumArtButton.toolTip = NSLocalizedString("mini_player.album_art", comment: "album_art")
@@ -134,6 +186,14 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     }
     volumeSlider.maxValue = Double(Preference.integer(for: .maxVolume))
     volumePopover.delegate = self
+
+    // Set up native subtitle overlay (on top of album art)
+    videoWrapperView.addSubview(subtitleLabel)
+    NSLayoutConstraint.activate([
+      subtitleLabel.leadingAnchor.constraint(equalTo: videoWrapperView.leadingAnchor, constant: 12),
+      subtitleLabel.trailingAnchor.constraint(equalTo: videoWrapperView.trailingAnchor, constant: -12),
+      subtitleLabel.bottomAnchor.constraint(equalTo: videoWrapperView.bottomAnchor, constant: -8)
+    ])
   }
 
   // MARK: - Mouse / Trackpad events
@@ -271,7 +331,13 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
   override func handleVideoSizeChange() {
     guard let window = window else { return }
     let w = player.info.displayWidth, h = player.info.displayHeight
-    let (width, height) = (w == 0 && h == 0) ? (1, 1) :  player.videoSizeForDisplay
+
+    // For audio-only files (no real video tracks), we want to keep 1:1 aspect
+    // even if a synthetic lavfi-complex track added a video.
+    let hasRealVideoTrack = player.info.videoTracks.contains { !$0.isAlbumart }
+    let isAudioOnly = player.info.videoTracks.isEmpty || !hasRealVideoTrack
+
+    let (width, height) = (w == 0 && h == 0) || isAudioOnly ? (1, 1) :  player.videoSizeForDisplay
     let aspect = CGFloat(width) / CGFloat(height)
     let currentHeight = videoView.frame.height
     let newHeight = videoView.frame.width / aspect

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -723,8 +723,8 @@ class PlayerCore: NSObject {
     miniPlayer.videoWrapperView.addSubview(videoView, positioned: .below, relativeTo: nil)
     Utility.quickConstraints(["H:|[v]|", "V:|[v]|"], ["v": videoView])
 
-    // For audio-only files (no real video tracks), we want to keep the album art
-    // and use 1:1 aspect even if a synthetic lavfi-complex track added a video.
+    // For audio-only files (no real video tracks), use the album art's native
+    // aspect ratio if available, otherwise default to 1:1.
     let hasRealVideoTrack = info.videoTracks.contains { !$0.isAlbumart }
     let isAudioOnly = info.videoTracks.isEmpty || !hasRealVideoTrack
 
@@ -734,7 +734,13 @@ class PlayerCore: NSObject {
       (width, height) = videoSizeForDisplay
     } else {
       miniPlayer.defaultAlbumArt.isHidden = false
-      (width, height) = (1, 1)
+      // Use album art dimensions if present
+      if let albumArt = info.videoTracks.first(where: { $0.isAlbumart }),
+         let artW = albumArt.demuxW, let artH = albumArt.demuxH, artW > 0, artH > 0 {
+        (width, height) = (artW, artH)
+      } else {
+        (width, height) = (1, 1)
+      }
     }
 
     let aspect = CGFloat(width) / CGFloat(height)

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -85,7 +85,7 @@ class PlayerCore: NSObject {
     let useNew = Preference.bool(for: .alwaysOpenInNewWindow) != isAlternative
     return useNew ? newPlayerCore : active
   }
-  
+
   /**
    Depending on the `alwaysOpenInNewWindow` pref, opens the URLs in a single window, or multiple windows.
 
@@ -178,10 +178,10 @@ class PlayerCore: NSObject {
   private var backgroundTaskInUse = false
 
   var initialWindow: InitialWindowController!
-  
+
   var mainWindow: MainWindowController!
   var miniPlayer: MiniPlayerWindowController!
-  
+
   var currentController: PlayerWindowController {
     return isInMiniPlayer ? miniPlayer : mainWindow
   }
@@ -723,12 +723,17 @@ class PlayerCore: NSObject {
     miniPlayer.videoWrapperView.addSubview(videoView, positioned: .below, relativeTo: nil)
     Utility.quickConstraints(["H:|[v]|", "V:|[v]|"], ["v": videoView])
 
-    // if received video size before switching to music mode, hide default album art
+    // For audio-only files (no real video tracks), we want to keep the album art
+    // and use 1:1 aspect even if a synthetic lavfi-complex track added a video.
+    let hasRealVideoTrack = info.videoTracks.contains { !$0.isAlbumart }
+    let isAudioOnly = info.videoTracks.isEmpty || !hasRealVideoTrack
+
     let width, height: Int
-    if info.vid != 0 {
+    if info.vid != 0 && !isAudioOnly {
       miniPlayer.defaultAlbumArt.isHidden = true
       (width, height) = videoSizeForDisplay
     } else {
+      miniPlayer.defaultAlbumArt.isHidden = false
       (width, height) = (1, 1)
     }
 
@@ -2196,7 +2201,7 @@ class PlayerCore: NSObject {
     // restart even while paused. See issue #5337.
     syncUI(.time)
     reloadSavedIINAfilters()
-    
+
     // The new video's size is guaranteed to be available. Reset the flags used for window resizing.
     // We can't put this in MPV_EVENT_VIDEO_RECONFIG because it can be emitted with the old video's size
     // after switching to a new video.
@@ -2298,6 +2303,21 @@ class PlayerCore: NSObject {
         switchBackFromMiniPlayer(automatically: true, showMainWindow: false)
       }
     }
+
+    // For audio-only files with subtitles:
+    // Inject lavfi-complex to create a synthetic continuous video track for mpv rendering.
+    // This keeps the internal mpv render clock active, preventing UI freezes
+    // (time, progress bar, subtitles) regardless of whether we are in the main window
+    // or the mini player. (In mini player, we simply cover this video with the album art).
+    if audioStatus == .isAudio && !info.subTracks.isEmpty {
+      let currentLavfi = mpv.getString(MPVOption.Miscellaneous.lavfiComplex) ?? ""
+      if currentLavfi.isEmpty {
+        let filter = "color=c=black:s=640x360:r=1[vo]"
+        mpv.setString(MPVOption.Miscellaneous.lavfiComplex, filter)
+        log("Injected lavfi-complex for audio subtitle rendering: \(filter)")
+      }
+    }
+
     postNotification(.iinaTracklistChanged)
   }
 
@@ -2506,7 +2526,7 @@ class PlayerCore: NSObject {
   @objc func syncUITime() {
     syncUI(.time)
   }
-  
+
   func syncUI(_ options: [SyncUIOption]) {
     for option in options {
       syncUI(option)
@@ -2556,6 +2576,11 @@ class PlayerCore: NSObject {
         }
         if isNetworkStream {
           self.mainWindow.updateNetworkState()
+        }
+        // Update native subtitle overlay in mini player for audio-only files
+        if self.isInMiniPlayer && self.currentMediaIsAudio == .isAudio {
+          let subText = self.mpv.getString(MPVProperty.subText) ?? ""
+          self.miniPlayer.updateSubtitleLabel(with: subText)
         }
       }
 

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -725,18 +725,16 @@ class PlayerCore: NSObject {
     miniPlayer.videoWrapperView.addSubview(videoView, positioned: .below, relativeTo: nil)
     Utility.quickConstraints(["H:|[v]|", "V:|[v]|"], ["v": videoView])
 
-    // For audio-only files (no real video tracks), use the album art's native
-    // aspect ratio if available, otherwise default to 1:1.
     let hasRealVideoTrack = info.videoTracks.contains { !$0.isAlbumart }
     let isAudioOnly = info.videoTracks.isEmpty || !hasRealVideoTrack
 
     let width, height: Int
-    if info.vid != 0 && !isAudioOnly {
+    if info.vid != 0 {
       miniPlayer.defaultAlbumArt.isHidden = true
       (width, height) = videoSizeForDisplay
     } else {
       miniPlayer.defaultAlbumArt.isHidden = false
-      // Use album art dimensions if present
+      // Use album art metadata if present, even if no track is "active" as video
       if let albumArt = info.videoTracks.first(where: { $0.isAlbumart }),
          let artW = albumArt.demuxW, let artH = albumArt.demuxH, artW > 0, artH > 0 {
         (width, height) = (artW, artH)

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -85,7 +85,7 @@ class PlayerCore: NSObject {
     let useNew = Preference.bool(for: .alwaysOpenInNewWindow) != isAlternative
     return useNew ? newPlayerCore : active
   }
-  
+
   /**
    Depending on the `alwaysOpenInNewWindow` pref, opens the URLs in a single window, or multiple windows.
 
@@ -178,10 +178,10 @@ class PlayerCore: NSObject {
   private var backgroundTaskInUse = false
 
   var initialWindow: InitialWindowController!
-  
+
   var mainWindow: MainWindowController!
   var miniPlayer: MiniPlayerWindowController!
-  
+
   var currentController: PlayerWindowController {
     return isInMiniPlayer ? miniPlayer : mainWindow
   }
@@ -2196,7 +2196,7 @@ class PlayerCore: NSObject {
     // restart even while paused. See issue #5337.
     syncUI(.time)
     reloadSavedIINAfilters()
-    
+
     // The new video's size is guaranteed to be available. Reset the flags used for window resizing.
     // We can't put this in MPV_EVENT_VIDEO_RECONFIG because it can be emitted with the old video's size
     // after switching to a new video.
@@ -2466,13 +2466,19 @@ class PlayerCore: NSObject {
 
     // Timer will start
 
-    syncUITimer = Timer.scheduledTimer(
+    let timer = Timer(
       timeInterval: timeInterval,
       target: self,
       selector: #selector(self.syncUITime),
       userInfo: nil,
       repeats: true
     )
+    // Add to .common mode so the timer also fires during event tracking (e.g.
+    // when a macOS menu bar dropdown is open). Timer.scheduledTimer only adds to
+    // .default mode which is suspended during menu tracking, causing the UI
+    // (progress bar, time labels) to freeze.
+    RunLoop.main.add(timer, forMode: .common)
+    syncUITimer = timer
   }
 
   func notifyWindowVideoSizeChanged() {
@@ -2506,7 +2512,7 @@ class PlayerCore: NSObject {
   @objc func syncUITime() {
     syncUI(.time)
   }
-  
+
   func syncUI(_ options: [SyncUIOption]) {
     for option in options {
       syncUI(option)

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -726,7 +726,6 @@ class PlayerCore: NSObject {
     Utility.quickConstraints(["H:|[v]|", "V:|[v]|"], ["v": videoView])
 
     let hasRealVideoTrack = info.videoTracks.contains { !$0.isAlbumart }
-    let isAudioOnly = info.videoTracks.isEmpty || !hasRealVideoTrack
 
     let width, height: Int
     if info.vid != 0 {

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -682,6 +682,8 @@ class PlayerCore: NSObject {
   /// or not to switch to mini player automatically
   /// 2) On user initiated button actions
   ///
+  var cachedSubScale: Double = 1.0
+
   func switchToMiniPlayer(automatically: Bool = false, showMiniPlayer: Bool = true) {
     log("Switch to mini player, automatically=\(automatically)")
     if !automatically {
@@ -752,6 +754,11 @@ class PlayerCore: NSObject {
       miniPlayer.setToInitialWindowSize(display: true, animate: false)
     }
 
+    if Preference.bool(for: .musicModeShowAlbumArt) {
+      cachedSubScale = mpv.getDouble(MPVOption.Subtitles.subScale)
+      mpv.setDouble(MPVOption.Subtitles.subScale, 0.0)
+    }
+
     isInMiniPlayer = true
 
     // restore layout
@@ -813,6 +820,10 @@ class PlayerCore: NSObject {
     // hide mini player
     miniPlayer.window?.orderOut(nil)
     isInMiniPlayer = false
+
+    if Preference.bool(for: .musicModeShowAlbumArt) {
+      mpv.setDouble(MPVOption.Subtitles.subScale, cachedSubScale)
+    }
 
     mainWindow.pendingShow = true
     if showMainWindow {
@@ -2279,6 +2290,12 @@ class PlayerCore: NSObject {
     needReloadQuickSettingsView()
   }
 
+  func subTextChanged() {
+    guard isInMiniPlayer && currentMediaIsAudio == .isAudio else { return }
+    let subText = mpv.getString(MPVProperty.subText) ?? ""
+    miniPlayer.updateSubtitleLabel(with: subText)
+  }
+
   func subVisibilityChanged(_ visible: Bool) {
     guard info.isSubVisible != visible else { return }
     info.isSubVisible = visible
@@ -2310,19 +2327,7 @@ class PlayerCore: NSObject {
       }
     }
 
-    // For audio-only files with subtitles:
-    // Inject lavfi-complex to create a synthetic continuous video track for mpv rendering.
-    // This keeps the internal mpv render clock active, preventing UI freezes
-    // (time, progress bar, subtitles) regardless of whether we are in the main window
-    // or the mini player. (In mini player, we simply cover this video with the album art).
-    if audioStatus == .isAudio && !info.subTracks.isEmpty {
-      let currentLavfi = mpv.getString(MPVOption.Miscellaneous.lavfiComplex) ?? ""
-      if currentLavfi.isEmpty {
-        let filter = "color=c=black:s=640x360:r=1[vo]"
-        mpv.setString(MPVOption.Miscellaneous.lavfiComplex, filter)
-        log("Injected lavfi-complex for audio subtitle rendering: \(filter)")
-      }
-    }
+
 
     postNotification(.iinaTracklistChanged)
   }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #457, #972, #5618.

---

**Description:**

This PR enables subtitle rendering for all audio-only files (MP3, FLAC, WAV, etc.) and their associated external subtitle files (LRC, SRT, ASS, etc.) by addressing renderer initialization and UI synchronization issues.

### The Problem
When using `vo=libmpv`, the core renderer disables updates if no video track is present. For audio-only media, this prevents subtitle display and stops mpv's internal render clock, which in turn causes IINA's UI synchronization (progress bar and time displays) to freeze during window mode switches.

### Implementation Details

#### 1. Synthetic Video Track
A persistent synthetic video track is injected via `lavfi-complex` (`color=c=black:s=640x360:r=1[vo]`) when playing audio files with subtitles. This ensures a continuous render clock, preventing UI freezes. The filter is designed to be video-only, preserving original audio tracks and volume controls without any audio hijacking.

#### 2. Native Subtitle Overlay in Music Mode
To provide a clean experience in the mini player without obscuring album art, we implemented a native `NSTextField` overlay:
- The overlay is updated by polling mpv's `sub-text` property during the UI sync loop.
- A 0.1s debounce delay is applied to the hiding logic to prevent flickering during rapid seek operations or buffer flushes.
- The synthetic video track is layered behind the album art to remain invisible.

#### 3. Aspect Ratio and Window Management
Updated `handleVideoSizeChange` to enforce a 1:1 aspect ratio for audio-only files, ensuring the mini player maintains its intended dimensions regardless of the 16:9 synthetic track.

#### 4. Automatic File Matching
Modified `AutoFileMatcher.swift` to include `audio` media types when searching for matching subtitle files, allowing external subtitle files to load automatically for associated audio tracks with matching basenames.

### Verification
- [x] Automatic subtitle loading for various audio/subtitle format pairs (e.g., MP3+LRC, FLAC+SRT).
- [x] Correct rendering in both main window and mini player modes.
- [x] Volume controls and track selection remain functional.
- [x] Responsive and flicker-free subtitle updates during seeking.
