### PR TITLE
Mention linking yt-dlp to deps/executable/youtube-dl 

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,15 +98,22 @@ IINA uses mpv for media playback. To build IINA, you can either fetch copies of 
 	port contents mpv | grep '\.dylib$' | xargs other/change_lib_dependencies.rb /opt/local
 	```
 
-5. Open `iina.xcodeproj` in the [latest public version of Xcode](https://apps.apple.com/app/xcode/id497799835). *IINA may not build if you use any other version.*
+5. Link the *yt-dlp* dependency to deps/executable 
+ 
+   ```console
+   mkdir -p deps/executable
+   ln -s $(which yt-dlp) deps/executable/youtube-dl
+   ```
+   
+6. Open `iina.xcodeproj` in the [latest public version of Xcode](https://apps.apple.com/app/xcode/id497799835). *IINA may not build if you use any other version.*
 
-6. Remove all references to `.dylib` files from the Frameworks group in the sidebar and add all the `.dylib` files in `deps/lib` to that group by clicking  "Add Files to iina..." in the context menu.
+7. Remove all references to `.dylib` files from the Frameworks group in the sidebar and add all the `.dylib` files in `deps/lib` to that group by clicking  "Add Files to iina..." in the context menu.
 
-7. Add all the imported `.dylib` files into the "Copy Dylibs" phase under "Build Phases" tab of the iina target.
+8. Add all the imported `.dylib` files into the "Copy Dylibs" phase under "Build Phases" tab of the iina target.
 
-8. Make sure the necessary `.dylib` files are present in the "Link Binary With Libraries" phase under "Build Phases". Xcode should have already added all dylibs under this section.
+9. Make sure the necessary `.dylib` files are present in the "Link Binary With Libraries" phase under "Build Phases". Xcode should have already added all dylibs under this section.
 
-9. Build the project.
+10. Build the project.
 
 ## Contributing
 


### PR DESCRIPTION
- [X] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**

When following the manual build instructions, xcode fails to build the app bundle due to a missing youtube-dl dependency, this should be mentioned in the readme