### PR TITLE
Handle `.toggleMusicMode` correctly

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -3279,6 +3279,16 @@ class MainWindowController: PlayerWindowController {
     }
   }
 
+  override func handleIINACommand(_ cmd: IINACommand) {
+    super.handleIINACommand(cmd)
+    switch cmd {
+    case .toggleMusicMode:
+      player.switchToMiniPlayer()
+    default:
+      break
+    }
+  }
+
   // MARK: - Time Preveiew & Thumbnail
 
   /** Display time label when mouse over slider */

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -404,6 +404,16 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     }
   }
 
+  override func handleIINACommand(_ cmd: IINACommand) {
+    super.handleIINACommand(cmd)
+    switch cmd {
+    case .toggleMusicMode:
+      player.switchBackFromMiniPlayer()
+    default:
+      break
+    }
+  }
+
   // MARK: - Utils
 
   private func normalWindowHeight() -> CGFloat {


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)

---

**Description:**
This is a followup fix of #6030. Currently, the `.toggleMusicMode` is only handled through menu, thus if the user has a second keybinding of `.toggleMusicMode` (which cannot be registered in the menu item), it will not work. This commit fix that.