### PR TITLE
plugin: added a new event "menu-update" for plugins to update their menu

### DIFF
--- a/iina/EventController.swift
+++ b/iina/EventController.swift
@@ -49,6 +49,8 @@ class EventController {
     static let mpvInitialized = Name("iina.mpv-initialized")
     static let thumbnailsReady = Name("iina.thumbnails-ready")
     static let pluginOverlayLoaded = Name("iina.plugin-overlay-loaded")
+
+    static let menuUpdate = Name("iina.menu-update")
   }
 
   var listeners: [Name: [String: EventCallable]] = [:]

--- a/iina/JavascriptAPICore.swift
+++ b/iina/JavascriptAPICore.swift
@@ -236,7 +236,7 @@ fileprivate class WindowAPI: JavascriptAPI, CoreSubAPIExportable {
     case "ontop":
       return window.isOntop
     case "visible":
-      return window.window!.occlusionState == .visible
+      return window.window!.occlusionState.contains(.visible)
     case "sidebar":
       return window.sideBarStatus == .settings ? window.quickSettingView.currentTab.name : NSNull()
     case "screens":

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -410,6 +410,7 @@ class MenuController: NSObject, NSMenuDelegate {
 
     if IINA_ENABLE_PLUGIN_SYSTEM {
       pluginMenu.delegate = self
+      pluginMenu.autoenablesItems = false
     } else {
       pluginMenuItem.isHidden = true
     }
@@ -814,6 +815,7 @@ class MenuController: NSObject, NSMenuDelegate {
     case savedAudioFiltersMenu:
       updateSavedFiltersMenu(type: MPVProperty.af)
     case pluginMenu:
+      PlayerCore.active.events.emit(.menuUpdate)
       updatePluginMenu()
     default: break
     }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
Added a new `menu-update` event. Previously the plugin only declare their menu once (both for global menu and instance menu). The menu state cannot be changed later (`enabled`, `selected`). With this change, the plugin can listen to this event and reconstruct their instance menu if needed. Following is an example of usage:

```js
event.on("iina.menu-update", () => {
  menu.removeAllItems()
  menu.addItem(
    menu.item(
      "Show Sidebar",
      () => {
        sidebar.show();
      },
      { keyBinding: "Meta+p", enabled: core.window.visible },
    ),
  );
});
```

Backward compatibility: if the plugin only declare instance menu once, the behavior should still be correct.

Also a bug where `core.window.visible` always returns false. `NSWindow.OcclusionState` is now `OptionSet`, have to check with `.contains(.visible)`.