### PR TITLE
pref: make `.scaleRemainingTime` independent from `.showRemainingTime`

### DIFF
--- a/iina/Pages/SettingsPageUI.swift
+++ b/iina/Pages/SettingsPageUI.swift
@@ -115,10 +115,8 @@ class SettingsPageUI: SettingsPage {
         SettingsItem.Switch()
           .image(name: "slider.horizontal.below.square.and.square.filled")
           .bindTo(.showRemainingTime)
-          .withDetailView {
-            SettingsItem.Switch()
-              .bindTo(.scaleRemainingTime)
-          }
+        SettingsItem.Switch()
+          .bindTo(.scaleRemainingTime)
         SettingsItem.Switch()
           .bindTo(.disablePlaySliderScrolling)
         SettingsItem.Switch()


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)

---

**Description:**
In the Interface settings page, the "Show remaining time instead of total duration" only sets the default behavior of the time label; with this option not enabled, the user can still show remaining time by clicking on the time label. Therefore "Base remaining time on playback speed" should be separated from "Show remaining time instead of total duration". With the current implementation, if "Show remaining time instead of total duration" is not enabled, we cannot control it from UI.