### PR TITLE
Fix invalid tone-mapping-param value for mpv 0.41.0

### DIFF
--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -337,7 +337,7 @@ class VideoView: NSView {
       player.mpv.setString(MPVOption.GPURendererOptions.targetPrim, "auto")
       player.mpv.setString(MPVOption.GPURendererOptions.targetPeak, "auto")
       player.mpv.setString(MPVOption.GPURendererOptions.toneMapping, "auto")
-      player.mpv.setString(MPVOption.GPURendererOptions.toneMappingParam, "default")
+      player.mpv.setDouble(MPVOption.GPURendererOptions.toneMappingParam, Double.nan)
       player.mpv.setFlag(MPVOption.Screenshot.screenshotTagColorspace, false)
     }
   }


### PR DESCRIPTION
## Summary

- Fix `tone-mapping-param` being set to the string `"default"`, which is invalid for this float-typed mpv option (`OPT_FLOATDEF`). This causes an error with mpv 0.41.0:
  ```
  [cplayer] error: The tone-mapping-param option is out of range: default
  ```
- Use `setDouble` with `Double.nan` instead, which is mpv's actual default for this option (NaN signals "use the tone-mapping curve's built-in default parameter")

This was found while investigating #5928. The blank screen reported there is primarily an upstream issue in Little CMS 2.18 affecting `icc-profile-auto` with `vo=libmpv` (see [mpv#17439](https://github.com/mpv-player/mpv/issues/17439)), but this tone-mapping-param error is a separate IINA-side compatibility issue with mpv 0.41.0 that should be fixed regardless.

## Test plan

- [ ] Build IINA with embedded mpv 0.41.0
- [ ] Play an SDR video with "Load ICC profile" enabled
- [ ] Verify no `tone-mapping-param option is out of range` error in mpv logs
- [ ] Verify tone mapping resets correctly when switching between HDR and SDR content


🤖 Generated with [Claude Code](https://claude.com/claude-code)