### PR TITLE
Remove More Seeking plugin from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ IINA is always looking for contributions, whether it's through bug reports, code
 ## IINA Plugins List
 
 ### Official Plugins
-- **[More Seeking](https://github.com/iina/plugin-more-seeking)** (`iina/plugin-more-seeking`) - Advanced seeking controls.
 - **[Online Media](https://github.com/iina/plugin-online-media)** (`iina/plugin-online-media`) - Enhances online streaming and downloading.
 - **[OpenSubtitles](https://github.com/iina/plugin-opensub)** (`iina/plugin-opensub`) - Search and download subtitles.
 - **[User Scripts](https://github.com/iina/plugin-userscript)** (`iina/plugin-userscript`) - Run custom JavaScript snippets.


### PR DESCRIPTION
This commit will remove the official [More Seeking](https://github.com/iina/plugin-more-seeking) plugin from the [Official Plugins](https://github.com/iina/iina?tab=readme-ov-file#official-plugins) list in the README.

The More Seeking plugin is currently considered _experimental_ and should not have been included in the list.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
