### PR TITLE
Improve the user-facing `infoString` of tracks

### DIFF
--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -535,6 +535,10 @@ extension String {
     return "\"\(self)\""
   }
 
+  var parenthesized: String {
+      return "(\(self))"
+  }
+
   mutating func deleteLast(_ num: Int) {
     removeLast(Swift.min(num, count))
   }

--- a/iina/MPVTrack.swift
+++ b/iina/MPVTrack.swift
@@ -128,7 +128,7 @@ class MPVTrack: NSObject {
       default:
         break
       }
-      let info = components.joined(separator: ", ")
+      let info = components.joined(separator: ", ").parenthesized
       // default
       let isDefault = isDefault ? "(" + NSLocalizedString("quicksetting.item_default", comment: "Default") + ")" : ""
       // final string


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)

---

**Description:**
This PR is an RFC on how to display the track info to users. There has been some issues about this before (might be incomplete):
- https://github.com/iina/iina/issues/5028
- https://github.com/iina/iina/issues/1470

I also found it's current pretty confusing sometimes:
<img width="161" height="80" alt="image" src="https://github.com/user-attachments/assets/6e79cbfd-79b0-409f-9d20-aeb04e57ec36" />

I've no idea why there's a "subrip" after the filename, until I found the implementation of the `infoString`:
```Swift
let info = components.joined(separator: ", ")
// default
let isDefault = isDefault ? "(" + NSLocalizedString("quicksetting.item_default", comment: "Default") + ")" : ""
// final string
return [language, title, info, isDefault].filter { !$0.isEmpty }.joined(separator: " ")
```
So this user-facing string is space-separated piece of information including language, title, INFO, and the isDefault attribute. If any of them are empty string, they will just be removed from the `infoString` without notifying the user some parts are missing.

Besides, when we look into the implementation of the INFO:
```Swift
// info
var components: [String] = []
if let codec {
  components.append(codec)
}
switch type {
case .video:
  if let demuxW, let demuxH {
    components.append("\(demuxW)\u{d7}\(demuxH)")
  }
  if let demuxFps {
    components.append("\(demuxFps.prettyFormat())fps")
  }
case .audio:
  if let demuxChannelCount {
    components.append("\(demuxChannelCount)ch")
  }
  if let demuxSamplerate {
    components.append("\((Double(demuxSamplerate)/1000).prettyFormat())kHz")
  }
default:
  break
}
let info = components.joined(separator: ", ")
```
It's a **comma-separated** string with information different depending on which type of track it is. This `infoString` could become very cluttered especially there are both space- and comma-separated strings.

The current change in this PR only adds parentheses around the comma-separated INFO part to make sure that at least those 2 modes are not mixed together.


| Before | After |
| :--- | :--- |
| <img width="163" height="84" alt="image" src="https://github.com/user-attachments/assets/5c0dbc41-86ce-4d25-a2aa-7e8843019179" /> | <img width="162" height="84" alt="image" src="https://github.com/user-attachments/assets/3a9281a4-39ef-4958-80f0-13687481224e" /> |

Another issue for the table view which displays these `infoString`s is that, they are often too long to fit in the table, therefore a richer view-based table view might be good to display different info separately, or at least a tooltip to show the full string.

Discussions on how to better present this `infoString` to users are expected in this PR before the actual landing.