### PR TITLE
Add media title to history file

### DIFF
--- a/iina/HistoryController.swift
+++ b/iina/HistoryController.swift
@@ -12,6 +12,12 @@ class HistoryController: NSObject {
 
   static let shared = HistoryController(plistFileURL: Utility.playbackHistoryURL)
 
+#if DEBUG
+  /// As logging of all history entries can produce a huge number of log messages this feature is only included in debug builds and
+  /// must be enabled by setting this property to `true` when you need investigate history file contents.
+  private static let logAllHistoryEntries = false
+#endif
+
   /// Cached copy of the playback history stored in the history file.
   ///
   /// This is accessed by both the main thread and a background thread and must be referenced under a lock.
@@ -45,6 +51,21 @@ class HistoryController: NSObject {
       self.history = history
       log("Read \(history.count) playback history entries")
       MemoryUsage.shared.logUsage("after reading history")
+
+      // As logging of all history entries can produce a huge number of log messages this feature is
+      // only included in debug builds.
+#if DEBUG
+      // IINA must be built with the property logAllHistoryEntries set to true when you want the
+      // history file contents to be logged when it is read.
+      guard HistoryController.logAllHistoryEntries, !history.isEmpty,
+            Logger.isEmitting(.verbose) else { return }
+      log("Playback history:", level: .verbose)
+      var index = 0
+      for entry in history {
+        log("History[\(index)] \(String(describing: entry))", level: .verbose)
+        index += 1
+      }
+#endif
     } catch {
       log("Failed to read playback history file \(plistURL.path): \(error)", level: .error)
     }
@@ -69,7 +90,8 @@ class HistoryController: NSObject {
   /// - Parameters:
   ///   - url: URL of the media being played.
   ///   - duration: Total duration of the media.
-  func add(_ url: URL, duration: Double) {
+  ///   - title: Title of the media (if available).
+  func add(_ url: URL, duration: Double, title: String?) {
     guard Preference.bool(for: .recordPlaybackHistory) else { return }
     $tasksOutstanding.withLock { $0 += 1 }
     queue.async { [self] in
@@ -78,7 +100,9 @@ class HistoryController: NSObject {
            let index = history.firstIndex(of: existingItem) {
           history.remove(at: index)
         }
-        history.insert(PlaybackHistory(url: url, duration: duration), at: 0)
+        let entry = PlaybackHistory(url: url, duration: duration, title: title)
+        history.insert(entry, at: 0)
+        log("Adding to history: \(String(describing: entry))", level: .verbose)
       }
       save()
       $tasksOutstanding.withLock { tasksOutstanding in

--- a/iina/PlaybackHistory.swift
+++ b/iina/PlaybackHistory.swift
@@ -14,6 +14,7 @@ fileprivate let KeyMpvMd5 = "IINAPHMpvmd5"
 fileprivate let KeyPlayed = "IINAPHPlayed"
 fileprivate let KeyAddedDate = "IINAPHDate"
 fileprivate let KeyDuration = "IINAPHDuration"
+fileprivate let KeyTitle = "IINAPHTitle"
 
 /// An entry in the playback history file.
 /// - Important: This class conforms to [NSSecureCoding](https://developer.apple.com/documentation/foundation/nssecurecoding).
@@ -22,6 +23,12 @@ class PlaybackHistory: NSObject, NSSecureCoding {
 
   /// Indicate this class supports secure coding.
   static var supportsSecureCoding: Bool { true }
+
+  private static let dateFormatter: DateFormatter = {
+    let dateFormatter = DateFormatter()
+    dateFormatter.dateFormat = "MM/dd/yyyy HH:mm:ss"
+    return dateFormatter
+  }()
 
   var url: URL
   var name: String
@@ -32,6 +39,21 @@ class PlaybackHistory: NSObject, NSSecureCoding {
 
   var duration: VideoTime
   var mpvProgress: VideoTime?
+
+  var title: String?
+
+  /// A description of this playback history entry suitable to include in a log message.
+  override var description: String {
+    var description = """
+      added: \(PlaybackHistory.dateFormatter.string(from: addedDate)) \
+      duration: \(duration.stringRepresentation)
+      """
+    if let mpvProgress { description += " progress: \(mpvProgress.stringRepresentation)" }
+    description += "\n  \(url)"
+    if let title { description += "\n  \(title)" }
+    description += "\n  MD5: \(mpvMd5)"
+    return description
+  }
 
   required init?(coder aDecoder: NSCoder) {
     guard
@@ -45,6 +67,7 @@ class PlaybackHistory: NSObject, NSSecureCoding {
 
     let played = aDecoder.decodeBool(forKey: KeyPlayed)
     let duration = aDecoder.decodeDouble(forKey: KeyDuration)
+    let title = aDecoder.decodeObject(of: NSString.self, forKey: KeyTitle)
 
     self.url = url as URL
     self.name = name as String
@@ -52,17 +75,19 @@ class PlaybackHistory: NSObject, NSSecureCoding {
     self.played = played
     self.addedDate = date as Date
     self.duration = VideoTime(duration)
+    self.title = title as String?
 
     self.mpvProgress = Utility.playbackProgressFromWatchLater(mpvMd5)
   }
 
-  init(url: URL, duration: Double, name: String? = nil) {
+  init(url: URL, duration: Double, name: String? = nil, title: String?) {
     self.url = url
     self.name = name ?? url.lastPathComponent
     self.mpvMd5 = Utility.mpvWatchLaterMd5(url.path)
     self.played = true
     self.addedDate = Date()
     self.duration = VideoTime(duration)
+    self.title = title
   }
 
   func encode(with aCoder: NSCoder) {
@@ -72,6 +97,6 @@ class PlaybackHistory: NSObject, NSSecureCoding {
     aCoder.encode(played, forKey: KeyPlayed)
     aCoder.encode(addedDate, forKey: KeyAddedDate)
     aCoder.encode(duration.second, forKey: KeyDuration)
+    aCoder.encode(title, forKey: KeyTitle)
   }
-
 }

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -2149,7 +2149,8 @@ class PlayerCore: NSObject {
     // add to history
     if let url = info.currentURL {
       let duration = info.videoDuration ?? .zero
-      HistoryController.shared.add(url, duration: duration.second)
+      let mediaTitle = mpv.getString(MPVProperty.mediaTitle)
+      HistoryController.shared.add(url, duration: duration.second, title: mediaTitle)
       if Preference.bool(for: .recordRecentFiles) && Preference.bool(for: .trackAllFilesInRecentOpenMenu) {
         AppDelegate.shared.noteNewRecentDocumentURL(url)
       }


### PR DESCRIPTION
This commit will:
- Add a title property to the `PlaybackHistory` class
- Add a `title` parameter to the `HistoryController.add` method
- Change `PlayerCore.fileLoaded` to pass the media title when calling the `HistoryController` to add an entry
- Add a `description` property to the `PlaybackHistory` class that provides a string representation suitable for a log message
- Change the `HistoryController.add` method to log the entry being added to the history file, if verbose logging is enabled
- Add a new `logAllHistoryEntries` property to `HistoryController` to disable logging of history entries by default
- Change the `HistoryController.read` method to log all history entries after reading the history file in debug builds of IINA, if enabled by `logAllHistoryEntries`

This commit will change IINA to start storing the media title in entries in the history file for media that have an associated title. This will provide the backend support required for the history window to be updated to display media titles.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
