### PR TITLE
new pref: enable the new settings window based on user defaults

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -11,7 +11,7 @@ import MediaPlayer
 import Sparkle
 
 let IINA_ENABLE_PLUGIN_SYSTEM = true
-let IINA_ENABLE_NEW_SETTINGS = false
+let IINA_ENABLE_NEW_SETTINGS = UserDefaults.standard.bool(forKey: "enableNewSettings")
 
 /** Max time interval for repeated `application(_:openFile:)` calls. */
 fileprivate let OpenFileRepeatTime = TimeInterval(0.2)


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
---

**Description:**
Add a new UserDefault `enableNewSettings` to enable the new settings window. The UserDefault replaces the hardcode `IINA_ENABLE_NEW_SETTINGS`.

With this commit, the new settings window can be enabled by:
```
defaults write com.colliderli.iina enableNewSettings -bool true
```