### PR TITLE
Fix opening audio file 2nd time shows main window, #6065

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -114,7 +114,7 @@ class PlayerCore: NSObject {
           let relevantActivePlayerCore = activePlayerCores.first { $0.info.currentURL == url }
           
           if let relevantActivePlayerCore {
-            relevantActivePlayerCore.mainWindow.window?.makeKeyAndOrderFront(nil)
+            relevantActivePlayerCore.currentController.window?.makeKeyAndOrderFront(nil)
             return currentReturnValue
           }
         }


### PR DESCRIPTION
This commit will change `PlayCore.openURLs` to use `currentController` instead of `mainWindow` when ordering the window of an existing player to the front and making it key.

This corrects a problem when the `Allow opening the same file in multiple windows` setting is disabled, a file is playing in the music player and that same file is opened again.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #6065.

---

**Description:**
