### PR TITLE
Add Skip Intro plugin to community plugins list

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ IINA is always looking for contributions, whether it's through bug reports, code
 - **[PiP Toggle for IINA](https://github.com/nastarandarjani/iina-pip-toggle)** (`nastarandarjani/iina-pip-toggle`) - Simple plugin to toggle Picture-in-Picture (PiP) to fullscreen.
 - **[PolyScript](https://github.com/SammoMichael/polyplugin-release)** (`SammoMichael/polyplugin-release`) - Dual subtitles, hover dictionary, and AI-assisted translation for language learning.
 - **[recorder](https://github.com/5thDimensionalVader/recorder-iina)** (`5thDimensionalVader/recorder-iina`) - to clip a video using ffmpeg.
+- **[Skip Intro](https://github.com/pparanoiidd/iina-skip-intro)** (`pparanoiidd/iina-skip-intro`) - Detect and skip intros, recaps and credits.
 
 > 💡 **Want to build your own plugin?**
 >


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
This PR adds my plugin [**Skip Intro**](https://github.com/pparanoiidd/iina-skip-intro) to the Community Plugins List in the README, placed last alphabetically (should have started my plugin name with the letter A!).

This plugin gives people who watch shows and movies locally a streaming-style way to skip intros and other sections. It detects sections through three different methods: chapter titles, audio fingerprint analysis, or chapter timings, then either shows a skip pop-up or auto-skips based on your preferences.

Had a lot of fun making it with the plugin API. 