### PR TITLE
Fix UI stuck on loading screen, #5922

### DIFF
--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -49,11 +49,11 @@ class PlaybackInfo {
       // Block inappropriate state changes.
       guard oldValue != .loading || state != .idle, oldValue != .stopping || state == .idle,
             oldValue != .shuttingDown || state == .shutDown, oldValue != .shutDown else {
-        player.log("Blocked attempt to change state from \(oldValue) to \(state)", level: .verbose)
+        player.log("Blocked attempt to change state from \(oldValue) to \(state)", level: .error)
         state = oldValue
         return
       }
-      player.log("State changed from \(oldValue) to \(state)", level: .verbose)
+      player.log("State changed from \(oldValue) to \(state)")
       switch state {
       case .idle:
         SleepPreventer.updateSleepPrevention()

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -273,6 +273,12 @@ class PlayerCore: NSObject {
     abLoopA != 0 && abLoopB != 0 && mpv.getString(MPVOption.PlaybackControl.abLoopCount) != "0"
   }
 
+  /// Whether to auto load files when opening the URL given in `pendingUrl`.
+  private var pendingAutoLoad = false
+
+  /// URL to open once an outstanding mpv stop command completes.
+  private var pendingUrl: URL?
+
   let playerNumber: Int
 
   static var keyBindings: [String: KeyMapping] = [:]
@@ -341,11 +347,28 @@ class PlayerCore: NSObject {
       log("empty file path or url", level: .error)
       return
     }
-    log("Open URL: \(url.absoluteString)")
-    let isNetwork = !url.isFileURL || url.pathExtension.starts(with: "m3u")
-    if isNetwork {
-      currentWindow?.close()
+    guard info.state != .stopping else {
+      // The mpv core is currently processing an asynchronous stop command. To avoid the complexity
+      // of coordinating two mpv commands executing at the same time, wait until the stop command
+      // finishes and the core becomes idle before sending the loadfile command. The stop command
+      // normally does not take long to complete, so this should not be noticeable to the user.
+      log("Waiting for stop command to finish before opening: \(url.absoluteString)")
+      pendingAutoLoad = shouldAutoLoad
+      pendingUrl = url
+      return
     }
+    let isNetwork = !url.isFileURL || url.pathExtension.starts(with: "m3u")
+    if isNetwork, info.state != .idle, let currentWindow {
+      // Replace the player window with the loading window. Closing the player window will result in
+      // an asynchronous stop command being sent to mpv. As described above, delay sending the
+      // loadfile command until the stop command finishes.
+      log("Closing window before opening: \(url.absoluteString)")
+      pendingAutoLoad = shouldAutoLoad
+      pendingUrl = url
+      currentWindow.close()
+      return
+    }
+    log("Open URL: \(url.absoluteString)")
     if shouldAutoLoad {
       info.shouldAutoLoadFiles = true
     }
@@ -2144,6 +2167,11 @@ class PlayerCore: NSObject {
       log("Playback has stopped")
       info.state = .idle
       postNotification(.iinaPlayerStopped)
+      if let pendingUrl {
+        self.pendingUrl = nil
+        log("Processing pending open")
+        open(pendingUrl, shouldAutoLoad: pendingAutoLoad)
+      }
     }
   }
 


### PR DESCRIPTION
This commit will:
- Add `pendingAutoLoad` and `pendingUrl` properties to `PlayerCore`
- Change the `PlayerCore.open` method to delay sending the `loadfile` command if a `stop` command is outstanding or if it needs to close the window
- Change `PlayerCore.idleActiveChanged` to open a pending URL
- Change `PlaybackInfo.state` to log blocked state changes as an error
- Change `PlaybackInfo.state` to log state changes at debug level instead of verbose

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5922.

---

**Description:**
