### PR TITLE
Add Episode Info plugin to plugins list

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,7 @@ IINA is always looking for contributions, whether it's through bug reports, code
 - **[Clickable Subtitles](https://github.com/kerim/iina-clickable-subtitles)** (`kerim/iina-clickable-subtitles`) - Click subtitles to define words (macOS Look Up).
 - **[Danmaku](https://github.com/xjbeta/iina-plugin-danmaku)** (`xjbeta/iina-plugin-danmaku`) - Overlay comments/danmaku on video.
 - **[Danmaku Cosmos](https://github.com/karappo-yu/iina-plugin-danmaku-cosmos)** (`karappo-yu/iina-plugin-danmaku-cosmos`) - Niconico/Bilibili danmaku with CSS/Canvas dual rendering, Comment Art support.
+- **[Episode Info](https://github.com/Zain-Imam/iina-episode-info)** (`Zain-Imam/iina-episode-info`) - TMDB episode/movie info overlay on pause, with built-in subtitle search.
 - **[File Viewer](https://github.com/qktechies/iina-plugin-file-viewer)** (`qktechies/iina-plugin-file-viewer`) - bookmark folders, browse directory contents, and play video files directly within IINA.
 - **[Jellyfin](https://github.com/mhajder/iina-jellyfin)** (`mhajder/iina-jellyfin`) - Browse and play media from Jellyfin servers.
 - **[Jump to Frame](https://github.com/bbeny123/iina-jump-to-frame)** (`bbeny123/iina-jump-to-frame`) - Navigate video by specific frame number.


### PR DESCRIPTION
Adds my plugin **Episode Info** to the IINA Plugins List in the README, in the Community Plugins section (alphabetically between Danmaku Cosmos and File Viewer).

**Repo:** https://github.com/Zain-Imam/iina-episode-info

**What it does:** Searches TMDB for episode and movie info and shows it as an overlay when the video is paused. Includes built-in subtitle search via Wyzie Subs and OpenSubtitles.com.

**Highlights:**
- Auto-overlay on pause with show/episode/movie metadata, poster, rating, synopsis
- Customizable overlay (shade, vertical position, configurable pause delay)
- Per-URL TMDB memory — restores your identification automatically when you re-play the same file
- Subtitle download via Wyzie Subs and OpenSubtitles.com
- Installs through IINA's `Install from GitHub...` flow with auto-update

**Compatibility:** IINA 1.4.0+, macOS 12+

**Permissions used:** `network-request`, `video-overlay`, `show-osd`. Network access is restricted to `api.themoviedb.org`, `image.tmdb.org`, `sub.wyzie.ru`, `sub.wyzie.io`, and `api.opensubtitles.com`.

**Test install:** IINA → Preferences → Plugins → Install from GitHub… → enter `Zain-Imam/iina-episode-info`.