### PR TITLE
Added section headers to playlist context menu (macOS 14+)

### DIFF
--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -396,6 +396,12 @@
 "pl_menu.browser" = "Open in Browser";
 "pl_menu.copy_url" = "Copy URL";
 "pl_menu.copy_url_multi" = "Copy URLs";
+"pl_menu.playback" = "Playback";
+"pl_menu.subtitles" = "Subtitles";
+"pl_menu.network_resources" = "Network Resources";
+"pl_menu.file_operations" = "File Operations";
+"pl_menu.plugin" = "Plugin";
+"pl_menu.playlist" = "Playlist";
 
 "keymapping.title" = "Key Mapping";
 "keymapping.message" = "Press any key to record.";

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -397,7 +397,7 @@
 "pl_menu.copy_url" = "Copy URL";
 "pl_menu.copy_url_multi" = "Copy URLs";
 "pl_menu.playback" = "Playback";
-"pl_menu.subtitles" = "Subtitles";
+"pl_menu.subtitles" = "Subtitles (%d loaded)";
 "pl_menu.network_resources" = "Network Resources";
 "pl_menu.file_operations" = "File Operations";
 "pl_menu.plugin" = "Plugin";

--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -789,10 +789,13 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
     let isSingleItem = rows.count == 1
 
     if !rows.isEmpty {
-      let firstURL = player.info.$playlist.withLock { $0[rows.first!] }
-      let matchedSubCount = player.info.getMatchedSubs(firstURL.filename)?.count ?? 0
+      let matchedSubCount = rows.map { index in
+        player.info.$playlist.withLock {
+          player.info.getMatchedSubs($0[index].filename)?.count ?? 0
+        }
+      }.reduce(0, +)
       let title: String = isSingleItem ?
-        firstURL.filenameForDisplay :
+        player.info.$playlist.withLock { $0[rows.first!] }.filenameForDisplay:
         String(format: NSLocalizedString("pl_menu.title_multi", comment: "%d Items"), rows.count)
 
       result.addItem(withTitle: title)
@@ -807,10 +810,11 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
       if !player.isInMiniPlayer && (isSingleItem || matchedSubCount != 0) {
         result.addItem(NSMenuItem.separator())
         if #available(macOS 14.0, *) {
-          result.addItem(.sectionHeader(title: NSLocalizedString("pl_menu.subtitles", comment: "Subtitles")))
+          result.addItem(.sectionHeader(title: String(format: NSLocalizedString("pl_menu.subtitles", comment: "Subtitles (%@ loaded)"), matchedSubCount)))
+        } else {
+          result.addItem(withTitle: String(format: NSLocalizedString("pl_menu.matched_sub", comment: "Matched %d Subtitle(s)"), matchedSubCount))
         }
         if isSingleItem {
-          result.addItem(withTitle: String(format: NSLocalizedString("pl_menu.matched_sub", comment: "Matched %d Subtitle(s)"), matchedSubCount))
           result.addItem(withTitle: NSLocalizedString("pl_menu.add_sub", comment: "Add Subtitle…"), action: #selector(self.contextMenuAddSubtitle(_:)))
         }
         if matchedSubCount != 0 {

--- a/iina/PlaylistViewController.swift
+++ b/iina/PlaylistViewController.swift
@@ -797,12 +797,18 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
 
       result.addItem(withTitle: title)
       result.addItem(NSMenuItem.separator())
+      if #available(macOS 14.0, *) {
+        result.addItem(.sectionHeader(title: NSLocalizedString("pl_menu.playback", comment: "Playback")))
+      }
       result.addItem(withTitle: NSLocalizedString("pl_menu.play_next", comment: "Play Next"), action: #selector(self.contextMenuPlayNext(_:)))
       result.addItem(withTitle: NSLocalizedString("pl_menu.play_in_new_window", comment: "Play in New Window"), action: #selector(self.contextMenuPlayInNewWindow(_:)))
       result.addItem(withTitle: NSLocalizedString(isSingleItem ? "pl_menu.remove" : "pl_menu.remove_multi", comment: "Remove"), action: #selector(self.contextMenuRemove(_:)))
 
-      if !player.isInMiniPlayer {
+      if !player.isInMiniPlayer && (isSingleItem || matchedSubCount != 0) {
         result.addItem(NSMenuItem.separator())
+        if #available(macOS 14.0, *) {
+          result.addItem(.sectionHeader(title: NSLocalizedString("pl_menu.subtitles", comment: "Subtitles")))
+        }
         if isSingleItem {
           result.addItem(withTitle: String(format: NSLocalizedString("pl_menu.matched_sub", comment: "Matched %d Subtitle(s)"), matchedSubCount))
           result.addItem(withTitle: NSLocalizedString("pl_menu.add_sub", comment: "Add Subtitle…"), action: #selector(self.contextMenuAddSubtitle(_:)))
@@ -818,6 +824,9 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
         rows.filter { playlist[$0].isNetworkResource }
       }.count
       if networkCount != 0 {
+        if #available(macOS 14.0, *) {
+          result.addItem(.sectionHeader(title: NSLocalizedString("pl_menu.network_resources", comment: "Network Resources")))
+        }
         result.addItem(withTitle: NSLocalizedString("pl_menu.browser", comment: "Open in Browser"), action: #selector(self.contextOpenInBrowser(_:)))
         result.addItem(withTitle: NSLocalizedString(networkCount == 1 ? "pl_menu.copy_url" : "pl_menu.copy_url_multi", comment: "Copy URL(s)"), action: #selector(self.contextCopyURL(_:)))
         result.addItem(NSMenuItem.separator())
@@ -825,6 +834,9 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
       // file related operations
       let localCount = rows.count - networkCount
       if localCount != 0 {
+        if #available(macOS 14.0, *) {
+          result.addItem(.sectionHeader(title: NSLocalizedString("pl_menu.file_operations", comment: "File Operations")))
+        }
         result.addItem(withTitle: NSLocalizedString(localCount == 1 ? "pl_menu.delete" : "pl_menu.delete_multi", comment: "Delete"), action: #selector(self.contextMenuDeleteFile(_:)))
         // result.addItem(withTitle: NSLocalizedString(isSingleItem ? "pl_menu.delete_after_play" : "pl_menu.delete_after_play_multi", comment: "Delete After Playback"), action: #selector(self.contextMenuDeleteFileAfterPlayback(_:)))
 
@@ -848,7 +860,7 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
       return (plugin, [])
     }
     if hasPluginMenuItems {
-      result.addItem(withTitle: NSLocalizedString("preference.plugins", comment: "Plugins"))
+      result.addItem(withTitle: NSLocalizedString("pl_menu.plugin", comment: "Plugin"))
       for (plugin, items) in pluginMenuItems {
         for item in items {
           add(menuItemDef: item, to: result, for: plugin)
@@ -857,6 +869,9 @@ class PlaylistViewController: NSViewController, NSTableViewDataSource, NSTableVi
       result.addItem(NSMenuItem.separator())
     }
 
+    if #available(macOS 14.0, *) {
+      result.addItem(.sectionHeader(title: NSLocalizedString("pl_menu.playlist", comment: "Playlist")))
+    }
     result.addItem(withTitle: NSLocalizedString("pl_menu.add_file", comment: "Add File"), action: #selector(self.addFileAction(_:)))
     result.addItem(withTitle: NSLocalizedString("pl_menu.add_url", comment: "Add URL"), action: #selector(self.addURLAction(_:)))
     result.addItem(withTitle: NSLocalizedString("pl_menu.clear_playlist", comment: "Clear Playlist"), action: #selector(self.clearPlaylistBtnAction(_:)))

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -400,7 +400,7 @@
 "pl_menu.copy_url" = "Copy URL";
 "pl_menu.copy_url_multi" = "Copy URLs";
 "pl_menu.playback" = "Playback";
-"pl_menu.subtitles" = "Subtitles";
+"pl_menu.subtitles" = "Subtitles (%d loaded)";
 "pl_menu.network_resources" = "Network Resources";
 "pl_menu.file_operations" = "File Operations";
 "pl_menu.plugin" = "Plugin";

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -399,6 +399,12 @@
 "pl_menu.browser" = "Open in Browser";
 "pl_menu.copy_url" = "Copy URL";
 "pl_menu.copy_url_multi" = "Copy URLs";
+"pl_menu.playback" = "Playback";
+"pl_menu.subtitles" = "Subtitles";
+"pl_menu.network_resources" = "Network Resources";
+"pl_menu.file_operations" = "File Operations";
+"pl_menu.plugin" = "Plugin";
+"pl_menu.playlist" = "Playlist";
 
 "keymapping.title" = "Key Mapping";
 "keymapping.message" = "Press any key to record.";


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)

---

**Description:**
Added section headers to the playlist context menu for macOS 14+ to increase its readability.

Before:
<img width="197" height="326" alt="image" src="https://github.com/user-attachments/assets/e4c3ec65-407e-4e10-ad36-2bc1001550a2" />

Now:
<img width="192" height="420" alt="image" src="https://github.com/user-attachments/assets/abfeaf44-74db-4c66-9cb4-fcf481c2a0b4" />
