### PR TITLE
Add floating OSC reset action, toolbar button, and command (#6011)

### DIFF
--- a/iina/Base.lproj/KeyBinding.strings
+++ b/iina/Base.lproj/KeyBinding.strings
@@ -55,6 +55,7 @@
 "iina.show-current-file-in-finder" = "Show current file in Finder";
 "iina.delete-current-file" = "Delete current file";
 "iina.delete-current-file-hard" = "Delete current file directly without moving to trash";
+"iina.reset-control-bar-position" = "Reset floating OSC position";
 "iina.find-online-subs" = "Find online subtitles";
 "iina.save-downloaded-sub" = "Save downloaded subtitle";
 

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -417,6 +417,7 @@
 "osc_toolbar.sub_track" = "Choose subtitle track";
 "osc_toolbar.screenshot" = "Take a screenshot";
 "osc_toolbar.plugins" = "Show plugins panel";
+"osc_toolbar.reset_position" = "Reset toolbar position";
 
 "mini_player.album_art" = "Toggle album art";
 "mini_player.loop" = "Repeat";

--- a/iina/IINACommand.swift
+++ b/iina/IINACommand.swift
@@ -33,6 +33,7 @@ enum IINACommand: String {
   case showCurrentFileInFinder = "show-current-file-in-finder"
   case deleteCurrentFile = "delete-current-file"
   case deleteCurrentFileHard = "delete-current-file-hard"
+  case resetControlBarPosition = "reset-control-bar-position"
 
   case findOnlineSubs = "find-online-subs"
   case saveDownloadedSub = "save-downloaded-sub"

--- a/iina/LanguageTokenField.swift
+++ b/iina/LanguageTokenField.swift
@@ -128,17 +128,16 @@ class LanguageTokenField: NSTokenField {
 
   func controlTextDidChange(_ obj: Notification) {
     guard let layoutManager = layoutManager else { return }
-    // WORKAROUND Xcode 26.4 defect where referencing NSTextAttachment.character causes a
-    // compilation error. As NSAttachmentCharacter was obsoleted in Swift 4.2, Xcode versions
-    // before 26.4 will not allow it to be used. As support for Swift 6.3 was added in 26.4 we can
-    // key off the Swift support to workaround the Xcode 26.4 defect without breaking support for
-    // older working versions of Xcode.
+    // Choose the correct attachment character depending on compiler/SDK availability.
+    // `NSTextAttachment.character` is the modern API; `NSAttachmentCharacter` is the older
+    // constant. Use `NSTextAttachment.character` for newer compilers/SDKs.
     let attachmentChar: Character
-#if compiler(>=6.3)
+  #if compiler(>=6.3)
+    let scalar = UnicodeScalar(UInt32(NSTextAttachment.character))
+    attachmentChar = Character(scalar!)
+  #else
     attachmentChar = Character(UnicodeScalar(NSAttachmentCharacter)!)
-#else
-    attachmentChar = Character(UnicodeScalar(NSTextAttachment.character)!)
-#endif
+  #endif
     let finished = layoutManager.attributedString().string.split(separator: attachmentChar).count == 0
     if finished {
       Logger.log("LTF Submitting changes from controlTextDidChange()", level: .verbose)

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1780,44 +1780,7 @@ class MainWindowController: PlayerWindowController {
       cropSettingsView?.cropBoxView.resized()
     }
 
-    // update control bar position
-    if oscPosition == .floating {
-      let cph = Preference.float(for: .controlBarPositionHorizontal)
-      let cpv = Preference.float(for: .controlBarPositionVertical)
-
-      let windowWidth = window.frame.width
-      let margin: CGFloat = 10
-      let minWindowWidth: CGFloat = 480 // 460 + 20 margin
-      var xPos: CGFloat
-
-      if windowWidth < minWindowWidth {
-        // osc is compressed
-        xPos = windowWidth / 2
-      } else {
-        // osc has full width
-        let oscHalfWidth: CGFloat = 230
-        xPos = windowWidth * CGFloat(cph)
-        if xPos - oscHalfWidth < margin {
-          xPos = oscHalfWidth + margin
-        } else if xPos + oscHalfWidth + margin > windowWidth {
-          xPos = windowWidth - oscHalfWidth - margin
-        }
-      }
-
-      let windowHeight = window.frame.height
-      var yPos = windowHeight * CGFloat(cpv)
-      let oscHeight: CGFloat = 67
-      let yMargin: CGFloat = 25
-
-      if yPos < 0 {
-        yPos = 0
-      } else if yPos + oscHeight + yMargin > windowHeight {
-        yPos = windowHeight - oscHeight - yMargin
-      }
-
-      controlBarFloating.xConstraint.constant = xPos
-      controlBarFloating.yConstraint.constant = yPos
-    }
+    updateFloatingControlBarPosition()
     
     // Detach the views in oscFloatingTopView manually on macOS 11 only; as it will cause freeze
     if isMacOS11 && oscPosition == .floating {
@@ -3287,6 +3250,8 @@ class MainWindowController: PlayerWindowController {
       player.screenshot()
     case .plugins:
       showPluginSidebar(tab: nil)
+    case .resetPosition:
+      resetFloatingOSCPosition()
     }
   }
 
@@ -3299,6 +3264,54 @@ class MainWindowController: PlayerWindowController {
     } else {
       window?.collectionBehavior = [.managed, .fullScreenPrimary]
     }
+  }
+
+  internal func resetFloatingOSCPosition() {
+    let defaultHorizontal = (Preference.defaultPreference[.controlBarPositionHorizontal] as? Float) ?? 0.5
+    let defaultVertical = (Preference.defaultPreference[.controlBarPositionVertical] as? Float) ?? 0.1
+    Preference.set(defaultHorizontal, for: .controlBarPositionHorizontal)
+    Preference.set(defaultVertical, for: .controlBarPositionVertical)
+    updateFloatingControlBarPosition()
+  }
+
+  private func updateFloatingControlBarPosition() {
+    guard let window = window, oscPosition == .floating else { return }
+
+    let cph = Preference.float(for: .controlBarPositionHorizontal)
+    let cpv = Preference.float(for: .controlBarPositionVertical)
+
+    let windowWidth = window.frame.width
+    let margin: CGFloat = 10
+    let minWindowWidth: CGFloat = 480 // 460 + 20 margin
+    var xPos: CGFloat
+
+    if windowWidth < minWindowWidth {
+      // osc is compressed
+      xPos = windowWidth / 2
+    } else {
+      // osc has full width
+      let oscHalfWidth: CGFloat = 230
+      xPos = windowWidth * CGFloat(cph)
+      if xPos - oscHalfWidth < margin {
+        xPos = oscHalfWidth + margin
+      } else if xPos + oscHalfWidth + margin > windowWidth {
+        xPos = windowWidth - oscHalfWidth - margin
+      }
+    }
+
+    let windowHeight = window.frame.height
+    var yPos = windowHeight * CGFloat(cpv)
+    let oscHeight: CGFloat = 67
+    let yMargin: CGFloat = 25
+
+    if yPos < 0 {
+      yPos = 0
+    } else if yPos + oscHeight + yMargin > windowHeight {
+      yPos = windowHeight - oscHeight - yMargin
+    }
+
+    controlBarFloating.xConstraint.constant = xPos
+    controlBarFloating.yConstraint.constant = yPos
   }
 
 }

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -702,6 +702,8 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
       menuActionHandler.menuDeleteCurrentFile(.dummy)
     case .deleteCurrentFileHard:
       menuActionHandler.menuDeleteCurrentFileHard(.dummy)
+    case .resetControlBarPosition:
+      player.mainWindow.resetFloatingOSCPosition()
     default:
       break
     }

--- a/iina/PrefOSCToolbarSettingsSheetController.swift
+++ b/iina/PrefOSCToolbarSettingsSheetController.swift
@@ -34,7 +34,7 @@ class PrefOSCToolbarSettingsSheetController: NSWindowController, PrefOSCToolbarC
     currentItemsView.currentItemsViewDelegate = self
     currentItemsView.initItems(fromItems: PrefUIViewController.oscToolbarButtons)
 
-    let allButtonTypes: [Preference.ToolBarButton] = [.settings, .playlist, .pip, .fullScreen, .musicMode, .subTrack, .screenshot, .plugins]
+    let allButtonTypes: [Preference.ToolBarButton] = [.settings, .playlist, .pip, .fullScreen, .musicMode, .subTrack, .screenshot, .plugins, .resetPosition]
     for type in allButtonTypes {
       let itemViewController = PrefOSCToolbarDraggingItemViewController(buttonType: type)
       itemViewController.availableItemsView = availableItemsView

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -823,6 +823,7 @@ struct Preference {
     case subTrack
     case screenshot
     case plugins
+    case resetPosition
 
     var description: String {
       switch self {
@@ -834,6 +835,7 @@ struct Preference {
       case .subTrack: "subTrack"
       case .screenshot: "screenshot"
       case .plugins: "plugins"
+      case .resetPosition: "resetPosition"
       }
     }
 
@@ -852,6 +854,7 @@ struct Preference {
       case .subTrack: return makeSymbol(["captions.bubble.fill"], "sub-track")
       case .screenshot: return makeSymbol(["camera.shutter.button"], "screenshot")
       case .plugins: return makeSymbol(["puzzlepiece.extension"], "plugin")
+      case .resetPosition: return makeSymbol(["arrow.counterclockwise"], NSImage.refreshTemplateName)
       }
     }
 
@@ -866,6 +869,7 @@ struct Preference {
       case .subTrack: key = "sub_track"
       case .screenshot: key = "screenshot"
       case .plugins: key = "plugins"
+      case .resetPosition: key = "reset_position"
       }
       return NSLocalizedString("osc_toolbar.\(key)", comment: key)
     }
@@ -956,7 +960,7 @@ struct Preference {
     .controlBarStickToCenter: true,
     .controlBarAutoHideTimeout: Float(2.5),
     .enableControlBarAutoHide: true,
-    .controlBarToolbarButtons: [ToolBarButton.plugins.rawValue, ToolBarButton.pip.rawValue, ToolBarButton.playlist.rawValue, ToolBarButton.settings.rawValue],
+    .controlBarToolbarButtons: [ToolBarButton.plugins.rawValue, ToolBarButton.pip.rawValue, ToolBarButton.playlist.rawValue, ToolBarButton.resetPosition.rawValue, ToolBarButton.settings.rawValue],
     .oscPosition: OSCPosition.floating.rawValue,
     .disablePlaySliderScrolling: false,
     .disableVolumeSliderScrolling: false,

--- a/iina/config/iina-default-input.conf
+++ b/iina/config/iina-default-input.conf
@@ -4,6 +4,7 @@
 #@iina Shift+Meta+v video-panel
 #@iina Shift+Meta+a audio-panel
 #@iina Shift+Meta+s sub-panel
+#@iina Shift+Meta+0 reset-control-bar-position
 
 Ctrl+Meta+v cycle video
 Ctrl+Meta+s cycle sub

--- a/iina/config/input.conf
+++ b/iina/config/input.conf
@@ -33,6 +33,7 @@
 #@iina Shift+Meta+m toggle-music-mode
 #@iina Ctrl+Meta+p toggle-pip
 #@iina Shift+Meta+r show-current-file-in-finder
+#@iina Shift+Meta+0 reset-control-bar-position
 
 MBTN_LEFT     ignore              # don't do anything
 MBTN_LEFT_DBL cycle fullscreen    # toggle fullscreen

--- a/iina/en.lproj/KeyBinding.strings
+++ b/iina/en.lproj/KeyBinding.strings
@@ -55,6 +55,7 @@
 "iina.show-current-file-in-finder" = "Show current file in Finder";
 "iina.delete-current-file" = "Delete current file";
 "iina.delete-current-file-hard" = "Delete current file directly without moving to trash";
+"iina.reset-control-bar-position" = "Reset floating OSC position";
 "iina.find-online-subs" = "Find online subtitles";
 "iina.save-downloaded-sub" = "Save downloaded subtitle";
 

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -418,6 +418,7 @@
 "osc_toolbar.sub_track" = "Choose subtitle track";
 "osc_toolbar.screenshot" = "Take a screenshot";
 "osc_toolbar.plugins" = "Show plugins panel";
+"osc_toolbar.reset_position" = "Reset toolbar position";
 
 "mini_player.album_art" = "Toggle album art";
 "mini_player.loop" = "Repeat";


### PR DESCRIPTION
## Description
Adds a floating On-Screen Controller (OSC) reset feature via a new toolbar button and keyboard shortcut (Default:Shift+⌘0).

## Changes
- **MainWindowController.swift**: Extract floating OSC placement logic into `updateFloatingControlBarPosition()` and add `resetFloatingOSCPosition()` to restore default positions.
- **IINACommand.swift & PlayerWindowController.swift**: Add `reset-control-bar-position` command routing.
- **Preference.swift & PrefOSCToolbarSettingsSheetController.swift**: Add `.resetPosition` toolbar button with refresh icon and expose in toolbar settings.
- **KeyBinding.strings & Localizable.strings**: Add Base/en localization strings for button tooltip and keybinding label.
- **config/iina-default-input.conf & config/input.conf**: Add suggested default keybinding and keybinding hint.

## Localization
- Added strings only to `Base.lproj` and `en.lproj` per CONTRIBUTING guidelines.
- Other locale translations will be synced via Crowdin.

## Testing
- Run the application and drag floating OSC.
- Click the new "Reset" button or press Shift+⌘0 to restore OSC to default position .
- Verify position persists across app restart by checking `~/Library/Preferences/com.iina.iina.plist` for `controlBarPositionHorizontal: 0.5` and `controlBarPositionVertical: 0.1`.

## Related
Closes #6011