### PR TITLE
Fix forced to restart IINA after installing plugin, #5952

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -761,7 +761,8 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
       return
     }
     let urls = pendingFilesForOpenFile.map { URL(fileURLWithPath: $0) }
-    
+    pendingFilesForOpenFile.removeAll()
+
     // if installing a plugin package
     if let pluginPackageURL = urls.first(where: { $0.pathExtension == "iinaplgz" }) {
       preferenceWindowController.performAction(.installPlugin(url: pluginPackageURL))
@@ -769,7 +770,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     }
 
     // open pending files
-    pendingFilesForOpenFile.removeAll()
     if PlayerCore.openURLs(urls) == 0 {
       Utility.showAlert("nothing_to_open")
     }


### PR DESCRIPTION
This commit will move the code that removes all entries in `pendingFilesForOpenFile` before the code that handles `iinaplgz` files in the `AppDelegate.handleOpenFile` method. This corrects a problem where IINA would process the `iinaplgz` again instead of opening media.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5952.

---

**Description:**
