### PR TITLE
Reorder fields on the file tab of the inspector

### DIFF
--- a/iina/Base.lproj/InspectorWindowController.xib
+++ b/iina/Base.lproj/InspectorWindowController.xib
@@ -827,88 +827,8 @@
                                         <box verticalHuggingPriority="750" boxType="separator" translatesAutoresizingMaskIntoConstraints="NO" id="507-xz-zeA">
                                             <rect key="frame" x="12" y="404" width="420" height="5"/>
                                         </box>
-                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="P6I-h4-MV9">
-                                            <rect key="frame" x="10" y="380" width="62" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Size:" id="KqD-NM-WiK">
-                                                <font key="font" metaFont="smallSystemBold"/>
-                                                <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UBX-ge-nPN">
-                                            <rect key="frame" x="78" y="380" width="356" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" id="Zaf-qd-A4D">
-                                                <font key="font" usesAppearanceFont="YES"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EaI-Lh-edg">
-                                            <rect key="frame" x="10" y="358" width="62" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Format:" id="mgl-Et-20K">
-                                                <font key="font" metaFont="smallSystemBold"/>
-                                                <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3Lj-7X-tNH">
-                                            <rect key="frame" x="78" y="358" width="356" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="QTi-nO-v8c">
-                                                <font key="font" usesAppearanceFont="YES"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SEN-lo-1AP">
-                                            <rect key="frame" x="10" y="336" width="62" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Duration:" id="OCm-zb-deg">
-                                                <font key="font" metaFont="smallSystemBold"/>
-                                                <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="uzH-YO-YLT">
-                                            <rect key="frame" x="78" y="336" width="356" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" id="sgp-Kk-awA">
-                                                <font key="font" usesAppearanceFont="YES"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IpH-Qz-kKo">
-                                            <rect key="frame" x="10" y="314" width="62" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Chapters:" id="PBk-VC-4gu">
-                                                <font key="font" metaFont="smallSystemBold"/>
-                                                <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="PgQ-KO-dy8">
-                                            <rect key="frame" x="78" y="314" width="356" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="IME-9M-YdQ">
-                                                <font key="font" usesAppearanceFont="YES"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2xR-1D-bSh">
-                                            <rect key="frame" x="10" y="292" width="62" height="14"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Editions:" id="POj-mQ-zP9">
-                                                <font key="font" metaFont="smallSystemBold"/>
-                                                <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
-                                        <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yhp-8h-TAd">
-                                            <rect key="frame" x="78" y="292" width="356" height="16"/>
-                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="xIH-Dc-ZRT">
-                                                <font key="font" usesAppearanceFont="YES"/>
-                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
-                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
-                                            </textFieldCell>
-                                        </textField>
                                         <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="il2-20-at1" userLabel="Title:">
-                                            <rect key="frame" x="10" y="270" width="62" height="14"/>
+                                            <rect key="frame" x="10" y="380" width="62" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Title:" id="ZXF-fr-bWN">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -916,7 +836,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="CBp-cL-4XL">
-                                            <rect key="frame" x="78" y="270" width="356" height="16"/>
+                                            <rect key="frame" x="78" y="380" width="356" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="8xH-t4-oLC">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
@@ -924,7 +844,7 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="Yqv-Nh-CNd" userLabel="Comment:">
-                                            <rect key="frame" x="10" y="248" width="62" height="14"/>
+                                            <rect key="frame" x="10" y="358" width="62" height="14"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Comment:" id="O4m-5f-4hM">
                                                 <font key="font" metaFont="smallSystemBold"/>
                                                 <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
@@ -932,8 +852,88 @@
                                             </textFieldCell>
                                         </textField>
                                         <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="884-L1-fum">
-                                            <rect key="frame" x="78" y="248" width="356" height="16"/>
+                                            <rect key="frame" x="78" y="358" width="356" height="16"/>
                                             <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="hf1-Gv-y0d">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="P6I-h4-MV9">
+                                            <rect key="frame" x="10" y="336" width="62" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Size:" id="KqD-NM-WiK">
+                                                <font key="font" metaFont="smallSystemBold"/>
+                                                <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="UBX-ge-nPN">
+                                            <rect key="frame" x="78" y="336" width="356" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" id="Zaf-qd-A4D">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="EaI-Lh-edg">
+                                            <rect key="frame" x="10" y="314" width="62" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Format:" id="mgl-Et-20K">
+                                                <font key="font" metaFont="smallSystemBold"/>
+                                                <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="3Lj-7X-tNH">
+                                            <rect key="frame" x="78" y="314" width="356" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="QTi-nO-v8c">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="SEN-lo-1AP">
+                                            <rect key="frame" x="10" y="292" width="62" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Duration:" id="OCm-zb-deg">
+                                                <font key="font" metaFont="smallSystemBold"/>
+                                                <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="uzH-YO-YLT">
+                                            <rect key="frame" x="78" y="292" width="356" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" selectable="YES" sendsActionOnEndEditing="YES" id="sgp-Kk-awA">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="IpH-Qz-kKo">
+                                            <rect key="frame" x="10" y="270" width="62" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Chapters:" id="PBk-VC-4gu">
+                                                <font key="font" metaFont="smallSystemBold"/>
+                                                <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="PgQ-KO-dy8">
+                                            <rect key="frame" x="78" y="270" width="356" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="IME-9M-YdQ">
+                                                <font key="font" usesAppearanceFont="YES"/>
+                                                <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField focusRingType="none" horizontalHuggingPriority="251" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="2xR-1D-bSh">
+                                            <rect key="frame" x="10" y="248" width="62" height="14"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" title="Editions:" id="POj-mQ-zP9">
+                                                <font key="font" metaFont="smallSystemBold"/>
+                                                <color key="textColor" name="secondaryLabelColor" catalog="System" colorSpace="catalog"/>
+                                                <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
+                                            </textFieldCell>
+                                        </textField>
+                                        <textField focusRingType="none" verticalHuggingPriority="750" translatesAutoresizingMaskIntoConstraints="NO" id="yhp-8h-TAd">
+                                            <rect key="frame" x="78" y="248" width="356" height="16"/>
+                                            <textFieldCell key="cell" controlSize="small" scrollable="YES" lineBreakMode="clipping" sendsActionOnEndEditing="YES" id="xIH-Dc-ZRT">
                                                 <font key="font" usesAppearanceFont="YES"/>
                                                 <color key="textColor" name="labelColor" catalog="System" colorSpace="catalog"/>
                                                 <color key="backgroundColor" name="controlColor" catalog="System" colorSpace="catalog"/>
@@ -942,51 +942,52 @@
                                     </subviews>
                                     <constraints>
                                         <constraint firstItem="3Lj-7X-tNH" firstAttribute="leading" secondItem="uzH-YO-YLT" secondAttribute="leading" id="098-D8-MFD"/>
+                                        <constraint firstItem="CBp-cL-4XL" firstAttribute="trailing" secondItem="884-L1-fum" secondAttribute="trailing" id="0xd-tn-OnG"/>
                                         <constraint firstItem="SEN-lo-1AP" firstAttribute="baseline" secondItem="uzH-YO-YLT" secondAttribute="baseline" id="1d2-7Z-MXW"/>
                                         <constraint firstItem="2xR-1D-bSh" firstAttribute="top" secondItem="IpH-Qz-kKo" secondAttribute="bottom" constant="8" symbolic="YES" id="1g1-Fb-bgm"/>
-                                        <constraint firstItem="PgQ-KO-dy8" firstAttribute="trailing" secondItem="UBX-ge-nPN" secondAttribute="trailing" id="33A-yV-hyv"/>
+                                        <constraint firstItem="il2-20-at1" firstAttribute="top" secondItem="507-xz-zeA" secondAttribute="bottom" constant="12" id="1za-F2-T3O"/>
                                         <constraint firstItem="PgQ-KO-dy8" firstAttribute="leading" secondItem="yhp-8h-TAd" secondAttribute="leading" id="39v-vb-d1W"/>
-                                        <constraint firstAttribute="trailing" secondItem="UBX-ge-nPN" secondAttribute="trailing" constant="12" id="3BP-GN-o2x"/>
                                         <constraint firstAttribute="trailing" relation="greaterThanOrEqual" secondItem="JYJ-iA-Cdg" secondAttribute="trailing" constant="12" id="3dO-5X-rZZ"/>
                                         <constraint firstItem="IpH-Qz-kKo" firstAttribute="top" secondItem="SEN-lo-1AP" secondAttribute="bottom" constant="8" symbolic="YES" id="3dm-Dy-3it"/>
-                                        <constraint firstItem="UBX-ge-nPN" firstAttribute="leading" secondItem="P6I-h4-MV9" secondAttribute="trailing" constant="10" id="5z6-Es-8y2"/>
+                                        <constraint firstItem="P6I-h4-MV9" firstAttribute="trailing" secondItem="Yqv-Nh-CNd" secondAttribute="trailing" id="5Cc-0F-sCe"/>
+                                        <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="2xR-1D-bSh" secondAttribute="bottom" constant="12" id="5aQ-VR-7to"/>
+                                        <constraint firstItem="884-L1-fum" firstAttribute="leading" secondItem="UBX-ge-nPN" secondAttribute="leading" id="6Zs-w4-dOu"/>
                                         <constraint firstAttribute="trailing" secondItem="507-xz-zeA" secondAttribute="trailing" constant="12" id="6dI-DY-sv4"/>
                                         <constraint firstItem="SEN-lo-1AP" firstAttribute="top" secondItem="EaI-Lh-edg" secondAttribute="bottom" constant="8" symbolic="YES" id="7HW-6J-gZ9"/>
                                         <constraint firstItem="JYJ-iA-Cdg" firstAttribute="top" secondItem="foT-8J-MwC" secondAttribute="top" constant="12" id="7eH-bs-Vdb"/>
+                                        <constraint firstAttribute="trailing" secondItem="CBp-cL-4XL" secondAttribute="trailing" constant="12" id="8II-59-QSZ"/>
                                         <constraint firstItem="884-L1-fum" firstAttribute="firstBaseline" secondItem="Yqv-Nh-CNd" secondAttribute="firstBaseline" id="8S8-Ts-ZJF"/>
+                                        <constraint firstItem="CBp-cL-4XL" firstAttribute="trailing" secondItem="PgQ-KO-dy8" secondAttribute="trailing" id="8uy-HE-Kr7"/>
                                         <constraint firstItem="884-L1-fum" firstAttribute="leading" secondItem="CBp-cL-4XL" secondAttribute="leading" id="ABl-8l-Hbn"/>
-                                        <constraint firstItem="il2-20-at1" firstAttribute="leading" secondItem="2xR-1D-bSh" secondAttribute="leading" id="Ama-rX-rgH"/>
                                         <constraint firstItem="yhp-8h-TAd" firstAttribute="firstBaseline" secondItem="2xR-1D-bSh" secondAttribute="firstBaseline" id="BoS-fn-ebZ"/>
                                         <constraint firstItem="EaI-Lh-edg" firstAttribute="baseline" secondItem="3Lj-7X-tNH" secondAttribute="baseline" id="D75-sx-C8F"/>
                                         <constraint firstItem="JYJ-iA-Cdg" firstAttribute="leading" secondItem="foT-8J-MwC" secondAttribute="leading" constant="12" id="Dhr-xA-SGC"/>
                                         <constraint firstItem="EaI-Lh-edg" firstAttribute="top" secondItem="P6I-h4-MV9" secondAttribute="bottom" constant="8" symbolic="YES" id="G0T-yB-BN9"/>
-                                        <constraint firstItem="507-xz-zeA" firstAttribute="leading" secondItem="P6I-h4-MV9" secondAttribute="leading" id="KMD-4e-Q1D"/>
-                                        <constraint firstAttribute="bottom" relation="greaterThanOrEqual" secondItem="Yqv-Nh-CNd" secondAttribute="bottom" constant="12" id="Ki2-vM-1qc"/>
+                                        <constraint firstItem="CBp-cL-4XL" firstAttribute="trailing" secondItem="yhp-8h-TAd" secondAttribute="trailing" id="IwE-H6-ZIg"/>
+                                        <constraint firstItem="il2-20-at1" firstAttribute="leading" secondItem="507-xz-zeA" secondAttribute="leading" id="Kd4-5W-8QK"/>
                                         <constraint firstItem="IpH-Qz-kKo" firstAttribute="leading" secondItem="2xR-1D-bSh" secondAttribute="leading" id="M9R-xK-z5j"/>
                                         <constraint firstItem="SEN-lo-1AP" firstAttribute="leading" secondItem="IpH-Qz-kKo" secondAttribute="leading" id="MsZ-Zx-rYy"/>
-                                        <constraint firstItem="yhp-8h-TAd" firstAttribute="trailing" secondItem="UBX-ge-nPN" secondAttribute="trailing" id="NSr-sY-Ub3"/>
                                         <constraint firstItem="UBX-ge-nPN" firstAttribute="trailing" secondItem="884-L1-fum" secondAttribute="trailing" id="PN5-fM-JpT"/>
                                         <constraint firstAttribute="trailing" secondItem="nJF-Fe-glJ" secondAttribute="trailing" constant="12" id="PpJ-iq-djq"/>
-                                        <constraint firstItem="P6I-h4-MV9" firstAttribute="top" secondItem="507-xz-zeA" secondAttribute="bottom" constant="12" id="QUK-V0-BmS"/>
                                         <constraint firstItem="PgQ-KO-dy8" firstAttribute="firstBaseline" secondItem="IpH-Qz-kKo" secondAttribute="firstBaseline" id="Rro-ga-4bH"/>
-                                        <constraint firstItem="UBX-ge-nPN" firstAttribute="trailing" secondItem="CBp-cL-4XL" secondAttribute="trailing" id="UjJ-BP-9bo"/>
+                                        <constraint firstItem="P6I-h4-MV9" firstAttribute="leading" secondItem="Yqv-Nh-CNd" secondAttribute="leading" id="S1l-8M-PeR"/>
                                         <constraint firstItem="507-xz-zeA" firstAttribute="top" secondItem="nJF-Fe-glJ" secondAttribute="bottom" constant="12" id="VGM-nM-VIz"/>
                                         <constraint firstItem="P6I-h4-MV9" firstAttribute="trailing" secondItem="EaI-Lh-edg" secondAttribute="trailing" id="VzA-D3-y2g"/>
                                         <constraint firstItem="SEN-lo-1AP" firstAttribute="trailing" secondItem="IpH-Qz-kKo" secondAttribute="trailing" id="WNP-Ik-PER"/>
+                                        <constraint firstItem="CBp-cL-4XL" firstAttribute="trailing" secondItem="UBX-ge-nPN" secondAttribute="trailing" id="X0Y-96-X8x"/>
                                         <constraint firstItem="Yqv-Nh-CNd" firstAttribute="leading" secondItem="il2-20-at1" secondAttribute="leading" id="XdK-Xd-gfQ"/>
                                         <constraint firstItem="UBX-ge-nPN" firstAttribute="leading" secondItem="3Lj-7X-tNH" secondAttribute="leading" id="Y2W-S8-LWi"/>
-                                        <constraint firstItem="uzH-YO-YLT" firstAttribute="trailing" secondItem="UBX-ge-nPN" secondAttribute="trailing" id="YoQ-q8-XPw"/>
+                                        <constraint firstItem="CBp-cL-4XL" firstAttribute="trailing" secondItem="uzH-YO-YLT" secondAttribute="trailing" id="Ydh-OL-rsj"/>
                                         <constraint firstItem="nJF-Fe-glJ" firstAttribute="top" secondItem="JYJ-iA-Cdg" secondAttribute="bottom" constant="4" id="ZvZ-Pq-WEE"/>
+                                        <constraint firstItem="CBp-cL-4XL" firstAttribute="leading" secondItem="il2-20-at1" secondAttribute="trailing" constant="10" id="bcJ-zj-Xbw"/>
                                         <constraint firstItem="CBp-cL-4XL" firstAttribute="firstBaseline" secondItem="il2-20-at1" secondAttribute="firstBaseline" id="cxT-an-GP8"/>
-                                        <constraint firstItem="CBp-cL-4XL" firstAttribute="leading" secondItem="yhp-8h-TAd" secondAttribute="leading" id="czl-2V-3wu"/>
                                         <constraint firstItem="EaI-Lh-edg" firstAttribute="trailing" secondItem="SEN-lo-1AP" secondAttribute="trailing" id="dDx-00-V1b"/>
                                         <constraint firstItem="uzH-YO-YLT" firstAttribute="leading" secondItem="PgQ-KO-dy8" secondAttribute="leading" id="dqw-N6-0EQ"/>
                                         <constraint firstItem="UBX-ge-nPN" firstAttribute="firstBaseline" secondItem="P6I-h4-MV9" secondAttribute="firstBaseline" id="f1G-co-fq6"/>
                                         <constraint firstItem="JYJ-iA-Cdg" firstAttribute="leading" secondItem="nJF-Fe-glJ" secondAttribute="leading" id="fPN-2U-rPc"/>
                                         <constraint firstItem="Yqv-Nh-CNd" firstAttribute="trailing" secondItem="il2-20-at1" secondAttribute="trailing" id="gHI-oj-g1O"/>
                                         <constraint firstItem="nJF-Fe-glJ" firstAttribute="leading" secondItem="507-xz-zeA" secondAttribute="leading" id="iOZ-re-91J"/>
-                                        <constraint firstItem="il2-20-at1" firstAttribute="top" secondItem="2xR-1D-bSh" secondAttribute="bottom" constant="8" symbolic="YES" id="kK8-Gx-8XU"/>
-                                        <constraint firstItem="il2-20-at1" firstAttribute="trailing" secondItem="2xR-1D-bSh" secondAttribute="trailing" id="mnV-AA-FPV"/>
+                                        <constraint firstItem="P6I-h4-MV9" firstAttribute="top" secondItem="Yqv-Nh-CNd" secondAttribute="bottom" constant="8" symbolic="YES" id="kch-43-3Xg"/>
                                         <constraint firstItem="IpH-Qz-kKo" firstAttribute="trailing" secondItem="2xR-1D-bSh" secondAttribute="trailing" id="rDd-UM-w28"/>
                                         <constraint firstItem="3Lj-7X-tNH" firstAttribute="trailing" secondItem="UBX-ge-nPN" secondAttribute="trailing" id="tLp-4a-8lM"/>
                                         <constraint firstItem="P6I-h4-MV9" firstAttribute="leading" secondItem="EaI-Lh-edg" secondAttribute="leading" id="vBw-t1-jxL"/>


### PR DESCRIPTION
This commit will move the new title and comment fields on the file tab of the inspector window so that they are right after the file path field.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
