### PR TITLE
fix: Validate JavaScript plugin input listener identifiers

### DIFF
--- a/iina/JavascriptAPIInput.swift
+++ b/iina/JavascriptAPIInput.swift
@@ -50,23 +50,34 @@ class JavascriptAPIInput: JavascriptAPI, JavascriptAPIInputExportable {
   }
   
   func onMouseUp(_ button: String, _ callback: JSValue, _ priority: JSValue) {
+    guard isValidMouseInput(button) else { return }
     addListener(.mouseUp, button, callback, priority, normalizeKey: false)
   }
 
   func onMouseDown(_ button: String, _ callback: JSValue, _ priority: JSValue) {
+    guard isValidMouseInput(button) else { return }
     addListener(.mouseDown, button, callback, priority, normalizeKey: false)
   }
 
   func onMouseDrag(_ button: String, _ callback: JSValue, _ priority: JSValue) {
+    guard isValidMouseInput(button) else { return }
     addListener(.mouseDrag, button, callback, priority, normalizeKey: false)
+  }
+
+  private func isValidMouseInput(_ button: String) -> Bool {
+    return button == PluginInputManager.Input.mouse ||
+           button == PluginInputManager.Input.rightMouse ||
+           button == PluginInputManager.Input.otherMouse
   }
 
   fileprivate func addListener(
     _ event: PluginInputManager.Event,
     _ key: String,  _ callback: JSValue, _ priority: JSValue, normalizeKey: Bool = true
   ) {
+    let normalizedKey = normalizeKey ? KeyCodeHelper.normalizeMpv(key) : key
+    guard !normalizedKey.isEmpty else { return }
     pluginInstance.input.addListener(
-      forInput: normalizeKey ? KeyCodeHelper.normalizeMpv(key) : key,
+      forInput: normalizedKey,
       event: event,
       callback: callback,
       priority: priority.isNumber ? Int(priority.toInt32()) : PluginInputManager.Priority.low.rawValue,


### PR DESCRIPTION
## Summary

This PR tightens validation for JavaScript plugin input listener registration.

Previously, mouse listener APIs accepted arbitrary button strings and registered them directly as plugin input keys. This could allow plugins to create nonsensical or unmatchable listener entries. The change restricts mouse listener registration to the documented mouse input constants and avoids registering empty normalized keyboard inputs.

## Changes

- Validate mouse button input for `onMouseUp`, `onMouseDown`, and `onMouseDrag`
- Reject empty normalized keyboard inputs before registering listeners
- Reuse the normalized key when adding the listener
- `iina/JavascriptAPIInput.swift`


## Security impact

This is a defensive validation/hardening change. I do not currently have a concrete command-injection proof of concept for this path, so I am not claiming CWE-78. The risk addressed here is accepting invalid plugin-controlled input identifiers into the native input listener registry.

## Testing

- Confirmed valid mouse constants continue to register
- Confirmed invalid mouse button names are ignored
- Confirmed empty/invalid normalized key values are not registered

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
