### PR TITLE
CI: skip plugin downloads in pull request builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,9 @@ jobs:
       - uses: actions/checkout@v6
 
       - name: Install dependencies
-        run: ./other/download_libs.sh
+        run: ./other/download_libs.sh $DOWNLOAD_LIBS_ARGS
+        env:
+          DOWNLOAD_LIBS_ARGS: ${{ github.event_name == 'pull_request' && '--skip-plugins' || '' }}
 
       - name: Build
         run: xcodebuild -project iina.xcodeproj ONLY_ACTIVE_ARCH=NO -scheme iina -configuration Nightly ${{ matrix.deployment_target }}
@@ -33,4 +35,3 @@ jobs:
         with:
           name: IINA
           path: ~/iina.tar.xz
-

--- a/other/download_libs.sh
+++ b/other/download_libs.sh
@@ -7,6 +7,7 @@ ARCH="universal"
 # github | iina (use iina to get the binary included in the latest release)
 YT_DLP_SOURCE="github"
 PARALLEL_DOWNLOADS=5
+SKIP_PLUGINS=false
 
 DYLIBS_DOWNLOAD_PATH="https://iina.io/dylibs/${ARCH}"
 YT_DLP_DOWNLOAD_PATH="https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp_macos"
@@ -19,7 +20,7 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # Reset in case getopts has been used previously in the shell.
-if ! OPTS=$(getopt -o "h": --long "arch:,yt-dlp-src:,parallel:,help": -n 'parse-options' -- "$@"); then
+if ! OPTS=$(getopt -o "h": --long "arch:,yt-dlp-src:,parallel:,skip-plugins,help": -n 'parse-options' -- "$@"); then
   echo -e "${RED}Failed parsing options.${NC}" >&2
   exit 1
 fi
@@ -31,6 +32,7 @@ printUsageHelp() {
   echo -e "    ${GREEN}$0 [--arch] <ARCH>:${NC}       Architecture to download dylibs for: universal | arm64 | x86_64"
   echo -e "    ${GREEN}$0 [--yt-dlp-src] <SRC>:${NC}  Source to download youtube-dl from: github | iina"
   echo -e "    ${GREEN}$0 [--parallel] <N>:${NC}      Number of parallel downloads (default: 5)"
+  echo -e "    ${GREEN}$0 [--skip-plugins]:${NC}      Skip downloading official plugins"
   echo
 }
 
@@ -79,6 +81,10 @@ while true; do
     fi
     PARALLEL_DOWNLOADS=$2
     shift 2
+    ;;
+  --skip-plugins)
+    SKIP_PLUGINS=true
+    shift
     ;;
   --)
     shift
@@ -162,6 +168,12 @@ curl -s -L "$YT_DLP_DOWNLOAD_PATH" -o "$YT_DLP_PATH" && echo -e "${GREEN}yt-dlp 
 chmod +x "$YT_DLP_PATH"
 
 mkdir -p "$PLUGIN_PATH"
+
+if [[ "$SKIP_PLUGINS" == true ]]; then
+  echo -e "${YELLOW}Skipping official plugin downloads.${NC}"
+  echo -e "${GREEN}All downloads completed.${NC}"
+  exit 0
+fi
 
 fetch_latest_plugin_asset() {
   local repo="$1"


### PR DESCRIPTION
## Summary
- add a `--skip-plugins` option to `other/download_libs.sh`
- skip official plugin downloads only for `pull_request` CI runs
- keep push builds on `develop` downloading plugins as before

## Why
PR CI intermittently fails in `download_libs.sh` because fetching the latest plugin releases hits the unauthenticated GitHub API rate limit described in #5992.

## Impact
PR builds avoid the GitHub API requests for plugin release assets, which removes the flaky failure mode without changing the normal dependency download path for `develop` pushes.

## Validation
- `bash -n other/download_libs.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml"); puts "ci.yml OK"'`
- `git diff --check`
