### PR TITLE
Fix rounding error in IINA Default key bindings, #5946

### DIFF
--- a/iina/config/iina-default-input.conf
+++ b/iina/config/iina-default-input.conf
@@ -35,7 +35,7 @@ Shift+Meta+< add chapter -1
 
 Meta+[ multiply speed 0.5
 Meta+] multiply speed 2.0
-Alt+Meta+[ multiply speed 0.9091
+Alt+Meta+[ multiply speed 1/1.1
 Alt+Meta+] multiply speed 1.1
 Meta+\ set speed 1.0
 


### PR DESCRIPTION
This commit will change the IINA key binding for Alt+Meta+[ to use 1/1.1 for the speed to multiply by instead of 0.9091. This matches the similar binding in the mpv key bindings.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5946.

---

**Description:**
