### PR TITLE
Fix miss-spelling of writable detected by typos

### DIFF
--- a/other/change_lib_dependencies.rb
+++ b/other/change_lib_dependencies.rb
@@ -30,7 +30,7 @@ class DylibFile
     @deps = libs.map { |lib| lib[OTOOL_RX, 1] }.compact
   end
 
-  def ensure_writeable
+  def ensure_writable
     saved_perms = nil
     unless File.writable_real?(path)
       saved_perms = File.stat(path).mode
@@ -42,13 +42,13 @@ class DylibFile
   end
 
   def change_id!
-    ensure_writeable do
+    ensure_writable do
       safe_system "install_name_tool", "-id", "@rpath/#{File.basename(self.id)}", path
     end
   end
 
   def change_install_name!(old_name, new_name)
-    ensure_writeable do
+    ensure_writable do
       safe_system "install_name_tool", "-change", old_name, new_name, path
     end
   end


### PR DESCRIPTION
This commit will correct the existing miss-spelling of writable in `change_lib_dependencies.rb` that is being detected by the latest version of `typos`.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
