### PR TITLE
Monitor file changes to auto-reload subtitles if they are modified (#3724)

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -320,6 +320,7 @@
 		B4E446F725CB54EF0069F06E /* Mustache in Frameworks */ = {isa = PBXBuildFile; productRef = B4E446F625CB54EF0069F06E /* Mustache */; };
 		B4E4470125CE3F930069F06E /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = B4E4470025CE3F930069F06E /* Sparkle */; };
 		C789872F1E34EF170005769F /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = C78987311E34EF170005769F /* InfoPlist.strings */; };
+		D1A4C2DC2BF97BB200CE32A9 /* FileMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = D141191B2F9F751D00E29772 /* FileMonitor.swift */; };
 		D17504A82918F13E005C3DD0 /* OSCToolbarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17504A72918F13E005C3DD0 /* OSCToolbarButton.swift */; };
 		D17B857B2C94C8B5002A8EDE /* movist-v2-default-input.conf in Copy Configs */ = {isa = PBXBuildFile; fileRef = D1F68E742C6ABC22003D1208 /* movist-v2-default-input.conf */; };
 		D1A4D98A2B1495270009AB4E /* LegacyMigration.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1A4D9892B1495270009AB4E /* LegacyMigration.swift */; };
@@ -1826,6 +1827,7 @@
 		C7DBA5EB1F07C5FD00C2B416 /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/InitialWindowController.strings; sourceTree = "<group>"; };
 		C7DC79CE1EC63821002DE23B /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/HistoryWindowController.strings; sourceTree = "<group>"; };
 		C7E90B522087EC5700A58B6B /* ko */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ko; path = ko.lproj/SubChooseViewController.strings; sourceTree = "<group>"; };
+		D141191B2F9F751D00E29772 /* FileMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileMonitor.swift; sourceTree = "<group>"; };
 		D17504A72918F13E005C3DD0 /* OSCToolbarButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OSCToolbarButton.swift; sourceTree = "<group>"; };
 		D1A4D9892B1495270009AB4E /* LegacyMigration.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LegacyMigration.swift; sourceTree = "<group>"; };
 		D1B4E24D2A3AFC9100E36F1D /* MiniPlayerWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MiniPlayerWindow.swift; sourceTree = "<group>"; };
@@ -2545,6 +2547,7 @@
 				51C1BA39291CA76700C1208A /* InfoDictionary.swift */,
 				51DE55C82A6646710050AD06 /* Sysctl.swift */,
 				519CCABC2BFFAEF10079DCAF /* HardwareDecodeCapabilities.swift */,
+				D141191B2F9F751D00E29772 /* FileMonitor.swift */,
 				51165FBB2E1D91290060B817 /* ReadWriteAtomic.swift */,
 				516B264C2EDA579600E3CB69 /* MemoryUsage.swift */,
 			);
@@ -3268,6 +3271,7 @@
 			files = (
 				E3EC8C432F94330400FBB51E /* Dialog.swift in Sources */,
 				E35306FA214808AB008FE492 /* JavascriptAPIEvent.swift in Sources */,
+				D1A4C2DC2BF97BB200CE32A9 /* FileMonitor.swift in Sources */,
 				849581F11F02728700D3B359 /* InitialWindowController.swift in Sources */,
 				8461C52E1D45FFF6006E91FF /* PlaySliderCell.swift in Sources */,
 				E33517602DFFC93100BBE169 /* SettingsLocalizationKeysVideoAudio.swift in Sources */,

--- a/iina/FileMonitor.swift
+++ b/iina/FileMonitor.swift
@@ -1,0 +1,59 @@
+/// (c) 2018 Daniel Galasko
+/// Ref: https://medium.com/over-engineering/monitoring-a-folder-for-changes-in-ios-dc3f8614f902
+/// Modified from FolderMonitor for use with a single file.
+import Foundation
+
+public class FileMonitor {
+  // MARK: Properties
+
+  /// A file descriptor for the monitored file.
+  private var monitoredFileFD: CInt = -1
+  /// A dispatch queue used for sending file changes in the file.
+  private let fileMonitorQueue = DispatchQueue(label: "com.iina.FileMonitorQueue", attributes: .concurrent)
+  /// A dispatch source to monitor a file descriptor created from the file.
+  private var monitorSource: DispatchSourceFileSystemObject?
+  /// URL for the file being monitored.
+  public let url: URL
+
+  public var fileDidChange: (() -> Void)?
+
+  // MARK: Initializers
+
+  public init(url: URL) {
+    self.url = url
+  }
+
+  // MARK: Monitoring
+
+  /// Listen for changes to the file (if we are not already).
+  public func startMonitoring() {
+    guard monitorSource == nil, monitoredFileFD == -1 else {
+      return
+    }
+    // Open the file referenced by URL for monitoring only.
+    monitoredFileFD = open(url.path, O_EVTONLY)
+    // Define a dispatch source monitoring the file for additions, deletions, and renamings.
+    monitorSource = DispatchSource.makeFileSystemObjectSource(
+      fileDescriptor: monitoredFileFD, eventMask: .all, queue: fileMonitorQueue
+    )
+    // Define the block to call when a file change is detected.
+    monitorSource?.setEventHandler { [weak self] in
+      guard let self = self else { return }
+      self.fileDidChange?()
+    }
+    // Define a cancel handler to ensure the file is closed when the source is cancelled.
+    monitorSource?.setCancelHandler { [weak self] in
+      guard let self = self else { return }
+      close(self.monitoredFileFD)
+      self.monitoredFileFD = -1
+      self.monitorSource = nil
+    }
+    // Start monitoring the file via the source.
+    monitorSource?.resume()
+  }
+
+  /// Stop listening for changes to the file, if the source has been created.
+  public func stopMonitoring() {
+    monitorSource?.cancel()
+  }
+}

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -222,6 +222,8 @@ class PlayerCore: NSObject {
     return controller
   }()
 
+  private var subFileMonitor: FileMonitor? = nil
+
   lazy var info: PlaybackInfo = PlaybackInfo(self)
 
   var syncUITimer: Timer?
@@ -911,6 +913,7 @@ class PlayerCore: NSObject {
   func stop() {
     guard info.state != .shutDown else { return }
     savePlaybackPosition()
+    stopWatchingSubFile()
 
     // The player may already be stopped in which case the state must not be set to stopping.
     if info.state != .idle {
@@ -1441,6 +1444,38 @@ class PlayerCore: NSObject {
     }
     mainWindow?.quickSettingView.reload()
   }
+
+  private func startWatchingSubFile() {
+    guard let currentSubTrack = info.currentTrack(.sub) else { return }
+    guard let externalFilename = currentSubTrack.externalFilename else {
+      log("Sub track \(currentSubTrack.id) is not an external file", level: .verbose)
+      return
+    }
+
+    // Stop previous watch (if any)
+    stopWatchingSubFile()
+
+    let subURL = URL(fileURLWithPath: externalFilename)
+    let fileMonitor = FileMonitor(url: subURL)
+    fileMonitor.fileDidChange = { [self] in
+      mpv.command(.subReload, args: [String(currentSubTrack.id)], checkError: false) { [self] code in
+        if code >= 0 { return }
+        log("Failed reloading sub track \(currentSubTrack.id): error code \(code)", level: .error)
+      }
+    }
+    subFileMonitor = fileMonitor
+    log("Starting FS watch of sub file \(subURL.path.quoted)", level: .verbose)
+    fileMonitor.startMonitoring()
+  }
+
+  private func stopWatchingSubFile() {
+    guard let subFileMonitor else { return }
+
+    log("Stopping FS watch of sub file \(subFileMonitor.url.path.quoted)", level: .verbose)
+    subFileMonitor.stopMonitoring()
+    self.subFileMonitor = nil
+  }
+
 
   func setAudioDelay(_ delay: Double) {
     mpv.setDouble(MPVOption.Audio.audioDelay, delay)
@@ -2027,6 +2062,9 @@ class PlayerCore: NSObject {
       }
     }
 
+    // Stop watchers from prev media (if any)
+    stopWatchingSubFile()
+
     NowPlayingInfoManager.shared.updateInfo(withTitle: true)
 
     // Auto load
@@ -2358,6 +2396,7 @@ class PlayerCore: NSObject {
   func sidChanged() {
     guard info.state.active else { return }
     info.sid = Int(mpv.getInt(MPVOption.TrackSelection.sid))
+    startWatchingSubFile()
     postNotification(.iinaSIDChanged)
     sendOSD(.track(info.currentTrack(.sub) ?? .noneSubTrack))
   }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #3724.

---

**Description:**
Back-porting this code from my IINA Advance project - might be advantageous to get this code into upstream.

This uses code from an earlier version of [vChewing_FolderMonitor](https://github.com/vChewing/vChewing-macOS/tree/main/Packages/vChewing_FolderMonitor) (the link on the bug report page is broken due to rename).

In `PlayerCore`, the complementary methods `startWatchingSubFile` and `stopWatchingSubFile` start and stop the file monitor, respectively - the former first calls the latter to stop any previous monitoring, so it can be called repeatedly without error.

The method `startWatchingSubFile` is called whenever the sub track changes, but the monitor is only set up if the current sub track is determined to be external. 
The method `stopWatchingSubFile` is called both in `PlayerCore`'s `fileStarted()` and `stop()`.

When the file changes, it triggers the following callback which reloads the sub track.
``` Swift
fileMonitor.fileDidChange = { [self] in
  mpv.command(.subReload, args: [String(currentSubTrack.id)], checkError: false)
}
```