### PR TITLE
sub: reload quicksetting for sub page when sid changes

### DIFF
--- a/iina/QuickSettingViewController.swift
+++ b/iina/QuickSettingViewController.swift
@@ -317,11 +317,7 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
     }
     observe(.iinaVIDChanged) { [unowned self] _ in self.videoTableView.reloadData() }
     observe(.iinaAIDChanged) { [unowned self] _ in self.audioTableView.reloadData() }
-    observe(.iinaSIDChanged) { [unowned self] _ in
-      self.subTableView.reloadData()
-      self.secSubTableView.reloadData()
-      reload()
-    }
+    observe(.iinaSIDChanged) { [unowned self] _ in self.reload() }
     observe(.iinaSecondSubVisibilityChanged) { [unowned self] _ in secHideSwitch.state = player.info.isSecondSubVisible ? .on : .off }
     observe(.iinaSubVisibilityChanged) { [unowned self] _ in hideSwitch.state = player.info.isSubVisible ? .on : .off }
   }

--- a/iina/QuickSettingViewController.swift
+++ b/iina/QuickSettingViewController.swift
@@ -320,6 +320,7 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
     observe(.iinaSIDChanged) { [unowned self] _ in
       self.subTableView.reloadData()
       self.secSubTableView.reloadData()
+      reload()
     }
     observe(.iinaSecondSubVisibilityChanged) { [unowned self] _ in secHideSwitch.state = player.info.isSecondSubVisible ? .on : .off }
     observe(.iinaSubVisibilityChanged) { [unowned self] _ in hideSwitch.state = player.info.isSubVisible ? .on : .off }
@@ -481,7 +482,6 @@ class QuickSettingViewController: NSViewController, NSTableViewDataSource, NSTab
     secHideSwitch.state = player.info.isSecondSubVisible ? .on : .off
 
     if let currSub = player.info.currentTrack(.sub) {
-      // FIXME: CollorWells cannot be disable?
       let enableTextSettings = !(currSub.isAssSub || currSub.isImageSub)
       [subTextColorWell, subTextSizePopUp, subTextBgColorWell, subTextBorderColorWell, subTextBorderWidthPopUp, subTextFontBtn].forEach { $0.isEnabled = enableTextSettings }
     }

--- a/iina/RoundedColorWell.swift
+++ b/iina/RoundedColorWell.swift
@@ -8,7 +8,7 @@
 
 import Cocoa
 
-/// For 10.12 or below only
+/// For macOS 12 or below only
 class RoundedColorWell: NSColorWell {
 
   var isMouseDown: Bool = false


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
---

**Description:**
When `sid` is changed from mpv (e.g. drag a sub file to window, the new sub file is enabled automatically), the sub page is not reloaded.

Step to reproduce:
- Open a video with ass subtitle enabled
- Open the quick settings subtitle panel
- Notice that the controls for sub text color are disabled
- Keep the panel opened
- Drag a srt subtitle file to the window, the srt subtitle should be enabled
- The controls should be enabled, but they are not
