### PR TITLE
Unlocking window aspect ratio

### DIFF
--- a/iina/Base.lproj/MainMenu.xib
+++ b/iina/Base.lproj/MainMenu.xib
@@ -378,6 +378,9 @@ CA
                             <menuItem title="Float on Top" secondaryImage="pin" catalog="system" id="wex-rX-PcY">
                                 <modifierMask key="keyEquivalentModifierMask"/>
                             </menuItem>
+                            <menuItem title="Lock Window Aspect Ratio" image="lock.rectangle" catalog="system" id="Saz-zT-RXt">
+                                <modifierMask key="keyEquivalentModifierMask"/>
+                            </menuItem>
                             <menuItem isSeparatorItem="YES" id="xpM-h7-A4R"/>
                             <menuItem title="Enter Music Mode" secondaryImage="music.microphone" catalog="system" id="bGN-E4-V5A">
                                 <modifierMask key="keyEquivalentModifierMask"/>
@@ -744,6 +747,7 @@ CA
                 <outlet property="jumpToBegin" destination="2Ya-3g-1hy" id="atq-PX-lIt"/>
                 <outlet property="loadExternalAudio" destination="3xl-iD-85w" id="e85-xo-lzs"/>
                 <outlet property="loadExternalSub" destination="k6x-hf-ATi" id="lVp-BV-A2C"/>
+                <outlet property="lockAspectRatio" destination="Saz-zT-RXt" id="wW5-HK-O3t"/>
                 <outlet property="miniPlayer" destination="bGN-E4-V5A" id="gMc-FE-SVO"/>
                 <outlet property="mirror" destination="JJq-qH-toq" id="EWI-VS-c7Q"/>
                 <outlet property="mute" destination="WOL-Us-ByA" id="Hry-sv-WhY"/>
@@ -895,6 +899,7 @@ CA
         <image name="info.circle" catalog="system" width="15" height="15"/>
         <image name="link" catalog="system" width="17" height="17"/>
         <image name="list.bullet.rectangle" catalog="system" width="18" height="14"/>
+        <image name="lock.rectangle" catalog="system" width="18" height="14"/>
         <image name="macwindow.badge.plus" catalog="system" width="21" height="16"/>
         <image name="minus.magnifyingglass" catalog="system" width="16" height="15"/>
         <image name="music.microphone" catalog="system" width="16" height="16"/>

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -356,7 +356,8 @@ class MainWindowController: PlayerWindowController {
     .useLegacyFullScreen,
     .displayTimeAndBatteryInFullScreen,
     .controlBarToolbarButtons,
-    .alwaysShowOnTopIcon
+    .alwaysShowOnTopIcon,
+    .unlockWindowAspectRatio,
   ]
 
   override func observeValue(forKeyPath keyPath: String?, of object: Any?, change: [NSKeyValueChangeKey: Any]?, context: UnsafeMutableRawPointer?) {
@@ -410,6 +411,8 @@ class MainWindowController: PlayerWindowController {
       }
     case PK.alwaysShowOnTopIcon.rawValue:
       updateOnTopIcon()
+    case PK.unlockWindowAspectRatio.rawValue:
+      handleVideoSizeChange()
     default:
       return
     }
@@ -1233,7 +1236,7 @@ class MainWindowController: PlayerWindowController {
         // changed
         let offset = recognizer.magnification - lastMagnification + 1.0;
         let newWidth = window.frame.width * offset
-        let newHeight = newWidth / window.aspectRatio.aspect
+        let newHeight = newWidth / currentAspectRatio.aspect
 
         //Check against max & min threshold
         if newHeight < screenFrame.height && newHeight > minSize.height && newWidth > minSize.width {
@@ -1739,7 +1742,7 @@ class MainWindowController: PlayerWindowController {
     }
     // then animate to the original frame
     window.setFrame(framePriorToBeingInFullscreen, display: true, animate: useAnimation)
-    window.aspectRatio = aspectRatio
+    setAspectRatio(aspectRatio)
     // call delegate
     windowDidExitFullScreen(Notification(name: .iinaLegacyFullScreen))
   }
@@ -1801,7 +1804,7 @@ class MainWindowController: PlayerWindowController {
   func windowWillResize(_ sender: NSWindow, to frameSize: NSSize) -> NSSize {
     guard let window = window else { return frameSize }
     if frameSize.height <= minSize.height || frameSize.width <= minSize.width {
-      return window.aspectRatio.grow(toSize: minSize)
+      return currentAspectRatio.grow(toSize: minSize)
     }
     return frameSize
   }
@@ -1813,6 +1816,10 @@ class MainWindowController: PlayerWindowController {
       forceDraw("window resized during animated enter or exit full screen")
     } else if !videoView.videoLayer.inLiveResize {
       forceDraw("window resized")
+    }
+
+    if Preference.bool(for: .unlockWindowAspectRatio) && videoView.isIdle {
+      forceDraw("window resized with aspect ratio unlocked and paused")
     }
 
     // interactive mode
@@ -2596,6 +2603,21 @@ class MainWindowController: PlayerWindowController {
 
   // MARK: - UI: Window size / aspect
 
+  private var currentAspectRatio: NSSize {
+    guard let window else { return .zero }
+    return Preference.bool(for: .unlockWindowAspectRatio) ? window.frame.size : window.aspectRatio
+  }
+
+  private func setAspectRatio(_ aspectRatio: NSSize) {
+    guard let window else { return }
+    if Preference.bool(for: .unlockWindowAspectRatio) {
+      window.aspectRatio = .zero
+      window.resizeIncrements = .init(width: 1, height: 1)
+    } else {
+      window.aspectRatio = aspectRatio
+    }
+  }
+
   /** Calculate the window frame from a parsed struct of mpv's `geometry` option. */
   func windowFrameFromGeometry(newSize: NSSize? = nil, screen: NSScreen? = nil) -> NSRect? {
     guard let geometry = cachedGeometry ?? player.getGeometry(),
@@ -2713,7 +2735,7 @@ class MainWindowController: PlayerWindowController {
 
     // set aspect ratio
     let originalVideoSize = NSSize(width: width, height: height)
-    window.aspectRatio = originalVideoSize
+    setAspectRatio(originalVideoSize)
     pip.aspectRatio = originalVideoSize
 
     var rect: NSRect

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1803,6 +1803,10 @@ class MainWindowController: PlayerWindowController {
 
   func windowWillResize(_ sender: NSWindow, to frameSize: NSSize) -> NSSize {
     guard let window = window else { return frameSize }
+    // disable resizing in interactive mode, little benefit but complicates the layout logic
+    if isInInteractiveMode {
+      return window.frame.size
+    }
     if frameSize.height <= minSize.height || frameSize.width <= minSize.width {
       return currentAspectRatio.grow(toSize: minSize)
     }
@@ -1820,11 +1824,6 @@ class MainWindowController: PlayerWindowController {
 
     if Preference.bool(for: .unlockWindowAspectRatio) && videoView.isIdle {
       forceDraw("window resized with aspect ratio unlocked and paused")
-    }
-
-    // interactive mode
-    if isInInteractiveMode {
-      cropSettingsView?.cropBoxView.resized()
     }
 
     // update control bar position
@@ -2485,10 +2484,6 @@ class MainWindowController: PlayerWindowController {
 
     self.cropSettingsView = controlView
 
-    let currentAspectRatio = window.frame.height / window.frame.width
-    aspectRatioConstraintForInteractiveMode = videoView.heightAnchor.constraint(equalTo: videoView.widthAnchor, multiplier: currentAspectRatio)
-    aspectRatioConstraintForInteractiveMode!.isActive = true
-
     // show crop settings view
     NSAnimationContext.runAnimationGroup({ (context) in
       context.duration = AccessibilityPreferences.adjustedDuration(CropAnimationDuration)
@@ -2504,6 +2499,7 @@ class MainWindowController: PlayerWindowController {
       self.videoView.layer?.shadowRadius = 3
       self.cropSettingsView?.cropBoxView.resized()
       self.cropSettingsView?.cropBoxView.isHidden = false
+      self.forceDraw("interactive cropping")
     }
   }
 
@@ -2828,16 +2824,18 @@ class MainWindowController: PlayerWindowController {
 
     shouldApplyInitialWindowSize = false
 
-    if fsState.isFullscreen {
+    let rectBefore = rect
+    rect = rect.constrain(in: screenRect)
+    if rectBefore != rect {
+      log("Constrained window frame to be in screen: \(rect)")
+    }
+
+    if Preference.bool(for: .unlockWindowAspectRatio) {
+      // do nothing when window aspect ratio is unlocked
+    } else if fsState.isFullscreen {
       log("In full screen mode, setting prior window frame")
       fsState.priorWindowedFrame = rect
     } else {
-      let rectBefore = rect
-      rect = rect.constrain(in: screenRect)
-      if rectBefore != rect {
-        log("Constrained window frame to be in screen: \(rect)")
-      }
-
       log("Setting window frame to: \(rect)")
       if player.disableWindowAnimation || Preference.bool(for: .disableAnimations) || !window.isVisible {
         window.setFrame(rect, display: true, animate: false)

--- a/iina/MainWindowMenuActions.swift
+++ b/iina/MainWindowMenuActions.swift
@@ -71,6 +71,11 @@ extension MainWindowController {
     setWindowFloatingOnTop(!isOntop)
   }
 
+  @objc func menuLockAspectRatio(_ sender: NSMenuItem) {
+    let unlock = Preference.bool(for: .unlockWindowAspectRatio)
+    Preference.set(!unlock, for: .unlockWindowAspectRatio)
+  }
+
   @objc func menuTogglePIP(_ sender: NSMenuItem) {
     switch pipStatus {
     case .notInPIP:

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -139,6 +139,7 @@ class MenuController: NSObject, NSMenuDelegate {
   @IBOutlet weak var fullScreen: NSMenuItem!
   @IBOutlet weak var pictureInPicture: NSMenuItem!
   @IBOutlet weak var alwaysOnTop: NSMenuItem!
+  @IBOutlet weak var lockAspectRatio: NSMenuItem!
   @IBOutlet weak var aspectMenu: NSMenu!
   @IBOutlet weak var cropMenu: NSMenu!
   @IBOutlet weak var rotationMenu: NSMenu!
@@ -291,6 +292,7 @@ class MenuController: NSObject, NSMenuDelegate {
     fullScreen.action = #selector(MainWindowController.menuToggleFullScreen(_:))
     pictureInPicture.action = #selector(MainWindowController.menuTogglePIP(_:))
     alwaysOnTop.action = #selector(MainWindowController.menuAlwaysOnTop(_:))
+    lockAspectRatio.action = #selector(MainWindowController.menuLockAspectRatio(_:))
 
     // -- aspect
     var aspectList = AppData.aspects
@@ -513,6 +515,7 @@ class MenuController: NSObject, NSMenuDelegate {
     let isOntop = player.isInMiniPlayer ? player.miniPlayer.isOntop : player.mainWindow.isOntop
     let isDelogo = player.info.delogoFilter != nil
     alwaysOnTop.state = isOntop ? .on : .off
+    lockAspectRatio.state = Preference.bool(for: .unlockWindowAspectRatio) ? .off : .on
     deinterlace.state = player.info.deinterlace ? .on : .off
     fullScreen.title = isInFullScreen ? Constants.String.exitFullScreen : Constants.String.fullScreen
     pictureInPicture?.title = isInPIP ? Constants.String.exitPIP : Constants.String.pip

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -163,6 +163,8 @@ struct Preference {
 
     static let disableAnimations = Key("disableAnimations")
 
+    static let unlockWindowAspectRatio = Key("unlockWindowAspectRatio")
+
     // Codec
 
     static let videoThreads = Key("videoThreads")
@@ -1032,6 +1034,7 @@ struct Preference {
     .togglePipByMinimizingWindow: false,
     .togglePipByMinimizingWindowForVideoOnly: false,
     .disableAnimations: false,
+    .unlockWindowAspectRatio: false,
 
     .videoThreads: 0,
     .hardwareDecoder: HardwareDecoderOption.auto.rawValue,

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -34,6 +34,7 @@ class VideoView: NSView {
   // cached indicator to prevent unnecessary updates of DisplayLink
   var currentDisplay: UInt32?
 
+  var isIdle = true
   private var displayIdleTimer: Timer?
 
   private lazy var hdrSubsystem = Logger.makeSubsystem("hdr\(player.playerNumber)", ["circle.righthalf.filled"])
@@ -274,6 +275,7 @@ class VideoView: NSView {
 
   /// Starts the display link if it has been stopped in order to save energy.
   func displayActive() {
+    isIdle = false
     displayIdleTimer?.invalidate()
     startDisplayLink()
   }
@@ -293,6 +295,7 @@ class VideoView: NSView {
   /// - Note: In addition to playback the display link must be running for operations such seeking, stepping and entering and leaving
   ///         full screen mode.
   func displayIdle() {
+    isIdle = true
     displayIdleTimer?.invalidate()
     // Because the display link is critical there is an internal setting that can be changed to
     // disable shutting down the display link should any problems with this energy saving feature


### PR DESCRIPTION
This is the prelude to implementing #6049. 

The aspect ratio will be force unlocked if we have the OSC or sidebar displayed outside the window.

<img width="325" height="435" alt="image" src="https://github.com/user-attachments/assets/5cdbd90d-3824-4562-b311-e2e999bcefea" />
