### PR TITLE
Grow window to prevent the quicksettings from distortion

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -2289,7 +2289,11 @@ class MainWindowController: PlayerWindowController {
         Logger.fatal("viewController is not a NSViewController")
     }
     sidebarAnimationState = .willShow
-    let width = type.width().clamped(to: 0...sidebarMaxWidth)
+    let width = if type == .playlist {
+      type.width().clamped(to: 0...sidebarMaxWidth)
+    } else {
+      type.width()
+    }
     sideBarWidthConstraint.constant = width
     // The macOS setting could change at any point in time. Remember which type of animation is
     // being used. Avoid using fading when disabling animations as that animation will initially
@@ -2318,6 +2322,11 @@ class MainWindowController: PlayerWindowController {
         sideBarView.animator().isHidden = false
       } else {
         sideBarRightConstraint.animator().constant = 0
+      }
+      if let window, window.frame.width < width / 0.8 {
+        let newSize = window.frame.size.shrink	(toSize: .init(width: width / 0.8, height: .infinity))
+        let frame = window.frame.centeredResize(to: newSize)
+        window.animator().setFrame(frame, display: true, animate: true)
       }
     }) {
       self.sidebarAnimationState = .shown


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #5645.

---

**Description:**
Currently, the minimal window size is too small to fit the quick settings panel + 20% margin, and the quick settings panel will shrink, which breaks the quick settings view. This commit first fixes the quick settings panel's width, then grow the window if needed. The quick settings are no longer distorted.

Before: see #5645 
Now:

https://github.com/user-attachments/assets/d6f0830b-9422-43b3-913b-336213b972c1

