### PR TITLE
ui: display chapter in the time preview when seeking

### DIFF
--- a/iina/Base.lproj/MainWindowController.xib
+++ b/iina/Base.lproj/MainWindowController.xib
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24127" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
+<document type="com.apple.InterfaceBuilder3.Cocoa.XIB" version="3.0" toolsVersion="24765" targetRuntime="MacOSX.Cocoa" propertyAccessControl="none" useAutolayout="YES" customObjectInstantitationMethod="direct">
     <dependencies>
         <deployment identifier="macosx"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24127"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.CocoaPlugin" version="24765"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <objects>
@@ -55,7 +55,8 @@
                 <outlet property="sideBarView" destination="epo-S6-QVB" id="5eE-aM-VUd"/>
                 <outlet property="sideBarWidthConstraint" destination="1BL-aP-tHS" id="Qbw-L4-DAp"/>
                 <outlet property="thumbnailPeekView" destination="vej-bg-g6C" id="sws-ib-t4r"/>
-                <outlet property="timePreviewWhenSeek" destination="qOq-6a-7j7" id="ngM-1f-G5D"/>
+                <outlet property="timePreviewTextField" destination="qOq-6a-7j7" id="ngM-1f-G5D"/>
+                <outlet property="timePreviewVisualEffectView" destination="S36-44-g7Z" id="Ftw-sI-zzC"/>
                 <outlet property="titleBarBottomBorder" destination="iA3-pt-6Jm" id="RD4-8v-bHB"/>
                 <outlet property="titleBarHeightConstraint" destination="1Dw-Bg-FRS" id="EC5-S5-p2j"/>
                 <outlet property="titleBarView" destination="TRx-2V-Gr3" id="kOU-nP-MAP"/>
@@ -70,7 +71,7 @@
         <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="" animationBehavior="default" tabbingMode="disallowed" id="F0z-JX-Cv5" customClass="MainWindow" customModule="IINA" customModuleProvider="target">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES" fullSizeContentView="YES"/>
             <rect key="contentRect" x="196" y="240" width="640" height="400"/>
-            <rect key="screenRect" x="0.0" y="0.0" width="3440" height="1409"/>
+            <rect key="screenRect" x="0.0" y="0.0" width="3008" height="1662"/>
             <view key="contentView" id="se5-gp-TjO" customClass="MainWindowContentView" customModule="IINA" customModuleProvider="target">
                 <rect key="frame" x="0.0" y="0.0" width="640" height="400"/>
                 <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -84,7 +85,7 @@
                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="P1S-9b-Nzw">
                                         <rect key="frame" x="0.0" y="0.0" width="56" height="30"/>
                                         <subviews>
-                                            <textField wantsLayer="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4mb-jy-Y1w">
+                                            <textField wantsLayer="YES" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="4mb-jy-Y1w">
                                                 <rect key="frame" x="4" y="6" width="54" height="21"/>
                                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="left" title="99:99" id="IyU-0H-hyV">
                                                     <font key="font" metaFont="system" size="18"/>
@@ -109,7 +110,7 @@
                                     <customView translatesAutoresizingMaskIntoConstraints="NO" id="Ybl-06-ksj">
                                         <rect key="frame" x="73" y="0.0" width="56" height="30"/>
                                         <subviews>
-                                            <textField wantsLayer="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1XY-X2-FcE">
+                                            <textField wantsLayer="YES" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="1XY-X2-FcE">
                                                 <rect key="frame" x="-2" y="8" width="60" height="16"/>
                                                 <textFieldCell key="cell" lineBreakMode="clipping" alignment="center" title="100%" id="va1-P5-3b0">
                                                     <font key="font" metaFont="systemBold"/>
@@ -146,7 +147,7 @@
                                     <real value="3.4028234663852886e+38"/>
                                 </customSpacing>
                             </stackView>
-                            <textField horizontalHuggingPriority="200" verticalHuggingPriority="750" horizontalCompressionResistancePriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="3uh-OF-zy6">
+                            <textField focusRingType="none" horizontalHuggingPriority="200" verticalHuggingPriority="750" horizontalCompressionResistancePriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="3uh-OF-zy6">
                                 <rect key="frame" x="14" y="38" width="133" height="21"/>
                                 <textFieldCell key="cell" lineBreakMode="clipping" alignment="right" title="Label" id="DVg-p3-w5Q">
                                     <font key="font" metaFont="system" size="18"/>
@@ -172,7 +173,7 @@
                                 <rect key="frame" x="277" y="166" width="87" height="68"/>
                                 <imageCell key="cell" refusesFirstResponder="YES" alignment="left" animates="YES" imageScaling="proportionallyDown" image="playing-in-pip" id="0QW-Vy-zmW"/>
                             </imageView>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="pxV-jX-kfL">
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="pxV-jX-kfL">
                                 <rect key="frame" x="196" y="142" width="248" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="This video is playing in picture in picture" id="gdE-b5-kod">
                                     <font key="font" metaFont="system"/>
@@ -198,7 +199,7 @@
                                     <constraint firstAttribute="width" constant="32" id="7BK-Wc-K9S"/>
                                 </constraints>
                             </progressIndicator>
-                            <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2gH-wF-EpI">
+                            <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2gH-wF-EpI">
                                 <rect key="frame" x="24" y="20" width="113" height="16"/>
                                 <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Buffering... 100%" id="3fe-fP-yMB">
                                     <font key="font" metaFont="system"/>
@@ -206,7 +207,7 @@
                                     <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
                                 </textFieldCell>
                             </textField>
-                            <textField wantsLayer="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hlZ-5D-Wag">
+                            <textField wantsLayer="YES" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="hlZ-5D-Wag">
                                 <rect key="frame" x="64" y="8" width="32" height="11"/>
                                 <textFieldCell key="cell" controlSize="mini" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" alignment="center" title="Label" id="WOE-SX-krh">
                                     <font key="font" metaFont="menu" size="9"/>
@@ -318,7 +319,7 @@
                             <stackView orientation="vertical" alignment="leading" spacing="2" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="249.99998474121094" translatesAutoresizingMaskIntoConstraints="NO" id="g0j-zS-jKv">
                                 <rect key="frame" x="16" y="8" width="161" height="54"/>
                                 <beginningViews>
-                                    <textField wantsLayer="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="499" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ofw-1d-N4T" userLabel="OSD">
+                                    <textField wantsLayer="YES" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="499" fixedFrame="YES" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Ofw-1d-N4T" userLabel="OSD">
                                         <rect key="frame" x="-2" y="30" width="165" height="24"/>
                                         <textFieldCell key="cell" lineBreakMode="truncatingMiddle" sendsActionOnEndEditing="YES" alignment="left" title="On Screen Display" usesSingleLineMode="YES" id="JAn-Yu-XA2">
                                             <font key="font" metaFont="system" size="20"/>
@@ -326,7 +327,7 @@
                                             <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
                                         </textFieldCell>
                                     </textField>
-                                    <textField wantsLayer="YES" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="499" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lb1-5R-hR3">
+                                    <textField wantsLayer="YES" focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" horizontalCompressionResistancePriority="499" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="lb1-5R-hR3">
                                         <rect key="frame" x="-2" y="14" width="33" height="14"/>
                                         <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Label" id="7aL-lH-m8i">
                                             <font key="font" metaFont="message" size="11"/>
@@ -438,10 +439,10 @@
                 <constraint firstAttribute="bottom" secondItem="2py-h1-0km" secondAttribute="bottom" id="wqB-gH-wXf"/>
                 <constraint firstItem="2py-h1-0km" firstAttribute="top" secondItem="N3B-DL-XOA" secondAttribute="top" id="zDt-kW-Co2"/>
             </constraints>
-            <point key="canvasLocation" x="318" y="584"/>
+            <point key="canvasLocation" x="597" y="659"/>
         </customView>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="BE1-yC-oJL" customClass="TimeLabelOverflowedView" customModule="IINA" customModuleProvider="target">
-            <rect key="frame" x="0.0" y="4" width="500" height="28"/>
+            <rect key="frame" x="0.0" y="0.0" width="500" height="28"/>
             <subviews>
                 <slider verticalHuggingPriority="750" mirrorLayoutDirectionWhenInternationalizing="never" translatesAutoresizingMaskIntoConstraints="NO" id="eBP-6g-bAT" customClass="PlaySlider" customModule="IINA" customModuleProvider="target">
                     <rect key="frame" x="50" y="6" width="400" height="16"/>
@@ -450,7 +451,7 @@
                         <action selector="playSliderChanges:" target="-2" id="UBG-Ky-3rr"/>
                     </connections>
                 </slider>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" alphaValue="0.5" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NBD-MV-OuG" userLabel="Left Label" customClass="DurationDisplayTextField" customModule="IINA" customModuleProvider="target">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" alphaValue="0.5" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="NBD-MV-OuG" userLabel="Left Label" customClass="DurationDisplayTextField" customModule="IINA" customModuleProvider="target">
                     <rect key="frame" x="0.0" y="7" width="50" height="14"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="46" id="CMl-dC-PCr"/>
@@ -464,7 +465,7 @@
                         <binding destination="-2" name="font" keyPath="monospacedFont" id="uHM-ya-PZy"/>
                     </connections>
                 </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" alphaValue="0.5" mirrorLayoutDirectionWhenInternationalizing="never" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GgV-Cc-sk0" userLabel="Right Label" customClass="DurationDisplayTextField" customModule="IINA" customModuleProvider="target">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" alphaValue="0.5" mirrorLayoutDirectionWhenInternationalizing="never" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="GgV-Cc-sk0" userLabel="Right Label" customClass="DurationDisplayTextField" customModule="IINA" customModuleProvider="target">
                     <rect key="frame" x="450" y="7" width="50" height="14"/>
                     <constraints>
                         <constraint firstAttribute="width" relation="greaterThanOrEqual" constant="46" id="sDf-om-KlV"/>
@@ -477,15 +478,6 @@
                     <connections>
                         <binding destination="-2" name="font" keyPath="monospacedFont" id="6lX-sn-136"/>
                     </connections>
-                </textField>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" fixedFrame="YES" alphaValue="0.5" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qOq-6a-7j7">
-                    <rect key="frame" x="196" y="15" width="44" height="12"/>
-                    <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" refusesFirstResponder="YES" sendsActionOnEndEditing="YES" alignment="center" title="-:--:--" id="Pw8-rd-mUu">
-                        <font key="font" metaFont="system" size="10"/>
-                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                        <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                    </textFieldCell>
                 </textField>
             </subviews>
             <constraints>
@@ -500,12 +492,12 @@
                 <constraint firstItem="eBP-6g-bAT" firstAttribute="leading" secondItem="NBD-MV-OuG" secondAttribute="trailing" constant="2" id="uHE-D2-HgP"/>
                 <constraint firstItem="GgV-Cc-sk0" firstAttribute="leading" secondItem="eBP-6g-bAT" secondAttribute="trailing" constant="2" id="vzW-0s-yR6"/>
             </constraints>
-            <point key="canvasLocation" x="236" y="506"/>
+            <point key="canvasLocation" x="249" y="659"/>
         </customView>
         <customView placeholderIntrinsicWidth="18" placeholderIntrinsicHeight="24" translatesAutoresizingMaskIntoConstraints="NO" id="8Ej-eH-OR9">
             <rect key="frame" x="0.0" y="0.0" width="26" height="24"/>
             <subviews>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" alphaValue="0.5" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Yg9-Sd-sWy" userLabel="Left Button Label">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" alphaValue="0.5" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="Yg9-Sd-sWy" userLabel="Left Button Label">
                     <rect key="frame" x="1" y="6" width="27" height="13"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" refusesFirstResponder="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="right" title="-32x" id="eCe-SS-Wlj">
                         <font key="font" metaFont="system" size="10"/>
@@ -521,12 +513,12 @@
                 <constraint firstAttribute="width" constant="26" id="grc-Ve-XDC"/>
                 <constraint firstAttribute="height" constant="24" id="zqT-9O-0G6"/>
             </constraints>
-            <point key="canvasLocation" x="-55" y="713"/>
+            <point key="canvasLocation" x="-54" y="727"/>
         </customView>
         <customView translatesAutoresizingMaskIntoConstraints="NO" id="Xts-Pc-T8d">
             <rect key="frame" x="0.0" y="0.0" width="26" height="24"/>
             <subviews>
-                <textField horizontalHuggingPriority="251" verticalHuggingPriority="750" alphaValue="0.5" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QTI-wi-oyB" userLabel="Right Button Label">
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" alphaValue="0.5" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="QTI-wi-oyB" userLabel="Right Button Label">
                     <rect key="frame" x="-2" y="6" width="22" height="13"/>
                     <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" refusesFirstResponder="YES" allowsUndo="NO" sendsActionOnEndEditing="YES" alignment="left" title="32x" id="ULE-u4-k9L">
                         <font key="font" metaFont="system" size="10"/>
@@ -542,7 +534,7 @@
                 <constraint firstAttribute="height" constant="24" id="sLY-0Y-Hql"/>
                 <constraint firstAttribute="width" constant="26" id="zCh-hV-cEH"/>
             </constraints>
-            <point key="canvasLocation" x="-143" y="713"/>
+            <point key="canvasLocation" x="-145" y="727"/>
         </customView>
         <customView placeholderIntrinsicWidth="184" placeholderIntrinsicHeight="24" translatesAutoresizingMaskIntoConstraints="NO" id="Yv6-0K-6E4">
             <rect key="frame" x="0.0" y="0.0" width="148" height="24"/>
@@ -601,11 +593,11 @@
                 <constraint firstItem="gxw-pJ-Lcg" firstAttribute="centerY" secondItem="Yv6-0K-6E4" secondAttribute="centerY" id="dBB-Jk-nlO"/>
                 <constraint firstAttribute="right" secondItem="EIi-qd-glM" secondAttribute="right" constant="14" id="enq-Gg-JrN"/>
             </constraints>
-            <point key="canvasLocation" x="377" y="703"/>
+            <point key="canvasLocation" x="374" y="727"/>
         </customView>
         <stackView orientation="horizontal" alignment="centerY" spacing="0.0" horizontalStackHuggingPriority="249.99998474121094" verticalStackHuggingPriority="249.99998474121094" horizontalClippingResistancePriority="500" translatesAutoresizingMaskIntoConstraints="NO" id="hDm-KI-3o4">
             <rect key="frame" x="0.0" y="0.0" width="200" height="24"/>
-            <point key="canvasLocation" x="133" y="703"/>
+            <point key="canvasLocation" x="133" y="727"/>
         </stackView>
         <customView wantsLayer="YES" id="vej-bg-g6C" customClass="ThumbnailPeekView" customModule="IINA" customModuleProvider="target">
             <rect key="frame" x="0.0" y="0.0" width="163" height="96"/>
@@ -628,12 +620,12 @@
             <connections>
                 <outlet property="imageView" destination="HHm-A9-jIP" id="KtN-I3-vJb"/>
             </connections>
-            <point key="canvasLocation" x="40" y="549"/>
+            <point key="canvasLocation" x="152" y="504"/>
         </customView>
         <stackView orientation="horizontal" alignment="centerY" spacing="0.0" horizontalStackHuggingPriority="250" verticalStackHuggingPriority="249.99998474121094" id="KfP-G9-8pD">
             <rect key="frame" x="0.0" y="0.0" width="106" height="24"/>
             <autoresizingMask key="autoresizingMask"/>
-            <point key="canvasLocation" x="591" y="676"/>
+            <point key="canvasLocation" x="587" y="727"/>
         </stackView>
         <customView id="maF-Zr-K8w">
             <rect key="frame" x="0.0" y="0.0" width="32" height="20"/>
@@ -661,8 +653,28 @@
         <customView id="A4M-zT-NFs">
             <rect key="frame" x="0.0" y="0.0" width="163" height="96"/>
             <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMinY="YES"/>
-            <point key="canvasLocation" x="355" y="437"/>
+            <point key="canvasLocation" x="375" y="504"/>
         </customView>
+        <visualEffectView blendingMode="withinWindow" material="appearanceBased" state="followsWindowActiveState" translatesAutoresizingMaskIntoConstraints="NO" id="S36-44-g7Z">
+            <rect key="frame" x="0.0" y="0.0" width="128" height="20"/>
+            <subviews>
+                <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" alphaValue="0.5" allowsCharacterPickerTouchBarItem="YES" translatesAutoresizingMaskIntoConstraints="NO" id="qOq-6a-7j7">
+                    <rect key="frame" x="0.0" y="2" width="128" height="16"/>
+                    <textFieldCell key="cell" scrollable="YES" lineBreakMode="clipping" refusesFirstResponder="YES" sendsActionOnEndEditing="YES" alignment="center" title="-:--:--" id="Pw8-rd-mUu">
+                        <font key="font" metaFont="system"/>
+                        <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                        <color key="backgroundColor" name="textBackgroundColor" catalog="System" colorSpace="catalog"/>
+                    </textFieldCell>
+                </textField>
+            </subviews>
+            <constraints>
+                <constraint firstItem="qOq-6a-7j7" firstAttribute="leading" secondItem="S36-44-g7Z" secondAttribute="leading" constant="2" id="7CJ-D5-iT3"/>
+                <constraint firstItem="qOq-6a-7j7" firstAttribute="top" secondItem="S36-44-g7Z" secondAttribute="top" constant="2" id="IGd-0I-r5a"/>
+                <constraint firstAttribute="trailing" secondItem="qOq-6a-7j7" secondAttribute="trailing" constant="2" id="UOf-Xl-baW"/>
+                <constraint firstAttribute="bottom" secondItem="qOq-6a-7j7" secondAttribute="bottom" constant="2" id="eq2-l5-BLv"/>
+            </constraints>
+            <point key="canvasLocation" x="141" y="600"/>
+        </visualEffectView>
     </objects>
     <resources>
         <image name="battery" width="57" height="30"/>

--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -10,32 +10,6 @@ import Cocoa
 import CryptoKit
 import MediaPlayer
 
-extension NSSlider {
-  /**
-   Returns the position of the knob's center point along the slider's track.
-
-   This method calculates the horizontal position of the center of the slider's knob based on the slider's current value (`doubleValue`), the minimum and maximum values, and the slider's dimensions. It can be useful for custom drawing, animations, or hit detection related to the knob's position.
-
-   - Returns: A `CGFloat` representing the x-coordinate of the knob's center along the slider's width.
-
-   - Important: Ensure that the slider's `maxValue` is greater than `minValue`. An assertion is used to validate this.
-
-   Example usage:
-   ```swift
-   let slider = NSSlider(value: 50, minValue: 0, maxValue: 100, target: nil, action: nil)
-   let knobPosition = slider.knobPointPosition()
-   print("The knob is positioned at x-coordinate: \(knobPosition)")
-   ```
-   */
-  func knobPointPosition() -> CGFloat {
-    let sliderOrigin = frame.origin.x + knobThickness / 2
-    let sliderWidth = frame.width - knobThickness
-    assert(maxValue > minValue)
-    let knobPos = sliderOrigin + sliderWidth * CGFloat((doubleValue - minValue) / (maxValue - minValue))
-    return knobPos
-  }
-}
-
 extension CGPoint {
   /**
    Uses the Pythagorean theorem to calculate the distance between two points.

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -3323,10 +3323,11 @@ class MainWindowController: PlayerWindowController {
   private func updateTimePreview(_ percentage: Double) {
     guard let duration = player.info.videoDuration else { return }
     let time = duration * percentage
-    timePreviewTextField.stringValue = time.stringRepresentation
-    if let chapter = player.info.getCurrentChapter(forVideoTime: time) {
-      timePreviewTextField.stringValue += " \(chapter.title)"
+    var labels: [String] = [time.stringRepresentation]
+    if let chapter = player.info.getChapter(forVideoTime: time) {
+      labels.insert(chapter.title, at: 0)
     }
+    timePreviewTextField.stringValue = labels.joined(separator: "\n")
 
     let sliderFrame = playSlider.convert(playSlider.bounds, to: nil)
     let timeLabelYPos: CGFloat

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -3309,11 +3309,10 @@ class MainWindowController: PlayerWindowController {
       let width = CGFloat(UserDefaults.standard.integer(forKey: "thumbnailWidth"))
       let height = round(width / displayAspectRatio)
       let showAbove = canShowThumbnailAbove(timePreviewYPos: timePreviewVisualEffectView.frame.origin.y, thumbnailHeight: height)
-      let yPos: CGFloat
-      if showAbove {
-        yPos = max(sliderFrameInWindow.maxY, timePreviewVisualEffectView.frame.maxY) + 5
+      let yPos = if showAbove {
+        max(sliderFrameInWindow.maxY, timePreviewVisualEffectView.frame.maxY) + 5
       } else {
-        yPos = min(sliderFrameInWindow.minY, timePreviewVisualEffectView.frame.minY) - height - 5
+        min(sliderFrameInWindow.minY, timePreviewVisualEffectView.frame.minY) - height - 5
       }
       thumbnailPeekView.frame.size = NSSize(width: width, height: height)
       thumbnailPeekView.frame.origin = NSPoint(x: round(posInWindow.x - thumbnailPeekView.frame.width / 2), y: yPos)
@@ -3323,11 +3322,12 @@ class MainWindowController: PlayerWindowController {
   private func updateTimePreview(_ percentage: Double) {
     guard let duration = player.info.videoDuration else { return }
     let time = duration * percentage
-    var labels: [String] = [time.stringRepresentation]
-    if let chapter = player.info.getChapter(forVideoTime: time) {
-      labels.insert(chapter.title, at: 0)
+    let chapterTitle = if let chapter = player.info.getChapter(forVideoTime: time) {
+      chapter.title + "\n"
+    } else {
+      ""
     }
-    timePreviewTextField.stringValue = labels.joined(separator: "\n")
+    timePreviewTextField.stringValue = chapterTitle + time.stringRepresentation
 
     let sliderFrame = playSlider.convert(playSlider.bounds, to: nil)
     let timeLabelYPos: CGFloat

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -615,7 +615,7 @@ class MainWindowController: PlayerWindowController {
     thumbnailPeekView.isHidden = true
     timePreviewVisualEffectView.isHidden = true
     timePreviewVisualEffectView.roundCorners(withRadius: 5)
-    timePreviewTextField.font = NSFont.monospacedDigitSystemFont(ofSize: 0, weight: .regular)
+    timePreviewTextField.font = monospacedFont
 
     // other initialization
     titleBarBottomBorder.fillColor = NSColor.titleBarBorder

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -453,7 +453,8 @@ class MainWindowController: PlayerWindowController {
 
   @IBOutlet weak var controlBarFloating: ControlBarView!
   @IBOutlet weak var controlBarBottom: NSVisualEffectView!
-  @IBOutlet weak var timePreviewWhenSeek: NSTextField!
+  @IBOutlet weak var timePreviewTextField: NSTextField!
+  @IBOutlet weak var timePreviewVisualEffectView: NSVisualEffectView!
   @IBOutlet weak var leftArrowButton: NSButton!
   @IBOutlet weak var rightArrowButton: NSButton!
   @IBOutlet weak var settingsButton: NSButton!
@@ -610,7 +611,11 @@ class MainWindowController: PlayerWindowController {
 
     // thumbnail peek view
     window.contentView?.addSubview(thumbnailPeekView)
+    window.contentView?.addSubview(timePreviewVisualEffectView)
     thumbnailPeekView.isHidden = true
+    timePreviewVisualEffectView.isHidden = true
+    timePreviewVisualEffectView.roundCorners(withRadius: 5)
+    timePreviewTextField.font = NSFont.monospacedDigitSystemFont(ofSize: 0, weight: .regular)
 
     // other initialization
     titleBarBottomBorder.fillColor = NSColor.titleBarBorder
@@ -624,7 +629,6 @@ class MainWindowController: PlayerWindowController {
     additionalInfoView.roundCorners(withRadius: 10)
     leftArrowLabel.isHidden = true
     rightArrowLabel.isHidden = true
-    timePreviewWhenSeek.isHidden = true
     bottomView.isHidden = true
     pipOverlayView.isHidden = true
     
@@ -1155,7 +1159,7 @@ class MainWindowController: PlayerWindowController {
       if controlBarFloating.isDragging { return }
       isMouseInSlider = true
       if !controlBarFloating.isDragging {
-        timePreviewWhenSeek.isHidden = false
+        timePreviewVisualEffectView.isHidden = false
         thumbnailPeekView.isHidden = !player.info.thumbnailsReady
       }
       refreshSeekTimeAndThumbnail(from: event)
@@ -1180,7 +1184,7 @@ class MainWindowController: PlayerWindowController {
     } else if obj == 1 {
       // slider
       isMouseInSlider = false
-      timePreviewWhenSeek.isHidden = true
+      timePreviewVisualEffectView.isHidden = true
       refreshSeekTimeAndThumbnail(from: event)
       thumbnailPeekView.isHidden = true
     }
@@ -1410,7 +1414,7 @@ class MainWindowController: PlayerWindowController {
     setWindowFloatingOnTop(false, updateOnTopStatus: false)
 
     thumbnailPeekView.isHidden = true
-    timePreviewWhenSeek.isHidden = true
+    timePreviewVisualEffectView.isHidden = true
     isMouseInSlider = false
 
     let isLegacyFullScreen = notification.name == .iinaLegacyFullScreen
@@ -1537,7 +1541,7 @@ class MainWindowController: PlayerWindowController {
     }
 
     thumbnailPeekView.isHidden = true
-    timePreviewWhenSeek.isHidden = true
+    timePreviewVisualEffectView.isHidden = true
     additionalInfoView.isHidden = true
     isMouseInSlider = false
 
@@ -2547,7 +2551,7 @@ class MainWindowController: PlayerWindowController {
     let isCoveredByOSD = !osdVisualEffectView.isHidden && isMouseEvent(event, inAnyOf: [osdVisualEffectView])
     let isCoveredBySidebar = !sideBarView.isHidden && isMouseEvent(event, inAnyOf: [sideBarView])
     if isMouseInSlider, !isCoveredByOSD, !isCoveredBySidebar {
-      updateTimeLabel(event.locationInWindow)
+      updateTimePreviewAndThumbnail(event.locationInWindow)
     } else {
       thumbnailPeekView.isHidden = true
     }
@@ -2568,7 +2572,7 @@ class MainWindowController: PlayerWindowController {
     guard oscPosition != .top else { return false }
     // The layout preference for the on screen controller is set to the default floating layout.
     // Must insure the top of the thumbnail would be below the top of the window.
-    let topOfThumbnail = timePreviewYPos + timePreviewWhenSeek.frame.height + thumbnailHeight
+    let topOfThumbnail = timePreviewYPos + timePreviewVisualEffectView.frame.height + thumbnailHeight
     // Normally the height of the usable area of the window can be obtained from the content
     // layout. But when the legacy full screen preference is enabled the layout height may be
     // larger than the content view if the display contains a camera housing. Use the lower of
@@ -2577,48 +2581,6 @@ class MainWindowController: PlayerWindowController {
     return topOfThumbnail <= windowContentHeight
   }
 
-  /** Display time label when mouse over slider */
-  private func updateTimeLabel(_ posInWindow: NSPoint) {
-    let mouseXPos = playSlider.convert(posInWindow, from: nil).x
-    let timeLabelXPos = round(mouseXPos + playSlider.frame.origin.x - timePreviewWhenSeek.frame.width / 2)
-    var timeLabelYPos = playSlider.frame.origin.y + playSlider.frame.height
-    if oscPosition == .bottom {
-      timeLabelYPos -= 2
-    }
-    timePreviewWhenSeek.frame.origin = NSPoint(x: timeLabelXPos, y: timeLabelYPos)
-    let sliderFrame = playSlider.bounds
-    let sliderFrameInWindow = playSlider.superview!.convert(playSlider.frame.origin, to: nil)
-    var percentage = Double((mouseXPos - 3) / (sliderFrame.width - 6))
-    if percentage < 0 {
-      percentage = 0
-    }
-
-    if let duration = player.info.videoDuration {
-      let previewTime = duration * percentage
-      timePreviewWhenSeek.stringValue = previewTime.stringRepresentation
-
-      if player.info.thumbnailsReady, let image = player.info.getThumbnail(forSecond: previewTime.second)?.image {
-        thumbnailPeekView.imageView.image = image.rotate(rotation)
-        thumbnailPeekView.isHidden = false
-
-        // In some formats (like most of Japanese TV video formats), display aspect ratios (DAR) are different from the
-        // sample aspect ratio (SAR). A typical configuration is SAR 1440x1080i (4:3) w/ DAR 1920x1080 (16:9). We use video
-        // display size to consider pixel formats as well as rotation from metadata properly display the thumbnail.
-        let (videoWidth, videoHeight) = player.videoSizeForDisplay
-        let displayAspectRatio = CGFloat(videoWidth) / CGFloat(videoHeight)
-
-        let width = CGFloat(UserDefaults.standard.integer(forKey: "thumbnailWidth"))
-        let height = round(width / displayAspectRatio)
-        let timePreviewFrameInWindow = timePreviewWhenSeek.superview!.convert(timePreviewWhenSeek.frame.origin, to: nil)
-        let showAbove = canShowThumbnailAbove(timePreviewYPos: timePreviewFrameInWindow.y, thumbnailHeight: height)
-        let yPos = showAbove ? timePreviewFrameInWindow.y + timePreviewWhenSeek.frame.height : sliderFrameInWindow.y - height
-        thumbnailPeekView.frame.size = NSSize(width: width, height: height)
-        thumbnailPeekView.frame.origin = NSPoint(x: round(posInWindow.x - thumbnailPeekView.frame.width / 2), y: yPos)
-      } else {
-        thumbnailPeekView.isHidden = true
-      }
-    }
-  }
 
   func updateBufferIndicatorView() {
     guard loaded else { return }
@@ -3288,17 +3250,7 @@ class MainWindowController: PlayerWindowController {
     guard player.info.state.active, player.info.state != .loading else { return }
     super.playSliderChanges(sender)
 
-    // seek and update time
-    let percentage = 100 * sender.doubleValue / sender.maxValue
-    // label
-    var timeLabelYPos = playSlider.frame.origin.y + playSlider.frame.height
-    if oscPosition == .bottom {
-      timeLabelYPos -= 2
-    }
-    timePreviewWhenSeek.frame.origin = CGPoint(
-      x: round(sender.knobPointPosition() - timePreviewWhenSeek.frame.width / 2),
-      y: timeLabelYPos)
-    timePreviewWhenSeek.stringValue = (player.info.videoDuration! * percentage * 0.01).stringRepresentation
+    updateTimePreview(sender.doubleValue / sender.maxValue)
   }
 
   @objc func toolBarButtonAction(_ sender: NSButton) {
@@ -3326,6 +3278,68 @@ class MainWindowController: PlayerWindowController {
       showPluginSidebar(tab: nil)
     }
   }
+
+  // MARK: - Time Preveiew & Thumbnail
+
+  /** Display time label when mouse over slider */
+  private func updateTimePreviewAndThumbnail(_ posInWindow: NSPoint) {
+    guard let duration = player.info.videoDuration else {
+      thumbnailPeekView.isHidden = true
+      timePreviewVisualEffectView.isHidden = true
+      return
+    }
+
+    let mouseXPos = playSlider.convert(posInWindow, from: nil).x
+    let percentage = max(0, Double((mouseXPos - 3) / (playSlider.bounds.width - 6)))
+
+    let previewTime = duration * percentage
+    updateTimePreview(percentage)
+    let sliderFrameInWindow = playSlider.convert(playSlider.frame, to: nil)
+
+    if player.info.thumbnailsReady, let image = player.info.getThumbnail(forSecond: previewTime.second)?.image {
+      thumbnailPeekView.imageView.image = image.rotate(rotation)
+      thumbnailPeekView.isHidden = false
+
+      // In some formats (like most of Japanese TV video formats), display aspect ratios (DAR) are different from the
+      // sample aspect ratio (SAR). A typical configuration is SAR 1440x1080i (4:3) w/ DAR 1920x1080 (16:9). We use video
+      // display size to consider pixel formats as well as rotation from metadata properly display the thumbnail.
+      let (videoWidth, videoHeight) = player.videoSizeForDisplay
+      let displayAspectRatio = CGFloat(videoWidth) / CGFloat(videoHeight)
+
+      let width = CGFloat(UserDefaults.standard.integer(forKey: "thumbnailWidth"))
+      let height = round(width / displayAspectRatio)
+      let showAbove = canShowThumbnailAbove(timePreviewYPos: timePreviewVisualEffectView.frame.origin.y, thumbnailHeight: height)
+      let yPos: CGFloat
+      if showAbove {
+        yPos = max(sliderFrameInWindow.maxY, timePreviewVisualEffectView.frame.maxY) + 5
+      } else {
+        yPos = min(sliderFrameInWindow.minY, timePreviewVisualEffectView.frame.minY) - height - 5
+      }
+      thumbnailPeekView.frame.size = NSSize(width: width, height: height)
+      thumbnailPeekView.frame.origin = NSPoint(x: round(posInWindow.x - thumbnailPeekView.frame.width / 2), y: yPos)
+    }
+  }
+
+  private func updateTimePreview(_ percentage: Double) {
+    guard let duration = player.info.videoDuration else { return }
+    let time = duration * percentage
+    timePreviewTextField.stringValue = time.stringRepresentation
+    if let chapter = player.info.getCurrentChapter(forVideoTime: time) {
+      timePreviewTextField.stringValue += " \(chapter.title)"
+    }
+
+    let sliderFrame = playSlider.convert(playSlider.bounds, to: nil)
+    let timeLabelYPos: CGFloat
+    if oscPosition == .top {
+      timeLabelYPos = sliderFrame.origin.y - timePreviewVisualEffectView.bounds.height - 5
+    } else {
+      timeLabelYPos = sliderFrame.origin.y + playSlider.frame.height + 5
+    }
+    timePreviewVisualEffectView.frame.origin = CGPoint(
+      x: round(sliderFrame.origin.x + sliderFrame.size.width * percentage - timePreviewVisualEffectView.frame.width / 2),
+      y: timeLabelYPos)
+  }
+
 
   // MARK: - Utility
 

--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -244,7 +244,7 @@ class PlaybackInfo {
   var chapters: [MPVChapter] = []
   var chapter = 0
 
-  func getCurrentChapter(forVideoTime time: VideoTime) -> MPVChapter? {
+  func getChapter(forVideoTime time: VideoTime) -> MPVChapter? {
     return chapters.last(where: { $0.time <= time })
   }
 

--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -244,6 +244,10 @@ class PlaybackInfo {
   var chapters: [MPVChapter] = []
   var chapter = 0
 
+  func getCurrentChapter(forVideoTime time: VideoTime) -> MPVChapter? {
+    return chapters.last(where: { $0.time <= time })
+  }
+
   @Atomic var matchedSubs: [String: [URL]] = [:]
 
   func getMatchedSubs(_ file: String) -> [URL]? { $matchedSubs.withLock { $0[file] } }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #4535, #5456

---

**Description:**

New           |  Old
:-------------------------:|:-------------------------:
![](https://github.com/user-attachments/assets/5f105f52-bec9-4450-a4e6-8d8b97e4e8f1) |  ![](https://github.com/user-attachments/assets/36da36d1-6d8c-4816-8df6-186d701c4fce)

This commit:
- Pulled out the `timePreviewTextField` (was `timePreviewWhenSeek`) from the slider view to the subview of the main window's content view
- Enclose the `timePreviewTextField` in a `timePreviewVisualEffectView`
- The time in the `timePreviewTextField` is now `.monospacedDigitSystemFont`
- Increased the padding between the text field and the thumbnail
- Light refactoring to reduce code duplication
- Remove unnecessary extension