### PR TITLE
Fix #5919 OSC Toolbar Settings Hidden Confirm Button

### DIFF
--- a/iina/Base.lproj/PrefOSCToolbarSettingsSheetController.xib
+++ b/iina/Base.lproj/PrefOSCToolbarSettingsSheetController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="21507" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24506" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="21507"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24506"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -19,13 +19,13 @@
             <windowStyleMask key="styleMask" closable="YES" fullSizeContentView="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="425" height="355"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="5120" height="1415"/>
-            <view key="contentView" wantsLayer="YES" id="se5-gp-TjO">
-                <rect key="frame" x="0.0" y="0.0" width="340" height="355"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="1512" height="949"/>
+            <view key="contentView" wantsLayer="YES" misplaced="YES" id="se5-gp-TjO">
+                <rect key="frame" x="0.0" y="0.0" width="425" height="355"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                 <subviews>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hAj-RR-fLd">
-                        <rect key="frame" x="261" y="13" width="66" height="32"/>
+                        <rect key="frame" x="349" y="20" width="56" height="24"/>
                         <buttonCell key="cell" type="push" title="Done" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="0wJ-C7-Gds">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -38,7 +38,7 @@ DQ
                         </connections>
                     </button>
                     <stackView orientation="vertical" alignment="leading" spacing="4" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="Sdu-Jk-G6t" customClass="PrefOSCToolbarAvailableItemsView" customModule="IINA" customModuleProvider="target">
-                        <rect key="frame" x="50" y="60" width="240" height="151"/>
+                        <rect key="frame" x="93" y="64" width="240" height="147"/>
                         <constraints>
                             <constraint firstAttribute="width" constant="240" id="WzW-Sh-d8e"/>
                         </constraints>
@@ -52,7 +52,7 @@ DQ
                         </textFieldCell>
                     </textField>
                     <textField horizontalHuggingPriority="249" verticalHuggingPriority="749" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="xw0-SN-fkf">
-                        <rect key="frame" x="18" y="301" width="304" height="14"/>
+                        <rect key="frame" x="18" y="301" width="389" height="14"/>
                         <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Drag an item out of the box to delete it." id="jlb-xc-k6x">
                             <font key="font" metaFont="smallSystem"/>
                             <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -68,7 +68,7 @@ DQ
                         </textFieldCell>
                     </textField>
                     <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" setsMaxLayoutWidthAtFirstLayout="YES" translatesAutoresizingMaskIntoConstraints="NO" id="BJG-7U-eKu">
-                        <rect key="frame" x="18" y="220" width="304" height="14"/>
+                        <rect key="frame" x="18" y="221" width="389" height="14"/>
                         <textFieldCell key="cell" controlSize="small" sendsActionOnEndEditing="YES" title="Drag an item and drop it to the box above to add it." id="VCG-VX-E3M">
                             <font key="font" metaFont="smallSystem"/>
                             <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -76,7 +76,7 @@ DQ
                         </textFieldCell>
                     </textField>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="LGR-5z-wrd">
-                        <rect key="frame" x="187" y="13" width="76" height="32"/>
+                        <rect key="frame" x="271" y="20" width="66" height="24"/>
                         <buttonCell key="cell" type="push" title="Cancel" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="Jrf-II-Cfc">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -89,7 +89,7 @@ Gw
                         </connections>
                     </button>
                     <button verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="I7y-Aj-ui3">
-                        <rect key="frame" x="13" y="13" width="128" height="32"/>
+                        <rect key="frame" x="20" y="20" width="118" height="24"/>
                         <buttonCell key="cell" type="push" title="Restore Default" bezelStyle="rounded" alignment="center" borderStyle="border" imageScaling="proportionallyDown" inset="2" id="SmC-AI-FG6">
                             <behavior key="behavior" pushIn="YES" lightByBackground="YES" lightByGray="YES"/>
                             <font key="font" metaFont="system"/>
@@ -99,13 +99,13 @@ Gw
                         </connections>
                     </button>
                     <box horizontalHuggingPriority="750" verticalHuggingPriority="750" horizontalCompressionResistancePriority="800" verticalCompressionResistancePriority="800" title="Box" titlePosition="noTitle" translatesAutoresizingMaskIntoConstraints="NO" id="l1W-AA-5L4">
-                        <rect key="frame" x="127" y="271" width="86" height="22"/>
+                        <rect key="frame" x="173" y="275" width="80" height="16"/>
                         <view key="contentView" id="Xci-wI-yo3">
-                            <rect key="frame" x="4" y="5" width="78" height="14"/>
+                            <rect key="frame" x="0.0" y="0.0" width="80" height="16"/>
                             <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                             <subviews>
                                 <stackView orientation="horizontal" alignment="centerY" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="63i-B1-8o0" customClass="PrefOSCToolbarCurrentItemsView" customModule="IINA" customModuleProvider="target">
-                                    <rect key="frame" x="4" y="0.0" width="70" height="14"/>
+                                    <rect key="frame" x="0.0" y="0.0" width="80" height="16"/>
                                     <constraints>
                                         <constraint firstAttribute="width" secondItem="63i-B1-8o0" secondAttribute="height" multiplier="5" id="lfY-RO-AJG"/>
                                     </constraints>
@@ -143,7 +143,7 @@ Gw
                     <constraint firstItem="l1W-AA-5L4" firstAttribute="top" secondItem="xw0-SN-fkf" secondAttribute="bottom" constant="10" id="Zjt-cE-loo"/>
                     <constraint firstAttribute="trailing" secondItem="xw0-SN-fkf" secondAttribute="trailing" constant="20" id="ZlJ-U9-bfM"/>
                     <constraint firstAttribute="trailing" secondItem="BJG-7U-eKu" secondAttribute="trailing" constant="20" id="aDG-GM-gtc"/>
-                    <constraint firstAttribute="width" secondItem="Sdu-Jk-G6t" secondAttribute="width" constant="100" id="aMe-sb-T9b"/>
+                    <constraint firstAttribute="width" relation="greaterThanOrEqual" secondItem="Sdu-Jk-G6t" secondAttribute="width" constant="100" id="aMe-sb-T9b"/>
                     <constraint firstItem="LGR-5z-wrd" firstAttribute="top" secondItem="Sdu-Jk-G6t" secondAttribute="bottom" constant="20" id="akC-N4-vOw"/>
                     <constraint firstAttribute="bottom" secondItem="LGR-5z-wrd" secondAttribute="bottom" constant="20" id="dKd-vg-mIB"/>
                     <constraint firstItem="hAj-RR-fLd" firstAttribute="top" secondItem="Sdu-Jk-G6t" secondAttribute="bottom" constant="20" id="jYb-eL-pbb"/>


### PR DESCRIPTION
Change constraint on OSC Toolbar Settings so the confirm button is not hidden in German.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5919 

---

**Description:**

Changes a width constraint on the PrefOSCToolbarSettingsSheetController.xib from equal to greater than so the done button doesn't get hidden in certain languages. 

Before
<img width="1709" height="970" alt="image" src="https://github.com/user-attachments/assets/bf5a7225-17dc-4d05-af7e-c093d68c41cb" />

After
<img width="952" height="814" alt="Screenshot 2026-03-12 at 9 36 16 PM" src="https://github.com/user-attachments/assets/76d33cef-59fb-4bd5-9a8e-80ffa4bf12e1" />
