### PR TITLE
add listenbrainz scrobbler to community plugins list

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ IINA is always looking for contributions, whether it's through bug reports, code
 - **[File Viewer](https://github.com/qktechies/iina-plugin-file-viewer)** (`qktechies/iina-plugin-file-viewer`) - bookmark folders, browse directory contents, and play video files directly within IINA.
 - **[Jellyfin](https://github.com/mhajder/iina-jellyfin)** (`mhajder/iina-jellyfin`) - Browse and play media from Jellyfin servers.
 - **[Jump to Frame](https://github.com/bbeny123/iina-jump-to-frame)** (`bbeny123/iina-jump-to-frame`) - Navigate video by specific frame number.
+- **[ListenBrainz Scrobbler](https://git.notfire.cc/notfire/iina-listenbrainz)** - Scrobble your music to ListenBrainz.
 - **[Multiple Clips](https://github.com/karthisnk/multi-cutter-iina)** (`karthisnk/multi-cutter-iina`) - multiple clip of a video using ffmpeg, with Batch Clipping, Vertical Clip, Format Selection, Preview Clip.
 - **[PiP Toggle for IINA](https://github.com/nastarandarjani/iina-pip-toggle)** (`nastarandarjani/iina-pip-toggle`) - Simple plugin to toggle Picture-in-Picture (PiP) to fullscreen.
 - **[PolyScript](https://github.com/SammoMichael/polyplugin-release)** (`SammoMichael/polyplugin-release`) - Dual subtitles, hover dictionary, and AI-assisted translation for language learning.


### PR DESCRIPTION
- [X] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
this pr just adds a small plugin i wrote to the community plugins list in the readme. it's hosted on my own git forge and not on github to have at least some control over LLMs being trained off my work. actually kinda funny considering pretty much every (probably every) other plugin is vibecoded..

a small note of something i discovered when writing the plugin: for some reason the `iina.file-started` event fires inconsistently (like, maybe half the time) especially when opening a file with the app closed beforehand. i switched to using `mpv.file-loaded` which is functionally identical but does fire every time. may be worth looking into that, i have no experience messing with swift stuff; i would've tried to make a patch otherwise.