### PR TITLE
Mention linking yt-dlp to deps/executable/youtube-dl when building mpv

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,10 +100,10 @@ IINA uses mpv for media playback. To build IINA, you can either fetch copies of 
 
 5. Link the *yt-dlp* dependency to deps/executable 
  
-  ```console
-  mkdir -p deps/executable
-  ln -s $(which yt-dlp) deps/executable/youtube-dl
-  ```
+   ```console
+   mkdir -p deps/executable
+   ln -s $(which yt-dlp) deps/executable/youtube-dl
+   ```
 
 6. Open `iina.xcodeproj` in the [latest public version of Xcode](https://apps.apple.com/app/xcode/id497799835). *IINA may not build if you use any other version.*
 

--- a/README.md
+++ b/README.md
@@ -98,15 +98,21 @@ IINA uses mpv for media playback. To build IINA, you can either fetch copies of 
 	port contents mpv | grep '\.dylib$' | xargs other/change_lib_dependencies.rb /opt/local
 	```
 
-5. Open `iina.xcodeproj` in the [latest public version of Xcode](https://apps.apple.com/app/xcode/id497799835). *IINA may not build if you use any other version.*
+5. Link the *yt-dlp* dependency to deps/executable 
+```console
+  mkdir -p deps/executable
+  ln -s $(which yt-dlp) deps/executable/youtube-dl
+  ```
 
-6. Remove all references to `.dylib` files from the Frameworks group in the sidebar and add all the `.dylib` files in `deps/lib` to that group by clicking  "Add Files to iina..." in the context menu.
+6. Open `iina.xcodeproj` in the [latest public version of Xcode](https://apps.apple.com/app/xcode/id497799835). *IINA may not build if you use any other version.*
 
-7. Add all the imported `.dylib` files into the "Copy Dylibs" phase under "Build Phases" tab of the iina target.
+7. Remove all references to `.dylib` files from the Frameworks group in the sidebar and add all the `.dylib` files in `deps/lib` to that group by clicking  "Add Files to iina..." in the context menu.
 
-8. Make sure the necessary `.dylib` files are present in the "Link Binary With Libraries" phase under "Build Phases". Xcode should have already added all dylibs under this section.
+8. Add all the imported `.dylib` files into the "Copy Dylibs" phase under "Build Phases" tab of the iina target.
 
-9. Build the project.
+9. Make sure the necessary `.dylib` files are present in the "Link Binary With Libraries" phase under "Build Phases". Xcode should have already added all dylibs under this section.
+
+10. Build the project.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ IINA uses mpv for media playback. To build IINA, you can either fetch copies of 
 	```
 
 5. Link the *yt-dlp* dependency to deps/executable 
+ 
   ```console
   mkdir -p deps/executable
   ln -s $(which yt-dlp) deps/executable/youtube-dl

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ IINA uses mpv for media playback. To build IINA, you can either fetch copies of 
 	```
 
 5. Link the *yt-dlp* dependency to deps/executable 
-```console
+  ```console
   mkdir -p deps/executable
   ln -s $(which yt-dlp) deps/executable/youtube-dl
   ```


### PR DESCRIPTION
The README does not mention that this step is necessary in the manual building instructions.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
