### PR TITLE
ui: enclose tableview with scrollview for mpv option editor

### DIFF
--- a/iina/Pages/SettingsPageAdvanced.swift
+++ b/iina/Pages/SettingsPageAdvanced.swift
@@ -90,23 +90,28 @@ class SettingsPageAdvanced: SettingsPage {
 }
 
 fileprivate class MPVOptionsEditor: SettingsAccessory.Base, NSTableViewDelegate, NSTableViewDataSource {
-  let tableView: NSTableView
-  let addBtn: NSButton
-  let delBtn: NSButton
+  private static let dragType = NSPasteboard.PasteboardType("com.colliderli.iina.mpv-option-row")
+
+  let tableView: NSTableView = NSTableView()
+  let scrollView: NSScrollView = NSScrollView()
+  let addBtn: NSButton = NSButton()
+  let delBtn: NSButton = NSButton()
 
   var options: [[String]] = []
 
   override init(l10n: SettingsLocalization.Context) {
-    self.tableView = NSTableView()
-    self.addBtn = NSButton()
-    self.delBtn = NSButton()
     addBtn.bezelStyle = .push
     delBtn.bezelStyle = .push
 
     super.init(l10n: l10n)
     
     let monoFont = NSFont.monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .regular)
-    
+
+    scrollView.documentView = tableView
+    scrollView.drawsBackground = false
+    tableView.backgroundColor = .clear
+    tableView.focusRingType = .none
+    tableView.registerForDraggedTypes([MPVOptionsEditor.dragType])
     tableView.delegate = self
     tableView.dataSource = self
     let columnKey = NSTableColumn(identifier: .key)
@@ -119,11 +124,13 @@ fileprivate class MPVOptionsEditor: SettingsAccessory.Base, NSTableViewDelegate,
     (columnValue.dataCell as? NSCell)?.font = monoFont
     tableView.addTableColumn(columnValue)
     tableView.columnAutoresizingStyle = .sequentialColumnAutoresizingStyle
+    tableView.rowHeight = 18
 
-    let stackView = makeStackView([tableView], orientation: .vertical)
+    let stackView = makeStackView([scrollView], orientation: .vertical)
     view.addSubview(stackView)
-    stackView.padding(.leading(SettingsSubListView.padding), .trailing(0), .bottom(0), .top(0))
-    
+    stackView.padding(.leading(SettingsSubListView.padding + 8), .trailing(0), .bottom(8), .top(0))
+    stackView.size(height: 500)
+
     addBtn.image = .findSFSymbol(["plus"])
     addBtn.target = self
     addBtn.action = #selector(addOptionAction)
@@ -198,5 +205,30 @@ fileprivate class MPVOptionsEditor: SettingsAccessory.Base, NSTableViewDelegate,
       tableView.reloadData()
     }
     delBtn.isEnabled = tableView.selectedRow != -1
+  }
+
+  func tableView(_ tableView: NSTableView, pasteboardWriterForRow row: Int) -> (any NSPasteboardWriting)? {
+    let item = NSPasteboardItem()
+    item.setString(String(row), forType: MPVOptionsEditor.dragType)
+    return item
+  }
+
+  func tableView(_ tableView: NSTableView, validateDrop info: any NSDraggingInfo, proposedRow row: Int, proposedDropOperation dropOperation: NSTableView.DropOperation) -> NSDragOperation {
+    guard dropOperation == .above else { return [] }
+    return .move
+  }
+
+  func tableView(_ tableView: NSTableView, acceptDrop info: any NSDraggingInfo, row: Int, dropOperation: NSTableView.DropOperation) -> Bool {
+    guard let str = info.draggingPasteboard.string(forType: MPVOptionsEditor.dragType),
+          let srcRow = Int(str),
+          srcRow != row, srcRow != row - 1 else { return false }
+    let option = options.remove(at: srcRow)
+    let destRow = srcRow < row ? row - 1 : row
+    options.insert(option, at: destRow)
+    tableView.beginUpdates()
+    tableView.moveRow(at: srcRow, to: destRow)
+    tableView.endUpdates()
+    saveToUserDefaults()
+    return true
   }
 }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
- allows reordering via drag and drop
- display headerview
- set row height to make text vertically centered

<img width="805" height="592" alt="image" src="https://github.com/user-attachments/assets/fe9238ef-5551-4692-9919-75d9745520a3" />
