### PR TITLE
Fix: issue #6096 Holding option key when opening new file from menu bar corrected

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -82,7 +82,7 @@ class PlayerCore: NSObject {
   }
 
   static func activeOrNewForMenuAction(isAlternative: Bool) -> PlayerCore {
-    let useNew = Preference.bool(for: .alwaysOpenInNewWindow) != isAlternative
+    let useNew = Preference.bool(for: .alwaysOpenInNewWindow) == isAlternative
     return useNew ? newPlayerCore : active
   }
   


### PR DESCRIPTION


- [ x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ x] This implements/fixes issue #6096 

---

Reversed functionality of option key when choosing file open from menu bar, without removing changes made in #5868, expected behavior: holding option while choosing open file from menu bar results in opening file in same window if the option to "allow multiple player windows" is checked. if the option is not checked, the option key changes the text to "open in new window" 