### PR TITLE
Fix auto-play when Bluetooth device connects, #6025

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -1382,7 +1382,7 @@ class RemoteCommandController {
 
     // For each command, apply a configured keybinding or fallback to default values.
     remoteCommand.playCommand.addTarget { _ in
-      if let action = PlayerCore.keyBindings["PLAY"] {
+      if let action = PlayerCore.keyBindings["PLAYONLY"] {
         PlayerCore.lastActive.mainWindow.handleKeyBinding(action)
       } else {
         PlayerCore.lastActive.resume()
@@ -1390,7 +1390,7 @@ class RemoteCommandController {
       return .success
     }
     remoteCommand.pauseCommand.addTarget { _ in
-      if let action = PlayerCore.keyBindings["PAUSE"] {
+      if let action = PlayerCore.keyBindings["PAUSEONLY"] {
         PlayerCore.lastActive.mainWindow.handleKeyBinding(action)
       } else {
         PlayerCore.lastActive.pause()

--- a/iina/config/iina-default-input.conf
+++ b/iina/config/iina-default-input.conf
@@ -110,6 +110,8 @@ POWER quit
 PLAY cycle pause
 PAUSE cycle pause
 PLAYPAUSE cycle pause
+PLAYONLY set pause no
+PAUSEONLY set pause yes
 STOP stop
 FORWARD seek 15
 REWIND seek -15

--- a/iina/config/movist-default-input.conf
+++ b/iina/config/movist-default-input.conf
@@ -72,6 +72,8 @@ POWER quit
 PLAY cycle pause
 PAUSE cycle pause
 PLAYPAUSE cycle pause
+PLAYONLY set pause no
+PAUSEONLY set pause yes
 STOP quit
 FORWARD seek 60
 REWIND seek -60

--- a/iina/config/movist-v2-default-input.conf
+++ b/iina/config/movist-v2-default-input.conf
@@ -75,6 +75,8 @@ POWER quit
 PLAY cycle pause
 PAUSE cycle pause
 PLAYPAUSE cycle pause
+PLAYONLY set pause no
+PAUSEONLY set pause yes
 STOP quit
 FORWARD seek 60
 REWIND seek -60

--- a/iina/config/vlc-default-input.conf
+++ b/iina/config/vlc-default-input.conf
@@ -58,6 +58,8 @@ POWER quit
 PLAY cycle pause
 PAUSE cycle pause
 PLAYPAUSE cycle pause
+PLAYONLY set pause no
+PAUSEONLY set pause yes
 STOP quit
 FORWARD seek 60
 REWIND seek -60


### PR DESCRIPTION
This commit will:
- Add `PLAYONLY` and `PAUSEONLY` keys to all default key bindings files except input.conf which already contained these keys
- Change the `RemoteCommandController.enable` method to use these new keys instead of the `PLAY` and `PAUSE` keys

This commit applies the changes made by mpv in mpv PR https://github.com/mpv-player/mpv/pull/7380 to IINA. The `PLAY` and `PAUSE` keys were configured to the mpv `cycle pause` command. That definitely does not match the expected behavior of the `MPRemoteCommandCenter` [playCommand](https://developer.apple.com/documentation/mediaplayer/mpremotecommandcenter/playcommand) and [pauseCommand](https://developer.apple.com/documentation/mediaplayer/mpremotecommandcenter/pausecommand). Over backward compatibility concerns the mpv project added the new keys `PLAYONLY` and `PAUSEONLY` with the commands `set pause no` and `set pause yes` and changed their `MPRemoteCommandCenter` implementation to use the new keys. This commit will apply similar changes to IINA's `MPRemoteCommandCenter` implementation.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #6025.

---

**Description:**
