### PR TITLE
Highlight OSC toolbar button when applicable

### DIFF
--- a/iina/AppData.swift
+++ b/iina/AppData.swift
@@ -156,6 +156,9 @@ extension Notification.Name {
   static let iinaSecondSubVisibilityChanged = Notification.Name("iinaSecondSubVisibilityChanged")
   static let iinaSubVisibilityChanged = Notification.Name("iinaSubVisibilityChanged")
   static let iinaHistoryTaskFinished = Notification.Name("iinaHistoryTaskFinished")
+  static let iinaPIPStatusChanged = Notification.Name("iinaPIPStatusChanged")
+  static let iinaFullscreenChanged = Notification.Name("iinaFullscreenChanged")
+  static let iinaSidebarStatusChanged = Notification.Name("iinaSidebarStatusChanged")
 }
 
 enum IINAError: Error {

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -3390,8 +3390,6 @@ extension MainWindowController: PIPViewControllerDelegate {
       // is chosen in this case. See https://bugs.swift.org/browse/SR-8956.
       pip.dismiss(pipVideo!)
     }
-    player.events.emit(.pipChanged, data: false)
-    NotificationCenter.default.post(name: .iinaPIPStatusChanged, object: self, userInfo: ["enable": false])
   }
 
   func doneExitingPIP() {
@@ -3413,6 +3411,8 @@ extension MainWindowController: PIPViewControllerDelegate {
 
     isWindowMiniaturizedDueToPip = false
     isWindowHidden = false
+    player.events.emit(.pipChanged, data: false)
+    NotificationCenter.default.post(name: .iinaPIPStatusChanged, object: self, userInfo: ["enable": false])
   }
 
   func prepareForPIPClosure(_ pip: PIPViewController) {

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -756,8 +756,8 @@ class MainWindowController: PlayerWindowController {
 
     func highlight(_ button: Preference.ToolBarButton, _ isHighlighted: Bool) {
       let buttons = fragToolbarView.subviews as! [NSButton]
-      let button = buttons.first(where: { $0.tag == button.rawValue })
-      button?.contentTintColor = isHighlighted ? .controlAccentColor : nil
+      let currentButton = buttons.first(where: { $0.tag == button.rawValue })
+      currentButton?.image = isHighlighted ? button.alternateImage() : button.image()
     }
 
     let enable = (notification.userInfo?["enable"] as? Bool ?? false)

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -310,7 +310,11 @@ class MainWindowController: PlayerWindowController {
     }
   }
 
-  var sideBarStatus: SideBarViewType = .hidden
+  var sideBarStatus: SideBarViewType = .hidden {
+    didSet {
+      NotificationCenter.default.post(name: .iinaSidebarStatusChanged, object: nil)
+    }
+  }
 
   enum PIPStatus {
     case notInPIP
@@ -672,6 +676,12 @@ class MainWindowController: PlayerWindowController {
       self.player.sendOSD(.abLoopUpdate(.bSet, VideoTime(seconds).stringRepresentation))
     }
 
+    // Observers for toolbar buttons
+    let notifications: [Notification.Name] = [.iinaPIPStatusChanged, .iinaFullscreenChanged, .iinaSidebarStatusChanged]
+    notifications.forEach {
+      NotificationCenter.default.addObserver(self, selector: #selector(updateOSCToolbarButtons(_:)), name: $0, object: nil)
+    }
+
     player.events.emit(.windowLoaded)
 
     // Must workaround an AppKit defect in some versions of macOS. This defect is known to exist in
@@ -738,6 +748,31 @@ class MainWindowController: PlayerWindowController {
       OSCToolbarButton.setStyle(of: button, buttonType: buttonType, reducedWidth: buttons.count > 4)
       button.action = #selector(self.toolBarButtonAction(_:))
       fragToolbarView.addView(button, in: .trailing)
+    }
+  }
+
+  @objc
+  private func updateOSCToolbarButtons(_ notification: Notification) {
+
+    func highlight(_ button: Preference.ToolBarButton, _ isHighlighted: Bool) {
+      let buttons = fragToolbarView.subviews as! [NSButton]
+      let button = buttons.first(where: { $0.tag == button.rawValue })
+      button?.contentTintColor = isHighlighted ? .controlAccentColor : nil
+    }
+
+    let enable = (notification.userInfo?["enable"] as? Bool ?? false)
+    switch notification.name {
+    case .iinaPIPStatusChanged:
+      highlight(.pip, enable)
+    case .iinaFullscreenChanged:
+      highlight(.fullScreen, enable)
+    case .iinaSidebarStatusChanged:
+      // no userInfo is provided in this notification
+      highlight(.settings, sideBarStatus == .settings)
+      highlight(.plugins, sideBarStatus == .plugins)
+      highlight(.playlist, sideBarStatus == .playlist)
+    default:
+      break
     }
   }
 
@@ -1431,6 +1466,7 @@ class MainWindowController: PlayerWindowController {
     
     updateAdditionalInfo()
     player.events.emit(.windowFullscreenChanged, data: true)
+    NotificationCenter.default.post(name: .iinaFullscreenChanged, object: nil, userInfo: ["enable": true])
   }
 
   /// Called if the window failed to enter full screen mode.
@@ -1595,6 +1631,7 @@ class MainWindowController: PlayerWindowController {
     updateWindowParametersForMPV()
 
     player.events.emit(.windowFullscreenChanged, data: false)
+    NotificationCenter.default.post(name: .iinaFullscreenChanged, object: nil, userInfo: ["enable": false])
   }
 
   /// Called if the window failed to exit full screen mode.
@@ -3341,6 +3378,7 @@ extension MainWindowController: PIPViewControllerDelegate {
     }
 
     player.events.emit(.pipChanged, data: true)
+    NotificationCenter.default.post(name: .iinaPIPStatusChanged, object: self, userInfo: ["enable": true])
   }
 
   func exitPIP() {
@@ -3353,6 +3391,7 @@ extension MainWindowController: PIPViewControllerDelegate {
       pip.dismiss(pipVideo!)
     }
     player.events.emit(.pipChanged, data: false)
+    NotificationCenter.default.post(name: .iinaPIPStatusChanged, object: self, userInfo: ["enable": false])
   }
 
   func doneExitingPIP() {

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -859,7 +859,7 @@ struct Preference {
     func alternateImage() -> NSImage? {
       switch self {
       case .settings: return makeSymbol(["gearshape.fill"], NSImage.actionTemplateName)
-      case .playlist: return makeSymbol(["list.bullet.rectangle.fill", "list.bullet.fill"], "playlist")
+      case .playlist: return makeSymbol(["list.bullet.rectangle.fill", "list.bullet"], "playlist")
       case .pip: return makeSymbol(["pip.exit"], "pip")
       case .fullScreen: return makeSymbol(["arrow.down.forward.and.arrow.up.backward.rectangle", "arrow.down.right.and.arrow.up.left"], "fullscreen")
       case .plugins: return makeSymbol(["puzzlepiece.extension.fill"], "plugin")

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -837,21 +837,33 @@ struct Preference {
       }
     }
 
-    func image() -> NSImage {
-      func makeSymbol(_ names: [String], _ fallbackImage: NSImage.Name) -> NSImage {
+    private func makeSymbol(_ names: [String], _ fallbackImage: NSImage.Name) -> NSImage {
         guard #available(macOS 14.0, *) else { return NSImage(named: fallbackImage)! }
         let configuration = NSImage.SymbolConfiguration(pointSize: 14, weight: .medium)
         return NSImage.findSFSymbol(names, withConfiguration: configuration)
       }
+
+    func image() -> NSImage {
       switch self {
       case .settings: return makeSymbol(["gearshape"], NSImage.actionTemplateName)
       case .playlist: return makeSymbol(["list.bullet.rectangle", "list.bullet"], "playlist")
-      case .pip: return makeSymbol(["pip.swap"], "pip")
+      case .pip: return makeSymbol(["pip.enter"], "pip")
       case .fullScreen: return makeSymbol(["arrow.up.backward.and.arrow.down.forward.rectangle", "arrow.up.left.and.arrow.down.right"], "fullscreen")
-      case .musicMode: return makeSymbol(["music.microphone", "music.mic"], "toggle-album-art")
+      case .musicMode: return makeSymbol(["music.microphone"], "toggle-album-art")
       case .subTrack: return makeSymbol(["captions.bubble.fill"], "sub-track")
       case .screenshot: return makeSymbol(["camera.shutter.button"], "screenshot")
       case .plugins: return makeSymbol(["puzzlepiece.extension"], "plugin")
+      }
+    }
+
+    func alternateImage() -> NSImage? {
+      switch self {
+      case .settings: return makeSymbol(["gearshape.fill"], NSImage.actionTemplateName)
+      case .playlist: return makeSymbol(["list.bullet.rectangle.fill", "list.bullet.fill"], "playlist")
+      case .pip: return makeSymbol(["pip.exit"], "pip")
+      case .fullScreen: return makeSymbol(["arrow.down.forward.and.arrow.up.backward.rectangle", "arrow.down.right.and.arrow.up.left"], "fullscreen")
+      case .plugins: return makeSymbol(["puzzlepiece.extension.fill"], "plugin")
+      default: return nil
       }
     }
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)

---

**Description:**
Highlight OSC toolbar buttons when the corresponding view is enabled/shown. Idea from #5867, but implemented a universal solution for all buttons on the OSC toolbar.

Example (pip, playlist, fullscreen enabled):
<img width="1280" height="785" alt="telegram-cloud-photo-size-5-6334452269520196098-y" src="https://github.com/user-attachments/assets/3b533508-708c-4642-b662-ae979a5596a5" />
