### PR TITLE
Enhancements to the utilities settings page

### DIFF
--- a/iina/Pages/SettingsPageUtilities.swift
+++ b/iina/Pages/SettingsPageUtilities.swift
@@ -7,6 +7,7 @@
 //
 
 import UniformTypeIdentifiers
+import SafariServices.SFSafariApplication
 
 class SettingsPageUtilities: SettingsPage {
   override var title: String {
@@ -72,6 +73,11 @@ class SettingsPageUtilities: SettingsPage {
   
   private func updateThumbnailCacheStat() {
     thumbCacheSizeLabel.stringValue = "\(FloatingPointByteCountFormatter.string(fromByteCount: CacheManager.shared.getCacheSize(), countStyle: .binary))B"
+  }
+
+  override init () {
+    super.init()
+    self.updateThumbnailCacheStat()
   }
 
   @objc func setIINAAsDefaultAction(_ sender: Any) {
@@ -267,16 +273,25 @@ fileprivate class BrowserExtensionView: SettingsAccessory.Base {
     ffBtn.imagePosition = .imageTrailing
     ffBtn.target = self
     ffBtn.action = #selector(extFirefoxBtnAction)
-    let stackView = makeStackView([chromeBtn, ffBtn])
+    let safariBtn = makeButton(.text_Chrome)
+    safariBtn.image = .findSFSymbol(["arrow.right"])
+    safariBtn.imagePosition = .imageTrailing
+    safariBtn.target = self
+    safariBtn.action = #selector(extSafariBtnAction)
+    let stackView = makeStackView([chromeBtn, ffBtn, safariBtn])
     view.addSubview(stackView)
     stackView.padding(.top(0), .bottom(16), .leading(SettingsSubListView.padding), .trailing(8))
   }
   
   @objc func extChromeBtnAction(_ sender: Any) {
-    NSWorkspace.shared.open(URL(string: AppData.chromeExtensionLink)!)
+    NSWorkspace.shared.open([URL(string: AppData.chromeExtensionLink)!], withApplicationAt: NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.google.Chrome") ?? NSWorkspace.shared.urlForApplication(toOpen: URL(string: "http://")!)!, configuration: NSWorkspace.OpenConfiguration())
   }
 
   @objc func extFirefoxBtnAction(_ sender: Any) {
-    NSWorkspace.shared.open(URL(string: AppData.firefoxExtensionLink)!)
+    NSWorkspace.shared.open([URL(string: AppData.firefoxExtensionLink)!], withApplicationAt: NSWorkspace.shared.urlForApplication(withBundleIdentifier: "org.mozilla.firefox") ?? NSWorkspace.shared.urlForApplication(toOpen: URL(string: "http://")!)!, configuration: NSWorkspace.OpenConfiguration())
+  }
+  
+  @objc func extSafariBtnAction() {
+    SFSafariApplication.showPreferencesForExtension(withIdentifier: "com.colliderli.iina.OpenInIINA")
   }
 }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)

---

**Fixes**
* Fixed thumbnail cache size not showing until it's cleared

**Additions**
* Chrome and Firefox extensions open in their respective apps when possible
* A button to get to the Safari extension's settings
   * This currently shows as a second Chrome button because I don't want to mess up the localization files
   * This [does not work](https://stackoverflow.com/questions/47456460/safari-app-extension-not-detected-in-showpreferencesforextension) when debugging, the app will have to be archived and exported to test it
   * The extension identifier is hardcoded which might be a bad idea

I was trying to make my own version of this page so I thought I'd bring over a couple improvements from there. Loving all the work that's been done over the past few weeks