### PR TITLE
Workaround Xcode 26.4 NSTextAttachment defect

### DIFF
--- a/iina/LanguageTokenField.swift
+++ b/iina/LanguageTokenField.swift
@@ -128,7 +128,17 @@ class LanguageTokenField: NSTokenField {
 
   func controlTextDidChange(_ obj: Notification) {
     guard let layoutManager = layoutManager else { return }
-    let attachmentChar = Character(UnicodeScalar(NSAttachmentCharacter)!)
+    // WORKAROUND Xcode 26.4 defect where referencing NSTextAttachment.character causes a
+    // compilation error. As NSAttachmentCharacter was obsoleted in Swift 4.2, Xcode versions
+    // before 26.4 will not allow it to be used. As support for Swift 6.3 was added in 26.4 we can
+    // key off the Swift support to workaround the Xcode 26.4 defect without breaking support for
+    // older working versions of Xcode.
+    let attachmentChar: Character
+#if compiler(>=6.3)
+    attachmentChar = Character(UnicodeScalar(NSAttachmentCharacter)!)
+#else
+    attachmentChar = Character(UnicodeScalar(NSTextAttachment.character)!)
+#endif
     let finished = layoutManager.attributedString().string.split(separator: attachmentChar).count == 0
     if finished {
       Logger.log("LTF Submitting changes from controlTextDidChange()", level: .verbose)


### PR DESCRIPTION
This commit will change LanguageTokenField.controlTextDidChange to correct a compilation error due to a defect in Xcode 26.4.

Xcode 26.4 reports a compilation error for references to NSTextAttachment.character. Falling back to NSAttachmentCharacter, which was obsoleted in Swift 4.2, works with Xcode 26.4 as a workaround. As using NSAttachmentCharacter results in a compilation error in Xcode 26.3 through Xcode 10, this commit uses conditional compilation based on support for  Swift 6.3, which currently only 26,4 supports, so the workaround does not break builds using earlier versions of Xcode.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
