### PR TITLE
Add Danmaku Cosmos to Community Plugins list

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,7 @@ IINA is always looking for contributions, whether it's through bug reports, code
 - **[Bookmarks](https://github.com/wyattowalsh/iina-plugin-bookmarks)** (`wyattowalsh/iina-plugin-bookmarks`) - Save and manage video timestamps.
 - **[Clickable Subtitles](https://github.com/kerim/iina-clickable-subtitles)** (`kerim/iina-clickable-subtitles`) - Click subtitles to define words (macOS Look Up).
 - **[Danmaku](https://github.com/xjbeta/iina-plugin-danmaku)** (`xjbeta/iina-plugin-danmaku`) - Overlay comments/danmaku on video.
+- **[Danmaku Cosmos](https://github.com/karappo-yu/iina-plugin-danmaku-cosmos)** (`karappo-yu/iina-plugin-danmaku-cosmos`) - Niconico/Bilibili danmaku with CSS/Canvas dual rendering, Comment Art support.
 - **[File Viewer](https://github.com/qktechies/iina-plugin-file-viewer)** (`qktechies/iina-plugin-file-viewer`) - bookmark folders, browse directory contents, and play video files directly within IINA.
 - **[Jellyfin](https://github.com/mhajder/iina-jellyfin)** (`mhajder/iina-jellyfin`) - Browse and play media from Jellyfin servers.
 - **[Jump to Frame](https://github.com/bbeny123/iina-jump-to-frame)** (`bbeny123/iina-jump-to-frame`) - Navigate video by specific frame number.


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
This PR adds Danmaku Cosmos ( https://github.com/karappo-yu/iina-plugin-danmaku-cosmos ) to the Community Plugins section of the README.

About Danmaku Cosmos:

Danmaku Cosmos is a feature-rich danmaku/comment overlay plugin for IINA, offering significantly more capabilities than the existing Danmaku plugin ( https://github.com/xjbeta/iina-plugin-danmaku ):

Key Features:

- Dual rendering modes — CSS mode (default, recommended for best smoothness) and Canvas mode (powered by niconicomments, with full Comment Art / コメントアート compatibility)
- Dual format support — Niconico format ( <chat> XML / v1 JSON) and Bilibili format ( XML)</chat>
- Sidebar control panel — Real-time adjustment of opacity, font scale, scroll duration, danmaku blocking (scroll/top/bottom), lane limit, and Canvas mode selection (Auto/HTML5/Flash) — all without needing to restart playback
- Auto-load local danmaku — Automatically finds danmaku files in the same directory as the video (supports same-name matching, subfolder search with 弹幕/Comments/コメント folders, and episode number extraction from filenames)
- Manual load — Load danmaku files via sidebar button or menu bar when auto-detection fails
- Keyboard shortcut — Press D to toggle danmaku visibility
