### PR TITLE
Fix timer being blocked in main thread

### DIFF
--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -976,6 +976,36 @@ extension CGSize {
   }
 }
 
+/// Creates a repeating scheduled on the main run loop in `.common` mode, so it continues to fire
+/// during UI tracking. Note that common mode is default + tracking, and `RunLoop.Mode.tracking` is
+/// a special run loop mode that the system switches into when the user is actively interacting with
+/// certain UI elements, including scrolling, dragging controls, holding on buttons, etc.
+extension Timer {
+  @discardableResult
+  static func scheduledTimerInCommonMode(
+    timeInterval ti: TimeInterval,
+    target: Any,
+    selector: Selector,
+    userInfo: Any? = nil,
+    repeats: Bool = true,
+  ) -> Timer {
+    let timer = Timer(timeInterval: ti, target: target, selector: selector, userInfo: userInfo, repeats: repeats)
+    RunLoop.main.add(timer, forMode: .common)
+    return timer
+  }
+
+  @discardableResult
+  static func scheduledTimerInCommonMode(
+    withTimeInterval interval: TimeInterval,
+    repeats: Bool = true,
+    block: @escaping (Timer) -> Void
+  ) -> Timer {
+    let timer = Timer(timeInterval: interval, repeats: repeats, block: block)
+    RunLoop.main.add(timer, forMode: .common)
+    return timer
+  }
+}
+
 #if DEBUG
 extension DispatchQueue {
 

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -2575,13 +2575,10 @@ class PlayerCore: NSObject {
     guard useTimer else { return }
 
     // Timer will start
-
-    syncUITimer = Timer.scheduledTimer(
+    syncUITimer = Timer.scheduledTimerInCommonMode(
       timeInterval: timeInterval,
       target: self,
       selector: #selector(self.syncUITime),
-      userInfo: nil,
-      repeats: true
     )
   }
 

--- a/iina/ScrollingTextField.swift
+++ b/iina/ScrollingTextField.swift
@@ -54,8 +54,7 @@ class ScrollingTextField: NSTextField {
     appendedStringCopyWidth = NSAttributedString(string: appendedStringCopy, attributes: attributes).size().width
     scrollingString = NSAttributedString(string: stringValue + appendedStringCopy, attributes: attributes)
     state = .scroll
-    scrollingTimer = Timer.scheduledTimer(timeInterval: updateInterval, target: self, selector: #selector(moveText),
-                                          userInfo: nil, repeats: true)
+    scrollingTimer = Timer.scheduledTimerInCommonMode(timeInterval: updateInterval, target: self, selector: #selector(moveText))
   }
 
   private func reset() {


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #168 & #1586.

---

**Description:**
Added a new helper function to run timer in common mode. Otherwise the timer might be blocked by user interactions (dragging, clicking on a button, etc).

Since most of the use cases for the helper function is repeated timer, the default value for `repeated` is set to true.