### PR TITLE
docs: add Trakt Scrobbler plugin to plugin list

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,8 @@ IINA is always looking for contributions, whether it's through bug reports, code
 - **[PolyScript](https://github.com/SammoMichael/polyplugin-release)** (`SammoMichael/polyplugin-release`) - Dual subtitles, hover dictionary, and AI-assisted translation for language learning.
 - **[recorder](https://github.com/5thDimensionalVader/recorder-iina)** (`5thDimensionalVader/recorder-iina`) - to clip a video using ffmpeg.
 - **[Skip Intro](https://github.com/pparanoiidd/iina-skip-intro)** (`pparanoiidd/iina-skip-intro`) - Detect and skip intros, recaps and credits.
+- **[Trakt Scrobbler](https://github.com/i3p9/iina-trakt-scrobbler)** (`i3p9/iina-trakt-scrobbler`) - Trakt.tv scrobbler plugin for IINA.
+
 
 > 💡 **Want to build your own plugin?**
 >


### PR DESCRIPTION
Added a new plugin entry for Trakt Scrobbler to the README.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
this is a simple plugin to scrobble to trakt.tv. everything works so far.

only thing I have yet to implement is a local cache of playback in case trakt not being available or for media played in offline mode.