### PR TITLE
Change volume slider to be greyscale

### DIFF
--- a/iina/Assets.xcassets/Colors/VolumeSliderBarLeft.colorset/Contents.json
+++ b/iina/Assets.xcassets/Colors/VolumeSliderBarLeft.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.400",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.300",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iina/Assets.xcassets/Colors/VolumeSliderBarRight.colorset/Contents.json
+++ b/iina/Assets.xcassets/Colors/VolumeSliderBarRight.colorset/Contents.json
@@ -1,0 +1,38 @@
+{
+  "colors" : [
+    {
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.100",
+          "blue" : "0.000",
+          "green" : "0.000",
+          "red" : "0.000"
+        }
+      },
+      "idiom" : "universal"
+    },
+    {
+      "appearances" : [
+        {
+          "appearance" : "luminosity",
+          "value" : "dark"
+        }
+      ],
+      "color" : {
+        "color-space" : "srgb",
+        "components" : {
+          "alpha" : "0.100",
+          "blue" : "1.000",
+          "green" : "1.000",
+          "red" : "1.000"
+        }
+      },
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/iina/VolumeSliderCell.swift
+++ b/iina/VolumeSliderCell.swift
@@ -15,17 +15,72 @@ class VolumeSliderCell: NSSliderCell {
     maxValue = Double(Preference.integer(for: .maxVolume))
   }
 
+  /// Draws the slider’s bar—but not its bezel or knob—inside the specified rectangle.
+  ///
+  /// IINA overrides the
+  /// [NSSliderCell.drawBar](https://developer.apple.com/documentation/appkit/nsslidercell/drawbar(inside:flipped:))
+  /// method in order to:
+  /// - Round the ends of the slider bar (matching the playback position slider)
+  /// - Alter the colors of the bar
+  /// - Leave a small gap that marks the position representing 100% volume, when the `Maximum volume` setting has been used to
+  ///     allow the volume to be set beyond 100%
+  ///
+  /// As merely moving the cursor displays the on screen controller it is desirable that this UI element not be intrusive. For this reason
+  /// the OSC intentionally differs in its appearance from other user interface elements. To make the OSC have a subtle appearance a
+  /// greyscale color scheme is used. In particular it is important to override the use of
+  /// [controlAccentColor](https://developer.apple.com/documentation/appkit/nscolor/controlaccentcolor)
+  /// by [NSSlider](https://developer.apple.com/documentation/appkit/nsslider) as that color is intended to stand
+  /// out and attract attention.
+  /// - Parameters:
+  ///   - rect: The bounds of the slider’s bar, not of its interior rectangle.
+  ///   - flipped: A Boolean value that indicates whether the cell’s control view—that is, the `NSSlider` or `NSMatrix`
+  ///       associated with the` NSSliderCell`—has a flipped coordinate system.
   override func drawBar(inside rect: NSRect, flipped: Bool) {
-    NSGraphicsContext.saveGraphicsState()
+
+    // The position of the knob, rounded for cleaner drawing.
+    let knobPos: CGFloat = round(knobRect(flipped: flipped).origin.x);
+
+    // Round the slider bar ends like is done for the playback progress slider.
+    let radius: CGFloat = 1.5
+    let path = NSBezierPath(roundedRect: rect, xRadius: radius, yRadius: radius)
+
+    // The position at which volume is set to 100 rounded to obtain a pixel perfect clip line.
+    let x100 = round(rect.minX + rect.width * CGFloat(100 / maxValue))
+
+    // If the IINA "Maximum volume" setting has been increased beyond 100 then the slider bar will
+    // be drawn with a small gap at the position that represents 100% volume.
+    let gapClip: NSBezierPath?
     if maxValue > 100 {
-      // round this value to obtain a pixel perfect clip line
-      let x = round(rect.minX + rect.width * CGFloat(100 / maxValue))
-      let clipPath = NSBezierPath(rect: NSRect(x: rect.minX, y: rect.minY, width: x - 1, height: rect.height))
-      clipPath.append(NSBezierPath(rect: NSRect(x: x + 1, y: rect.minY, width: rect.maxX - x - 1, height: rect.height)))
-      clipPath.setClip()
+      let width: CGFloat = 2
+      let gapRect = NSMakeRect(x100 - width / 2, rect.minY, width, rect.height)
+      gapClip = NSBezierPath(rect: gapRect).reversed
+    } else {
+      gapClip = nil
     }
-    super.drawBar(inside: rect, flipped: flipped)
+
+    // Draw the portion of the slider bar that is to the left of the knob.
+    NSGraphicsContext.saveGraphicsState()
+    let clipLeft = NSBezierPath(rect: NSMakeRect(rect.minX, rect.minY, knobPos, rect.height))
+    if let gapClip, x100 < knobPos {
+      // The gap representing 100% volume is in this portion of the bar.
+      clipLeft.append(gapClip)
+    }
+    clipLeft.addClip()
+    NSColor.volumeSliderBarLeft.setFill()
+    path.fill()
+    NSGraphicsContext.restoreGraphicsState()
+
+    // Draw the portion of the slider bar that is to the right of the knob.
+    NSGraphicsContext.saveGraphicsState()
+    let rightRect = NSMakeRect(rect.minX + knobPos, rect.minY, rect.width - knobPos, rect.height)
+    let clipRight = NSBezierPath(rect: rightRect)
+    if let gapClip, knobPos < x100 {
+      // The gap representing 100% volume is in this portion of the bar.
+      clipRight.append(gapClip)
+    }
+    clipRight.addClip()
+    NSColor.volumeSliderBarRight.setFill()
+    path.fill()
     NSGraphicsContext.restoreGraphicsState()
   }
-
 }


### PR DESCRIPTION
This commit will:
- Change `VolumeSliderCell.drawBar` to draw the full slider bar itself using greyscale colors
- Change `drawBar` to round the ends of the slider bar (matching the playback position slider)
- Change `drawBar` to correctly draw the gap in the bar representing 100% volume

These changes will cause the volume slider to match up with the greyscale color scheme of the reset of the on screen controller. They will also fix a problem with failing to draw the small gap that marks the position representing 100% volume. This indicator is present when the IINA `Maximum volume` setting is used to allow the volume to exceed 100%.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
