### PR TITLE
Searching in the new Settings window (with refactor)

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -404,6 +404,7 @@
 		E38EA5AE2F31429F00FB51CE /* SettingsPagePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38EA5AD2F31429900FB51CE /* SettingsPagePlugin.swift */; };
 		E38EA5B12F3142C700FB51CE /* SettingsPluginLocalizable.strings in Resources */ = {isa = PBXBuildFile; fileRef = E38EA5B02F3142C700FB51CE /* SettingsPluginLocalizable.strings */; };
 		E38EA5B22F3142C700FB51CE /* SettingsLocalizationKeysPlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38EA5AF2F3142C700FB51CE /* SettingsLocalizationKeysPlugin.swift */; };
+		E392B8CC2FB2263F005F2C24 /* SettingsSearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = E392B8CB2FB2263A005F2C24 /* SettingsSearch.swift */; };
 		E3958565253133E80096811F /* SidebarTabView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3958563253133E80096811F /* SidebarTabView.swift */; };
 		E3958566253133E80096811F /* SidebarTabView.xib in Resources */ = {isa = PBXBuildFile; fileRef = E3958564253133E80096811F /* SidebarTabView.xib */; };
 		E3958586253309C90096811F /* PluginSidebarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3958585253309C90096811F /* PluginSidebarView.swift */; };
@@ -1960,6 +1961,7 @@
 		E38EA5AD2F31429900FB51CE /* SettingsPagePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPagePlugin.swift; sourceTree = "<group>"; };
 		E38EA5AF2F3142C700FB51CE /* SettingsLocalizationKeysPlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsLocalizationKeysPlugin.swift; sourceTree = "<group>"; };
 		E38EA5B02F3142C700FB51CE /* SettingsPluginLocalizable.strings */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; path = SettingsPluginLocalizable.strings; sourceTree = "<group>"; };
+		E392B8CB2FB2263A005F2C24 /* SettingsSearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsSearch.swift; sourceTree = "<group>"; };
 		E393669923BDD1850070D626 /* IINA.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = IINA.entitlements; sourceTree = "<group>"; };
 		E3958563253133E80096811F /* SidebarTabView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarTabView.swift; sourceTree = "<group>"; };
 		E3958564253133E80096811F /* SidebarTabView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = SidebarTabView.xib; sourceTree = "<group>"; };
@@ -2852,6 +2854,7 @@
 				E34BC28C2C27733200A94680 /* SettingsPage.swift */,
 				E34BC28E2C27A68100A94680 /* SettingsItem.swift */,
 				E34BC2AB2C27DAE900A94680 /* SettingsHelper.swift */,
+				E392B8CB2FB2263A005F2C24 /* SettingsSearch.swift */,
 				E3EC8C402F92E69C00FBB51E /* PluginManager.swift */,
 				E3EC8C452F9475BC00FBB51E /* PluginStorePanel.swift */,
 			);
@@ -3387,6 +3390,7 @@
 				E34EAA83251A36CE00057F27 /* JavascriptAPIFile.swift in Sources */,
 				E32712B024EAA14500359DAB /* ScreenshootOSDView.swift in Sources */,
 				E3BA79EE2131443A00529D99 /* OpenURLWindowController.swift in Sources */,
+				E392B8CC2FB2263F005F2C24 /* SettingsSearch.swift in Sources */,
 				E3FF5AC02938582F0019CE45 /* JavascriptDevTool.swift in Sources */,
 				84FBCB381EEACDDD0076C77C /* FFmpegController.m in Sources */,
 				84879A981E0FFC7E0004F894 /* PrefUIViewController.swift in Sources */,

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -16,6 +16,7 @@
 "general.username" = "Username";
 "general.password" = "Password";
 "general.na" = "N/A";
+"general.no_result" = "No Result";
 
 "input.value_is_empty" = "Value cannot be empty.";
 "input.already_exists" = "Value already exists.";

--- a/iina/ConstraintsSugar.swift
+++ b/iina/ConstraintsSugar.swift
@@ -131,9 +131,16 @@ extension NSView {
     let noArg = x == nil && y == nil
     if x == true || noArg {
       self.superview!.addConstraint(self.centerXAnchor.constraint(equalTo: aView.centerXAnchor))
-    } else if y == true || noArg {
+    }
+    if y == true || noArg {
       self.superview!.addConstraint(self.centerYAnchor.constraint(equalTo: aView.centerYAnchor))
     }
+    return self
+  }
+
+  @discardableResult
+  func alignBaseLine(with aView: NSView) -> Self {
+    self.superview!.addConstraint(self.firstBaselineAnchor.constraint(equalTo: aView.firstBaselineAnchor))
     return self
   }
 

--- a/iina/Pages/SettingsPageAdvanced.swift
+++ b/iina/Pages/SettingsPageAdvanced.swift
@@ -7,18 +7,22 @@
 //
 
 class SettingsPageAdvanced: SettingsPage {
+  override var identifier: String {
+    "advanced"
+  }
+  
   override var title: String {
     return NSLocalizedString("preference.advanced", comment: "Advanced")
   }
-  
+
   override var image: NSImage {
     return makeSymbol("flask", fallbackImage: "pref_advanced")
   }
-  
+
   override var localizationTable: String {
     "SettingsAdvancedLocalizable"
   }
-  
+
   private lazy var fileChooseView: SettingsAccessory.FileChooserView = .init(.userDefinedConfDir)
   private lazy var mpvOptionsEditor: MPVOptionsEditor = .init(l10n: localizationContext)
   private lazy var openLogFolderBtn: NSButton = {
@@ -27,17 +31,17 @@ class SettingsPageAdvanced: SettingsPage {
     return btn
   }()
 
-  override func content() -> NSView {
+  override func content() -> [SettingsSection] {
     return sections {
       sectionEnableAdvanced()
       sectionLogging()
       sectionMPV()
     }
   }
-  
-  private func sectionEnableAdvanced() -> [NSView] {
+
+  private func sectionEnableAdvanced() -> SettingsSection {
     return section {
-      SettingsListView() {
+      SettingsList() {
         SettingsItem.Switch()
           .bindTo(.enableAdvancedSettings)
           .image(name: ["flask"])
@@ -47,9 +51,9 @@ class SettingsPageAdvanced: SettingsPage {
     }
   }
 
-  private func sectionLogging() -> [NSView] {
+  private func sectionLogging() -> SettingsSection {
     return section {
-      SettingsListView(title: .text_Logging) {
+      SettingsList(title: .text_Logging) {
         SettingsItem.PopupButton()
           .bindTo(.logLevel, ofType: Logger.Level.self)
           .image(name: "cylinder.split.1x2")
@@ -57,28 +61,28 @@ class SettingsPageAdvanced: SettingsPage {
           .bindTo(.enableLogging)
           .extraViews(openLogFolderBtn)
       }
-      SettingsListView {
+      SettingsList {
         SettingsItem.General(title: .text_OpenLogWindow)
           .image(name: "macwindow")
           .extraViews(NSButton(image: .findSFSymbol(["arrow.right"])!, target: AppDelegate.shared, action: #selector(AppDelegate.showLogWindow)))
       }
     }
   }
-  
-  private func sectionMPV() -> [NSView] {
+
+  private func sectionMPV() -> SettingsSection {
     return section {
-      SettingsListView(title: .text_MPVSettings) {
+      SettingsList(title: .text_MPVSettings) {
         SettingsItem.Switch()
           .bindTo(.useMpvOsd)
           .image(name: "ellipsis.bubble")
       }
-      SettingsListView {
+      SettingsList {
         SettingsItem.Switch()
           .image(name: ["folder.badge.gearshape", "folder.badge.gear"])
           .bindTo(.useUserDefinedConfDir)
           .extraViews(fileChooseView.textField, fileChooseView.chooseButton)
       }
-      SettingsListView {
+      SettingsList {
         SettingsItem.General(title: .text_AdditionalMpvOptions)
           .image(name: ["document.badge.gearshape", "doc.badge.gearshape"])
           .extraViews(mpvOptionsEditor.delBtn, mpvOptionsEditor.addBtn)
@@ -104,7 +108,7 @@ fileprivate class MPVOptionsEditor: SettingsAccessory.Base, NSTableViewDelegate,
     delBtn.bezelStyle = .push
 
     super.init(l10n: l10n)
-    
+
     let monoFont = NSFont.monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .regular)
 
     scrollView.documentView = tableView
@@ -126,9 +130,9 @@ fileprivate class MPVOptionsEditor: SettingsAccessory.Base, NSTableViewDelegate,
     tableView.columnAutoresizingStyle = .sequentialColumnAutoresizingStyle
     tableView.rowHeight = 18
 
-    let stackView = makeStackView([scrollView], orientation: .vertical)
+    let stackView = ui.vStack(scrollView)
     view.addSubview(stackView)
-    stackView.padding(.leading(SettingsSubListView.padding + 8), .trailing(0), .bottom(8), .top(0))
+    stackView.padding(.leading(SettingsSubList.indent + 8), .trailing(0), .bottom(8), .top(0))
     stackView.size(height: 120)
 
     addBtn.image = .findSFSymbol(["plus"])
@@ -145,12 +149,12 @@ fileprivate class MPVOptionsEditor: SettingsAccessory.Base, NSTableViewDelegate,
     }
     options = op
   }
-  
+
   private func saveToUserDefaults() {
     Preference.set(options, for: .userOptions)
     UserDefaults.standard.synchronize()
   }
-  
+
   @objc func addOptionAction(_ sender: AnyObject) {
     options.append(["name", "value"])
     tableView.reloadData()

--- a/iina/Pages/SettingsPageControl.swift
+++ b/iina/Pages/SettingsPageControl.swift
@@ -7,32 +7,36 @@
 //
 
 class SettingsPageControl: SettingsPage {
+  override var identifier: String {
+    "control"
+  }
+  
   override var title: String {
     return NSLocalizedString("preference.control", comment: "control")
   }
-  
+
   override var image: NSImage {
     return makeSymbol("computermouse", fallbackImage: "pref_network")
   }
-  
+
   override var localizationTable: String {
     "SettingsControlLocalizable"
   }
-  
+
   private lazy var sensSeek: SliderView = .init(l10n: localizationContext, key: .relativeSeekAmount)
   private lazy var sensVolume: SliderView = .init(l10n: localizationContext, key: .volumeScrollAmount)
   private lazy var sensSpeed: SliderView = .init(l10n: localizationContext, key: .playbackSpeedScrollAmount)
 
-  override func content() -> NSView {
+  override func content() -> [SettingsSection] {
     return sections {
       sectionTrackpad()
       sectionMouse()
     }
   }
-  
-  private func sectionTrackpad() -> [NSView] {
+
+  private func sectionTrackpad() -> SettingsSection {
     return section {
-      SettingsListView(title: .text_Trackpad) {
+      SettingsList(title: .text_Trackpad) {
         SettingsItem.PopupButton()
           .bindTo(.pinchAction, ofType: Preference.PinchAction.self)
           .image(name: "rectangle.fill")
@@ -41,10 +45,10 @@ class SettingsPageControl: SettingsPage {
       }
     }
   }
-  
-  private func sectionMouse() -> [NSView] {
+
+  private func sectionMouse() -> SettingsSection {
     return section {
-      SettingsListView(title: .text_Mouse) {
+      SettingsList(title: .text_Mouse) {
         SettingsItem.PopupButton()
           .bindTo(.singleClickAction, ofType: Preference.MouseClickAction.self)
           .image(name: ["pointer.arrow.click", "cursorarrow.click"])
@@ -58,14 +62,14 @@ class SettingsPageControl: SettingsPage {
           .bindTo(.videoViewAcceptsFirstMouse)
           .image(name: ["macwindow.and.pointer.arrow", "macwindow.and.cursorarrow"])
       }
-      SettingsListView {
+      SettingsList {
         SettingsItem.PopupButton()
           .bindTo(.verticalScrollAction, ofType: Preference.ScrollAction.self)
           .image(name: "magicmouse.fill")
         SettingsItem.PopupButton()
           .bindTo(.horizontalScrollAction, ofType: Preference.ScrollAction.self)
       }
-      SettingsListView {
+      SettingsList {
         SettingsItem.PopupButton()
           .bindTo(.useExactSeek, ofType: Preference.SeekOption.self)
           .image(name: ["15.arrow.trianglehead.clockwise", "goforward.15"])
@@ -84,23 +88,23 @@ class SettingsPageControl: SettingsPage {
 fileprivate class SliderView: SettingsAccessory.Base {
   init(l10n: SettingsLocalization.Context, key: Preference.Key) {
     super.init(l10n: l10n)
-    
+
     let label = NSTextField(labelWithString: l10n.localized(.init("\(key.rawValue).label")))
     label.translatesAutoresizingMaskIntoConstraints = false
     let slider = NSSlider()
     slider.translatesAutoresizingMaskIntoConstraints = false
-    
+
     slider.allowsTickMarkValuesOnly = true
     slider.numberOfTickMarks = 4
     slider.minValue = 1
     slider.maxValue = 4
     slider.size(width: 100)
     slider.bind(.value, to: UserDefaults.standard, withKeyPath: key.rawValue)
-    
+
     view.addSubview(label)
     view.addSubview(slider)
-    
-    label.padding(.leading(SettingsSubListView.padding + 8), .vertical(12))
+
+    label.padding(.leading(SettingsSubList.indent + 8), .vertical(12))
     slider.padding(.trailing(16))
       .center(with: label, y: true)
       .flexibleSpacingTo(view: label)

--- a/iina/Pages/SettingsPageGeneral.swift
+++ b/iina/Pages/SettingsPageGeneral.swift
@@ -11,6 +11,10 @@ import Foundation
 class SettingsPageGeneral: SettingsPage {
   private lazy var fileChooseView: SettingsAccessory.FileChooserView = .init(.screenshotFolder)
 
+  override var identifier: String {
+    "general"
+  }
+
   override var title: String {
     return NSLocalizedString("preference.general", comment: "General")
   }
@@ -23,7 +27,7 @@ class SettingsPageGeneral: SettingsPage {
     "SettingsGeneralLocalizable"
   }
 
-  override func content() -> NSView {
+  override func content() -> [SettingsSection] {
     return sections {
       sectionBehavior()
       sectionHistory()
@@ -32,9 +36,9 @@ class SettingsPageGeneral: SettingsPage {
     }
   }
 
-  private func sectionBehavior() -> [NSView] {
+  private func sectionBehavior() -> SettingsSection {
     return section {
-      SettingsListView(title: .text_Behavior) {
+      SettingsList(title: .text_Behavior) {
         SettingsItem.PopupButton()
           .image(name: "custom.menubar.rectangle.badge.sparkles")
           .bindTo(.actionAfterLaunch, ofType: Preference.ActionAfterLaunch.self)
@@ -46,7 +50,7 @@ class SettingsPageGeneral: SettingsPage {
             SettingsItem.Switch()
               .bindTo(.fullScreenWhenOpen)
           }
-        SettingsItem.General(title: .text_PauseresumeWhen)
+        SettingsItem.General(title: .pauseresumeWhen)
           .image(name: "custom.playpause.arrow.trianglehead.clockwise")
           .withExpandingDetailView {
             SettingsItem.Switch()
@@ -62,7 +66,7 @@ class SettingsPageGeneral: SettingsPage {
           }
       }
 
-      SettingsListView {
+      SettingsList {
         SettingsItem.Switch()
           .image(name: "macwindow.on.rectangle")
           .bindTo(.alwaysOpenInNewWindow)
@@ -80,7 +84,7 @@ class SettingsPageGeneral: SettingsPage {
           .bindTo(.keepOpenOnFileEnd)
       }
 
-      SettingsListView {
+      SettingsList {
         SettingsItem.Switch()
           .image(name: ["arrow.up.left.and.arrow.down.right.rectangle", "rectangle.expand.diagonal"])
           .bindTo(.useLegacyFullScreen)
@@ -97,13 +101,13 @@ class SettingsPageGeneral: SettingsPage {
           }
       }
 
-      SettingsListView {
+      SettingsList {
         SettingsItem.Switch()
           .image(name: "music.note.list")
           .bindTo(.autoSwitchToMusicMode)
       }
 
-      SettingsListView {
+      SettingsList {
         SettingsItem.SwitchWithPopupButton(title: .text_CheckForUpdates)
           .image(name: "arrowshape.up.circle")
           .bindSwitchToCustom {
@@ -120,9 +124,9 @@ class SettingsPageGeneral: SettingsPage {
     }
   }
 
-  private func sectionHistory() -> [NSView] {
+  private func sectionHistory() -> SettingsSection {
     return section {
-      SettingsListView(title: .text_History) {
+      SettingsList(title: .text_History) {
         SettingsItem.Switch()
           .image(name: "custom.arrow.clockwise.badge.clock")
           .bindTo(.resumeLastPosition)
@@ -141,9 +145,9 @@ class SettingsPageGeneral: SettingsPage {
     }
   }
 
-  private func sectionPlayList() -> [NSView] {
+  private func sectionPlayList() -> SettingsSection {
     return section {
-      SettingsListView(title: .text_Playlist) {
+      SettingsList(title: .text_Playlist) {
         SettingsItem.Switch()
           .image(name: "custom.list.bullet.badge.plus")
           .bindTo(.playlistAutoAdd)
@@ -166,9 +170,9 @@ class SettingsPageGeneral: SettingsPage {
     }
   }
 
-  private func sectionScreenshots() -> [NSView] {
+  private func sectionScreenshots() -> SettingsSection {
     return section {
-      SettingsListView(title: .text_Screenshots) {
+      SettingsList(title: .text_Screenshots) {
         SettingsItem.Switch()
           .image(name: "camera.on.rectangle")
           .bindTo(.screenshotSaveToFile)

--- a/iina/Pages/SettingsPageKeyBindings.swift
+++ b/iina/Pages/SettingsPageKeyBindings.swift
@@ -7,6 +7,10 @@
 //
 
 class SettingsPageKeyBindings: SettingsPage {
+  override var identifier: String {
+    "key.bindings"
+  }
+  
   override var title: String {
     return NSLocalizedString("preference.keybindings", comment: "Key Bindings")
   }
@@ -21,16 +25,16 @@ class SettingsPageKeyBindings: SettingsPage {
 
   private lazy var configEditor: ConfigEditor = .init(l10n: localizationContext)
 
-  override func content() -> NSView {
+  override func content() -> [SettingsSection] {
     return sections {
       sectionMediaControl()
       sectionConfiguration()
     }
   }
 
-  private func sectionMediaControl() -> [NSView] {
+  private func sectionMediaControl() -> SettingsSection {
     return section {
-      SettingsListView {
+      SettingsList {
         SettingsItem.Switch()
           .bindTo(.useMediaKeys)
           .image(name: ["playpause.circle", "playpause"])
@@ -39,9 +43,9 @@ class SettingsPageKeyBindings: SettingsPage {
     }
   }
 
-  private func sectionConfiguration() -> [NSView] {
+  private func sectionConfiguration() -> SettingsSection {
     return section {
-      SettingsListView {
+      SettingsList {
         SettingsItem.General(title: .text_KeyBindingSet)
           .image(name: ["book.and.wrench", "wrench.adjustable", "wrench"])
           .withValueView(configEditor.chooserView)
@@ -167,7 +171,7 @@ fileprivate class ConfigEditor: SettingsAccessory.Base {
     delConfBtn.target = self
     delConfBtn.action = #selector(deleteConfFileAction)
 
-    let chooserStackView = makeStackView([chooserPopupButton, delConfBtn, addConfBtn])
+    let chooserStackView = ui.hStack(chooserPopupButton, delConfBtn, addConfBtn)
     chooserView.addSubview(chooserStackView)
     chooserStackView.padding(.all(8))
 
@@ -182,13 +186,11 @@ fileprivate class ConfigEditor: SettingsAccessory.Base {
     let headerViewContainer = NSView()
     headerViewContainer.translatesAutoresizingMaskIntoConstraints = false
     headerViewContainer.size(height: 32)
-    let headerView = makeStackView([searchField, addKeyMappingBtn])
+    let headerView = ui.hStack(searchField, addKeyMappingBtn)
     headerViewContainer.addSubview(headerView)
     headerView.padding(.top(8), .leading(16), .trailing(16))
 
-    let editorStackView = makeStackView([headerViewContainer, kbTableView], orientation: .vertical)
-    editorStackView.alignment = .leading
-    editorStackView.spacing = 0
+    let editorStackView = ui.vStack(align: .leading, spacing: 0, headerViewContainer, kbTableView)
 
     searchField.setContentHuggingPriority(.defaultLow, for: .horizontal)
     searchField.bind(

--- a/iina/Pages/SettingsPageNetwork.swift
+++ b/iina/Pages/SettingsPageNetwork.swift
@@ -7,29 +7,33 @@
 //
 
 class SettingsPageNetwork: SettingsPage {
+  override var identifier: String {
+    "network"
+  }
+  
   override var title: String {
     return NSLocalizedString("preference.network", comment: "Network")
   }
-  
+
   override var image: NSImage {
     return makeSymbol("globe", fallbackImage: "pref_network")
   }
-  
+
   override var localizationTable: String {
     "SettingsNetworkLocalizable"
   }
-  
-  override func content() -> NSView {
+
+  override func content() -> [SettingsSection] {
     return sections {
       sectionCache()
       sectionNetwork()
       sectionYTDL()
     }
   }
-  
-  private func sectionCache() -> [NSView] {
+
+  private func sectionCache() -> SettingsSection {
     return section {
-      SettingsListView(title: .text_Cache) {
+      SettingsList(title: .text_Cache) {
         SettingsItem.Switch()
           .image(name: ["inset.filled.topthird.middlethird.bottomthird.rectangle", ""])
           .bindTo(.enableCache)
@@ -47,10 +51,10 @@ class SettingsPageNetwork: SettingsPage {
       }
     }
   }
-  
-  private func sectionNetwork() -> [NSView] {
+
+  private func sectionNetwork() -> SettingsSection {
     return section {
-      SettingsListView(title: .text_Network) {
+      SettingsList(title: .text_Network) {
         SettingsItem.LongInput()
           .bindTo(.userAgent)
           .image(name: ["person.crop.circle"])
@@ -63,15 +67,15 @@ class SettingsPageNetwork: SettingsPage {
       }
     }
   }
-  
-  private func sectionYTDL() -> [NSView] {
+
+  private func sectionYTDL() -> SettingsSection {
     return section {
-      SettingsListView(title: .text_YTDL) {
+      SettingsList(title: .text_YTDL) {
         SettingsItem.General(title: .text_onlineMediaPluginAdvice)
           .image(name: "puzzlepiece.extension")
           .hasDescription(content: .text_ytdlWarning)
       }
-      SettingsListView {
+      SettingsList {
         SettingsItem.Switch()
           .bindTo(.ytdlEnabled)
           .image(name: "square.and.arrow.down")

--- a/iina/Pages/SettingsPagePlugin.swift
+++ b/iina/Pages/SettingsPagePlugin.swift
@@ -10,14 +10,18 @@ import WebKit
 import Just
 
 class SettingsPagePlugin: SettingsPage {
+  override var identifier: String {
+    "plugin"
+  }
+  
   override var title: String {
     return NSLocalizedString("preference.plugins", comment: "Plugins")
   }
-  
+
   override var image: NSImage {
     return makeSymbol("puzzlepiece.extension", fallbackImage: "plugin")
   }
-  
+
   override var localizationTable: String {
     "SettingsPluginLocalizable"
   }
@@ -30,26 +34,26 @@ class SettingsPagePlugin: SettingsPage {
   fileprivate lazy var listView: PluginListView = .init(l10n: localizationContext, page: self)
   fileprivate lazy var updateView: PluginUpdateView = .init(l10n: localizationContext, page: self)
 
-  override func content() -> NSView {
+  override func content() -> [SettingsSection] {
     return sections {
       sectionInstall()
       sectionPluginList()
     }
   }
-  
-  private func sectionInstall() -> [NSView] {
+
+  private func sectionInstall() -> SettingsSection {
     return section {
-      SettingsListView() {
+      SettingsList() {
         SettingsItem.Custom()
           .view(installView.view)
       }
     }
   }
 
-  private func sectionPluginList() -> [NSView] {
+  private func sectionPluginList() -> SettingsSection {
     return section {
       updateView
-      SettingsListView() {
+      SettingsList() {
         SettingsItem.Custom()
           .view(listView.view)
       }
@@ -65,21 +69,21 @@ fileprivate class PluginInstallView: SettingsAccessory.Base {
   init(l10n: SettingsLocalization.Context, page: SettingsPagePlugin) {
     self.page = page
     super.init(l10n: l10n)
-    
-    let githubBtn = makeButton(.text_InstallFromGitHub)
+
+    let githubBtn = ui.button(.text_InstallFromGitHub)
     githubBtn.target = self
     githubBtn.action = #selector(installPluginFromGitHub)
-    let localBtn = makeButton(.text_InstallPackage)
+    let localBtn = ui.button(.text_InstallPackage)
     localBtn.target = self
     localBtn.action = #selector(installPluginFromLocalPackage)
 
-    let btnStackView = makeStackView([githubBtn, localBtn])
-    
-    let installLabel = makeLabel(.text_YouCanInstallANew).makeMultiLine()
-    
-    let stackView = makeStackView([installLabel, btnStackView], orientation: .vertical)
+    let btnStackView = ui.hStack(githubBtn, localBtn)
+
+    let installLabel = ui.label(.text_YouCanInstallANew).makeMultiLine()
+
+    let stackView = ui.vStack(installLabel, btnStackView)
     stackView.alignment = .leading
-    
+
     view.addSubview(stackView)
     stackView.padding(.all(12))
   }
@@ -101,9 +105,12 @@ fileprivate class PluginInstallView: SettingsAccessory.Base {
 }
 
 
-fileprivate class PluginUpdateView: NSView, SettingsContainer {
+fileprivate class PluginUpdateView: SettingsContainer {
+  lazy var itemID = SettingsContainerUUID.next()
+  let view: NSView
+
   func getContainer() -> NSView {
-    return self
+    return view
   }
 
   enum Status {
@@ -118,10 +125,10 @@ fileprivate class PluginUpdateView: NSView, SettingsContainer {
 
   init(l10n: SettingsLocalization.Context, page: SettingsPagePlugin) {
     self.page = page
+    self.view = .init(frame: .zero)
     self.checkUpdateLabel = NSTextField(labelWithString: "Checking for updates…")
     self.checkUpdateButton = NSButton()
     checkUpdateButton.translatesAutoresizingMaskIntoConstraints = false
-    super.init(frame: .zero)
 
     checkUpdateLabel.font = .systemFont(ofSize: NSFont.smallSystemFontSize, weight: .bold)
     checkUpdateLabel.textColor = .secondaryLabelColor
@@ -138,14 +145,18 @@ fileprivate class PluginUpdateView: NSView, SettingsContainer {
     checkUpdateStackView.translatesAutoresizingMaskIntoConstraints = false
     checkUpdateStackView.orientation = .horizontal
 
-    self.translatesAutoresizingMaskIntoConstraints = false
-    self.addSubview(checkUpdateStackView)
+    view.translatesAutoresizingMaskIntoConstraints = false
+    view.addSubview(checkUpdateStackView)
 
     checkUpdateStackView.padding(.top(8), .bottom, .horizontal(16))
   }
-  
+
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
+  }
+
+  func makeView(context: SettingsLocalization.Context) -> NSView {
+    return view
   }
 
   @objc func checkForUpdates(_ sender: AnyObject) {
@@ -183,19 +194,31 @@ fileprivate extension NSPasteboard.PasteboardType {
 
 
 fileprivate class PluginListView: SettingsAccessory.Base {
+  // TODO: this is a workaround.
+  // SettingsItem.Custom should also adopt the "build first, render later" design.
+  class TableView: NSTableView {
+    weak var listView: PluginListView!
+
+    override func viewDidMoveToWindow() {
+      super.viewDidMoveToWindow()
+      listView.checkForAllPluginUpdates()
+    }
+  }
+
   static var currentPlugin: JavascriptPlugin?
   static var pluginHasUpdate: [String: Bool] = [:]
   static var isCheckingForUpdates: Bool = false
 
-  let tableView: NSTableView
+  let tableView: TableView
   unowned let page: SettingsPagePlugin
 
   init(l10n: SettingsLocalization.Context, page: SettingsPagePlugin) {
-    self.tableView = NSTableView()
+    self.tableView = TableView()
     self.page = page
 
     super.init(l10n: l10n)
-    
+    tableView.listView = self
+
     let column = NSTableColumn(identifier: .pluginItem)
     column.title = "Items"
     tableView.style = .plain
@@ -208,8 +231,6 @@ fileprivate class PluginListView: SettingsAccessory.Base {
 
     view.addSubview(tableView)
     tableView.padding(.all(0))
-
-    checkForAllPluginUpdates()
   }
 
   func checkForAllPluginUpdates() {
@@ -258,10 +279,10 @@ extension PluginListView: NSTableViewDelegate, NSTableViewDataSource {
 
     private lazy var pluginManager: PluginManager = PluginManager(window: self.nameLabel.window!)
     weak private var listView: PluginListView!
-    
+
     func setup(plugin: JavascriptPlugin, listView: PluginListView) {
       self.plugin = plugin
-      
+
       if nameLabel == nil {
         self.identifier = .pluginItem
         self.listView = listView
@@ -269,7 +290,7 @@ extension PluginListView: NSTableViewDelegate, NSTableViewDataSource {
         // left
         nameLabel = NSTextField(labelWithString: plugin.name)
         nameLabel.font = NSFont.systemFont(ofSize: NSFont.systemFontSize, weight: .bold)
-        
+
         enabledSwitch = NSSwitch()
         enabledSwitch.state = plugin.enabled ? .on : .off
         enabledSwitch.controlSize = .mini
@@ -317,18 +338,18 @@ extension PluginListView: NSTableViewDelegate, NSTableViewDataSource {
         [enabledSwitch, nameLabel, progressIndicator, versionLabel, updateBtn, devLabel, actionsBtn].forEach {
           nameStackView.addArrangedSubview($0)
         }
-        
+
         // bottom
         descLabel = NSTextField(labelWithString: plugin.desc ?? "No description")
         descLabel.lineBreakMode = .byTruncatingTail
         descLabel.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize)
         descLabel.textColor = .secondaryLabelColor
-        
+
         let stackView = NSStackView(views: [nameStackView, descLabel])
         stackView.translatesAutoresizingMaskIntoConstraints = false
         stackView.orientation = .vertical
         stackView.alignment = .leading
-        
+
         self.aboutBtn = NSButton()
         aboutBtn.size(width: 18, height: 18)
         aboutBtn.image = .findSFSymbol(["info.circle"])
@@ -337,10 +358,10 @@ extension PluginListView: NSTableViewDelegate, NSTableViewDataSource {
         aboutBtn.translatesAutoresizingMaskIntoConstraints = false
         aboutBtn.target = self
         aboutBtn.action = #selector(aboutBtnAction)
-        
+
         self.addSubview(stackView)
         self.addSubview(aboutBtn)
-        
+
         stackView.padding(.top(12), .bottom(4), .leading(8), .trailing(20))
         aboutBtn.padding(.trailing(8))
           .center(with: self, y: true)
@@ -362,7 +383,7 @@ extension PluginListView: NSTableViewDelegate, NSTableViewDataSource {
 
     @objc func actionsBtnAction(_ sender: NSButton) {
       PluginListView.currentPlugin = plugin
-      
+
       let l10n = listView.l10n!
       let actionMenu = NSMenu()
       actionMenu.addItem(withTitle: l10n.localized(.text_Uninstall), image: ["trash"],
@@ -372,10 +393,10 @@ extension PluginListView: NSTableViewDelegate, NSTableViewDataSource {
                          action: #selector(showPluginInFinderAction), target: listView)
       NSMenu.popUpContextMenu(actionMenu, with: NSApp.currentEvent!, for: sender)
     }
-    
+
     @objc func aboutBtnAction(_ sender: NSButton) {
       PluginListView.currentPlugin = plugin
-      
+
       let sheetWindow = PluginDetailsWindow(l10n: listView.l10n, plugin: plugin, window: window!)
       window!.beginSheet(sheetWindow)
     }
@@ -412,11 +433,11 @@ extension PluginListView: NSTableViewDelegate, NSTableViewDataSource {
   func numberOfRows(in tableView: NSTableView) -> Int {
     return JavascriptPlugin.plugins.count
   }
-  
+
   func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
     return 60
   }
-  
+
   func selectionShouldChange(in tableView: NSTableView) -> Bool {
     return false
   }
@@ -428,7 +449,7 @@ extension PluginListView: NSTableViewDelegate, NSTableViewDataSource {
   func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
     let identifier: NSUserInterfaceItemIdentifier = .pluginItem
     guard let plugin = JavascriptPlugin.plugins[at: row] else { return nil }
-    
+
     let view = (tableView.makeView(withIdentifier: identifier, owner: self) as? ItemView) ?? ItemView()
     view.setup(plugin: plugin, listView: self)
     return view
@@ -474,7 +495,7 @@ extension PluginListView {
       }
     }
   }
-  
+
   @objc func showPluginInFinderAction(_ sender: Any) {
     guard let currentPlugin = PluginListView.currentPlugin else { return }
     NSWorkspace.shared.activateFileViewerSelecting([currentPlugin.root])
@@ -491,13 +512,13 @@ fileprivate class PluginDetailsWindow: NSWindow {
   private let loadingIndicator: NSProgressIndicator
   private let loadingFailedView: NSTextField
   private var currentTab: Tab = .about
-  
+
   unowned let window: NSWindow
-  
+
   enum Tab: Int {
     case settings = 0, about, help
   }
-  
+
   init(l10n: SettingsLocalization.Context, plugin: JavascriptPlugin, window: NSWindow) {
     self.l10n = l10n
     self.window = window
@@ -506,7 +527,7 @@ fileprivate class PluginDetailsWindow: NSWindow {
 
     self.okButton = NSButton(title: l10n.localized(.text_OK), target: nil, action: nil)
     okButton.translatesAutoresizingMaskIntoConstraints = false
-    
+
     self.loadingIndicator = NSProgressIndicator()
     loadingIndicator.translatesAutoresizingMaskIntoConstraints = false
 
@@ -528,11 +549,11 @@ fileprivate class PluginDetailsWindow: NSWindow {
 
     okButton.target = self
     okButton.action = #selector(dismissSheet)
-    
+
     let nameLabel = NSTextField(labelWithString: plugin.name)
     nameLabel.translatesAutoresizingMaskIntoConstraints = false
     nameLabel.font = .systemFont(ofSize: NSFont.systemFontSize, weight: .bold)
-    
+
     let versionLabel = NSTextField(labelWithString: plugin.version)
     versionLabel.translatesAutoresizingMaskIntoConstraints = false
     versionLabel.textColor = .secondaryLabelColor
@@ -542,7 +563,7 @@ fileprivate class PluginDetailsWindow: NSWindow {
     iconView.image = .findSFSymbol(["puzzlepiece.extension"])
     iconView.translatesAutoresizingMaskIntoConstraints = false
     iconView.size(width: 24, height: 24)
-    
+
     segControl.segmentCount = 3
     segControl.segmentStyle = .texturedSquare
     if #available(macOS 26.0, *) {
@@ -562,7 +583,7 @@ fileprivate class PluginDetailsWindow: NSWindow {
       segControl.setImage(.findSFSymbol([seg.0]), forSegment: i)
       segControl.setLabel(l10n.localized(seg.1), forSegment: i)
     }
-    
+
     contentView.addSubview(iconView)
     iconView.padding(.leading(16), .top(20))
     contentView.addSubview(nameLabel)
@@ -573,7 +594,7 @@ fileprivate class PluginDetailsWindow: NSWindow {
     segControl.padding(.top(16), .trailing(16))
     contentView.addSubview(okButton)
     okButton.padding(.bottom(16), .trailing(16))
-    
+
     createWebView()
     contentView.addSubview(webView)
     webView.padding(.horizontal(16))
@@ -625,7 +646,7 @@ fileprivate class PluginDetailsWindow: NSWindow {
     """, injectionTime: .atDocumentEnd, forMainFrameOnly: true))
 
     config.userContentController.add(self, name: "iina")
-    
+
     self.webView = WKWebView(frame: .zero, configuration: config)
     if #available(macOS 13.3, *) {
       webView.isInspectable = true
@@ -674,7 +695,7 @@ fileprivate class PluginDetailsWindow: NSWindow {
     }
     webView.loadHTMLString(generateHTML(body: body), baseURL: nil)
   }
-  
+
   private func generateHelpPage() {
     if let helpURL = plugin.helpPageURL {
       if helpURL.isFileURL {
@@ -686,7 +707,7 @@ fileprivate class PluginDetailsWindow: NSWindow {
       webView.loadHTMLString(generateHTML(body: "This plugin does not have a help page."), baseURL: nil)
     }
   }
-  
+
   private func generateHTML(body: String) -> String {
     return """
     <!DOCTYPE html>
@@ -754,11 +775,11 @@ extension PluginDetailsWindow: WKScriptMessageHandler, WKNavigationDelegate {
   func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
     // Since all tabs share the same webview, we don't want uncontrolled message from anywhere, e.g. the help page
     guard currentTab == .settings else { return }
-    
+
     guard let dict = message.body as? [Any], dict.count == 2 else { return }
     guard let name = dict[0] as? String else { return }
     guard let data = dict[1] as? [Any], let prefName = data[0] as? String else { return }
-    
+
     if name == "set" {
       plugin.preferences[prefName] = data[1]
     } else if name == "get" {

--- a/iina/Pages/SettingsPageSubtitles.swift
+++ b/iina/Pages/SettingsPageSubtitles.swift
@@ -9,6 +9,10 @@
 import Foundation
 
 class SettingsPageSubtitles: SettingsPage {
+  override var identifier: String {
+    "subtitles"
+  }
+  
   override var title: String {
     return NSLocalizedString("preference.subtitle", comment: "Subtitles")
   }
@@ -31,7 +35,7 @@ class SettingsPageSubtitles: SettingsPage {
   private lazy var subtitlesEncodingView: SubtitlesEncodingView = .init(l10n: localizationContext)
   private lazy var subtitleSourceView: SubtitleSourceView = .init(l10n: localizationContext)
 
-  override func content() -> NSView {
+  override func content() -> [SettingsSection] {
     return sections {
       sectionAutoLoad()
       sectionASS()
@@ -42,9 +46,9 @@ class SettingsPageSubtitles: SettingsPage {
     }
   }
 
-  private func sectionAutoLoad() -> [NSView] {
+  private func sectionAutoLoad() -> SettingsSection {
     return section {
-      SettingsListView(title: .text_AutoLoad) {
+      SettingsList(title: .text_AutoLoad) {
         SettingsItem.PopupButton()
           .image(name: ["bolt.badge.automatic", "bolt.badge.a"])
           .bindTo(.subAutoLoadIINA, ofType: Preference.IINAAutoLoadAction.self)
@@ -63,21 +67,21 @@ class SettingsPageSubtitles: SettingsPage {
     }
   }
 
-  private func sectionASS() -> [NSView] {
+  private func sectionASS() -> SettingsSection {
     return section {
-      SettingsListView(title: .text_ASSSubtitles) {
+      SettingsList(title: .text_ASSSubtitles) {
         SettingsItem.General(title: .text_OverrideLevel)
           .image(name: "pencil.slash")
           .withHelpLink("https://mpv.io/manual/stable/#options-sub-ass-override")
           .withValueView(subtitlesASSView.segmentControl)
-          .withDetailView(subtitlesASSView.view)
+          .withDetailView(subtitlesASSView)
       }
     }
   }
 
-  private func sectionText() -> [NSView] {
+  private func sectionText() -> SettingsSection {
     return section {
-      SettingsListView(title: .text_TextSubtitles) {
+      SettingsList(title: .text_TextSubtitles) {
         SettingsItem.General(title: .text_Font)
           .image(name: "textformat")
           .withValueView(subtitlesFontView.view)
@@ -89,7 +93,7 @@ class SettingsPageSubtitles: SettingsPage {
           .withValueView(subtitlesBorderView.view)
       }
 
-      SettingsListView {
+      SettingsList {
         SettingsItem.General(title: .text_Shadow)
           .image(name: ["lightspectrum.horizontal", "lightbulb"])
           .withValueView(subtitlesShadowView.view)
@@ -105,9 +109,9 @@ class SettingsPageSubtitles: SettingsPage {
     }
   }
 
-  private func sectionPosition() -> [NSView] {
+  private func sectionPosition() -> SettingsSection {
     return section {
-      SettingsListView(title: .text_Position) {
+      SettingsList(title: .text_Position) {
         SettingsItem.General(title: .text_Align)
           .image(name: "arrow.up.and.down.and.arrow.left.and.right")
           .withValueView(subtitlesAlignView.view)
@@ -120,13 +124,13 @@ class SettingsPageSubtitles: SettingsPage {
           .trailingLabel(.text_Percent)
       }
 
-      SettingsListView {
+      SettingsList {
         SettingsItem.Switch()
           .image(name: ["arrow.up.left.and.arrow.down.right.rectangle", "arrow.up.backward.and.arrow.down.forward"])
           .bindTo(.subScaleWithWindow)
       }
 
-      SettingsListView {
+      SettingsList {
         SettingsItem.Switch()
           .image(name: ["inset.filled.bottomthird.rectangle", "rectangle.bottomthird.inset.filled", "rectangle.bottomthird.inset.fill"])
           .bindTo(.displayInLetterBox)
@@ -134,12 +138,12 @@ class SettingsPageSubtitles: SettingsPage {
     }
   }
 
-  private func sectionOnlineSubtitles() -> [NSView] {
+  private func sectionOnlineSubtitles() -> SettingsSection {
     return section {
-      SettingsListView(title: .text_OnlineSubtitles) {
+      SettingsList(title: .text_OnlineSubtitles) {
         SettingsItem.General(title: .text_SubtitleSource)
           .image(name: "server.rack")
-          .withDetailView(subtitleSourceView.view)
+          .withDetailView(subtitleSourceView)
         SettingsItem.Switch()
           .image(name: ["text.magnifyingglass", "magnifyingglass"])
           .bindTo(.autoSearchOnlineSub)
@@ -148,9 +152,9 @@ class SettingsPageSubtitles: SettingsPage {
     }
   }
 
-  private func sectionOther() -> [NSView] {
+  private func sectionOther() -> SettingsSection {
     return section {
-      SettingsListView(title: .text_Other) {
+      SettingsList(title: .text_Other) {
         SettingsItem.General(title: .text_PreferredLanguage)
           .image(name: "character.book.closed")
           .withDetailView(
@@ -159,7 +163,7 @@ class SettingsPageSubtitles: SettingsPage {
               .hasDescription()
           )
         SettingsItem.General(title: .text_DefaultEncoding)
-          .withDetailView(subtitlesEncodingView.view)
+          .withDetailView(subtitlesEncodingView)
       }
     }
   }
@@ -219,8 +223,8 @@ fileprivate class SubtitlesASSView: SettingsAccessory.Base {
   let segmentControl: NSSegmentedControl
 
   private let stackView: NSStackView
-  private let primarySelection: NSView
-  private let secondarySelection: NSView
+  private let primarySelection: SettingsAccessory.Selection
+  private let secondarySelection: SettingsAccessory.Selection
 
   override init(l10n: SettingsLocalization.Context) {
     self.segmentControl = NSSegmentedControl(
@@ -233,7 +237,8 @@ fileprivate class SubtitlesASSView: SettingsAccessory.Base {
     self.secondarySelection = SettingsAccessory.Selection(l10nKey: .subOverrideLevel, topPadding: 0)
       .bindTo(.secondarySubOverrideLevel, ofType: Preference.SubOverrideLevel.self)
       .order([4, 0, 3, 1, 2])
-    self.stackView = NSStackView(views: [primarySelection, secondarySelection])
+    self.stackView = NSStackView()
+    stackView.translatesAutoresizingMaskIntoConstraints = false
 
     super.init(l10n: l10n)
 
@@ -242,22 +247,31 @@ fileprivate class SubtitlesASSView: SettingsAccessory.Base {
     segmentControl.action = #selector(subOverrideLevelSegmentedControlAction(_:))
     segmentControl.selectedSegment = 0
 
-    stackView.translatesAutoresizingMaskIntoConstraints = false
-    stackView.orientation = .vertical
-    stackView.alignment = .width
-    stackView.setVisibilityPriority(.notVisible, for: secondarySelection)
-
     view.addSubview(stackView)
     stackView.padding(.top(4), .bottom, .horizontal)
   }
 
+  override func registerSearchEntry(context: SettingsSearch.Context) {
+    primarySelection.registerSearchEntry(context: context)
+  }
+
+  override func makeView(context: SettingsLocalization.Context) -> NSView {
+    stackView.addArrangedSubview(primarySelection.makeView(context: context))
+    stackView.addArrangedSubview(secondarySelection.makeView(context: context))
+    stackView.orientation = .vertical
+    stackView.alignment = .width
+    stackView.setVisibilityPriority(.notVisible, for: secondarySelection.builtView!)
+
+    return super.makeView(context: context)
+  }
+
   @objc func subOverrideLevelSegmentedControlAction(_ sender: NSSegmentedControl) {
     if sender.selectedSegment == 0 {
-      stackView.setVisibilityPriority(.mustHold, for: primarySelection)
-      stackView.setVisibilityPriority(.notVisible, for: secondarySelection)
+      stackView.setVisibilityPriority(.mustHold, for: primarySelection.builtView!)
+      stackView.setVisibilityPriority(.notVisible, for: secondarySelection.builtView!)
     } else {
-      stackView.setVisibilityPriority(.notVisible, for: primarySelection)
-      stackView.setVisibilityPriority(.mustHold, for: secondarySelection)
+      stackView.setVisibilityPriority(.notVisible, for: primarySelection.builtView!)
+      stackView.setVisibilityPriority(.mustHold, for: secondarySelection.builtView!)
     }
   }
 }
@@ -277,7 +291,7 @@ fileprivate class SubtitlesFontView: SettingsAccessory.Base {
     fontButton.bind(.title, to: UserDefaults.standard, withKeyPath: Preference.Key.subTextFont.rawValue)
     fontButton.size(height: 25)
 
-    let sizeInput = makeInput(.subTextSize)
+    let sizeInput = ui.input(.subTextSize)
 
     let boldButton = SButton(image: .findSFSymbol(["bold"]))
     boldButton.translatesAutoresizingMaskIntoConstraints = false
@@ -291,7 +305,7 @@ fileprivate class SubtitlesFontView: SettingsAccessory.Base {
     italicButton.cell!.bind(.state, to: UserDefaults.standard, withKeyPath: Preference.Key.subItalic.rawValue)
     italicButton.size(width: 32, height: 25)
 
-    let stackView = makeStackView([fontButton, sizeInput, boldButton, italicButton])
+    let stackView = ui.hStack(fontButton, sizeInput, boldButton, italicButton)
 
     view.addSubview(stackView)
     stackView.padding(.top(8), .bottom(8), .leading, .trailing)
@@ -311,13 +325,13 @@ fileprivate class SubtitlesColorView: SettingsAccessory.Base {
   override init(l10n: SettingsLocalization.Context) {
     super.init(l10n: l10n)
 
-    let colorLabel = makeLabel(.text_Color)
-    let colorWell = makeColorWell(.subTextColorString)
+    let colorLabel = ui.label(.text_Color)
+    let colorWell = ui.colorWell(.subTextColorString)
 
-    let backgroundLabel = makeLabel(.text_Background)
-    let backgroundWell = makeColorWell(.subBgColorString)
+    let backgroundLabel = ui.label(.text_Background)
+    let backgroundWell = ui.colorWell(.subBgColorString)
 
-    let stackView = makeStackView([colorLabel, colorWell, backgroundLabel, backgroundWell])
+    let stackView = ui.hStack(colorLabel, colorWell, backgroundLabel, backgroundWell)
 
     view.addSubview(stackView)
     stackView.padding(.top(8), .bottom(8), .leading, .trailing)
@@ -328,14 +342,14 @@ fileprivate class SubtitlesColorView: SettingsAccessory.Base {
 fileprivate class SubtitlesBorderView: SettingsAccessory.Base {
   override init(l10n: SettingsLocalization.Context) {
     super.init(l10n: l10n)
-    
-    let widthLabel = makeLabel(.text_Size)
-    let widthInput = makeInput(.subBorderSize)
 
-    let colorLabel = makeLabel(.text_Color)
-    let colorWell = makeColorWell(.subBorderColorString)
+    let widthLabel = ui.label(.text_Size)
+    let widthInput = ui.input(.subBorderSize)
 
-    let stackView = makeStackView([widthLabel, widthInput, colorLabel, colorWell])
+    let colorLabel = ui.label(.text_Color)
+    let colorWell = ui.colorWell(.subBorderColorString)
+
+    let stackView = ui.hStack(widthLabel, widthInput, colorLabel, colorWell)
 
     view.addSubview(stackView)
     stackView.padding(.vertical(8), .leading, .trailing)
@@ -347,13 +361,13 @@ fileprivate class SubtitlesShadowView: SettingsAccessory.Base {
   override init(l10n: SettingsLocalization.Context) {
     super.init(l10n: l10n)
 
-    let sizeLabel = makeLabel(.text_Offset)
-    let sizeInput = makeInput(.subShadowSize)
+    let sizeLabel = ui.label(.text_Offset)
+    let sizeInput = ui.input(.subShadowSize)
 
-    let colorLabel = makeLabel(.text_Color)
-    let colorWell = makeColorWell(.subShadowColorString)
+    let colorLabel = ui.label(.text_Color)
+    let colorWell = ui.colorWell(.subShadowColorString)
 
-    let stackView = makeStackView([sizeLabel, sizeInput, colorLabel, colorWell])
+    let stackView = ui.hStack(sizeLabel, sizeInput, colorLabel, colorWell)
 
     view.addSubview(stackView)
     stackView.padding(.vertical(8), .leading, .trailing)
@@ -365,13 +379,13 @@ fileprivate class SubtitlesMarginView: SettingsAccessory.Base {
   override init(l10n: SettingsLocalization.Context) {
     super.init(l10n: l10n)
 
-    let xLabel = makeLabel(.text_X)
-    let xInput = makeInput(.subMarginX)
+    let xLabel = ui.label(.text_X)
+    let xInput = ui.input(.subMarginX)
 
-    let yLabel = makeLabel(.text_Y)
-    let yInput = makeInput(.subMarginY)
+    let yLabel = ui.label(.text_Y)
+    let yInput = ui.input(.subMarginY)
 
-    let stackView = makeStackView([xLabel, xInput, yLabel, yInput])
+    let stackView = ui.hStack(xLabel, xInput, yLabel, yInput)
 
     view.addSubview(stackView)
     stackView.padding(.vertical(8), .leading, .trailing)
@@ -383,13 +397,13 @@ fileprivate class SubtitlesAlignView: SettingsAccessory.Base {
   override init(l10n: SettingsLocalization.Context) {
     super.init(l10n: l10n)
 
-    let xLabel = makeLabel(.text_X)
+    let xLabel = ui.label(.text_X)
     let xPopUp = makePopUp(.subAlignX)
 
-    let yLabel = makeLabel(.text_Y)
+    let yLabel = ui.label(.text_Y)
     let yPopUp = makePopUp(.subAlignY)
 
-    let stackView = makeStackView([xLabel, xPopUp, yLabel, yPopUp])
+    let stackView = ui.hStack(xLabel, xPopUp, yLabel, yPopUp)
 
     view.addSubview(stackView)
     stackView.padding(.vertical(8), .leading, .trailing)
@@ -436,7 +450,7 @@ fileprivate class SubtitlesEncodingView: SettingsAccessory.Base {
 
     popupButton.menu?.insertItem(NSMenuItem.separator(), at: 1)
     view.addSubview(popupButton)
-    popupButton.padding(.leading(SettingsSubListView.padding), .top, .bottom(8), .trailing(8))
+    popupButton.padding(.leading(SettingsSubList.indent), .top, .bottom(8), .trailing(8))
   }
 
   @objc func changeDefaultEncoding(_ sender: NSPopUpButton) {
@@ -451,7 +465,7 @@ fileprivate class SubtitleSourceView: SettingsAccessory.Base {
   var subSourceStackView: NSStackView!
   let subSourcePopUpButton: NSPopUpButton
   let loginIndicator: NSProgressIndicator
-  
+
   override init(l10n: SettingsLocalization.Context) {
     self.subSourcePopUpButton = NSPopUpButton()
     subSourcePopUpButton.translatesAutoresizingMaskIntoConstraints = false
@@ -462,40 +476,39 @@ fileprivate class SubtitleSourceView: SettingsAccessory.Base {
     loginIndicator.style = .spinning
     loginIndicator.isHidden = true
     super.init(l10n: l10n)
-    
-    let descLabel = makeLabel(.text_SubtitleSource_desc).makeMultiLine()
-    
+
+    let descLabel = ui.label(.text_SubtitleSource_desc).makeMultiLine()
+
     // don't add legacy opensub support (is the API still alive?)
-    let legacyOpenSubLabel = makeLabel(.text_LegacyOpenSubAlert).makeMultiLine()
-//    let openSubAccountName = makeLabel(.text_NotLoggedIn)
-//    let openSubLoginBtn = makeButton(.text_Login)
+    let legacyOpenSubLabel = ui.label(.text_LegacyOpenSubAlert).makeMultiLine()
+//    let openSubAccountName = ui.label(.text_NotLoggedIn)
+//    let openSubLoginBtn = ui.button(.text_Login)
 //    let legacyOpenSubSettingsView = makeStackView([openSubLoginBtn, openSubAccountName, loginIndicator])
-    let legacyOpenSubView = makeStackView([legacyOpenSubLabel], orientation: .vertical)
+    let legacyOpenSubView = ui.vStack(legacyOpenSubLabel)
 
     let assrtHelpBtn = NSButton(title: "", target: self, action: #selector(assrtHelpBtnAction))
     assrtHelpBtn.bezelStyle = .helpButton
-    let assrtLabel = makeLabel(.text_AssrtAPIToken, isSmall: false)
-    let assrtTokenField = makeInput(.assrtToken, isFixedSize: false)
-    let assrtView = makeStackView([assrtLabel, assrtTokenField, assrtHelpBtn])
-    
-    let pluginDescLabel = makeLabel(.text_SubtitleSourcePluginDesc).makeMultiLine()
-    
-    subSourceStackView = makeStackView(
-      [subSourcePopUpButton, descLabel, legacyOpenSubView, assrtView, pluginDescLabel],
-      orientation: .vertical
+    let assrtLabel = ui.label(.text_AssrtAPIToken, isSmall: false)
+    let assrtTokenField = ui.input(.assrtToken, isFixedSize: false)
+    let assrtView = ui.hStack(assrtLabel, assrtTokenField, assrtHelpBtn)
+
+    let pluginDescLabel = ui.label(.text_SubtitleSourcePluginDesc).makeMultiLine()
+
+    subSourceStackView = ui.vStack(
+      subSourcePopUpButton, descLabel, legacyOpenSubView, assrtView, pluginDescLabel
     )
     subSourcePopUpButton.padding(.horizontal)
 
     view.addSubview(subSourceStackView)
-    subSourceStackView.padding(.top, .bottom(8), .leading(SettingsSubListView.padding), .trailing(8))
-    
+    subSourceStackView.padding(.top, .bottom(8), .leading(SettingsSubList.indent), .trailing(8))
+
     subSourcePopUpButton.target = self
     subSourcePopUpButton.action = #selector(refreshSubSourceAccessoryView)
-    
+
     refreshSubSources()
     refreshSubSourceAccessoryView()
   }
-  
+
   @objc private func assrtHelpBtnAction(_ sender: AnyObject) {
     NSWorkspace.shared.open(URL(string: AppData.wikiLink.appending("/Download-Online-Subtitles#assrt"))!)
   }

--- a/iina/Pages/SettingsPageUI.swift
+++ b/iina/Pages/SettingsPageUI.swift
@@ -13,6 +13,10 @@ class SettingsPageUI: SettingsPage {
   private lazy var oscLayoutView: OSCLayoutView = OSCLayoutView(l10n: localizationContext)
   private lazy var oscToolbarView: OSCToolbarView = OSCToolbarView(l10n: localizationContext)
 
+  override var identifier: String {
+    "ui"
+  }
+
   override var title: String {
     return NSLocalizedString("preference.ui", comment: "UI")
   }
@@ -25,7 +29,7 @@ class SettingsPageUI: SettingsPage {
     "SettingsUILocalizable"
   }
 
-  override func content() -> NSView {
+  override func content() -> [SettingsSection] {
     return sections {
       sectionAppearance()
       sectionWindow()
@@ -37,9 +41,9 @@ class SettingsPageUI: SettingsPage {
     }
   }
 
-  private func sectionAppearance() -> [NSView] {
+  private func sectionAppearance() -> SettingsSection {
     return section {
-      SettingsListView(title: .text_Appearance) {
+      SettingsList(title: .text_Appearance) {
         SettingsItem.PopupButton()
           .image(name: "moonphase.first.quarter")
           .bindTo(.themeMaterial, ofType: Preference.Theme.self)
@@ -47,33 +51,33 @@ class SettingsPageUI: SettingsPage {
     }
   }
 
-  private func sectionWindow() -> [NSView] {
+  private func sectionWindow() -> SettingsSection {
     return section {
-      SettingsListView(title: .text_Window) {
+      SettingsList(title: .text_Window) {
         SettingsItem.Switch(title: .text_InitialWindowSize)
           .image(name: "custom.arrow.up.left.and.down.right.and.arrow.up.right.and.down.left.rectangle")
-          .withExpandingDetailView(windowInitialSizeView.container)
+          .withExpandingDetailView(windowInitialSizeView)
           .bindExpandableView()
         SettingsItem.Switch(title: .text_InitialWindowPosition)
           .image(name: "arrow.up.and.down.and.arrow.left.and.right")
-          .withExpandingDetailView(windowInitialPositionView.container)
+          .withExpandingDetailView(windowInitialPositionView)
           .bindExpandableView()
       }
 
-      SettingsListView {
+      SettingsList {
         SettingsItem.PopupButton()
           .image(name: "arrow.up.left.bottomright.rectangle")
           .bindTo(.resizeWindowOption, ofType: Preference.ResizeWindowOption.self)
-          .withDetailView(resizeWindowView.view)
+          .withDetailView(resizeWindowView)
       }
 
-      SettingsListView {
+      SettingsList {
         SettingsItem.Switch()
           .image(name: "desktopcomputer")
           .bindTo(.usePhysicalResolution)
       }
 
-      SettingsListView {
+      SettingsList {
         SettingsItem.Switch()
           .image(name: "square.2.layers.3d.top.filled")
           .bindTo(.alwaysFloatOnTop)
@@ -84,18 +88,18 @@ class SettingsPageUI: SettingsPage {
     }
   }
 
-  private func sectionOSC() -> [NSView] {
+  private func sectionOSC() -> SettingsSection {
     return section {
-      SettingsListView(title: .text_OnScreenController) {
+      SettingsList(title: .text_OnScreenController) {
         SettingsItem.General(title: .text_Layout)
           .image(name: "menubar.dock.rectangle")
-          .withDetailView(oscLayoutView.view)
+          .withDetailView(oscLayoutView)
         SettingsItem.General(title: .text_Toolbar)
           .image(name: "ellipsis.rectangle")
-          .withDetailView(oscToolbarView.view)
+          .withDetailView(oscToolbarView)
       }
 
-      SettingsListView() {
+      SettingsList() {
         SettingsItem.PopupButton()
           .image(name: "forward.fill")
           .bindTo(.arrowButtonAction, ofType: Preference.ArrowButtonAction.self)
@@ -105,7 +109,7 @@ class SettingsPageUI: SettingsPage {
           .trailingLabel(.text_s)
       }
 
-      SettingsListView {
+      SettingsList {
         SettingsItem.Switch()
           .image(name: "arrow.right.and.line.vertical.and.arrow.left")
           .bindTo(.controlBarStickToCenter)
@@ -126,9 +130,9 @@ class SettingsPageUI: SettingsPage {
     }
   }
 
-  private func sectionOSD() -> [NSView] {
+  private func sectionOSD() -> SettingsSection {
     return section {
-      SettingsListView(title: .text_OnScreenDisplay) {
+      SettingsList(title: .text_OnScreenDisplay) {
         SettingsItem.Switch()
           .image(name: ["inset.filled.topleft.rectangle", "app.badge"])
           .bindTo(.enableOSD)
@@ -145,7 +149,7 @@ class SettingsPageUI: SettingsPage {
           }
       }
 
-      SettingsListView() {
+      SettingsList() {
         SettingsItem.Input(title: .controlBarAutoHideTimeoutLabel)
           .image(name: "timer")
           .bindTo(.osdAutoHideTimeout)
@@ -161,9 +165,9 @@ class SettingsPageUI: SettingsPage {
     }
   }
 
-  private func sectionThumbnail() -> [NSView] {
+  private func sectionThumbnail() -> SettingsSection {
     return section {
-      SettingsListView(title: .text_ThumbnailPreview) {
+      SettingsList(title: .text_ThumbnailPreview) {
         SettingsItem.Switch()
           .image(name: "custom.photo.bubble.left")
           .bindTo(.enableThumbnailPreview)
@@ -182,9 +186,9 @@ class SettingsPageUI: SettingsPage {
     }
   }
 
-  private func sectionPIP() -> [NSView] {
+  private func sectionPIP() -> SettingsSection {
     return section {
-      SettingsListView(title: .text_PictureinnPicture) {
+      SettingsList(title: .text_PictureinnPicture) {
         SettingsItem.General(title: .text_WhenEnteringPIP)
           .image(name: "pip.enter")
           .withDetailView {
@@ -204,9 +208,9 @@ class SettingsPageUI: SettingsPage {
     }
   }
 
-  private func sectionAccessibility() -> [NSView] {
+  private func sectionAccessibility() -> SettingsSection {
     return section {
-      SettingsListView(title: .text_Accessibility) {
+      SettingsList(title: .text_Accessibility) {
         SettingsItem.Switch()
           .image(name: "accessibility")
           .bindTo(.disableAnimations)
@@ -218,7 +222,8 @@ class SettingsPageUI: SettingsPage {
 }
 
 
-fileprivate class WindowInitialSizeView: WithSettingsLocalizationContext {
+fileprivate class WindowInitialSizeView: WithSettingsLocalizationContext, SettingsContainer {
+  lazy var itemID = SettingsContainerUUID.next()
   var l10n: SettingsLocalization.Context!
   let container: NSView
   let view: NSStackView
@@ -247,12 +252,17 @@ fileprivate class WindowInitialSizeView: WithSettingsLocalizationContext {
     view.addArrangedSubview(popupButtonUnit)
 
     container.addSubview(view)
-    view.padding(.bottom(8), .top(0), .leading(SettingsSubListView.padding), .trailing(0))
+    view.padding(.bottom(8), .top(0), .leading(SettingsSubList.indent), .trailing(0))
+  }
+
+  func makeView(context: SettingsLocalization.Context) -> NSView {
+    return container
   }
 }
 
 
-fileprivate class WindowInitialPositionView: WithSettingsLocalizationContext {
+fileprivate class WindowInitialPositionView: WithSettingsLocalizationContext, SettingsContainer {
+  lazy var itemID = SettingsContainerUUID.next()
   var l10n: SettingsLocalization.Context!
   let container: NSView
   let view: NSStackView
@@ -287,25 +297,30 @@ fileprivate class WindowInitialPositionView: WithSettingsLocalizationContext {
     self.view.alignment = .leading
 
     view.addArrangedSubview(
-      ui.hStack(ui.image("arrow.left.to.line"), ui.label(.text_XOffset), textFieldX, popupButtonXUnit)
+      ui.hStack(align: .firstBaseline, ui.image("arrow.left.to.line"), ui.label(.text_XOffset), textFieldX, popupButtonXUnit)
     )
     view.addArrangedSubview(
-      ui.hStack(ui.space(width: 16), ui.label(.text_toThe), popupButtonXPos, ui.label(.text_sideOfTheScreen))
+      ui.hStack(align: .firstBaseline, ui.space(width: 16), ui.label(.text_toThe), popupButtonXPos, ui.label(.text_sideOfTheScreen))
     )
     view.addArrangedSubview(
-      ui.hStack(ui.image("arrow.up.to.line"), ui.label(.text_YOffset), textFieldY, popupButtonYUnit)
+      ui.hStack(align: .firstBaseline, ui.image("arrow.up.to.line"), ui.label(.text_YOffset), textFieldY, popupButtonYUnit)
     )
     view.addArrangedSubview(
-      ui.hStack(ui.space(width: 16), ui.label(.text_toThe), popupButtonYPos, ui.label(.text_sideOfTheScreen))
+      ui.hStack(align: .firstBaseline, ui.space(width: 16), ui.label(.text_toThe), popupButtonYPos, ui.label(.text_sideOfTheScreen))
     )
 
     container.addSubview(view)
-    view.padding(.bottom(8), .top(0), .leading(SettingsSubListView.padding), .trailing(0))
+    view.padding(.bottom(8), .top(0), .leading(SettingsSubList.indent), .trailing(0))
+  }
+
+  func makeView(context: SettingsLocalization.Context) -> NSView {
+    return container
   }
 }
 
 
-fileprivate class ResizeWindowView: WithSettingsLocalizationContext {
+fileprivate class ResizeWindowView: WithSettingsLocalizationContext, SettingsContainer {
+  lazy var itemID = SettingsContainerUUID.next()
   var l10n: SettingsLocalization.Context!
   lazy var ui: SettingsUIHelper = SettingsUIHelper(l10n)
 
@@ -324,10 +339,15 @@ fileprivate class ResizeWindowView: WithSettingsLocalizationContext {
     }
     SettingsUIHelper.vEquallySpaced(buttons, 8, top: 0, bottom: 12)
   }
+
+  func makeView(context: SettingsLocalization.Context) -> NSView {
+    return view
+  }
 }
 
 
-fileprivate class OSCLayoutView: WithSettingsLocalizationContext {
+fileprivate class OSCLayoutView: WithSettingsLocalizationContext, SettingsContainer {
+  lazy var itemID = SettingsContainerUUID.next()
   var l10n: SettingsLocalization.Context!
   lazy var ui: SettingsUIHelper = SettingsUIHelper(l10n)
 
@@ -356,7 +376,7 @@ fileprivate class OSCLayoutView: WithSettingsLocalizationContext {
       container.addSubview(iv)
       iv.padding(.top(4)).size(width: 480 * 0.22, height: 270 * 0.22)
     }
-    SettingsUIHelper.hEquallySpaced(imageViews, 8, leading: SettingsSubListView.padding, trailing: 8)
+    SettingsUIHelper.hEquallySpaced(imageViews, 8, leading: SettingsSubList.indent, trailing: 8)
 
     let buttons = ui.radioGroup(.oscPosition, size: .regular, [
       (.oscPositionItem0, 0), (.oscPositionItem1, 1), (.oscPositionItem2, 2)
@@ -371,12 +391,15 @@ fileprivate class OSCLayoutView: WithSettingsLocalizationContext {
     view.addSubview(container)
     container.padding(.vertical).center(x: true)
   }
+
+  func makeView(context: SettingsLocalization.Context) -> NSView {
+    return view
+  }
 }
 
 
-private class OSCToolbarView: WithSettingsLocalizationContext {
-  var l10n: SettingsLocalization.Context!
-  lazy var ui: SettingsUIHelper = SettingsUIHelper(l10n)
+private class OSCToolbarView: SettingsContainer {
+  lazy var itemID = SettingsContainerUUID.next()
 
   let view: NSView
   let oscToolbarStackView: NSStackView
@@ -384,40 +407,9 @@ private class OSCToolbarView: WithSettingsLocalizationContext {
   private let toolbarSettingsSheetController = PrefOSCToolbarSettingsSheetController()
 
   init(l10n: SettingsLocalization.Context) {
-    self.l10n = l10n
     self.view = NSView()
     self.oscToolbarStackView = NSStackView()
     self.customizeButton = NSButton(title: l10n.localized(.text_Customize), target: nil, action: nil)
-    let container = NSView()
-    container.translatesAutoresizingMaskIntoConstraints = false
-
-    oscToolbarStackView.translatesAutoresizingMaskIntoConstraints = false
-    oscToolbarStackView.orientation = .horizontal
-    oscToolbarStackView.distribution = .gravityAreas
-    oscToolbarStackView.spacing = 0
-
-    let box = NSBox()
-    box.translatesAutoresizingMaskIntoConstraints = false
-    box.boxType = .primary
-    box.titlePosition = .noTitle
-    box.contentViewMargins = .zero
-    box.addSubview(oscToolbarStackView)
-    oscToolbarStackView.padding(.vertical, .leading(greaterThan: 0), .trailing(0))
-    container.addSubview(box)
-    box.padding(.top, .bottom(8))
-    box.widthAnchor
-      .constraint(equalTo: box.heightAnchor, multiplier: 5).isActive = true
-
-    customizeButton.target = self
-    customizeButton.action = #selector(customizeOSCToolbarAction(_:))
-    customizeButton.translatesAutoresizingMaskIntoConstraints = false
-    container.addSubview(customizeButton)
-    customizeButton.center(with: box, y: true)
-    SettingsUIHelper.hEquallySpaced([box, customizeButton], 8, leading: SettingsSubListView.padding, trailing: 8)
-
-    view.addSubview(container)
-    container.padding(.vertical).center(x: true)
-    updateOSCToolbarButtons()
   }
 
   private func updateOSCToolbarButtons() {
@@ -443,5 +435,39 @@ private class OSCToolbarView: WithSettingsLocalizationContext {
       Preference.set(array, for: .controlBarToolbarButtons)
       self.updateOSCToolbarButtons()
     }
+  }
+
+  func makeView(context: SettingsLocalization.Context) -> NSView {
+    let container = NSView()
+    container.translatesAutoresizingMaskIntoConstraints = false
+
+    oscToolbarStackView.translatesAutoresizingMaskIntoConstraints = false
+    oscToolbarStackView.orientation = .horizontal
+    oscToolbarStackView.distribution = .gravityAreas
+    oscToolbarStackView.spacing = 0
+
+    let box = NSBox()
+    box.translatesAutoresizingMaskIntoConstraints = false
+    box.boxType = .primary
+    box.titlePosition = .noTitle
+    box.contentViewMargins = .zero
+    box.addSubview(oscToolbarStackView)
+    oscToolbarStackView.padding(.vertical, .leading(greaterThan: 0), .trailing(0))
+    container.addSubview(box)
+    box.padding(.top, .bottom(8))
+    box.widthAnchor
+      .constraint(equalTo: box.heightAnchor, multiplier: 5).isActive = true
+
+    customizeButton.target = self
+    customizeButton.action = #selector(customizeOSCToolbarAction(_:))
+    customizeButton.translatesAutoresizingMaskIntoConstraints = false
+    container.addSubview(customizeButton)
+    customizeButton.center(with: box, y: true)
+    SettingsUIHelper.hEquallySpaced([box, customizeButton], 8, leading: SettingsSubList.indent, trailing: 8)
+
+    view.addSubview(container)
+    container.padding(.vertical).center(x: true)
+    updateOSCToolbarButtons()
+    return view
   }
 }

--- a/iina/Pages/SettingsPageUtilities.swift
+++ b/iina/Pages/SettingsPageUtilities.swift
@@ -10,67 +10,73 @@ import UniformTypeIdentifiers
 import SafariServices.SFSafariApplication
 
 class SettingsPageUtilities: SettingsPage {
+  override var identifier: String {
+    "utilities"
+  }
+  
   override var title: String {
     return NSLocalizedString("preference.utilities", comment: "Utilities")
   }
-  
+
   override var image: NSImage {
     return makeSymbol("wrench.and.screwdriver", fallbackImage: "pref_utils")
   }
-  
+
   override var localizationTable: String {
     "SettingsUtilsLocalizable"
   }
-  
+
   private lazy var setAsDefaultSheet = SetAsDefaultSheetWindow(l10n: localizationContext)
   private lazy var browserExtensionView = BrowserExtensionView(l10n: localizationContext)
   private lazy var thumbCacheSizeLabel: NSTextField = makeLabel()
 
-  override func content() -> NSView {
+  override func content() -> [SettingsSection] {
     return sections {
-      sectionDefaultApp()
-    }
-  }
-  
-  private func sectionDefaultApp() -> [NSView] {
-    return section {
-      SettingsListView(title: .text_DefaultApplication) {
-        SettingsItem.General(title: .text_SetIINAAsTheDefault)
-          .image(name: ["app.badge.checkmark.fill", "app"])
-          .extraViews(actionButton(action: #selector(setIINAAsDefaultAction)))
+      section {
+        SettingsList(title: .text_DefaultApplication) {
+          SettingsItem.General(title: .text_SetIINAAsTheDefault)
+            .image(name: ["app.badge.checkmark.fill", "app"])
+            .extraViews(actionButton(action: #selector(setIINAAsDefaultAction)))
+        }
       }
-      SettingsListView(title: .text_RestoreAlerts) {
-        SettingsItem.General(title: .text_RestoreSuppressedAlerts)
-          .image(name: "arrow.counterclockwise")
-          .extraViews(actionButton(action: #selector(resetSuppressedAlertsBtnAction)))
-          .hasDescription(content: .text_RestoreAllAlertsThat)
+      section {
+        SettingsList(title: .text_RestoreAlerts) {
+          SettingsItem.General(title: .text_RestoreSuppressedAlerts)
+            .image(name: "arrow.counterclockwise")
+            .extraViews(actionButton(action: #selector(resetSuppressedAlertsBtnAction)))
+            .hasDescription(content: .text_RestoreAllAlertsThat)
+        }
       }
-      SettingsListView(title: .text_ClearCache) {
-        SettingsItem.General(title: .text_ClearSavedPlaybackProgress)
-          .image(name: "clock")
-          .extraViews(actionButton(action: #selector(clearWatchLaterBtnAction), symbolName: ["trash"]))
-          .hasDescription(content: .text_DeleteAllWatchLater)
-        SettingsItem.General(title: .text_ClearPlaybackHistory)
-          .image(name: ["document.badge.clock", "doc.badge.clock", "doc"])
-          .extraViews(thumbCacheSizeLabel, actionButton(action: #selector(clearCacheBtnAction), symbolName: ["trash"]))
-          .hasDescription(content: .text_DeleteAllPlaybackHistories)
-        SettingsItem.General(title: .text_ClearThumbnailCache)
-          .image(name: "photo")
-          .extraViews(thumbCacheSizeLabel, actionButton(action: #selector(clearCacheBtnAction), symbolName: ["trash"]))
+      section {
+        SettingsList(title: .text_ClearCache) {
+          SettingsItem.General(title: .text_ClearSavedPlaybackProgress)
+            .image(name: "clock")
+            .extraViews(actionButton(action: #selector(clearWatchLaterBtnAction), symbolName: ["trash"]))
+            .hasDescription(content: .text_DeleteAllWatchLater)
+          SettingsItem.General(title: .text_ClearPlaybackHistory)
+            .image(name: ["document.badge.clock", "doc.badge.clock", "doc"])
+            .extraViews(thumbCacheSizeLabel, actionButton(action: #selector(clearCacheBtnAction), symbolName: ["trash"]))
+            .hasDescription(content: .text_DeleteAllPlaybackHistories)
+          SettingsItem.General(title: .text_ClearThumbnailCache)
+            .image(name: "photo")
+            .extraViews(thumbCacheSizeLabel, actionButton(action: #selector(clearCacheBtnAction), symbolName: ["trash"]))
+        }
       }
-      SettingsListView(title: .text_BrowserExtensions) {
-        SettingsItem.General(title: .text_GetBrowserExtensionsForIINA)
-          .image(name: "globe")
-          .hasDescription(content: .text_OpenLinksOrCurrentWebpage)
-          .withDetailView(browserExtensionView.view)
+      section {
+        SettingsList(title: .text_BrowserExtensions) {
+          SettingsItem.General(title: .text_GetBrowserExtensionsForIINA)
+            .image(name: "globe")
+            .hasDescription(content: .text_OpenLinksOrCurrentWebpage)
+            .withDetailView(browserExtensionView)
+        }
       }
     }
   }
 
-  func actionButton(action: Selector, symbolName: [String] = []) -> NSButton {
+  private func actionButton(action: Selector, symbolName: [String] = []) -> NSButton {
     return NSButton(title: "", image: .findSFSymbol(symbolName + ["arrow.right"])!, target: self, action: action)
   }
-  
+
   private func updateThumbnailCacheStat() {
     thumbCacheSizeLabel.stringValue = "\(FloatingPointByteCountFormatter.string(fromByteCount: CacheManager.shared.getCacheSize(), countStyle: .binary))B"
   }
@@ -142,18 +148,18 @@ fileprivate func makeLabel() -> NSTextField {
 
 fileprivate class SetAsDefaultSheetWindow: NSWindow {
   var contextWindow: NSWindow!
-  
+
   private let label: NSTextField
   private let okButton: NSButton
   private let cancelButton: NSButton
-  
+
   private let videoCheckBox: NSButton
   private let audioCheckBox: NSButton
   private let playListCheckBox: NSButton
 
   init(l10n: SettingsLocalization.Context) {
     let style: NSWindow.StyleMask = [.titled, .resizable, .fullSizeContentView]
-    
+
     self.okButton = NSButton(title: l10n.localized(.text_OK), target: nil, action: nil)
     okButton.translatesAutoresizingMaskIntoConstraints = false
     self.cancelButton = NSButton(title: l10n.localized(.text_Cancel), target: nil, action: nil)
@@ -171,29 +177,29 @@ fileprivate class SetAsDefaultSheetWindow: NSWindow {
                styleMask: style,
                backing: .buffered,
                defer: false)
-    
+
     okButton.target = self
     okButton.action = #selector(okBtnAction)
     cancelButton.target = self
     cancelButton.action = #selector(cancelBtnAction)
-    
+
     let stackView = NSStackView(views: [label, videoCheckBox, audioCheckBox, playListCheckBox])
     stackView.translatesAutoresizingMaskIntoConstraints = false
     stackView.orientation = .vertical
     stackView.spacing = 8
     stackView.alignment = .leading
-    
+
     contentView?.addSubview(stackView)
     contentView?.addSubview(okButton)
     contentView?.addSubview(cancelButton)
-    
+
     stackView.padding(.leading(24), .trailing(24), .top(24))
       .spacing(to: okButton, .bottom(16))
     cancelButton.center(with: okButton, y: true)
     okButton.padding(.bottom(24), .trailing(24))
       .spacing(to: cancelButton, .leading(8))
   }
-  
+
   @objc func okBtnAction(_ sender: Any) {
     guard let window = contextWindow else { return }
     guard
@@ -261,7 +267,7 @@ fileprivate class SetAsDefaultSheetWindow: NSWindow {
 
 fileprivate class BrowserExtensionView: SettingsAccessory.Base {
   func linkButton(_ key: SettingsLocalization.Key, _ selector: Selector, _ symbolName: [String] = []) -> NSButton {
-    let button = makeButton(key)
+    let button = ui.button(key)
     button.image = .findSFSymbol(symbolName + ["square.and.arrow.down"])
     button.imagePosition = .imageTrailing
     button.target = self
@@ -271,15 +277,15 @@ fileprivate class BrowserExtensionView: SettingsAccessory.Base {
 
   override init(l10n: SettingsLocalization.Context) {
     super.init(l10n: l10n)
-    
+
     let chromeBtn = linkButton(.text_Chrome, #selector(extChromeBtnAction))
     let firefoxBtn = linkButton(.text_Firefox, #selector(extFirefoxBtnAction))
     let safariBtn = linkButton(.text_Safari, #selector(extSafariBtnAction), ["safari"])
-    let stackView = makeStackView([safariBtn, chromeBtn, firefoxBtn])
+    let stackView = ui.hStack(safariBtn, chromeBtn, firefoxBtn)
     view.addSubview(stackView)
-    stackView.padding(.top(0), .bottom(16), .leading(SettingsSubListView.padding), .trailing(8))
+    stackView.padding(.top(0), .bottom(16), .leading(SettingsSubList.indent), .trailing(8))
   }
-  
+
   @objc func extChromeBtnAction(_ sender: Any) {
     NSWorkspace.shared.open([URL(string: AppData.chromeExtensionLink)!], withApplicationAt: NSWorkspace.shared.urlForApplication(withBundleIdentifier: "com.google.Chrome") ?? NSWorkspace.shared.urlForApplication(toOpen: URL(string: "http://")!)!, configuration: NSWorkspace.OpenConfiguration())
   }
@@ -287,7 +293,7 @@ fileprivate class BrowserExtensionView: SettingsAccessory.Base {
   @objc func extFirefoxBtnAction(_ sender: Any) {
     NSWorkspace.shared.open([URL(string: AppData.firefoxExtensionLink)!], withApplicationAt: NSWorkspace.shared.urlForApplication(withBundleIdentifier: "org.mozilla.firefox") ?? NSWorkspace.shared.urlForApplication(toOpen: URL(string: "http://")!)!, configuration: NSWorkspace.OpenConfiguration())
   }
-  
+
   @objc func extSafariBtnAction() {
     SFSafariApplication.showPreferencesForExtension(withIdentifier: "com.colliderli.iina.OpenInIINA")
   }

--- a/iina/Pages/SettingsPageVideoAudio.swift
+++ b/iina/Pages/SettingsPageVideoAudio.swift
@@ -9,7 +9,11 @@
 import Foundation
 
 class SettingsPageVideoAudio: SettingsPage {
-  private lazy var audioOutputDeviceView: AudioOutputDeviceView = AudioOutputDeviceView(l10n: localizationContext)
+  private lazy var audioOutputDeviceView: AudioOutputDeviceView = AudioOutputDeviceView()
+
+  override var identifier: String {
+    "video.audio"
+  }
 
   override var title: String {
     return NSLocalizedString("preference.video_audio", comment: "Codec")
@@ -23,7 +27,7 @@ class SettingsPageVideoAudio: SettingsPage {
     "SettingsVideoAudioLocalizable"
   }
 
-  override func content() -> NSView {
+  override func content() -> [SettingsSection] {
     return sections {
       sectionVideo()
       sectionAudio()
@@ -31,9 +35,9 @@ class SettingsPageVideoAudio: SettingsPage {
     }
   }
 
-  private func sectionVideo() -> [NSView] {
+  private func sectionVideo() -> SettingsSection {
     return section {
-      SettingsListView(title: .text_Video) {
+      SettingsList(title: .text_Video) {
         SettingsItem.Input()
           .image(name: "number")
           .bindTo(.videoThreads)
@@ -49,14 +53,14 @@ class SettingsPageVideoAudio: SettingsPage {
           .hasDescription()
       }
 
-      SettingsListView {
+      SettingsList {
         SettingsItem.Switch()
           .image(name: ["document.badge.gearshape", "doc.badge.gearshape"])
           .bindTo(.loadIccProfile)
           .hasDescription()
       }
 
-      SettingsListView {
+      SettingsList {
         SettingsItem.Switch()
           .image(name: ["sun.lefthalf.filled", "sun.max"])
           .bindTo(.enableHdrSupport)
@@ -79,9 +83,9 @@ class SettingsPageVideoAudio: SettingsPage {
     }
   }
 
-  private func sectionAudio() -> [NSView] {
+  private func sectionAudio() -> SettingsSection {
     return section {
-      SettingsListView(title: .text_Audio) {
+      SettingsList(title: .text_Audio) {
         SettingsItem.General(title: .audioDriverEnableAVFoundationLabel)
           .image(name: "waveform")
           .withHelpLink(AppData.audioDriverHellpLink)
@@ -101,7 +105,7 @@ class SettingsPageVideoAudio: SettingsPage {
           .hasDescription(content: .videoThreadsDesc)
       }
 
-      SettingsListView {
+      SettingsList {
         SettingsItem.SwitchWithInput()
           .image(name: "speaker.wave.3")
           .labelKey(.enableInitialVolume)
@@ -112,10 +116,10 @@ class SettingsPageVideoAudio: SettingsPage {
           .hasDescription()
       }
 
-      SettingsListView {
+      SettingsList {
         SettingsItem.General(title: .text_PreferredAudioDevice)
           .image(name: "hifispeaker.and.homepod")
-          .withDetailView(audioOutputDeviceView.view)
+          .withDetailView(audioOutputDeviceView)
         SettingsItem.General(title: .text_SPDIFOutput)
           .image(name: "audio.jack.stereo")
           .withExpandingDetailView {
@@ -128,7 +132,7 @@ class SettingsPageVideoAudio: SettingsPage {
           }
       }
 
-      SettingsListView {
+      SettingsList {
         SettingsItem.General(title: .text_PreferredLanguage)
           .image(name: "character.book.closed")
           .withDetailView(
@@ -139,9 +143,9 @@ class SettingsPageVideoAudio: SettingsPage {
     }
   }
 
-  private func sectionReplayGain() -> [NSView] {
+  private func sectionReplayGain() -> SettingsSection {
     return section {
-      SettingsListView(title: .text_ReplayGain) {
+      SettingsList(title: .text_ReplayGain) {
         SettingsItem.PopupButton()
           .image(name: "speaker.plus")
           .bindTo(.replayGain, ofType: Preference.ReplayGainOption.self)
@@ -187,18 +191,20 @@ fileprivate enum AudioDriver: Int, InitializingFromKey, CaseIterable {
 }
 
 
-fileprivate class AudioOutputDeviceView: WithSettingsLocalizationContext {
-  var l10n: SettingsLocalization.Context!
-  lazy var ui: SettingsUIHelper = SettingsUIHelper(l10n)
+fileprivate class AudioOutputDeviceView: SettingsContainer {
+  lazy var itemID = SettingsContainerUUID.next()
 
   let view: NSView
   let audioDevicePopUp: NSPopUpButton
 
-  init(l10n: SettingsLocalization.Context) {
-    self.l10n = l10n
+  init() {
     self.view = NSView()
     self.audioDevicePopUp = NSPopUpButton()
+  }
 
+  func makeView(context: SettingsLocalization.Context) -> NSView {
+    let l10n = context
+    let ui = SettingsUIHelper(l10n)
     audioDevicePopUp.translatesAutoresizingMaskIntoConstraints = false
     audioDevicePopUp.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
     audioDevicePopUp.removeAllItems()
@@ -255,7 +261,9 @@ fileprivate class AudioOutputDeviceView: WithSettingsLocalizationContext {
     audioDevicePopUp.action = #selector(audioDeviceAction)
 
     view.addSubview(audioDevicePopUp)
-    audioDevicePopUp.padding(.top(-4), .bottom(8), .leading(SettingsSubListView.padding), .trailing(8))
+    audioDevicePopUp.padding(.top(-4), .bottom(8), .leading(SettingsSubList.indent), .trailing(8))
+
+    return view
   }
 
   @objc func audioDeviceAction(_ sender: Any) {

--- a/iina/SettingsGeneralLocalizable.strings
+++ b/iina/SettingsGeneralLocalizable.strings
@@ -8,6 +8,7 @@
 "actionAfterLaunch.items.2" = "Do nothing";
 /* id="M0z-bI-88d" */
 "alwaysOpenInNewWindow.label" = "Allow multiple player windows";
+
 /* id="WZE-pS-9ne" */
 "groupSimultaneousOpensInPlaylist.label" = "Group media in playlist when opening multiple files at once";
 /* id="Z7U-cf-ezr" */
@@ -123,7 +124,7 @@
 /* key="uQR-Fx-oEm" */
 "$Behavior" = "Behavior";
 /* key="xr2-rB-O0x" */
-"$PauseresumeWhen" = "Pause/resume when";
+"pauseresumeWhen" = "Pause/resume when";
 
 "$CheckForUpdates.items.3600" = "Hourly";
 "$CheckForUpdates.items.86400" = "Daily";

--- a/iina/SettingsHelper.swift
+++ b/iina/SettingsHelper.swift
@@ -26,6 +26,12 @@ class SettingsUIHelper {
     self.l10n = l10n
   }
 
+  func button(_ key: SettingsLocalization.Key) -> NSButton {
+    let btn = NSButton(title: l10n.localized(key), target: nil, action: nil)
+    btn.translatesAutoresizingMaskIntoConstraints = false
+    return btn
+  }
+
   func popupButton(_ items: [(SettingsLocalization.Key, Int)]) -> NSPopUpButton {
     let button = NSPopUpButton()
     button.bezelStyle = .accessoryBarAction
@@ -49,24 +55,58 @@ class SettingsUIHelper {
     return textField
   }
 
-  func label(_ key: SettingsLocalization.Key) -> NSTextField {
+  func input(_ key: Preference.Key, fixedAlignmentRect: Bool = true, isFixedSize: Bool = true) -> NSTextField {
+    let input = fixedAlignmentRect ? TextFieldWithFixedAlignmentRect() : NSTextField()
+    input.translatesAutoresizingMaskIntoConstraints = false
+    input.bezelStyle = .roundedBezel
+    input.bind(.value, to: UserDefaults.standard, withKeyPath: key.rawValue)
+    if isFixedSize {
+      input.size(width: 48, height: 25)
+    }
+    return input
+  }
+
+  func label(_ key: SettingsLocalization.Key, isSmall: Bool = true, isSecondary: Bool = true) -> NSTextField {
     let textField = NSTextField(labelWithString: l10n.localized(key))
-    textField.controlSize = .small
-    textField.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+    textField.translatesAutoresizingMaskIntoConstraints = false
+    if isSmall {
+      textField.controlSize = .small
+      textField.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+    }
+    if isSecondary {
+      textField.textColor = .secondaryLabelColor
+    }
     return textField
   }
 
-  func hStack(align: NSLayoutConstraint.Attribute = .firstBaseline, _ views: NSView...) -> NSStackView {
+  func colorWell(_ key: Preference.Key) -> NSColorWell {
+    let colorWell = NSColorWell()
+    colorWell.translatesAutoresizingMaskIntoConstraints = false
+    if #available(macOS 13.0, *) {
+      colorWell.colorWellStyle = .expanded
+    }
+    colorWell.size(height: 24)
+    colorWell.bind(.value, to: UserDefaults.standard,
+                   withKeyPath: key.rawValue,
+                   options: [.valueTransformer: MPVColorStringTransformer()])
+    return colorWell
+  }
+
+  func hStack(align: NSLayoutConstraint.Attribute = .centerY, spacing: CGFloat = 8, _ views: NSView...) -> NSStackView {
     let stackView = NSStackView(views: views)
+    stackView.translatesAutoresizingMaskIntoConstraints = false
     stackView.orientation = .horizontal
     stackView.alignment = align
+    stackView.spacing = spacing
     return stackView
   }
 
-  func vStack(_ views: NSView...) -> NSStackView {
+  func vStack(align: NSLayoutConstraint.Attribute = .leading, spacing: CGFloat = 8, _ views: NSView...) -> NSStackView {
     let stackView = NSStackView(views: views)
+    stackView.translatesAutoresizingMaskIntoConstraints = false
     stackView.orientation = .vertical
-    stackView.alignment = .leading
+    stackView.alignment = align
+    stackView.spacing = spacing
     return stackView
   }
 
@@ -80,6 +120,12 @@ class SettingsUIHelper {
     let imageView = NSImageView(image: .findSFSymbol([symbol])!)
     imageView.size(width: size, height: size)
     return imageView
+  }
+
+  fileprivate class TextFieldWithFixedAlignmentRect: NSTextField {
+    override func frame(forAlignmentRect alignmentRect: NSRect) -> NSRect {
+      return alignmentRect
+    }
   }
 
   private class RadioTagTransformer: ValueTransformer {

--- a/iina/SettingsItem.swift
+++ b/iina/SettingsItem.swift
@@ -9,12 +9,13 @@
 import Cocoa
 
 struct SettingsItem {
-  class Base: NSView, WithSettingsLocalizationContext  {
+  class Base: NSObject, SettingsContainer {
+    lazy var itemID = SettingsContainerUUID.next()
     var l10n: SettingsLocalization.Context!
 
     var isFirstItem = false
     var isLastItem = false
-    
+
     var controlSize: NSControl.ControlSize = .regular
 
     func setControlSize(_ label: NSTextField) {
@@ -30,68 +31,63 @@ struct SettingsItem {
         label.font = NSFont.systemFont(ofSize: NSFont.systemFontSize)
       }
     }
+
+    func makeView(context: SettingsLocalization.Context) -> NSView {
+      self.l10n = context
+      let view = NSView()
+      view.translatesAutoresizingMaskIntoConstraints = false
+      return view
+    }
+
+    func registerSearchEntry(context: SettingsSearch.Context) {
+      return
+    }
   }
 
   class Custom: Base {
     var customView: NSView!
 
-    init() {
-      super.init(frame: NSRect())
-      self.translatesAutoresizingMaskIntoConstraints = false
+    override init() {
+      super.init()
     }
-    
-    @MainActor required init?(coder: NSCoder) {
-      fatalError("init(coder:) has not been implemented")
-    }
-    
+
     func view(_ view: NSView) -> Self {
       self.customView = view
       return self
     }
 
-    override func viewDidMoveToWindow() {
-      guard window != nil else { return }
+    override func makeView(context: SettingsLocalization.Context) -> NSView {
+      self.l10n = context
+      let view = View(tag: itemID)
+      view.translatesAutoresizingMaskIntoConstraints = false
       customView.translatesAutoresizingMaskIntoConstraints = false
-      self.addSubview(customView)
+      view.addSubview(customView)
       customView.padding(.all)
-      self.wantsLayer = true
-      self.layer?.cornerRadius = 6
-      self.layer?.masksToBounds = true
+      view.wantsLayer = true
+      view.layer?.cornerRadius = 6
+      view.layer?.masksToBounds = true
+      return view
     }
+
+    class View: SettingsView { }
   }
-  
+
   class LongInput: Base {
-    let label: NSTextField
-    let textField: NSTextField
-    
-    var iconView: NSImageView!
     var imageName: [String]?
 
     var key: Preference.Key?
     var hasDesc: Bool = false
     var descKey: SettingsLocalization.Key?
 
-    init() {
-      self.label = NSTextField(labelWithString: "")
-      label.translatesAutoresizingMaskIntoConstraints = false
-      self.textField = NSTextField()
-      textField.translatesAutoresizingMaskIntoConstraints = false
-      iconView = NSImageView()
-      iconView.translatesAutoresizingMaskIntoConstraints = false
+    override init() {
+      super.init()
+    }
 
-      super.init(frame: NSRect())
-      self.translatesAutoresizingMaskIntoConstraints = false
-    }
-    
-    @MainActor required init?(coder: NSCoder) {
-      fatalError("init(coder:) has not been implemented")
-    }
-    
     func bindTo(_ key: Preference.Key) -> Self {
       self.key = key
       return self
     }
-    
+
     public func image(name: [String]) -> Self {
       self.imageName = name
       return self
@@ -101,24 +97,35 @@ struct SettingsItem {
       self.controlSize = size
       return self
     }
-    
+
     func hasDescription(content: SettingsLocalization.Key? = nil) -> Self {
       self.hasDesc = true
       self.descKey = content
       return self
     }
 
-    override func viewDidMoveToWindow() {
+    override func makeView(context: SettingsLocalization.Context) -> NSView {
+      self.l10n = context
+      let view = View(tag: itemID)
+      view.translatesAutoresizingMaskIntoConstraints = false
+
+      let label = NSTextField(labelWithString: "")
+      label.translatesAutoresizingMaskIntoConstraints = false
+      let textField = NSTextField()
+      textField.translatesAutoresizingMaskIntoConstraints = false
+      let iconView = NSImageView()
+      iconView.translatesAutoresizingMaskIntoConstraints = false
+
       setControlSize(label)
       setControlSize(textField)
-      
+
       if let key = key {
         label.stringValue = l10n.localized(.init("\(key.rawValue).label"))
         textField.bind(.value, to: UserDefaults.standard, withKeyPath: key.rawValue)
       }
-      
+
       let labelStackView = NSStackView(views: [iconView, label])
-      
+
       if let imageName, let symbol = NSImage.findSFSymbol(imageName) {
         iconView.image = symbol
         iconView.size(width: 24, height: 20)
@@ -126,7 +133,7 @@ struct SettingsItem {
         iconView.isHidden = true
         label.padding(.leading(30))
       }
-      
+
       labelStackView.translatesAutoresizingMaskIntoConstraints = false
       labelStackView.orientation = .horizontal
       labelStackView.spacing = 6
@@ -135,7 +142,7 @@ struct SettingsItem {
       stackView.translatesAutoresizingMaskIntoConstraints = false
       stackView.orientation = .vertical
       stackView.alignment = .leading
-      
+
       if hasDesc {
         let descKey =  descKey ?? .init("\(key!.rawValue).desc")
         let descLabel = NSTextField(labelWithString: l10n.localized(descKey))
@@ -145,18 +152,31 @@ struct SettingsItem {
         descLabel.makeMultiLine()
         descLabel.padding(.leading(30))
       }
-      
-      self.addSubview(stackView)
-      
+
+      view.addSubview(stackView)
+
       textField.padding(.leading(30), .trailing)
-      
+
       stackView.padding(.leading(6), .trailing(8), .vertical(8))
+      return view
     }
+
+    override func registerSearchEntry(context: SettingsSearch.Context) {
+      let l10n = context.l10n
+      context.add(itemID,
+                  (key?.rawValue).map { l10n.localized(.init($0 + ".label")) },
+                  isMain: true)
+      context.add(itemID,
+                  (descKey?.rawValue).map { l10n.localized(.init($0 + ".desc")) },
+                  isMain: true)
+    }
+
+    class View: SettingsView { }
   }
 
 
   class General: Base {
-    var detailView: NSView?
+    var detailContainer: SettingsContainer?
     var valueView: NSView?
     var extraViews: [NSView] = []
 
@@ -164,10 +184,11 @@ struct SettingsItem {
     var desc: NSTextField!
     var labelStackView: NSStackView!
     var image: NSImageView!
-    var mainView: NSView!
     var valueStackView: NSStackView!
     var expandingStackView: NSStackView?
     var disclosureButton: NSButton!
+    var renderedDetailView: NSView?
+    weak var renderedView: View?
 
     var labelLocalizationKey: SettingsLocalization.Key?
     var imageName: [String]?
@@ -189,7 +210,6 @@ struct SettingsItem {
     var isExpandable = false
     var isExpandableAndClickable: Bool = true
     var isExpanded = false
-    private var missingL10n = false
 
     var key: Preference.Key?
 
@@ -197,8 +217,7 @@ struct SettingsItem {
 
     init(title l10nKey: SettingsLocalization.Key? = nil) {
       self.labelLocalizationKey = l10nKey
-      super.init(frame: NSRect())
-      self.translatesAutoresizingMaskIntoConstraints = false
+      super.init()
     }
 
     public func hasDescription() -> Self {
@@ -232,22 +251,56 @@ struct SettingsItem {
       return self
     }
 
-    private func populateViews() {
+    func getChildren() -> [any SettingsContainer] {
+      if let detailContainer {
+        return [detailContainer]
+      }
+      return []
+    }
+
+    override func makeView(context: SettingsLocalization.Context) -> NSView {
+      self.l10n = context
+      let view = View(owner: self, tag: itemID)
+      view.translatesAutoresizingMaskIntoConstraints = false
+      self.renderedView = view
+      populateViews(on: view)
+      initBinding()
+      return view
+    }
+
+    private func localizedTitle(_ context: SettingsLocalization.Context? = nil) -> String {
+      let l10n = context ?? l10n!
+      if let labelLocalizationKey = labelLocalizationKey {
+        return l10n.localized(labelLocalizationKey)
+      } else if let key = key {
+        let l10nKey = labelLocalizationKey ?? .init("\(key.rawValue).label")
+        return l10n.localized(l10nKey)
+      } else {
+        return "# Localization Missing"
+      }
+    }
+
+    override func registerSearchEntry(context: SettingsSearch.Context) {
+      let l10n = context.l10n
+      context.add(itemID, localizedTitle(l10n), isMain: true)
+      if hasDesc {
+        context.add(itemID, l10n.localized(descKey ?? .init("\(key!.rawValue).desc")))
+      }
+      if let detailContainer {
+        let newContext = context.with(parent: itemID)
+        detailContainer.registerSearchEntry(context: newContext)
+      }
+    }
+
+    private func populateViews(on view: View) {
       backgroundView = ClickableView()
       backgroundView.showTopRoundCorner = isFirstItem
       backgroundView.showBottomRoundCorner = isLastItem
       backgroundView.translatesAutoresizingMaskIntoConstraints = false
-      self.addSubview(backgroundView)
+      view.addSubview(backgroundView)
       backgroundView.padding(.all)
 
-      if let labelLocalizationKey = labelLocalizationKey {
-        label = NSTextField(labelWithString: l10n.localized(labelLocalizationKey))
-      } else if let key = key {
-        let l10nKey = labelLocalizationKey ?? .init("\(key.rawValue).label")
-        label = NSTextField(labelWithString: l10n.localized(l10nKey))
-      } else {
-        label = NSTextField(labelWithString: "# Localization Missing")
-      }
+      label = NSTextField(labelWithString: localizedTitle())
       label.translatesAutoresizingMaskIntoConstraints = false
       label.controlSize = controlSize
       label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
@@ -310,11 +363,8 @@ struct SettingsItem {
       backgroundView.addSubview(disclosureButton)
 
       let valueViews = self.getValueViews()
-      valueViews.forEach { view in
-        view.translatesAutoresizingMaskIntoConstraints = false
-        if let l10n = l10n {
-          SettingsLocalization.injectContext(view, l10n)
-        }
+      valueViews.forEach {
+        $0.translatesAutoresizingMaskIntoConstraints = false
       }
 
       valueStackView = NSStackView()
@@ -352,35 +402,29 @@ struct SettingsItem {
 
     func initBinding() {}
 
-    override func viewDidMoveToWindow() {
-      guard window != nil else { return }
-      populateViews()
-      initBinding()
-    }
-
     @discardableResult
-    func withExpandingDetailView(@SettingsSubListBuilder _ view: () -> NSView) -> Self {
+    func withExpandingDetailView(@SettingsSubListBuilder _ view: () -> SettingsSubList) -> Self {
       isExpandable = true
-      detailView = view()
+      detailContainer = view()
       return self
     }
 
     @discardableResult
-    func withExpandingDetailView(_ view: NSView) -> Self {
+    func withExpandingDetailView(_ view: SettingsContainer) -> Self {
       isExpandable = true
-      detailView = view
+      detailContainer = view
       return self
     }
 
     @discardableResult
-    func withDetailView(@SettingsSubListBuilder _ view: () -> NSView) -> Self {
-      detailView = view()
+    func withDetailView(@SettingsSubListBuilder _ view: () -> SettingsSubList) -> Self {
+      detailContainer = view()
       return self
     }
 
     @discardableResult
-    func withDetailView(_ view: NSView) -> Self {
-      detailView = view
+    func withDetailView(_ view: SettingsContainer) -> Self {
+      detailContainer = view
       return self
     }
 
@@ -391,11 +435,10 @@ struct SettingsItem {
     }
 
     private func prepareExpandableView() {
-      guard let detailView = detailView else { return }
+      guard let detailContainer else { return }
+      let detailView = detailContainer.makeView(context: l10n)
+      renderedDetailView = detailView
       detailView.translatesAutoresizingMaskIntoConstraints = false
-      if let l10n = l10n {
-        SettingsLocalization.injectContext(detailView, l10n)
-      }
 
       backgroundView.removeFromSuperview()
       backgroundView.clickable = isExpandable && isExpandableAndClickable
@@ -404,7 +447,7 @@ struct SettingsItem {
       expandingStackView!.orientation = .vertical
       expandingStackView!.spacing = 0
       expandingStackView?.translatesAutoresizingMaskIntoConstraints = false
-      self.addSubview(expandingStackView!)
+      renderedView?.addSubview(expandingStackView!)
       expandingStackView!.padding(.all)
       expandingStackView!.addArrangedSubview(backgroundView)
       expandingStackView!.addArrangedSubview(detailView)
@@ -420,14 +463,10 @@ struct SettingsItem {
       }
     }
 
-    override func mouseUp(with event: NSEvent) {
+    func handleMouseUp() {
       guard isExpandable && isExpandableAndClickable else { return }
 
       toggleExpandable()
-    }
-
-    required init?(coder: NSCoder) {
-      fatalError("init(coder:) has not been implemented")
     }
 
     @objc private func openHelpLink(_ sender: NSButton!) {
@@ -436,35 +475,59 @@ struct SettingsItem {
       }
     }
 
-    func toggleExpandable(_ setValue: Bool? = nil) {
+    func toggleExpandable(_ setValue: Bool? = nil, animated: Bool = true) {
       if let setValue = setValue {
         isExpanded = setValue
       } else {
         isExpanded.toggle()
       }
 
+      guard let renderedDetailView else { return }
+
       if isExpanded {
         disclosureButton.state = .on
-        expandingStackView!.setVisibilityPriority(.mustHold, for: detailView!)
+        expandingStackView!.setVisibilityPriority(.mustHold, for: renderedDetailView)
         backgroundView.enableRoundCorner = false
       } else {
         disclosureButton.state = .off
-        expandingStackView!.setVisibilityPriority(.notVisible, for: detailView!)
+        expandingStackView!.setVisibilityPriority(.notVisible, for: renderedDetailView)
         backgroundView.enableRoundCorner = true
       }
 
-      let duration = AccessibilityPreferences.adjustedDuration(0.25)
-      NSAnimationContext.runAnimationGroup({ context in
-        context.duration = duration
-        context.allowsImplicitAnimation = true
-        self.window?.layoutIfNeeded()
-      }, completionHandler: nil)
-
-      DispatchQueue.main.asyncAfter(deadline: .now() + duration / 3) {
+      if animated {
+        let duration = AccessibilityPreferences.adjustedDuration(0.25)
         NSAnimationContext.runAnimationGroup({ context in
           context.duration = duration
-          self.detailView?.alphaValue = self.isExpanded ? 1 : 0
+          context.allowsImplicitAnimation = true
+          self.renderedView?.window?.layoutIfNeeded()
         }, completionHandler: nil)
+
+        DispatchQueue.main.asyncAfter(deadline: .now() + duration / 3) {
+          NSAnimationContext.runAnimationGroup({ context in
+            context.duration = duration
+            self.renderedDetailView?.alphaValue = self.isExpanded ? 1 : 0
+          }, completionHandler: nil)
+        }
+      } else {
+        self.renderedDetailView?.alphaValue = self.isExpanded ? 1 : 0
+        self.renderedView?.window?.layoutIfNeeded()
+      }
+    }
+
+    class View: SettingsView {
+      unowned let owner: General
+
+      init(owner: General, tag: Int) {
+        self.owner = owner
+        super.init(tag: tag)
+      }
+
+      required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+      }
+
+      override func mouseUp(with event: NSEvent) {
+        owner.handleMouseUp()
       }
     }
   }
@@ -488,6 +551,16 @@ struct SettingsItem {
       popupButton.target = self
       popupButton.action = #selector(popupChanged)
       return [popupButton]
+    }
+
+    override func registerSearchEntry(context: SettingsSearch.Context) {
+      super.registerSearchEntry(context: context)
+      let l10n = context.l10n
+      guard let l10nKey = key?.rawValue ?? labelLocalizationKey?.rawValue else { return }
+      for (tag, _) in valueTypes {
+        let title = l10n.localized(.init("\(l10nKey).items.\(tag)"))
+        context.add(itemID, title)
+      }
     }
 
     func bindTo<T>(_ key: Preference.Key, ofType t: T.Type) -> Self
@@ -535,7 +608,7 @@ struct SettingsItem {
     }
 
     @objc func popupChanged(_ sender: NSPopUpButton) {
-      guard let detailView = detailView, let tag = tagForDisabled else { return }
+      guard let detailView = renderedDetailView, let tag = tagForDisabled else { return }
 
       let enabled = sender.selectedTag() != tag
       setSubControls(detailView, enabled: enabled)
@@ -592,7 +665,7 @@ struct SettingsItem {
     }
 
     @objc func switchChanged(_ sender: NSSwitch) {
-      guard let detailView = detailView else { return }
+      guard let detailView = renderedDetailView else { return }
 
       let enabled = sender.state == .on
       if !isExpandableAndClickable {
@@ -705,7 +778,7 @@ struct SettingsItem {
     @objc func switchChanged(_ sender: NSSwitch) {
       let enableSubControls = sender.state == .on
       setSubControls(popupButton, enabled: enableSubControls)
-      if let detailView = detailView {
+      if let detailView = renderedDetailView {
         setSubControls(detailView, enabled: enableSubControls)
       }
     }
@@ -776,6 +849,7 @@ struct SettingsItem {
       setControlSize(textField)
       let stack = NSStackView(views: [textField])
       if let stepper {
+        stepper.controlSize = controlSize
         stack.addView(stepper, in: .trailing)
         stack.spacing = 2
       }
@@ -889,7 +963,7 @@ struct SettingsItem {
     @objc func switchChanged(_ sender: NSSwitch) {
       let enableSubControls = sender.state == .on
       setSubControls(textField, enabled: enableSubControls)
-      if let detailView = detailView {
+      if let detailView = renderedDetailView {
         setSubControls(detailView, enabled: enableSubControls)
       }
     }
@@ -960,7 +1034,7 @@ fileprivate class ClickableView: NSView {
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
   }
-  
+
   override func viewDidChangeEffectiveAppearance() {
     backgroundColor = if #available(macOS 26, *) {
       if effectiveAppearance.isDark {
@@ -983,7 +1057,8 @@ fileprivate class NonClickableButton: NSButton {
 
 class SettingsAccessory {
   /// A Base class for customized controls.
-  class Base: NSObject, WithSettingsLocalizationContext {
+  class Base: NSObject, WithSettingsLocalizationContext, SettingsContainer {
+    lazy var itemID = SettingsContainerUUID.next()
     var l10n: SettingsLocalization.Context!
     let view: NSView
     lazy var ui: SettingsUIHelper = SettingsUIHelper(l10n)
@@ -994,64 +1069,17 @@ class SettingsAccessory {
       self.view.translatesAutoresizingMaskIntoConstraints = false
     }
 
-    func makeLabel(_ key: SettingsLocalization.Key, isSmall: Bool = true) -> NSTextField {
-      let label = NSTextField(labelWithString: l10n.localized(key))
-      label.translatesAutoresizingMaskIntoConstraints = false
-      if isSmall {
-        label.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
-        label.textColor = .secondaryLabelColor
-      }
-      return label
-    }
-    
-    func makeButton(_ key: SettingsLocalization.Key) -> NSButton {
-      let btn = NSButton(title: l10n.localized(key), target: nil, action: nil)
-      btn.translatesAutoresizingMaskIntoConstraints = false
-      return btn
+    func registerSearchEntry(context: SettingsSearch.Context) {
+      return
     }
 
-    func makeColorWell(_ key: Preference.Key) -> NSColorWell {
-      let colorWell = NSColorWell()
-      colorWell.translatesAutoresizingMaskIntoConstraints = false
-      if #available(macOS 13.0, *) {
-        colorWell.colorWellStyle = .expanded
-      }
-      colorWell.size(height: 24)
-      colorWell.bind(.value, to: UserDefaults.standard,
-                     withKeyPath: key.rawValue,
-                     options: [.valueTransformer: MPVColorStringTransformer()])
-      return colorWell
-    }
-
-    func makeInput(_ key: Preference.Key, fixedAlignmentRect: Bool = true, isFixedSize: Bool = true) -> NSTextField {
-      let input = fixedAlignmentRect ? TextFieldWithFixedAlignmentRect() : NSTextField()
-      input.translatesAutoresizingMaskIntoConstraints = false
-      input.bezelStyle = .roundedBezel
-      input.bind(.value, to: UserDefaults.standard, withKeyPath: key.rawValue)
-      if isFixedSize {
-        input.size(width: 48, height: 25)
-      }
-      return input
-    }
-
-    func makeStackView(_ views: [NSView], orientation: NSUserInterfaceLayoutOrientation = .horizontal) -> NSStackView {
-      let stackView = NSStackView(views: views)
-      stackView.translatesAutoresizingMaskIntoConstraints = false
-      stackView.orientation = orientation
-      stackView.alignment = orientation == .horizontal ? .centerY : .centerX
-      stackView.spacing = 8
-      return stackView
+    func makeView(context: SettingsLocalization.Context) -> NSView {
+      return view
     }
   }
-  
-  fileprivate class TextFieldWithFixedAlignmentRect: NSTextField {
-    override func frame(forAlignmentRect alignmentRect: NSRect) -> NSRect {
-      return alignmentRect
-    }
-  }
-  
-  class Selection: NSView, WithSettingsLocalizationContext {
-    var l10n: SettingsLocalization.Context!
+
+  class Selection: NSObject, SettingsContainer {
+    lazy var itemID = SettingsContainerUUID.next()
 
     private class ClickableBox: NSBox {
       var listener: (() -> Void)?
@@ -1061,12 +1089,15 @@ class SettingsAccessory {
       }
     }
 
-    let view: NSBox
+    let view: SettingsView
+    let box: NSBox
     let stackView: NSStackView
     var key: Preference.Key? = nil
     var items: [Int: NSBox] = [:]
     var customtransformer: (((Int) -> Any), (Any?) -> Int)?
     var localizationKey: Preference.Key?
+
+    var builtView: NSView?
 
     private var valueTypes: [(Int, String)] = []
     @objc private var selectedValue: Int = 0 {
@@ -1076,17 +1107,17 @@ class SettingsAccessory {
     }
 
     init(l10nKey: Preference.Key? = nil, topPadding: CGFloat = -4) {
-      self.view = NSBox()
+      self.view = SettingsView(tag: -1)
+      self.box = NSBox()
       self.stackView = NSStackView()
       self.localizationKey = l10nKey
-      super.init(frame: NSRect())
-      self.translatesAutoresizingMaskIntoConstraints = false
-
       view.translatesAutoresizingMaskIntoConstraints = false
-      view.boxType = .custom
-      view.borderWidth = 0
-      view.titlePosition = .noTitle
-      view.contentView = stackView
+
+      box.translatesAutoresizingMaskIntoConstraints = false
+      box.boxType = .custom
+      box.borderWidth = 0
+      box.titlePosition = .noTitle
+      box.contentView = stackView
 
       stackView.translatesAutoresizingMaskIntoConstraints = false
       stackView.orientation = .vertical
@@ -1099,6 +1130,69 @@ class SettingsAccessory {
 
     @MainActor required init?(coder: NSCoder) {
       fatalError("init(coder:) has not been implemented")
+    }
+
+    func makeView(context: SettingsLocalization.Context) -> NSView {
+      if let builtView {
+        return builtView
+      }
+
+      let l10n = context
+      guard let l10nKey = localizationKey?.rawValue ?? key?.rawValue else {
+        fatalError("No localization key provided")
+      }
+      for (tag, _) in valueTypes {
+        let title = l10n.localized(.init("\(l10nKey).items.\(tag)"))
+        let desc = l10n.localized(.init("\(l10nKey).items.\(tag).desc"))
+        let box = ClickableBox()
+        box.translatesAutoresizingMaskIntoConstraints = false
+        box.boxType = .custom
+        box.titlePosition = .noTitle
+        let itemTitle = NSTextField(labelWithString: title)
+        let itemDesc = NSTextField(labelWithString: desc)
+        itemDesc.textColor = .secondaryLabelColor
+        itemDesc.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+        itemDesc.lineBreakMode = .byWordWrapping
+        itemDesc.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+        let itemStackView = NSStackView(views: [itemTitle, itemDesc])
+        itemStackView.translatesAutoresizingMaskIntoConstraints = false
+        itemStackView.spacing = 2
+        itemStackView.orientation = .vertical
+        itemStackView.alignment = .leading
+        itemStackView.setHuggingPriority(.init(100), for: .horizontal)
+        box.contentView = itemStackView
+        box.cornerRadius = 6
+        box.listener = { [unowned self] in
+          if let transformer = self.customtransformer {
+            Preference.set(transformer.0(tag), for: self.key!)
+          } else {
+            Preference.set(tag, for: self.key!)
+          }
+        }
+        items[tag] = box
+        itemStackView.padding(.vertical(6), .horizontal(12))
+        stackView.addArrangedSubview(box)
+      }
+
+      view.addSubview(box)
+      box.padding(.top, .leading(SettingsSubList.indent), .trailing(8), .bottom(8))
+
+      initBinding()
+      builtView = view
+
+      view.tag = itemID
+      return view
+    }
+
+    func registerSearchEntry(context: SettingsSearch.Context) {
+      let l10n = context.l10n
+      guard let l10nKey = localizationKey?.rawValue ?? key?.rawValue else { return }
+      for (tag, _) in valueTypes {
+        let title = l10n.localized(.init("\(l10nKey).items.\(tag)"))
+        let desc = l10n.localized(.init("\(l10nKey).items.\(tag).desc"))
+        context.add(itemID, title)
+        context.add(itemID, desc)
+      }
     }
 
     func order(_ order: [Int]) -> Self {
@@ -1167,52 +1261,9 @@ class SettingsAccessory {
         }
       }
     }
-
-    override func viewDidMoveToWindow() {
-      guard window != nil, stackView.arrangedSubviews.isEmpty else { return }
-
-      guard let l10nKey = localizationKey?.rawValue ?? key?.rawValue else { return }
-      for (tag, _) in valueTypes {
-        let title = l10n.localized(.init("\(l10nKey).items.\(tag)"))
-        let desc = l10n.localized(.init("\(l10nKey).items.\(tag).desc"))
-        let box = ClickableBox()
-        box.translatesAutoresizingMaskIntoConstraints = false
-        box.boxType = .custom
-        box.titlePosition = .noTitle
-        let itemTitle = NSTextField(labelWithString: title)
-        let itemDesc = NSTextField(labelWithString: desc)
-        itemDesc.textColor = .secondaryLabelColor
-        itemDesc.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
-        itemDesc.lineBreakMode = .byWordWrapping
-        itemDesc.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
-        let itemStackView = NSStackView(views: [itemTitle, itemDesc])
-        itemStackView.translatesAutoresizingMaskIntoConstraints = false
-        itemStackView.spacing = 2
-        itemStackView.orientation = .vertical
-        itemStackView.alignment = .leading
-        itemStackView.setHuggingPriority(.init(100), for: .horizontal)
-        box.contentView = itemStackView
-        box.cornerRadius = 6
-        box.listener = { [unowned self] in
-          if let transformer = self.customtransformer {
-            Preference.set(transformer.0(tag), for: self.key!)
-          } else {
-            Preference.set(tag, for: self.key!)
-          }
-        }
-        items[tag] = box
-        itemStackView.padding(.vertical(6), .horizontal(12))
-        stackView.addArrangedSubview(box)
-      }
-
-      self.addSubview(view)
-      view.padding(.top, .leading(SettingsSubListView.padding), .trailing(8), .bottom(8))
-
-      initBinding()
-    }
   }
- 
-  
+
+
   class FileChooserView {
     var textField: NSTextField
     var chooseButton: NSButton
@@ -1238,30 +1289,32 @@ class SettingsAccessory {
   }
 
 
-  class LanguageSelector: NSView, WithSettingsLocalizationContext {
-    var l10n: SettingsLocalization.Context!
+  class LanguageSelector: NSObject, SettingsContainer {
+    var itemID = SettingsContainerUUID.next()
 
+    let view: NSView
     private var key: Preference.Key? = nil
     private var hasDesc = false
     private let stackView: NSStackView
     private let audioLangTokenField: LanguageTokenField
-    
-    init() {
+
+    override init() {
+      self.view = NSView()
       self.audioLangTokenField = .init()
       self.stackView = NSStackView()
-      super.init(frame: NSRect())
+      super.init()
 
       audioLangTokenField.translatesAutoresizingMaskIntoConstraints = false
       audioLangTokenField.bezelStyle = .roundedBezel
       audioLangTokenField.target = self
       audioLangTokenField.action = #selector(preferredLanguageAction(_:))
-      
+
       stackView.translatesAutoresizingMaskIntoConstraints = false
       stackView.orientation = .vertical
       stackView.addArrangedSubview(audioLangTokenField)
-      self.addSubview(stackView)
+      view.addSubview(stackView)
 
-      stackView.padding(.top(-4), .leading(SettingsSubListView.padding), .trailing(8), .bottom(8))
+      stackView.padding(.top(-4), .leading(SettingsSubList.indent), .trailing(8), .bottom(8))
     }
 
     @MainActor required init?(coder: NSCoder) {
@@ -1272,15 +1325,14 @@ class SettingsAccessory {
       self.key = key
       return self
     }
-    
+
     func hasDescription() -> Self {
       self.hasDesc = true
       return self
     }
 
-    override func viewDidMoveToWindow() {
-      guard window != nil else { return }
-
+    func makeView(context: SettingsLocalization.Context) -> NSView {
+      let l10n = context
       audioLangTokenField.awakeFromNib()
       if let key = key {
         audioLangTokenField.commaSeparatedValues = Preference.string(for: key) ?? ""
@@ -1292,7 +1344,7 @@ class SettingsAccessory {
           stackView.addArrangedSubview(descLabel)
         }
       }
-      
+      return view
     }
 
     @objc func preferredLanguageAction(_ sender: LanguageTokenField) {

--- a/iina/SettingsLocalization.swift
+++ b/iina/SettingsLocalization.swift
@@ -24,25 +24,25 @@ struct SettingsLocalization {
 
   class Context {
     var tableName: String
+    var keyPrefix: String?
 
-    init(tableName: String) {
+    init(tableName: String, keyPrefix: String? = nil) {
       self.tableName = tableName
+      self.keyPrefix = keyPrefix
+    }
+
+    func scoped(to keyPrefix: String?) -> Context {
+      Context(tableName: tableName, keyPrefix: keyPrefix)
     }
 
     func localized(_ key: Key) -> String {
-      return NSLocalizedString(key.rawValue, tableName: tableName, comment: key.rawValue)
+      var k = key.rawValue
+      if !k.hasPrefix("$") {
+        k = (keyPrefix ?? "") + (keyPrefix == nil ? "" : ".") + k
+      }
+      return NSLocalizedString(k, tableName: tableName, comment: key.rawValue)
     }
   }
-
-  static func injectContext(_ view: NSView, _ context: SettingsLocalization.Context!) {
-    if var vc = view as? WithSettingsLocalizationContext {
-      vc.l10n = context
-    }
-    for v in view.subviews {
-      injectContext(v, context)
-    }
-  }
-
 }
 
 protocol WithSettingsLocalizationContext {

--- a/iina/SettingsLocalizationKeysGeneral.swift
+++ b/iina/SettingsLocalizationKeysGeneral.swift
@@ -59,5 +59,6 @@ extension SettingsLocalization.Key {
   static let text_Screenshots = SettingsLocalization.Key("$Screenshots")
   static let text_Hourly = SettingsLocalization.Key("$Hourly")
   static let text_Behavior = SettingsLocalization.Key("$Behavior")
-  static let text_PauseresumeWhen = SettingsLocalization.Key("$PauseresumeWhen")
+  
+  static let pauseresumeWhen = SettingsLocalization.Key("pauseresumeWhen")
 }

--- a/iina/SettingsPage.swift
+++ b/iina/SettingsPage.swift
@@ -9,13 +9,66 @@
 import Cocoa
 
 
+protocol SettingsContainer {
+  var itemID: Int { get }
+  func makeView(context: SettingsLocalization.Context) -> NSView
+  func getChildren() -> [any SettingsContainer]
+  func registerSearchEntry(context: SettingsSearch.Context)
+}
+
+extension SettingsContainer {
+  func getChildren() -> [any SettingsContainer] { [] }
+  func registerSearchEntry(context: SettingsSearch.Context) { }
+
+  func find(where predicate: (any SettingsContainer) -> Bool) -> SettingsContainer? {
+    if predicate(self) {
+      return self
+    }
+    for item in getChildren() {
+      if let res = item.find(where: predicate) {
+        return res
+      }
+    }
+    return nil
+  }
+}
+
+
+enum SettingsContainerUUID {
+  static private var counter: Int = 70000
+  static func next() -> Int {
+    counter += 1
+    return counter
+  }
+}
+
+
+class SettingsView: NSView {
+  private var tag_: Int
+
+  override var tag: Int {
+    get { tag_ }
+    set { tag_ = newValue }
+  }
+
+  init(tag: Int) {
+    self.tag_ = tag
+    super.init(frame: .zero)
+  }
+  
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+}
+
+
 @resultBuilder
 struct SettingsViewsBuilder {
-  static func buildBlock(_ components: NSView...) -> [NSView] {
+  static func buildBlock(_ components: SettingsSection...) -> [SettingsSection] {
     return components
   }
 
-  static func buildBlock(_ components: [NSView]...) -> [NSView] {
+  static func buildBlock(_ components: [SettingsSection]...) -> [SettingsSection] {
     components.flatMap { $0 }
   }
 }
@@ -30,8 +83,8 @@ struct SettingsItemsBuilder {
 @resultBuilder
 struct SettingsSubItemsBuilder {
   static func buildBlock(_ components: SettingsItem.Base...) -> [SettingsItem.Base] {
-    for c in components {
-      c.controlSize = .small
+    for component in components {
+      component.controlSize = .small
     }
     return components
   }
@@ -39,21 +92,18 @@ struct SettingsSubItemsBuilder {
 
 @resultBuilder
 struct SettingsSubListBuilder {
-  static func buildBlock(_ components: SettingsItem.Base...) -> SettingsSubListView {
-    return SettingsSubListView(components)
+  static func buildBlock(_ components: SettingsItem.Base...) -> SettingsSubList {
+    return SettingsSubList(components)
   }
 }
 
 @resultBuilder
 struct SettingsSectionBuilder {
-  static func buildBlock(_ components: SettingsContainer...) -> [NSView] {
-    return components.map { $0.getContainer() }
+  static func buildBlock(_ components: SettingsContainer...) -> [SettingsContainer] {
+    return components
   }
 }
 
-protocol SettingsContainer {
-  func getContainer() -> NSView
-}
 
 class SettingsPage {
   var identifier: String { "" }
@@ -74,37 +124,50 @@ class SettingsPage {
     SettingsLocalization.Context(tableName: localizationTable)
   }()
 
-  final func getContent() -> NSView {
-    let view = content()
-    // inject l10n context
-    SettingsLocalization.injectContext(view, localizationContext)
+  lazy var builtSections: [SettingsSection] = {
+    content()
+  }()
+
+  final func getView() -> NSView {
+    let view = makeContentView()
 
     let containerView = NSView()
     containerView.translatesAutoresizingMaskIntoConstraints = false
     containerView.addSubview(view)
-    view.padding(.horizontal(4), .bottom(8), .top)
+    view.padding(to: containerView, .horizontal(4), .bottom(8), .top)
     return containerView
   }
 
-  func content() -> NSView {
-    return NSView()
+  func content() -> [SettingsSection] {
+    return []
   }
 
-  final func section(@SettingsSectionBuilder _ containers: () -> [NSView]) -> [NSView] {
-    return containers()
+  final func section(@SettingsSectionBuilder _ containers: () -> [SettingsContainer]) -> SettingsSection {
+    SettingsSection(spacing: sectionSpacing, containers())
   }
 
-  final func sections(@SettingsViewsBuilder _ sections: () -> [NSView]) -> NSStackView {
-    let views: [NSView] = sections()
+  final func sections(@SettingsViewsBuilder _ sections: () -> [SettingsSection]) -> [SettingsSection] {
+    sections()
+  }
+
+  private func makeContentView() -> NSView {
+    let views = builtSections.map {
+      $0.makeView(context: localizationContext)
+    }
     let stackView = NSStackView(views: views)
     stackView.translatesAutoresizingMaskIntoConstraints = false
     stackView.orientation = .vertical
     stackView.spacing = self.sectionSpacing
     views.forEach {
-      $0.padding(.horizontal)
+      $0.padding(to: stackView, .horizontal)
       stackView.setVisibilityPriority(.mustHold, for: $0)
     }
     return stackView
+  }
+
+  func registerSearchEntries() {
+    let context = SettingsSearch.Context(l10n: localizationContext, page: identifier, section: nil, parent: nil)
+    builtSections.forEach { $0.registerSearchEntry(context: context) }
   }
 
   func makeSymbol(_ name: String, fallbackImage: NSImage.Name) -> NSImage {
@@ -115,28 +178,184 @@ class SettingsPage {
 }
 
 
-class SettingsListView: NSBox, SettingsContainer, WithSettingsLocalizationContext {
-  var container: Container!
-
+class SettingsSection: SettingsContainer {
+  lazy var itemID = SettingsContainerUUID.next()
+  let spacing: CGFloat
   var titleKey: SettingsLocalization.Key?
-  var listTitle: String?
-  var l10n: SettingsLocalization.Context!
+  let children: [SettingsContainer]
+
+  init(titleKey: SettingsLocalization.Key? = nil, spacing: CGFloat, _ children: [SettingsContainer]) {
+    self.spacing = spacing
+    self.titleKey = titleKey
+    self.children = children
+
+    if self.titleKey == nil,
+       let firstList = children.first as? SettingsList,
+       let titleKey = firstList.titleKey
+    {
+      self.titleKey = titleKey
+      firstList.titleKey = nil
+    }
+  }
+
+  func getChildren() -> [any SettingsContainer] {
+    children
+  }
+
+  func makeView(context: SettingsLocalization.Context) -> NSView {
+    let view = View()
+    let childViews = children.map { $0.makeView(context: context) }
+    let stackView = NSStackView(views: childViews)
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+    stackView.orientation = .vertical
+    stackView.spacing = spacing
+    childViews.forEach {
+      $0.padding(to: stackView, .horizontal)
+      stackView.setVisibilityPriority(.mustHold, for: $0)
+    }
+    view.addSubview(stackView)
+
+    if let titleKey {
+      let title = context.localized(titleKey)
+      view.sectionTitle = title
+      let titleField = NSTextField(labelWithString: title)
+      titleField.font = NSFont.systemFont(ofSize: 14, weight: .bold)
+      titleField.translatesAutoresizingMaskIntoConstraints = false
+      titleField.textColor = NSColor.secondaryLabelColor
+      view.titleField = titleField
+      view.addSubview(titleField)
+      titleField.padding(to: view, .top, .leading(16), .trailing(8))
+      stackView.spacing(to: titleField, .top(12)).padding(to: view, .leading, .trailing, .bottom)
+    } else {
+      stackView.padding(to: view, .all)
+    }
+
+    return view
+  }
+
+  func registerSearchEntry(context: SettingsSearch.Context) {
+    let context = context.with(section: titleKey.map { context.l10n.localized($0) })
+    return children.forEach { $0.registerSearchEntry(context: context) }
+  }
+
+  class View: NSView {
+    var sectionTitle: String?
+    var titleField: NSTextField?
+  }
+}
+
+
+class SettingsList: SettingsContainer {
+  lazy var itemID = SettingsContainerUUID.next()
+  var titleKey: SettingsLocalization.Key?
+  var items: [SettingsItem.Base]
+  var horizontalPadding: CGFloat { 8 }
 
   static private let SMALL_TITLE = false
 
-  class Container: NSView, WithSettingsLocalizationContext {
-    var l10n: SettingsLocalization.Context!
-    let listView: SettingsListView
-    var titleKey: SettingsLocalization.Key?
-    var titleField: NSTextField!
+  init(title: SettingsLocalization.Key? = nil, _ items: [SettingsItem.Base]? = nil) {
+    self.titleKey = title
+    self.items = items ?? []
+  }
 
-    init(_ listView: SettingsListView, titleKey: SettingsLocalization.Key? = nil) {
+  convenience init(title: SettingsLocalization.Key? = nil, @SettingsItemsBuilder _ items: () -> [SettingsItem.Base]) {
+    self.init(title: title, items())
+  }
+
+  func getChildren() -> [any SettingsContainer] {
+    items
+  }
+
+  func makeView(context: SettingsLocalization.Context) -> NSView {
+    let listView = makeListView(context: context)
+    let container = ContainerView(listView: listView)
+    container.addSubview(listView)
+
+    guard let titleKey else {
+      listView.padding(to: container, .vertical, .horizontal(horizontalPadding))
+      return container
+    }
+
+    let title = context.localized(titleKey)
+    let titleField = NSTextField(labelWithString: SettingsList.SMALL_TITLE ? title.localizedUppercase : title)
+    titleField.font = SettingsList.SMALL_TITLE ?
+      NSFont.systemFont(ofSize: NSFont.smallSystemFontSize, weight: .bold) :
+      NSFont.systemFont(ofSize: 14, weight: .bold)
+    titleField.translatesAutoresizingMaskIntoConstraints = false
+    titleField.textColor = NSColor.secondaryLabelColor
+    container.titleField = titleField
+    container.addSubview(titleField)
+    titleField.padding(to: container, .top, .leading(16), .trailing(8))
+    listView.spacing(to: titleField, .top(SettingsList.SMALL_TITLE ? 8 : 12))
+    listView.padding(to: container, .bottom, .horizontal(8))
+    return container
+  }
+
+  func registerSearchEntry(context: SettingsSearch.Context) {
+    items.forEach { $0.registerSearchEntry(context: context) }
+  }
+
+  func makeListView(context: SettingsLocalization.Context) -> View {
+    let listView = View()
+    addItems(to: listView, context: context)
+    return listView
+  }
+
+  func addItems(to listView: View, context: SettingsLocalization.Context) {
+    items.forEach {
+      $0.isFirstItem = false
+      $0.isLastItem = false
+    }
+    items.first?.isFirstItem = true
+    items.last?.isLastItem = true
+
+    let itemViews = items.map { item -> NSView in
+      item.makeView(context: context)
+    }
+    itemViews.forEach {
+      listView.contentView!.addSubview($0)
+      $0.padding(to: listView.contentView, .horizontal)
+    }
+    itemViews.first?.padding(to: listView.contentView, .top(0))
+    itemViews.last?.padding(to: listView.contentView, .bottom)
+    zip(itemViews.dropFirst(), itemViews.dropLast()).forEach { (bottomItem, topItem) in
+      bottomItem.spacing(to: topItem, .top)
+      let separator = NSBox()
+      separator.translatesAutoresizingMaskIntoConstraints = false
+      separator.boxType = .separator
+      separator.titlePosition = .noTitle
+      listView.contentView!.addSubview(separator)
+      separator.padding(to: topItem, .bottom, .leading(36), .trailing)
+    }
+  }
+
+  /// A container view for displaying the list with a title.
+  class ContainerView: NSView {
+    let listView: SettingsList.View
+    var titleField: NSTextField?
+
+    init(listView: SettingsList.View) {
       self.listView = listView
       super.init(frame: NSRect())
-
-      self.titleKey = titleKey
       self.translatesAutoresizingMaskIntoConstraints = false
-      self.addSubview(listView)
+    }
+
+    required init?(coder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+  }
+
+  class View: NSBox {
+    init() {
+      super.init(frame: NSRect())
+      self.translatesAutoresizingMaskIntoConstraints = false
+      self.titlePosition = .noTitle
+      self.contentViewMargins = NSSize(width: 0, height: 0)
+
+      if #available(macOS 26, *) {
+        self.boxType = .custom
+        self.cornerRadius = SettingsPage.corderRadius
+      }
     }
 
     required init?(coder: NSCoder) {
@@ -144,123 +363,58 @@ class SettingsListView: NSBox, SettingsContainer, WithSettingsLocalizationContex
     }
 
     override func viewDidMoveToWindow() {
-      if let key = titleKey {
-        let title = l10n.localized(key)
-        if (SMALL_TITLE) {
-          titleField = NSTextField(labelWithString: title.localizedUppercase)
-          titleField.font = NSFont.systemFont(ofSize: NSFont.smallSystemFontSize, weight: .bold)
+      guard window != nil else { return }
+      viewDidChangeEffectiveAppearance()
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+      if #available(macOS 26, *) {
+        if effectiveAppearance.isDark {
+          self.borderColor = .separatorColor
+          self.fillColor = .underPageBackgroundColor
         } else {
-          titleField = NSTextField(labelWithString: title)
-          titleField.font = NSFont.systemFont(ofSize: 14, weight: .bold)
+          self.borderColor = .black.withAlphaComponent(0.05)
+          self.fillColor = .black.withAlphaComponent(0.02)
         }
-        titleField.translatesAutoresizingMaskIntoConstraints = false
-        self.addSubview(titleField)
-        titleField.padding(.top, .leading(16), .trailing(8))
-        titleField.textColor = NSColor.secondaryLabelColor
-        listView.spacing(to: titleField, .top(SMALL_TITLE ? 8 : 12))
-        listView.padding(.bottom, .horizontal(8))
-      } else {
-        listView.padding(.vertical, .horizontal(8))
-      }
-    }
-  }
-
-  init(title: SettingsLocalization.Key? = nil, _ items: [SettingsItem.Base]? = nil) {
-    super.init(frame: NSRect())
-    self.translatesAutoresizingMaskIntoConstraints = false
-
-    self.titleKey = title
-    self.container = Container(self, titleKey: title)
-    self.titlePosition = .noTitle
-    self.contentViewMargins = NSSize(width: 0, height: 0)
-    
-    if #available(macOS 26, *) {
-      self.boxType = .custom
-      self.cornerRadius = SettingsPage.corderRadius
-    }
-
-    if let items = items {
-      addItems(items)
-    }
-  }
-
-  convenience init(title: SettingsLocalization.Key? = nil, @SettingsItemsBuilder _ items: () -> [SettingsItem.Base]) {
-    self.init(title: title, items())
-  }
-
-  func getContainer() -> NSView {
-    return container
-  }
-
-  private func addItems(_ subItems: [SettingsItem.Base]) {
-    subItems.forEach {
-      self.contentView!.addSubview($0)
-      $0.padding(.horizontal)
-    }
-    subItems.first?.padding(.top(0))
-    subItems.first?.isFirstItem = true
-    subItems.last?.padding(.bottom)
-    subItems.last?.isLastItem = true
-    zip(subItems.dropFirst(), subItems.dropLast()).forEach { (bottomItem, topItem) in
-      bottomItem.spacing(to: topItem, .top)
-      let separator = NSBox()
-      separator.translatesAutoresizingMaskIntoConstraints = false
-      separator.boxType = .separator
-      separator.titlePosition = .noTitle
-      self.contentView!.addSubview(separator)
-      separator.padding(to: topItem, .bottom, .leading(36), .trailing)
-    }
-  }
-
-  required init?(coder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
-
-  override func viewDidMoveToWindow() {
-    self.listTitle = titleKey.map(l10n.localized(_:))
-    self.viewDidChangeEffectiveAppearance()
-  }
-  
-  override func viewDidChangeEffectiveAppearance() {
-    if #available(macOS 26, *) {
-      if effectiveAppearance.isDark {
-        self.borderColor = .separatorColor
-        self.fillColor = .underPageBackgroundColor
-      } else {
-        self.borderColor = .black.withAlphaComponent(0.05)
-        self.fillColor = .black.withAlphaComponent(0.02)
       }
     }
   }
 }
 
 
-class SettingsSubListView: SettingsListView {
-  static let padding: CGFloat = 28
+class SettingsSubList: SettingsList {
+  static let indent: CGFloat = 28
+  override var horizontalPadding: CGFloat { 0 }
 
-  init(_ items: [SettingsItem.Base]? = nil) {
-    super.init(items)
+  override func makeListView(context: SettingsLocalization.Context) -> View {
+    items.forEach { $0.controlSize = .small }
 
-    self.fillColor = .clear
-    self.boxType = .custom
-    self.borderWidth = 0
+    let listView = View()
+    addItems(to: listView, context: context)
 
     let separator = NSBox()
     separator.translatesAutoresizingMaskIntoConstraints = false
     separator.boxType = .separator
     separator.titlePosition = .noTitle
-    self.contentView!.addSubview(separator)
-    separator.padding(.top, .leading(36), .trailing)
-
-    items?.forEach { $0.controlSize = .small }
+    listView.contentView!.addSubview(separator)
+    separator.padding(to: listView.contentView, .top, .leading(36), .trailing)
+    return listView
   }
 
-  required init?(coder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
-  }
-  
-  override func viewDidChangeEffectiveAppearance() {
-    return
+  class View: SettingsList.View {
+    override init() {
+      super.init()
+      self.fillColor = .clear
+      self.boxType = .custom
+      self.borderWidth = 0
+    }
+
+    required init?(coder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+
+    override func viewDidChangeEffectiveAppearance() {
+      return
+    }
   }
 }
-

--- a/iina/SettingsSearch.swift
+++ b/iina/SettingsSearch.swift
@@ -1,0 +1,179 @@
+//
+//  SettingsSearch.swift
+//  iina
+//
+//  Created by Hechen Li on 2026-05-11.
+//  Copyright © 2026 lhc. All rights reserved.
+//
+
+fileprivate class Trie {
+  class Node {
+    var children: [Node] = []
+    let char: Character
+    init(_ c: Character) {
+      char = c
+    }
+  }
+
+  let entry: SettingsSearch.Entry
+
+  private let root: Node
+  private var lastPosition: Node
+  var active: Bool
+
+  init(_ entry: SettingsSearch.Entry) {
+    self.entry = entry
+    self.root = Node(" ")
+    self.lastPosition = root
+    self.active = true
+
+    let s = [[entry.title], entry.extraTerms]
+      .flatMap { $0 }.compactMap { $0 }.joined(separator: " ").lowercased()
+    let strings = s.components(separatedBy: " ")
+    for string in strings {
+      var t = string
+      while t.count != 0 {
+        addString(t)
+        t.removeFirst()
+      }
+    }
+  }
+
+  func reset() {
+    lastPosition = root
+    active = true
+  }
+
+  func addString(_ str: String) {
+    var current = root
+    for c in Array(str) {
+      if let next = current.children.first(where: { $0.char == c }) {
+        current = next
+      } else {
+        let newNode = Node(c)
+        current.children.append(newNode)
+        current = newNode
+      }
+    }
+  }
+
+  func search(_ str: String) {
+    for c in str {
+      // half-width and full-width spaces
+      if c == " " || c == "　" {
+        lastPosition = root
+        continue
+      }
+      if let next = lastPosition.children.first(where: { $0.char == c }) {
+        lastPosition = next
+      } else {
+        active = false
+        return
+      }
+    }
+  }
+}
+
+
+struct SettingsSearch {
+  class Entry {
+    let page: String
+    let anchor: Int
+    let title: String
+    let isMain: Bool
+    let extraTerms: [String] = []
+    let section: String?
+    let parent: Int?
+
+    let icon: NSImage?
+
+    var pageTitle: String?
+    var parentEntry: Entry?
+    var mainEntry: Entry?
+
+    var isPageHeader: Bool {
+      icon != nil
+    }
+
+    var titleForDisplay: String {
+      mainEntry?.title ?? title
+    }
+
+    init(page: String, anchor: Int, title: String, isMain: Bool, section: String?, parent: Int?, icon: NSImage? = nil) {
+      self.page = page
+      self.anchor = anchor
+      self.title = title
+      self.isMain = isMain
+      self.section = section
+      self.parent = parent
+      self.icon = icon
+    }
+
+    /// For displaying group headers in the result table
+    convenience init(pageHeader header: String, icon: NSImage) {
+      self.init(page: header, anchor: -1, title: "", isMain: false, section: nil, parent: nil, icon: icon)
+    }
+
+    static func assignMainAndParentEntries(_ entries: [Entry]) {
+      let dict = Dictionary(grouping: entries, by: \.anchor)
+      for (_, group) in dict {
+        let mainEntry = group.first(where: \.isMain)
+        group.filter { !$0.isMain }.forEach { $0.mainEntry = mainEntry }
+      }
+      for entry in entries where entry.parent != nil {
+        entry.parentEntry = dict[entry.parent!]?.first(where: \.isMain)
+      }
+    }
+  }
+
+  struct Context {
+    let l10n: SettingsLocalization.Context
+    let page: String
+    let section: String?
+    let parent: Int?
+
+    func with(section: String?) -> Self {
+      .init(l10n: l10n, page: page, section: section, parent: parent)
+    }
+
+    func with(parent: Int?) -> Self {
+      .init(l10n: l10n, page: page, section: section, parent: parent)
+    }
+
+    func add(_ tag: Int, _ entry: String?, isMain: Bool = false) {
+      guard let entry else { return }
+      entries.append(.init(page: page, anchor: tag, title: entry,
+                           isMain: isMain, section: section, parent: parent))
+    }
+  }
+
+  static var entries: [Entry] = []
+
+  static private var tries: [Trie] = []
+  static private var lastString: String = ""
+
+  static func makeTries() {
+    Entry.assignMainAndParentEntries(entries)
+    for entry in entries {
+      add(entry: entry)
+    }
+  }
+
+  static func search(_ searchString: String) -> [SettingsSearch.Entry]? {
+    if searchString == lastString {
+      return nil
+    }
+    if searchString.hasPrefix(lastString) {
+      tries.filter { $0.active }.forEach { $0.search(String(searchString.dropFirst(lastString.count))) }
+    } else {
+      tries.forEach { $0.reset(); $0.search(searchString) }
+    }
+    lastString = searchString
+    return tries.filter { $0.active }.map { $0.entry }
+  }
+
+  static func add(entry: SettingsSearch.Entry) {
+    tries.append(Trie(entry))
+  }
+}
+

--- a/iina/SettingsWindow.swift
+++ b/iina/SettingsWindow.swift
@@ -33,7 +33,10 @@ class SettingsWindow: NSWindow {
     SettingsPageUtilities(),
   ])
 
-  let contentScrollView: NSScrollView
+  let sidebarList: NSTableView
+  private let contentScrollView: NSScrollView
+  private let highlightView: HighlightView
+
   var pages: [SettingsPage]
 
   private var sectionNames: [String] = []
@@ -42,10 +45,20 @@ class SettingsWindow: NSWindow {
 
   private var prevPageIndex: Int?
 
+  private let searchBox: NSSearchField
+  private lazy var completionPopover: NSPopover = createSearchPopover()
+  private var currentCompletionResults: [SettingsSearch.Entry] = []
+
+  private var pendingHighlightItem: (id: Int, parentId: Int?)?
+
   init(_ pages: [SettingsPage]) {
     self.pages = pages
     contentScrollView = NSScrollView()
     contentScrollView.autohidesScrollers = true
+
+    self.sidebarList = NSTableView()
+    self.searchBox = NSSearchField()
+    self.highlightView = HighlightView()
 
     super.init(contentRect: NSRect(x: 0, y: 0, width: 600, height: 480),
                styleMask: [.closable, .miniaturizable, .resizable, .titled, .fullSizeContentView],
@@ -67,10 +80,12 @@ class SettingsWindow: NSWindow {
     sidebarViewController.view.addSubview(sidebarBackground)
     sidebarBackground.translatesAutoresizingMaskIntoConstraints = false
     sidebarBackground.padding(.all)
-    let searchBox = NSSearchField()
     sidebarBackground.addSubview(searchBox)
     searchBox.translatesAutoresizingMaskIntoConstraints = false
     searchBox.controlSize = .large
+
+    searchBox.target = self
+    searchBox.action = #selector(searchBoxAction(_:))
 
     let sidebarScrollView = NSScrollView()
     sidebarScrollView.hasVerticalScroller = true
@@ -78,7 +93,8 @@ class SettingsWindow: NSWindow {
     sidebarScrollView.translatesAutoresizingMaskIntoConstraints = false
     sidebarScrollView.borderType = .noBorder
     sidebarScrollView.drawsBackground = false
-    let sidebarList = NSTableView()
+
+    sidebarList.translatesAutoresizingMaskIntoConstraints = false
     sidebarList.style = .sourceList
     sidebarList.autoresizingMask = [.width, .height]
     sidebarList.headerView = nil
@@ -88,7 +104,7 @@ class SettingsWindow: NSWindow {
 
     sidebarBackground.addSubview(sidebarScrollView)
     sidebarScrollView.padding(.bottom, .horizontal)
-    
+
     if #available(macOS 26, *) {
       searchBox.padding(.top(40), .horizontal(8))
       sidebarScrollView.spacing(to: searchBox, .top(16))
@@ -110,6 +126,10 @@ class SettingsWindow: NSWindow {
 
     contentViewController.view.addSubview(contentScrollView)
     contentScrollView.padding(.all)
+
+    highlightView.translatesAutoresizingMaskIntoConstraints = false
+    contentViewController.view.addSubview(highlightView)
+    highlightView.padding(.all)
 
     NotificationCenter.default.addObserver(self, selector: #selector(scrolled),
                                            name: NSView.boundsDidChangeNotification, object: nil)
@@ -135,6 +155,9 @@ class SettingsWindow: NSWindow {
     self.toolbar = NSToolbar()
     self.toolbar?.displayMode = .iconOnly
 
+    pages.forEach { $0.registerSearchEntries() }
+    SettingsSearch.makeTries()
+
     loadPage(at: 0)
     sidebarList.addTableColumn(col)
     sidebarScrollView.documentView = sidebarList
@@ -143,20 +166,20 @@ class SettingsWindow: NSWindow {
 
   func loadPage(at index: Int) {
     guard let page = pages[at: index] else { return }
-    let content = page.getContent()
+    let content = page.getView()
     content.autoresizingMask = [.width, .height]
     contentScrollView.documentView = content
     content.padding(to: contentScrollView.contentView, .horizontal)
     contentScrollView.documentView!.topAnchor.constraint(equalTo: contentView!.topAnchor).isActive = true
 
     sectionNames = content.allSubviews.compactMap {
-      if let view = $0 as? SettingsListView { view.listTitle } else { nil }
+      ($0 as? SettingsSection.View)?.sectionTitle
     }
     // if no section name, add the page name to avoid layout issues
     if sectionNames.isEmpty {
       sectionNames.append(page.title)
     }
-    
+
     self.title = page.title
 
     DispatchQueue.main.async {
@@ -189,16 +212,17 @@ class SettingsWindow: NSWindow {
       // get the section that is in the middle of the viewport
       let vr = documentView.visibleRect
       let midRect = NSRect(x: vr.origin.x, y: vr.origin.y + vr.height * 0.33, width: vr.width, height: 40)
-      let listViews = documentView.allSubviews
-        .compactMap { $0 as? SettingsListView }
-        .filter { !($0 is SettingsSubListView) }
+      let sectionViews = documentView.allSubviews
+        .compactMap { $0 as? SettingsSection.View }
       if
-        let visibleIndex = listViews.firstIndex(where: {
+        let visibleIndex = sectionViews.firstIndex(where: {
           midRect.intersects($0.convert($0.bounds, to: documentView))
         }),
-        let title = listViews[0...visibleIndex].last(where: { $0.listTitle != nil })?.listTitle
+        let title = sectionViews[0...visibleIndex].last(where: { $0.sectionTitle != nil })?.sectionTitle
       {
         firstVisibleTitle = title
+      } else if sectionNames.count == 1 {
+        firstVisibleTitle = sectionNames.first
       }
     }
 
@@ -227,7 +251,376 @@ class SettingsWindow: NSWindow {
     })
   }
 
-  private var stopCall = true
+  private func highlightItem() {
+    guard let pendingHighlightItem,
+          let view = contentView?.allSubviews.first(where: { $0.tag == pendingHighlightItem.id })
+    else { return }
+
+    if let prevPageIndex, let parentId = pendingHighlightItem.parentId,
+       let parent = pages[prevPageIndex].builtSections
+         .compactMap ({ $0.find(where: { $0.itemID == parentId }) as? SettingsItem.General }).first,
+       !parent.isExpanded {
+      parent.toggleExpandable(true, animated: false)
+    }
+
+    contentScrollView.scrollToVisible(highlightView.bounds)
+
+    highlightView.highlight(view)
+    self.pendingHighlightItem = nil
+  }
+}
+
+
+extension SettingsWindow {
+  private class HighlightView: NSView {
+    private var maskRect: NSRect?
+    private var ticket: Int = 0
+
+    override static func defaultAnimation(forKey key: NSAnimatablePropertyKey) -> Any? {
+      if key == "alphaValue" {
+        let kfa = CAKeyframeAnimation(keyPath: "alphaValue")
+        kfa.duration = 1.0
+        kfa.timingFunctions = [CAMediaTimingFunction(name: .default), CAMediaTimingFunction(name: .linear)]
+        kfa.values = [1, 1, 0]
+        kfa.keyTimes = [0, 0.8, 1.0]
+        return kfa
+      } else {
+        return super.defaultAnimation(forKey: key)
+      }
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+      guard let maskRect = maskRect else { return }
+      NSGraphicsContext.saveGraphicsState()
+      let borderPath = NSBezierPath(roundedRect: maskRect, xRadius: 8, yRadius: 8)
+      borderPath.lineWidth = 4
+      NSColor.white.setStroke()
+      borderPath.stroke()
+      let rectPath = NSBezierPath(roundedRect: maskRect, xRadius: 8, yRadius: 8)
+      rectPath.lineWidth = 3
+      NSColor.controlAccentColor.setStroke()
+      rectPath.stroke()
+      NSGraphicsContext.restoreGraphicsState()
+    }
+
+    func highlight(_ view: NSView) {
+      ticket += 1
+      let currentTicket = ticket
+
+      view.scrollToVisible(view.bounds.insetBy(dx: 0, dy: -20))
+      isHidden = false
+      alphaValue = 1
+
+      let rectInWindow = view.convert(view.bounds.insetBy(dx: -4, dy: -4), to: nil)
+      maskRect = convert(rectInWindow, from: nil)
+      needsDisplay = true
+
+      NSAnimationContext.runAnimationGroup({ _ in
+        self.animator().alphaValue = 0
+      }, completionHandler: { [unowned self] in
+        guard currentTicket == self.ticket else { return }
+        self.isHidden = true
+      })
+    }
+  }
+}
+
+
+fileprivate extension NSUserInterfaceItemIdentifier {
+  static let searchResultItem: NSUserInterfaceItemIdentifier = .init(rawValue: "searchResultItem")
+  static let searchResultItemWithParent: NSUserInterfaceItemIdentifier = .init(rawValue: "searchResultItemWithParent")
+  static let searchResultHeader: NSUserInterfaceItemIdentifier = .init(rawValue: "searchResultHeader")
+}
+
+
+extension SettingsWindow {
+  private class PopoverViewController: NSViewController, NSTableViewDelegate, NSTableViewDataSource {
+    unowned var window: SettingsWindow
+
+    let tableView: NSTableView = NSTableView()
+    let scrollView: NSScrollView = NSScrollView()
+    let noResultLabel: NSTextField = NSTextField(labelWithString: NSLocalizedString("general.no_result", comment: "No Result"))
+    var results: [SettingsSearch.Entry] = []
+
+    private var contentHeightConstraint: NSLayoutConstraint!
+
+    init(window: SettingsWindow) {
+      self.window = window
+      super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+      fatalError("init(coder:) has not been implemented")
+    }
+    
+    override func viewDidLoad() {
+      tableView.translatesAutoresizingMaskIntoConstraints = false
+      tableView.style = .plain
+      tableView.delegate = self
+      tableView.dataSource = self
+      tableView.headerView = nil
+      tableView.floatsGroupRows = false
+      tableView.addTableColumn(NSTableColumn(identifier: .searchResultItem))
+      tableView.target = self
+      tableView.doubleAction = #selector(closePopover)
+
+      // make the scroll view's height synchronize with its content
+      tableView.postsFrameChangedNotifications = true
+      NotificationCenter.default.addObserver(
+        forName: NSView.frameDidChangeNotification,
+        object: tableView,
+        queue: .main
+      ) { [unowned self] notification in
+        guard let tableView = notification.object as? NSTableView else { return }
+        let height = tableView.numberOfRows == 0 ? 0 :
+          tableView.rect(ofRow: tableView.numberOfRows - 1).maxY + tableView.intercellSpacing.height
+        self.contentHeightConstraint.constant = height + 8 // bottom inset
+      }
+
+      scrollView.translatesAutoresizingMaskIntoConstraints = false
+      scrollView.documentView = tableView
+      view.addSubview(scrollView)
+      scrollView.padding(.all(0))
+      scrollView.automaticallyAdjustsContentInsets = false
+      scrollView.contentInsets.bottom = 8
+      scrollView.widthAnchor.constraint(equalToConstant: 340).isActive = true
+      scrollView.heightAnchor.constraint(greaterThanOrEqualToConstant: 120).isActive = true
+      scrollView.heightAnchor.constraint(lessThanOrEqualToConstant: 400).isActive = true
+      self.contentHeightConstraint = scrollView.heightAnchor.constraint(equalToConstant: 0)
+      contentHeightConstraint.priority = .defaultHigh
+      contentHeightConstraint.isActive = true
+
+      noResultLabel.translatesAutoresizingMaskIntoConstraints = false
+      noResultLabel.textColor = .secondaryLabelColor
+      noResultLabel.isHidden = true
+      view.addSubview(noResultLabel)
+      noResultLabel.center()
+    }
+
+    func reloadData(_ data: [SettingsSearch.Entry]) {
+      let dict = Dictionary(grouping: data, by: \.page)
+      results = []
+      for page in SettingsWindow.default.pages {
+        if let entries = dict[page.identifier] {
+          entries.forEach { $0.pageTitle = page.title }
+          results.append(SettingsSearch.Entry(pageHeader: page.title, icon: page.image))
+          // only show one entry per anchor
+          // make sure parent entries displayed before children
+          let sorted = Dictionary(grouping: entries, by: \.anchor).values.map { $0.first! }.sorted {
+            if $0.parentEntry === $1 { return false }
+            if $1.parentEntry === $0 { return true }
+            if let section0 = $0.section, let section1 = $1.section {
+              switch section0.localizedCompare(section1) {
+              case .orderedSame: return $0.title.localizedCompare($1.title) == .orderedAscending
+              case .orderedAscending: return true
+              case .orderedDescending: return false
+              }
+            }
+            return $0.title.localizedCompare($1.title) == .orderedAscending
+          }
+          results.append(contentsOf: sorted)
+        }
+      }
+      noResultLabel.isHidden = !data.isEmpty
+      tableView.reloadData()
+    }
+
+    @objc func closePopover() {
+      window.completionPopover.close()
+    }
+
+    func numberOfRows(in tableView: NSTableView) -> Int {
+      return results.count
+    }
+
+    func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
+      guard let entry = results[at: row] else { return 0 }
+      return entry.isPageHeader ? 38 : entry.parentEntry != nil ? 46 : 25
+    }
+
+    func tableView(_ tableView: NSTableView, isGroupRow row: Int) -> Bool {
+      return results[at: row]?.isPageHeader == true
+    }
+
+    func tableView(_ tableView: NSTableView, viewFor tableColumn: NSTableColumn?, row: Int) -> NSView? {
+      guard let entry = results[at: row] else { return nil }
+
+      if entry.isPageHeader {
+        let view = (tableView.makeView(withIdentifier: .searchResultHeader,
+                                       owner: self) as? HeaderView) ?? HeaderView()
+        view.setup(entry: entry)
+        return view
+      } else if entry.parentEntry != nil {
+        let view = (tableView.makeView(withIdentifier: .searchResultItemWithParent,
+                                       owner: self) as? ItemWithParentView) ?? ItemWithParentView()
+        view.setup(entry: entry)
+        return view
+      } else {
+        let view = (tableView.makeView(withIdentifier: .searchResultItem,
+                                       owner: self) as? ItemView) ?? ItemView()
+        view.setup(entry: entry)
+        return view
+      }
+    }
+
+    func tableViewSelectionDidChange(_ notification: Notification) {
+      guard let entry = results[at: tableView.selectedRow] else { return }
+      window.pendingHighlightItem = (entry.anchor, entry.parent)
+      window.navigateTo(page: entry.page)
+
+      DispatchQueue.main.async {
+        self.window.highlightItem()
+      }
+    }
+
+    class HeaderView: NSTableCellView {
+      var titleLabel: NSTextField!
+      var iconView: NSImageView!
+
+      func setup(entry: SettingsSearch.Entry) {
+        if textField == nil {
+          titleLabel = NSTextField(labelWithString: "")
+          titleLabel.textColor = .secondaryLabelColor
+          titleLabel.font = .systemFont(ofSize: NSFont.systemFontSize, weight: .bold)
+          titleLabel.translatesAutoresizingMaskIntoConstraints = false
+          addSubview(titleLabel)
+
+          iconView = NSImageView(image: entry.icon!)
+          iconView.imageScaling = .scaleProportionallyDown
+          iconView.translatesAutoresizingMaskIntoConstraints = false
+          addSubview(iconView)
+
+          titleLabel.padding(.trailing(8), .bottom(8))
+          iconView.padding(.leading(8), .bottom(8))
+            .spacing(to: titleLabel, .trailing(8))
+            .size(width: 16, height: 16)
+        }
+        titleLabel.stringValue = entry.page
+        iconView.image = entry.icon
+      }
+    }
+
+    class ItemView: NSTableCellView {
+      var sectionLabel: NSTextField!
+      var titleLabel: NSTextField!
+
+      func setup(entry: SettingsSearch.Entry) {
+        if textField == nil {
+          sectionLabel = NSTextField(labelWithString: "")
+          sectionLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+          sectionLabel.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+          sectionLabel.textColor = .textBackgroundColor
+          sectionLabel.translatesAutoresizingMaskIntoConstraints = false
+          sectionLabel.wantsLayer = true
+          sectionLabel.layer?.cornerRadius = 3
+          sectionLabel.drawsBackground = true
+          sectionLabel.backgroundColor = .secondaryLabelColor
+          addSubview(sectionLabel)
+
+          titleLabel = NSTextField(labelWithString: "")
+          titleLabel.font = .systemFont(ofSize: NSFont.systemFontSize)
+          titleLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+          titleLabel.lineBreakMode = .byTruncatingMiddle
+          titleLabel.translatesAutoresizingMaskIntoConstraints = false
+          addSubview(titleLabel)
+
+          sectionLabel.padding(.leading(8), .bottom(6))
+            .spacing(to: titleLabel, .trailing(4))
+          titleLabel.padding(.trailing(8), .bottom(6))
+        }
+        sectionLabel.stringValue = entry.section ?? entry.pageTitle ?? ""
+        titleLabel.stringValue = entry.titleForDisplay
+      }
+    }
+
+    class ItemWithParentView: NSTableCellView {
+      var sectionLabel: NSTextField!
+      var parentLabel: NSTextField!
+      var titleLabel: NSTextField!
+
+      func setup(entry: SettingsSearch.Entry) {
+        if textField == nil {
+          sectionLabel = NSTextField(labelWithString: "")
+          sectionLabel.setContentHuggingPriority(.defaultHigh, for: .horizontal)
+          sectionLabel.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+          sectionLabel.textColor = .textBackgroundColor
+          sectionLabel.translatesAutoresizingMaskIntoConstraints = false
+          sectionLabel.wantsLayer = true
+          sectionLabel.layer?.cornerRadius = 3
+          sectionLabel.drawsBackground = true
+          sectionLabel.backgroundColor = .secondaryLabelColor
+          addSubview(sectionLabel)
+
+          parentLabel = NSTextField(labelWithString: "")
+          parentLabel.setContentHuggingPriority(.defaultLow, for: .horizontal)
+          parentLabel.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+          parentLabel.textColor = .secondaryLabelColor
+          parentLabel.lineBreakMode = .byTruncatingMiddle
+          parentLabel.translatesAutoresizingMaskIntoConstraints = false
+          addSubview(parentLabel)
+
+          let icon = NSImageView(image: .findSFSymbol(["arrow.turn.down.right"])!)
+          icon.translatesAutoresizingMaskIntoConstraints = false
+          addSubview(icon)
+
+          titleLabel = NSTextField(labelWithString: "")
+          titleLabel.font = .systemFont(ofSize: NSFont.systemFontSize)
+          titleLabel.lineBreakMode = .byTruncatingMiddle
+          titleLabel.translatesAutoresizingMaskIntoConstraints = false
+          addSubview(titleLabel)
+
+          sectionLabel.padding(.leading(8)).spacing(to: parentLabel, .trailing(4))
+            .center(with: parentLabel, y: true)
+          parentLabel.padding(.top(6), .trailing(8))
+            .spacing(to: titleLabel, .bottom(4))
+          icon.padding(.leading(12)).spacing(to: titleLabel, .trailing(4))
+            .size(width: 11, height: 11).center(with: titleLabel, y: true)
+          titleLabel.padding(.trailing(8), .bottom(6))
+        }
+
+        sectionLabel.stringValue = entry.section ?? entry.pageTitle ?? ""
+        parentLabel.stringValue = entry.parentEntry!.titleForDisplay
+        titleLabel.stringValue = entry.titleForDisplay
+      }
+    }
+  }
+
+  private func createSearchPopover() -> NSPopover {
+    let popover = NSPopover()
+    popover.behavior = .transient
+    popover.animates = false
+    popover.contentViewController = PopoverViewController(window: self)
+    return popover
+  }
+
+  @objc func searchBoxAction(_ sender: Any) {
+    let searchString = searchBox.stringValue.lowercased().trimWhitespaceSuffix().removedLastSemicolon()
+    // if no search string, close the popover
+    guard !searchString.isEmpty else {
+      completionPopover.close()
+      return
+    }
+
+    let popoverViewController = completionPopover.contentViewController as! PopoverViewController
+    if !completionPopover.isShown {
+      let range = searchBox.currentEditor()?.selectedRange
+      completionPopover.show(relativeTo: searchBox.bounds, of: searchBox, preferredEdge: .maxY)
+      searchBox.selectText(self)
+      searchBox.currentEditor()?.selectedRange = range ?? NSMakeRange(0, 0)
+    }
+    if let result = SettingsSearch.search(searchString) {
+      popoverViewController.reloadData(result)
+    }
+  }
+
+  func navigateTo(page: String) {
+    guard let idx = pages.firstIndex(where: { $0.identifier == page }) else { return }
+
+    if idx != sidebarList.selectedRow {
+      let selectIdx = idx < sidebarList.selectedRow ? idx : idx + 1
+      sidebarList.selectRowIndexes(IndexSet(integer: selectIdx), byExtendingSelection: false)
+    }
+  }
 }
 
 
@@ -235,24 +628,24 @@ extension SettingsWindow: NSTableViewDataSource, NSTableViewDelegate {
   func numberOfRows(in tableView: NSTableView) -> Int {
     return pages.count + 1
   }
-  
+
   @objc
   private func jumpToSection(_ sender: NSButton) {
     guard let documentView = contentScrollView.documentView else { return }
     let sectionName = sender.title
 
     guard let view = documentView.allSubviews.first(where: {
-      ($0 as? SettingsListView)?.listTitle == sectionName
+      ($0 as? SettingsSection.View)?.sectionTitle == sectionName
     }) else { return }
 
-    guard let label = (view as? SettingsListView)?.container.titleField else { return }
+    guard let label = (view as? SettingsSection.View)?.titleField else { return }
     let clipView = contentScrollView.contentView
     let labelRect = label.convert(label.bounds, to: clipView)
-    
+
     let vr = documentView.visibleRect
     let y = labelRect.minY - vr.height * 0.33 - 40
     let rect = NSRect(x: labelRect.minX, y: y, width: labelRect.width, height: vr.height - 40)
-    
+
     var newOrigin = clipView.bounds.origin
     if newOrigin.x > rect.origin.x {
       newOrigin.x = rect.origin.x
@@ -266,7 +659,7 @@ extension SettingsWindow: NSTableViewDataSource, NSTableViewDelegate {
     if rect.origin.y > newOrigin.y + clipView.bounds.height - rect.height {
       newOrigin.y = rect.origin.y - clipView.bounds.height + rect.height
     }
-    
+
     NSAnimationContext.runAnimationGroup({ context in
       context.duration = AccessibilityPreferences.adjustedDuration(0.25)
       clipView.animator().setBoundsOrigin(newOrigin)
@@ -397,3 +790,17 @@ fileprivate class VerticalLine: NSView {
     super.draw(dirtyRect)
   }
 }
+
+
+fileprivate extension String {
+  func removedLastSemicolon() -> String {
+    let trimmed = trimWhitespaceSuffix()
+    guard !trimmed.hasSuffix(":") else { return String(trimmed.dropLast()) }
+    return self
+  }
+
+  func trimWhitespaceSuffix() -> String {
+    self.replacingOccurrences(of: "\\s+$", with: "", options: .regularExpression)
+  }
+}
+

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -16,6 +16,7 @@
 "general.username" = "Username";
 "general.password" = "Password";
 "general.na" = "N/A";
+"general.no_result" = "No Result";
 
 "input.value_is_empty" = "Value cannot be empty.";
 "input.already_exists" = "Value already exists.";


### PR DESCRIPTION
Needed to refactor the whole framework to support searching.

- The builder only creates a tree of lightweight representations (Page, Section, List, Item).
- All strings for searching can be gathered through `registerSearchEntry()` from this tree without creating the `NSView`s. Each component can implement custom logic determining what content is searchable.
- When displaying the page, the actual `NSView` hierarchy is built by `makeView()`.
- Each component has an `itemID` corresponding to the materialized `NSView`'s tag.

Known issues / Todo:

- `SettingsItem.Custom()` currently doesn't automatically inherit the above behavior.
