### PR TITLE
Sync playlist with external file deletions

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		1326717E20852D0D000FA7E2 /* SubChooseViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1326718020852D0D000FA7E2 /* SubChooseViewController.xib */; };
 		3412DB8E2C2FC64C00BBC142 /* Equalizations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3412DB8D2C2FC64800BBC142 /* Equalizations.swift */; };
 		348F71962DE2A819006C587D /* MPVCommandWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348F71952DE2A814006C587D /* MPVCommandWrappers.swift */; };
+		BD69B6CBE0BF44C68B1A703A /* PlaylistFileMonitor.swift in Sources */ = {isa = PBXBuildFile; fileRef = C55FCB1A2ADE4A1FBFF29EFF /* PlaylistFileMonitor.swift */; };
 		34ACAB722C142A0500F871A0 /* libintl.8.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB2D2C142A0300F871A0 /* libintl.8.dylib */; };
 		34ACAB732C142A0500F871A0 /* libgraphite2.3.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB2E2C142A0300F871A0 /* libgraphite2.3.dylib */; };
 		34ACAB742C142A0500F871A0 /* liblcms2.2.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34ACAB2F2C142A0300F871A0 /* liblcms2.2.dylib */; };
@@ -934,6 +935,7 @@
 		348BFFFE28DC688D0045F683 /* sr-Latn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "sr-Latn"; path = "sr-Latn.lproj/HistoryWindowController.strings"; sourceTree = "<group>"; };
 		348BFFFF28DC688D0045F683 /* sr-Latn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "sr-Latn"; path = "sr-Latn.lproj/InitialWindowController.strings"; sourceTree = "<group>"; };
 		348F71952DE2A814006C587D /* MPVCommandWrappers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPVCommandWrappers.swift; sourceTree = "<group>"; };
+		C55FCB1A2ADE4A1FBFF29EFF /* PlaylistFileMonitor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlaylistFileMonitor.swift; sourceTree = "<group>"; };
 		3494B3F42C00254500F57FC2 /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		3494B3F52C00254800F57FC2 /* da */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = da; path = da.lproj/InfoPlist.strings; sourceTree = "<group>"; };
 		34ACAB2D2C142A0300F871A0 /* libintl.8.dylib */ = {isa = PBXFileReference; lastKnownFileType = "compiled.mach-o.dylib"; name = libintl.8.dylib; path = deps/lib/libintl.8.dylib; sourceTree = "<group>"; };
@@ -2539,6 +2541,7 @@
 				84A0BA961D2FA1CE00BC8DA1 /* PlayerCore.swift */,
 				84A0BA981D2FAAA700BC8DA1 /* MPVController.swift */,
 				348F71952DE2A814006C587D /* MPVCommandWrappers.swift */,
+				C55FCB1A2ADE4A1FBFF29EFF /* PlaylistFileMonitor.swift */,
 				84C6D3611EAF8D63009BF721 /* HistoryController.swift */,
 				84FBCB361EEACDDD0076C77C /* FFmpegController.h */,
 				84FBCB371EEACDDD0076C77C /* FFmpegController.m */,
@@ -3306,6 +3309,7 @@
 				84D123B41ECAA405004E0D53 /* TouchBarSupport.swift in Sources */,
 				E36E8D7C24F6052F00B8C097 /* GuideWindowController.swift in Sources */,
 				E38EA5A52F30762300FB51CE /* SettingsLocalizationKeysAdvanced.swift in Sources */,
+				BD69B6CBE0BF44C68B1A703A /* PlaylistFileMonitor.swift in Sources */,
 				84817C981DBDCE4300CC2279 /* RoundedColorWell.swift in Sources */,
 				E38372922443634500F57718 /* LanguageTokenField.swift in Sources */,
 				E360A5CD2C23C1BC006EA412 /* SettingsWindow.swift in Sources */,

--- a/iina/MPVPlaylistItem.swift
+++ b/iina/MPVPlaylistItem.swift
@@ -23,12 +23,14 @@ class MPVPlaylistItem: NSObject, Identifiable {
   var isNetworkResource: Bool
 
   var title: String?
+  var playlistPath: String?
 
-  init(filename: String, isCurrent: Bool, isPlaying: Bool, title: String?) {
+  init(filename: String, isCurrent: Bool, isPlaying: Bool, title: String?, playlistPath: String? = nil) {
     self.filename = filename
     self.isCurrent = isCurrent
     self.isPlaying = isPlaying
     self.title = title
+    self.playlistPath = playlistPath
     self.isNetworkResource = Regex.url.matches(filename)
   }
 }

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -3361,9 +3361,9 @@ class MainWindowController: PlayerWindowController {
     } else {
       timeLabelYPos = sliderFrame.origin.y + playSlider.frame.height + 5
     }
-    timePreviewVisualEffectView.frame.origin = CGPoint(
-      x: round(sliderFrame.origin.x + sliderFrame.size.width * percentage - timePreviewVisualEffectView.frame.width / 2),
-      y: timeLabelYPos)
+    let sliderPercentage = CGFloat(percentage)
+    let timeLabelXPos = sliderFrame.origin.x + sliderFrame.size.width * sliderPercentage - timePreviewVisualEffectView.frame.width / 2
+    timePreviewVisualEffectView.frame.origin = CGPoint(x: round(timeLabelXPos), y: timeLabelYPos)
   }
 
 

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -194,6 +194,9 @@ class PlayerCore: NSObject {
   }
 
   private var backgroundTaskInUse = false
+  private lazy var playlistFileMonitor = PlaylistFileMonitor { [weak self] in
+    self?.removeMissingPlaylistItems()
+  }
 
   var initialWindow: InitialWindowController!
   
@@ -524,6 +527,7 @@ class PlayerCore: NSObject {
     info.audioTracks = []
     info.chapters = []
     info.playlist = []
+    playlistFileMonitor.stop()
     info.subTracks = []
     info.thumbnails = []
     info.thumbnailsReady = false
@@ -691,6 +695,7 @@ class PlayerCore: NSObject {
   ///     down was in progress and will call this method again to continue the process of shutting down..
   func shutdown() {
     info.state = .shuttingDown
+    playlistFileMonitor.stop()
     guard !backgroundTaskInUse else { return }
     log("Shutting down")
     savePlayerState()
@@ -720,6 +725,7 @@ class PlayerCore: NSObject {
     let suffix = isMPVInitiated ? " (initiated by mpv)" : ""
     log("Player has shutdown\(suffix)")
     info.state = .shutDown
+    playlistFileMonitor.stop()
     if isMPVInitiated {
       // The user must have used mpv's IPC interface to send a quit command directly to mpv. Must
       // perform the actions that were skipped when IINA's normal shutdown process was bypassed.
@@ -945,6 +951,8 @@ class PlayerCore: NSObject {
         mpv.setFlag(MPVOption.PlaybackControl.pause, true, level: .verbose)
       }
     }
+
+    playlistFileMonitor.stop()
 
     // Must first stop the background task if it is running.
     if backgroundTaskInUse {
@@ -1537,6 +1545,77 @@ class PlayerCore: NSObject {
   func clearPlaylist() {
     mpv.command(.playlistClear)
     postNotification(.iinaPlaylistChanged)
+  }
+
+  private func schedulePlaylistFileMonitorRefresh() {
+    if Thread.isMainThread {
+      refreshPlaylistFileMonitor()
+    } else {
+      DispatchQueue.main.async { [weak self] in
+        self?.refreshPlaylistFileMonitor()
+      }
+    }
+  }
+
+  private func refreshPlaylistFileMonitor() {
+    guard info.state.active else {
+      playlistFileMonitor.stop()
+      return
+    }
+
+    getPlaylist()
+    let workingDirectory = mpv.getString(MPVProperty.workingDirectory)
+    let paths = info.$playlist.withLock { playlist in
+      playlist.compactMap { localPlaylistFilePath(for: $0, workingDirectory: workingDirectory) }
+    }
+    playlistFileMonitor.update(paths: paths)
+  }
+
+  private func localPlaylistFilePath(for item: MPVPlaylistItem, workingDirectory: String?) -> String? {
+    guard !item.isNetworkResource else { return nil }
+    if NSString(string: item.filename).isAbsolutePath {
+      return URL(fileURLWithPath: item.filename).standardizedFileURL.path
+    }
+    guard let baseURL = localPlaylistBaseURL(for: item, workingDirectory: workingDirectory) else { return nil }
+    return URL(fileURLWithPath: item.filename, relativeTo: baseURL).standardizedFileURL.path
+  }
+
+  private func localPlaylistBaseURL(for item: MPVPlaylistItem, workingDirectory: String?) -> URL? {
+    if let playlistPath = item.playlistPath, !playlistPath.isEmpty, !Regex.url.matches(playlistPath) {
+      if NSString(string: playlistPath).isAbsolutePath {
+        return URL(fileURLWithPath: playlistPath).deletingLastPathComponent().standardizedFileURL
+      }
+      guard let workingDirectory, !workingDirectory.isEmpty, !Regex.url.matches(workingDirectory) else { return nil }
+      let workingDirectoryURL = URL(fileURLWithPath: workingDirectory, isDirectory: true)
+      return URL(fileURLWithPath: playlistPath, relativeTo: workingDirectoryURL).standardizedFileURL.deletingLastPathComponent()
+    }
+
+    guard let workingDirectory, !workingDirectory.isEmpty, !Regex.url.matches(workingDirectory) else { return nil }
+    return URL(fileURLWithPath: workingDirectory, isDirectory: true).standardizedFileURL
+  }
+
+  private func removeMissingPlaylistItems() {
+    guard info.state.active else {
+      playlistFileMonitor.stop()
+      return
+    }
+
+    getPlaylist()
+    let workingDirectory = mpv.getString(MPVProperty.workingDirectory)
+    let missingItems = info.$playlist.withLock { playlist -> IndexSet in
+      var indexSet = IndexSet()
+      for (index, item) in playlist.enumerated() {
+        guard let path = localPlaylistFilePath(for: item, workingDirectory: workingDirectory) else { continue }
+        if !FileManager.default.fileExists(atPath: path) {
+          indexSet.insert(index)
+        }
+      }
+      return indexSet
+    }
+
+    guard !missingItems.isEmpty else { return }
+    log("Removing \(missingItems.count) missing playlist item(s)")
+    playlistRemove(missingItems)
   }
 
   /// Play the entry at the given position in the playlist.
@@ -2148,6 +2227,7 @@ class PlayerCore: NSObject {
     // call `trackListChanged` to load tracks and check whether need to switch to music mode
     trackListChanged()
     getPlaylist()
+    refreshPlaylistFileMonitor()
     getChapters()
     syncAbLoop()
     refreshSyncUITimer()
@@ -2940,7 +3020,8 @@ class PlayerCore: NSObject {
         let playlistItem = MPVPlaylistItem(filename: mpv.getString(MPVProperty.playlistNFilename(index))!,
                                            isCurrent: mpv.getFlag(MPVProperty.playlistNCurrent(index)),
                                            isPlaying: mpv.getFlag(MPVProperty.playlistNPlaying(index)),
-                                           title: mpv.getString(MPVProperty.playlistNTitle(index)))
+                                           title: mpv.getString(MPVProperty.playlistNTitle(index)),
+                                           playlistPath: mpv.getString(MPVProperty.playlistNPlaylistPath(index)))
         playlist.append(playlistItem)
       }
     }
@@ -2966,6 +3047,9 @@ class PlayerCore: NSObject {
   // MARK: - Notifications
 
   func postNotification(_ name: Notification.Name) {
+    if name == .iinaPlaylistChanged {
+      schedulePlaylistFileMonitorRefresh()
+    }
     NotificationCenter.default.post(Notification(name: name, object: self))
   }
 

--- a/iina/PlaylistFileMonitor.swift
+++ b/iina/PlaylistFileMonitor.swift
@@ -1,0 +1,93 @@
+//
+//  PlaylistFileMonitor.swift
+//  iina
+//
+
+import Darwin
+import Foundation
+
+final class PlaylistFileMonitor {
+
+  private let queue: DispatchQueue
+  private let handler: () -> Void
+  private var sources: [String: DispatchSourceFileSystemObject] = [:]
+  private var pendingHandler: DispatchWorkItem?
+
+  init(queue: DispatchQueue = DispatchQueue(label: "IINAPlaylistFileMonitor", qos: .utility),
+       handler: @escaping () -> Void) {
+    self.queue = queue
+    self.handler = handler
+  }
+
+  func update(paths: [String]) {
+    queue.async { [weak self] in
+      guard let self else { return }
+      let folders = self.parentFolders(for: paths)
+      self.removeSources(excluding: folders)
+      self.addSources(for: folders)
+    }
+  }
+
+  func stop() {
+    queue.async { [weak self] in
+      self?.removeAllSources()
+    }
+  }
+
+  private func parentFolders(for paths: [String]) -> Set<String> {
+    Set(paths.compactMap { path in
+      let folder = URL(fileURLWithPath: path).deletingLastPathComponent().standardizedFileURL.path
+      guard FileManager.default.fileExists(atPath: folder) else { return nil }
+      return folder
+    })
+  }
+
+  private func addSources(for folders: Set<String>) {
+    for folder in folders where sources[folder] == nil {
+      let fileDescriptor = open(folder, O_EVTONLY)
+      guard fileDescriptor >= 0 else { continue }
+
+      let source = DispatchSource.makeFileSystemObjectSource(fileDescriptor: fileDescriptor,
+                                                             eventMask: [.write, .delete, .rename, .revoke],
+                                                             queue: queue)
+      source.setEventHandler { [weak self] in
+        self?.scheduleHandler()
+      }
+      source.setCancelHandler {
+        _ = close(fileDescriptor)
+      }
+      sources[folder] = source
+      source.resume()
+    }
+  }
+
+  private func removeSources(excluding folders: Set<String>) {
+    let removedFolders = sources.keys.filter { !folders.contains($0) }
+    for folder in removedFolders {
+      sources.removeValue(forKey: folder)?.cancel()
+    }
+    if sources.isEmpty {
+      pendingHandler?.cancel()
+      pendingHandler = nil
+    }
+  }
+
+  private func removeAllSources() {
+    sources.values.forEach { $0.cancel() }
+    sources.removeAll()
+    pendingHandler?.cancel()
+    pendingHandler = nil
+  }
+
+  private func scheduleHandler() {
+    pendingHandler?.cancel()
+    let workItem = DispatchWorkItem { [weak self] in
+      guard let self else { return }
+      DispatchQueue.main.async {
+        self.handler()
+      }
+    }
+    pendingHandler = workItem
+    queue.asyncAfter(deadline: .now() + .milliseconds(250), execute: workItem)
+  }
+}


### PR DESCRIPTION
## Summary
- Add a small player-owned `PlaylistFileMonitor` that watches parent folders for local playlist files and debounces filesystem events.
- Refresh the playlist from mpv before updating monitor subscriptions or pruning missing entries, keeping mpv as the source of truth.
- Remove missing local playlist items through the existing `PlayerCore.playlistRemove(_:)` path while leaving network/URL entries untouched.

## Why
Deleting or renaming a playlist file in Finder currently leaves a stale row in IINA's playlist. Trying to play that row fails because the file no longer exists. This keeps the playlist aligned with local filesystem changes without adding preference UI or changing playback APIs.

## Contribution notes
- Checked `CONTRIBUTING.md`; this PR targets `iina/iina`'s `develop` branch.
- Re-ran issue search for an exact duplicate and did not find one. Closest adjacent issue found: #4548.
- No localization changes, no generated mpv source edits, and the project file change is only to add the new Swift file.

## Validation
- `git diff --check`
- `plutil -lint iina.xcodeproj/project.pbxproj`
- `xcodebuild -project iina.xcodeproj -scheme iina build`
- `xcodebuild -project iina.xcodeproj -scheme iina test` cannot run because the `iina` scheme is not configured for the test action.
