### PR TITLE
Added secondary subtitle features and search

### DIFF
--- a/iina/Base.lproj/PrefSubViewController.xib
+++ b/iina/Base.lproj/PrefSubViewController.xib
@@ -24,6 +24,8 @@
                 <outlet property="subOverrideLevelSegmentedControl" destination="mqJ-QH-Pfa" id="hcK-8B-EzR"/>
                 <outlet property="subOverrideLevelSlider" destination="7UX-IL-hdk" id="fem-nv-O1m"/>
                 <outlet property="subOverrideLevelText" destination="FR3-Ar-5Dw" id="BSP-zH-sos"/>
+                <outlet property="subPosSegmentedControl" destination="pos-Sg-Ctl" id="psc-1a-abc"/>
+                <outlet property="subPosTextField" destination="HKD-K0-lsV" id="ptf-2b-bcd"/>
                 <outlet property="subShadowColorWell" destination="Gtc-ii-hE0" id="hh5-ON-mLf"/>
                 <outlet property="subSourcePopUpButton" destination="UHS-ce-8t5" id="zmW-Jx-JMg"/>
                 <outlet property="subSourceStackView" destination="bSz-xd-6o2" id="UOh-XZ-MhE"/>
@@ -1164,13 +1166,6 @@
                         <color key="textColor" name="controlTextColor" catalog="System" colorSpace="catalog"/>
                         <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
-                    <connections>
-                        <binding destination="5Up-Ab-aAm" name="value" keyPath="values.subPos" id="BIO-yY-56q">
-                            <dictionary key="options">
-                                <bool key="NSContinuouslyUpdatesValue" value="YES"/>
-                            </dictionary>
-                        </binding>
-                    </connections>
                 </textField>
                 <textField identifier="AccessoryLabelVerticalPos" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="9sd-YV-QMQ">
                     <rect key="frame" x="316" y="64" width="16" height="16"/>
@@ -1180,6 +1175,22 @@
                         <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                     </textFieldCell>
                 </textField>
+                <segmentedControl verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="pos-Sg-Ctl">
+                    <rect key="frame" x="120" y="178" width="304" height="21"/>
+                    <constraints>
+                        <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="300" id="psc-w-cst"/>
+                    </constraints>
+                    <segmentedCell key="cell" controlSize="small" borderStyle="border" alignment="left" segmentDistribution="fillEqually" style="rounded" trackingMode="selectOne" id="psc-cell">
+                        <font key="font" metaFont="smallSystem"/>
+                        <segments>
+                            <segment label="Primary Subtitles" selected="YES"/>
+                            <segment label="Secondary Subtitles" tag="1"/>
+                        </segments>
+                    </segmentedCell>
+                    <connections>
+                        <action selector="subPosSegmentedControlAction:" target="-2" id="psc-act"/>
+                    </connections>
+                </segmentedControl>
                 <button translatesAutoresizingMaskIntoConstraints="NO" id="pyx-K4-cgm">
                     <rect key="frame" x="118" y="31" width="327" height="18"/>
                     <buttonCell key="cell" type="check" title="Display subtitles in letterboxes while in full screen" bezelStyle="regularSquare" imagePosition="left" state="on" inset="2" id="2XY-Un-0Fg">
@@ -1292,13 +1303,15 @@
                 <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="9sd-YV-QMQ" secondAttribute="trailing" constant="20" symbolic="YES" id="b4z-Pm-kMs"/>
                 <constraint firstItem="HKD-K0-lsV" firstAttribute="leading" secondItem="eAH-hV-xRg" secondAttribute="trailing" constant="8" id="brp-Tf-Kqk"/>
                 <constraint firstItem="WeJ-3X-tJy" firstAttribute="top" secondItem="ZpT-fB-Daq" secondAttribute="top" constant="8" id="fSA-DB-ixN"/>
-                <constraint firstItem="kvJ-Tj-KMb" firstAttribute="top" secondItem="WeJ-3X-tJy" secondAttribute="top" id="hIu-B2-Hhm"/>
+                <constraint firstItem="kvJ-Tj-KMb" firstAttribute="top" secondItem="pos-Sg-Ctl" secondAttribute="bottom" constant="8" id="hIu-B2-Hhm"/>
                 <constraint firstAttribute="trailing" secondItem="pRe-wv-VVi" secondAttribute="trailing" id="mFg-UV-tG6"/>
                 <constraint firstItem="9sd-YV-QMQ" firstAttribute="baseline" secondItem="HKD-K0-lsV" secondAttribute="baseline" id="oaJ-pb-z4Y"/>
                 <constraint firstItem="WeJ-3X-tJy" firstAttribute="leading" secondItem="ZpT-fB-Daq" secondAttribute="leading" id="pJT-C6-3JH"/>
                 <constraint firstItem="pyx-K4-cgm" firstAttribute="top" secondItem="eAH-hV-xRg" secondAttribute="bottom" constant="16" id="rl5-bs-BFj"/>
                 <constraint firstItem="pRe-wv-VVi" firstAttribute="leading" secondItem="kvJ-Tj-KMb" secondAttribute="leading" id="sZg-mz-LOl"/>
                 <constraint firstItem="HKD-K0-lsV" firstAttribute="firstBaseline" secondItem="eAH-hV-xRg" secondAttribute="firstBaseline" id="vFi-8B-moM"/>
+                <constraint firstItem="pos-Sg-Ctl" firstAttribute="leading" secondItem="ZpT-fB-Daq" secondAttribute="leading" constant="120" id="psc-lead"/>
+                <constraint firstItem="pos-Sg-Ctl" firstAttribute="top" secondItem="WeJ-3X-tJy" secondAttribute="top" id="psc-top"/>
             </constraints>
             <point key="canvasLocation" x="-782" y="590"/>
         </customView>

--- a/iina/Base.lproj/SubChooseViewController.xib
+++ b/iina/Base.lproj/SubChooseViewController.xib
@@ -157,7 +157,7 @@ Gw
                 <constraint firstAttribute="trailing" secondItem="T82-Op-UIR" secondAttribute="trailing" id="3rq-7N-FxN"/>
                 <constraint firstItem="i9Z-jA-8gU" firstAttribute="leading" secondItem="tFf-9S-9GB" secondAttribute="trailing" constant="8" id="5Ic-qQ-aEq"/>
                 <constraint firstItem="T82-Op-UIR" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="6Xh-Bu-7TR"/>
-                <constraint firstItem="T82-Op-UIR" firstAttribute="top" secondItem="CFP-kG-Ixy" secondAttribute="bottom" constant="8" id="FZN-8k-JXM"/>
+                <constraint firstItem="T82-Op-UIR" firstAttribute="top" secondItem="CFP-kG-Ixy" secondAttribute="bottom" constant="54" id="FZN-8k-JXM"/>
                 <constraint firstAttribute="width" priority="499" constant="600" id="Fm1-BD-B4h"/>
                 <constraint firstAttribute="trailing" secondItem="CFP-kG-Ixy" secondAttribute="trailing" id="Qnk-7D-vre"/>
                 <constraint firstItem="CFP-kG-Ixy" firstAttribute="leading" secondItem="Hz6-mo-xeY" secondAttribute="leading" id="Qzc-2o-vZl"/>

--- a/iina/LanguageTokenField.swift
+++ b/iina/LanguageTokenField.swift
@@ -128,7 +128,7 @@ class LanguageTokenField: NSTokenField {
 
   func controlTextDidChange(_ obj: Notification) {
     guard let layoutManager = layoutManager else { return }
-    let attachmentChar = Character(UnicodeScalar(NSTextAttachment.character)!)
+    let attachmentChar = Character(UnicodeScalar(NSAttachmentCharacter)!)
     let finished = layoutManager.attributedString().string.split(separator: attachmentChar).count == 0
     if finished {
       Logger.log("LTF Submitting changes from controlTextDidChange()", level: .verbose)

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -513,6 +513,7 @@ class MPVController: NSObject {
                   verboseIfDefault: true)
 
     setUserOption(PK.subPos, type: .float, forName: MPVOption.Subtitles.subPos, verboseIfDefault: true)
+    setUserOption(PK.secondarySubPos, type: .float, forName: MPVOption.Subtitles.secondarySubPos, verboseIfDefault: true)
 
     setUserOption(PK.subLang, type: .string, forName: MPVOption.TrackSelection.slang, level: .verbose)
 
@@ -652,6 +653,12 @@ class MPVController: NSObject {
          !watchLaterOptions.contains(MPVOption.Subtitles.secondarySubDelay) {
         log("Adding \(MPVOption.Subtitles.secondarySubDelay) to \(MPVOption.WatchLater.watchLaterOptions)")
         watchLaterOptions += "," + MPVOption.Subtitles.secondarySubDelay
+        needsUpdate = true
+      }
+      if watchLaterOptions.contains(MPVOption.Subtitles.subPos),
+         !watchLaterOptions.contains(MPVOption.Subtitles.secondarySubPos) {
+        log("Adding \(MPVOption.Subtitles.secondarySubPos) to \(MPVOption.WatchLater.watchLaterOptions)")
+        watchLaterOptions += "," + MPVOption.Subtitles.secondarySubPos
         needsUpdate = true
       }
       if needsUpdate {

--- a/iina/PrefSubViewController.swift
+++ b/iina/PrefSubViewController.swift
@@ -52,6 +52,9 @@ class PrefSubViewController: PreferenceViewController, PreferenceWindowEmbeddabl
   @IBOutlet weak var subOverrideLevelText: NSTextField!
   @IBOutlet weak var subOverrideLevelDescriptiveText: NSTextField!
 
+  @IBOutlet weak var subPosTextField: NSTextField!
+  @IBOutlet weak var subPosSegmentedControl: NSSegmentedControl!
+
   override func viewDidLoad() {
     super.viewDidLoad()
 
@@ -80,6 +83,11 @@ class PrefSubViewController: PreferenceViewController, PreferenceWindowEmbeddabl
 
     refreshSubSources()
     refreshSubSourceAccessoryView()
+
+    // Establish initial programmatic binding for vertical sub position (primary by default)
+    subPosTextField.bind(.value, to: UserDefaults.standard,
+                         withKeyPath: PK.subPos.rawValue,
+                         options: [.continuouslyUpdatesValue: true])
 
     NotificationCenter.default.addObserver(forName: .iinaPluginChanged, object: nil, queue: .main) { [unowned self] _ in
       self.refreshSubSources()
@@ -184,6 +192,13 @@ class PrefSubViewController: PreferenceViewController, PreferenceWindowEmbeddabl
     subOverrideLevelSlider.bind(.value, to: UserDefaults.standard, withKeyPath: keyPath, options: [.valueTransformer: ASSOverrideLevelValueTransformer()])
     subOverrideLevelText.bind(.value, to: UserDefaults.standard, withKeyPath: keyPath, options: [.valueTransformer: ASSOverrideLevelTextTransformer()])
     subOverrideLevelDescriptiveText.bind(.value, to: UserDefaults.standard, withKeyPath: keyPath, options: [.valueTransformer: ASSOverrideLevelDescriptiveTextTransformer()])
+  }
+
+  @IBAction func subPosSegmentedControlAction(_ sender: NSSegmentedControl) {
+    let keyPath = sender.selectedSegment == 0 ? PK.subPos.rawValue : PK.secondarySubPos.rawValue
+    subPosTextField.bind(.value, to: UserDefaults.standard,
+                         withKeyPath: keyPath,
+                         options: [.continuouslyUpdatesValue: true])
   }
 }
 

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -224,6 +224,7 @@ struct Preference {
     static let subMarginX = Key("subMarginX")
     static let subMarginY = Key("subMarginY")
     static let subPos = Key("subPos")
+    static let secondarySubPos = Key("secondarySubPos")
     static let subLang = Key("subLang")
     static let legacyOnlineSubSource = Key("onlineSubSource")
     static let onlineSubProvider = Key("onlineSubProvider")
@@ -953,6 +954,7 @@ struct Preference {
     .subMarginX: Float(25),
     .subMarginY: Float(22),
     .subPos: Float(100),
+    .secondarySubPos: Float(100),
     .subLang: "",
     .legacyOnlineSubSource: 1, /* openSub */
     .onlineSubProvider: OnlineSubtitle.Providers.openSub.id,

--- a/iina/SubChooseViewController.swift
+++ b/iina/SubChooseViewController.swift
@@ -16,12 +16,21 @@ class SubChooseViewController: NSViewController {
   @IBOutlet weak var tableView: NSTableView!
   @IBOutlet weak var downloadBtn: NSButton!
 
-  var subtitles: [OnlineSubtitle] = []
+  var subtitles: [OnlineSubtitle] = [] {
+    didSet {
+      filteredSubtitles = subtitles
+      tableView?.reloadData()
+    }
+  }
+
+  var filteredSubtitles: [OnlineSubtitle] = []
 
   var userDoneAction: (([OnlineSubtitle]) -> Void)?
   var userCanceledAction: (() -> Void)?
 
   var context: Any?
+
+  private var searchField: NSSearchField!
 
   override func viewDidLoad() {
     super.viewDidLoad()
@@ -37,11 +46,32 @@ class SubChooseViewController: NSViewController {
     // Download subtitle when table view row is double clicked
     tableView.target = self
     tableView.doubleAction = #selector(downloadBtnAction(_:))
+
+    // Add search field programmatically above the scroll view
+    searchField = NSSearchField()
+    searchField.translatesAutoresizingMaskIntoConstraints = false
+    searchField.placeholderString = "Filter subtitles…"
+    searchField.delegate = self
+    view.addSubview(searchField)
+
+    guard let scrollView = tableView.enclosingScrollView else { return }
+
+    // Anchor search field: 16pt below the description label, 8pt above the scroll view.
+    // The description label is the first text field in the view loaded from the XIB.
+    let descriptionLabel = view.subviews.first { $0 is NSTextField }
+    let topAnchor: NSLayoutYAxisAnchor = descriptionLabel?.bottomAnchor ?? view.topAnchor
+
+    NSLayoutConstraint.activate([
+      searchField.leadingAnchor.constraint(equalTo: scrollView.leadingAnchor),
+      searchField.trailingAnchor.constraint(equalTo: scrollView.trailingAnchor),
+      searchField.topAnchor.constraint(equalTo: topAnchor, constant: 16),
+      searchField.bottomAnchor.constraint(equalTo: scrollView.topAnchor, constant: -8),
+    ])
   }
 
   @IBAction func downloadBtnAction(_ sender: Any) {
     guard let userDoneAction = userDoneAction else { return }
-    userDoneAction(tableView.selectedRowIndexes.map { subtitles[$0] })
+    userDoneAction(tableView.selectedRowIndexes.map { filteredSubtitles[$0] })
     PlayerCore.active.hideOSD()
     context = nil
   }
@@ -58,11 +88,11 @@ class SubChooseViewController: NSViewController {
 extension SubChooseViewController: NSTableViewDelegate, NSTableViewDataSource {
 
   func numberOfRows(in tableView: NSTableView) -> Int {
-    return subtitles.count
+    return filteredSubtitles.count
   }
 
   func tableView(_ tableView: NSTableView, objectValueFor tableColumn: NSTableColumn?, row: Int) -> Any? {
-    let (name, left, right) = subtitles[row].getDescription()
+    let (name, left, right) = filteredSubtitles[row].getDescription()
     return ["name": name, "left": left, "right": right]
   }
 
@@ -71,6 +101,25 @@ extension SubChooseViewController: NSTableViewDelegate, NSTableViewDataSource {
   }
 
   func tableViewSelectionDidChange(_ notification: Notification) {
+    downloadBtn.isEnabled = tableView.selectedRow != -1
+  }
+}
+
+
+extension SubChooseViewController: NSSearchFieldDelegate {
+  func controlTextDidChange(_ obj: Notification) {
+    let query = searchField.stringValue.trimmingCharacters(in: .whitespaces).lowercased()
+    if query.isEmpty {
+      filteredSubtitles = subtitles
+    } else {
+      filteredSubtitles = subtitles.filter { sub in
+        let (name, left, right) = sub.getDescription()
+        return name.lowercased().contains(query)
+          || left.lowercased().contains(query)
+          || right.lowercased().contains(query)
+      }
+    }
+    tableView.reloadData()
     downloadBtn.isEnabled = tableView.selectedRow != -1
   }
 }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)

---
🚀 **QUICK SUMMARY**
This PR introduces three user-facing enhancements and two technical fixes to improve subtitle management:

🎛️ Secondary Subtitle Control: Adds a toggle in Preferences > Subtitles to set a permanent vertical position for secondary subtitles (matching the primary subtitle settings).

💾 Session Persistence: Ensures that secondary subtitle positions are correctly saved and restored when resuming a video (fixes a known watch-later limitation).

🔍 Subtitle Search Filter: Adds a live-search field to the Online Subtitle Downloader to quickly filter results by name, language, or date.

🔧 Compatibility Fix: Replaces a macOS 13+ specific property with a backwards-compatible constant to prevent build failures on older macOS versions.

____________________________________

**MORE DETAILED**

**Feature Changes Overview
This submission adds three user-facing improvements to subtitle handling, one session-persistence fix, and one build compatibility fix.

1. 🎛️ Secondary Subtitle Vertical Position in Preferences
Files changed: iina/Preference.swift, iina/MPVController.swift, iina/PrefSubViewController.swift, iina/Base.lproj/PrefSubViewController.xib

What changed:

The Preferences → Subtitle → Position section previously only allowed configuring the vertical position (sub-pos) for primary subtitles. Secondary subtitles had no equivalent static preference — their position could only be adjusted during playback via the Quick Settings panel, and the value was lost on restart.

A "Primary Subtitles / Secondary Subtitles" segmented control has been added above the Vertical position field, following the same established pattern already used by the ASS Subtitles → Override Level section.

Details:
* Added secondarySubPos preference key (Preference.Key) with a default value of 100.
* Registered secondarySubPos as an mpv user option bound to secondary-sub-pos, so the saved value is applied at startup automatically — identical to how subPos works for primary subtitles.
* The segmented control dynamically rebinds the text field between values.subPos and values.secondarySubPos using bind(_:to:withKeyPath:options:), the same mechanism subOverrideLevelSegmentedControlAction uses.

2. 💾 Secondary Subtitle Position Persisted in Watch-Later Files
File changed: iina/MPVController.swift

What changed:
IINA uses mpv's watch-later feature to restore playback state (including subtitle position) when re-opening a video. A known mpv issue (#14417) means that secondary-sub-pos is not included in the list of saved options by default, even though the equivalent sub-pos for primary subtitles is.
IINA already contained a workaround for similar missing secondary subtitle options (secondary-sid, secondary-sub-delay). This extends that workaround to also include secondary-sub-pos.

Details:
* secondary-sub-pos is now automatically appended to watch-later-options if sub-pos is present but secondary-sub-pos is not. This mirrors what was already done for secondary-sid and secondary-sub-delay.

3. 🔍 Search/Filter Field in Online Subtitle Downloader
Files changed: iina/SubChooseViewController.swift, iina/Base.lproj/SubChooseViewController.xib

What changed:
When searching for online subtitles and clicking "Search Online", IINA presents a sheet with a list of results. Previously there was no way to filter this list — users had to scroll through all results manually.

A live search field has been added above the results table. As the user types, the list is filtered in real time across subtitle name, language, and date columns.

Details:
* NSSearchField is added programmatically in viewDidLoad and positioned between the instructional label and the results table with proper Auto Layout constraints.
* A filteredSubtitles array drives the table view. It mirrors the full subtitles array by default and is updated on each keystroke via NSSearchFieldDelegate.controlTextDidChange.
* Filtering is case-insensitive and matches across all three description fields returned by getDescription().
* The XIB's scroll view top constraint is updated to accommodate the new search field's height (16 pt gap above, 8 pt gap below).

4. 🔧 Build Fix: NSTextAttachment.character Compatibility
File changed: iina/LanguageTokenField.swift

What changed:
NSTextAttachment.character is only available on macOS 13+. The original code used this property unconditionally, causing a build failure on earlier deployment targets.

Details:
* Replaced NSTextAttachment.character with the backwards-compatible NSAttachmentCharacter constant (Unicode U+FFFC), which works on all supported macOS versions.
**
