### PR TITLE
Fix watch later MD5 sum calculation

### DIFF
--- a/iina/HistoryController.swift
+++ b/iina/HistoryController.swift
@@ -91,16 +91,18 @@ class HistoryController: NSObject {
   ///   - url: URL of the media being played.
   ///   - duration: Total duration of the media.
   ///   - title: Title of the media (if available).
-  func add(_ url: URL, duration: Double, title: String?) {
+  ///   - ignorePath: When `true`, only the URL's filename will be used for the sum if the URL does not contain a scheme.
+  func add(_ url: URL, duration: Double, title: String?, _ ignorePath: Bool) {
     guard Preference.bool(for: .recordPlaybackHistory) else { return }
     $tasksOutstanding.withLock { $0 += 1 }
     queue.async { [self] in
+      let mpvMd5 = Utility.mpvWatchLaterMd5(url, ignorePath)
       $history.withLock { history in
-        if let existingItem = history.first(where: { $0.mpvMd5 == url.path.md5 }),
+        if let existingItem = history.first(where: { $0.mpvMd5 == mpvMd5 }),
            let index = history.firstIndex(of: existingItem) {
           history.remove(at: index)
         }
-        let entry = PlaybackHistory(url: url, duration: duration, title: title)
+        let entry = PlaybackHistory(url: url, duration: duration, title: title, mpvMd5: mpvMd5)
         history.insert(entry, at: 0)
         log("Adding to history: \(String(describing: entry))", level: .verbose)
       }

--- a/iina/PlaybackHistory.swift
+++ b/iina/PlaybackHistory.swift
@@ -80,10 +80,10 @@ class PlaybackHistory: NSObject, NSSecureCoding {
     self.mpvProgress = Utility.playbackProgressFromWatchLater(mpvMd5)
   }
 
-  init(url: URL, duration: Double, name: String? = nil, title: String?) {
+  init(url: URL, duration: Double, name: String? = nil, title: String?, mpvMd5: String) {
     self.url = url
     self.name = name ?? url.lastPathComponent
-    self.mpvMd5 = Utility.mpvWatchLaterMd5(url.path)
+    self.mpvMd5 = mpvMd5
     self.played = true
     self.addedDate = Date()
     self.duration = VideoTime(duration)

--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -83,11 +83,8 @@ class PlaybackInfo {
 
   var currentURL: URL? {
     didSet {
-      if let url = currentURL {
-        mpvMd5 = Utility.mpvWatchLaterMd5(url.path)
-      } else {
-        mpvMd5 = nil
-      }
+      guard currentURL == nil else { return }
+      mpvMd5 = nil
     }
   }
   var isNetworkResource: Bool = false

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -291,6 +291,23 @@ class PlayerCore: NSObject {
     abLoopA != 0 && abLoopB != 0 && mpv.getString(MPVOption.PlaybackControl.abLoopCount) != "0"
   }
 
+  /// Whether to only use the URL's filename when calculating the mpv
+  /// [Watch Later](https://mpv.io/manual/stable/#watch-later) MD5 sum.
+  ///
+  /// This supports the mpv
+  /// [ignore-path-in-watch-later-config](https://mpv.io/manual/stable/#options-ignore-path-in-watch-later-config)
+  /// option. As this option is only used by advanced users there is intentionally no support in IINA's UI for this option. This is also an
+  /// option that you would set and not change as changing it means existing watch later files will no longer be found. For this reason
+  /// IINA does not support dynamic changes to this option. The value of this option is obtained and cached. Setting this option
+  /// requires IINA to be restarted.
+  lazy var ignorePathInWatchLaterConfig: Bool = {
+    let ignorePath = mpv.getFlag(MPVOption.WatchLater.ignorePathInWatchLaterConfig)
+    if ignorePath {
+      log("Will use filename instead of path when calculating watch later MD5 sum")
+    }
+    return ignorePath
+  }()
+
   /// Whether to auto load files when opening the URL given in `pendingUrl`.
   private var pendingAutoLoad = false
 
@@ -502,6 +519,7 @@ class PlayerCore: NSObject {
   private func openMainWindow(path: String, url: URL, isNetwork: Bool) {
     log("Opening \(path) in main window")
     info.currentURL = url
+    info.mpvMd5 = Utility.mpvWatchLaterMd5(url, ignorePathInWatchLaterConfig)
     info.isNetworkResource = isNetwork
     info.audioTracks = []
     info.chapters = []
@@ -2012,6 +2030,9 @@ class PlayerCore: NSObject {
     info.currentURL = path.contains("://") ?
       URL(string: path.addingPercentEncoding(withAllowedCharacters: .urlAllowed) ?? path) :
       URL(fileURLWithPath: path)
+    if let url = info.currentURL {
+      info.mpvMd5 = Utility.mpvWatchLaterMd5(url, ignorePathInWatchLaterConfig)
+    }
     info.isNetworkResource = !info.currentURL!.isFileURL
 
     // set "date last opened" attribute
@@ -2150,7 +2171,8 @@ class PlayerCore: NSObject {
     if let url = info.currentURL {
       let duration = info.videoDuration ?? .zero
       let mediaTitle = mpv.getString(MPVProperty.mediaTitle)
-      HistoryController.shared.add(url, duration: duration.second, title: mediaTitle)
+      HistoryController.shared.add(url, duration: duration.second, title: mediaTitle,
+                                   ignorePathInWatchLaterConfig)
       if Preference.bool(for: .recordRecentFiles) && Preference.bool(for: .trackAllFilesInRecentOpenMenu) {
         AppDelegate.shared.noteNewRecentDocumentURL(url)
       }
@@ -3092,7 +3114,11 @@ class PlayerCore: NSObject {
    */
   func refreshCachedVideoInfo(forVideoPath path: String) {
     guard let dict = FFmpegController.probeVideoInfo(forFile: path) else { return }
-    let progress = Utility.playbackProgressFromWatchLater(path.md5)
+    let progress: VideoTime? = {
+      guard let url = URL(string: path) else { return nil }
+      let mpvMd5 = Utility.mpvWatchLaterMd5(url, ignorePathInWatchLaterConfig)
+      return Utility.playbackProgressFromWatchLater(mpvMd5)
+    }()
     self.info.setCachedVideoDurationAndProgress(path, (
       duration: dict["@iina_duration"] as? Double,
       progress: progress?.second

--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -514,14 +514,27 @@ class Utility {
     }
   }
 
-  /// See `mp_get_playback_resume_config_filename` in mpv/configfiles.c
-  static func mpvWatchLaterMd5(_ filename: String) -> String {
-    // mp_is_url
-    // if(!Regex.mpvURL.matches(filename)) {
-      // ignore_path_in_watch_later_config
-    // }
-    // handle dvd:// and bd://
-    return filename.md5
+  /// Calculates and returns a MD5 sum for the given URL.
+  ///
+  /// The mpv [Watch Later](https://mpv.io/manual/stable/#watch-later) feature saves options and their values in a
+  /// file whose name is based on the MD5 sum of the media's URL. IINA calculates this MD5 sum in order to find and read the watch
+  /// later file created by `libmpv` to be able to display the saved playback progress. For this to work the MD5 sum calculated by
+  /// IINA _must_ match the sum calculated by mpv or IINA will not be able to find the file created by mpv. The mpv code of interest is
+  /// the function
+  /// [mp_get_playback_resume_config_filename](https://github.com/mpv-player/mpv/blob/f5d4d9b029affa4d5b7eb13b28d91a96e6a92280/player/configfiles.c#L213-L229).
+  /// The code of this method differs slightly due to the way IINA uses URLs.
+  ///
+  /// If the `ignorePath` parameter is `true` that means the user has enabled the mpv
+  /// [ignore-path-in-watch-later-config](https://mpv.io/manual/stable/#options-ignore-path-in-watch-later-config)
+  /// option and the MD5 sum should only use the filename and not the full path.
+  /// - Parameters:
+  ///   - url: URL of the media.
+  ///   - ignorePath: When `true`, only use the URL's filename when calculating the sum.
+  /// - Returns: The appropriate MD5 sum as a hexadecimal string.
+  static func mpvWatchLaterMd5(_ url: URL, _ ignorePath: Bool) -> String {
+    if ignorePath, url.scheme == nil || url.isFileURL { return url.lastPathComponent.md5 }
+    if url.isFileURL { return url.path.md5 }
+    return url.absoluteString.md5
   }
 
   static func playbackProgressFromWatchLater(_ mpvMd5: String) -> VideoTime? {

--- a/other/cat_watch_later_file.sh
+++ b/other/cat_watch_later_file.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+#
+#  cat_watch_later_file.sh
+#  iina
+#
+#  Created by low-batt on 6/1/26.
+#  Copyright © 2026 lhc. All rights reserved.
+#
+
+# Show the contents of the mpv watch later file for the specified media. This
+# script expects the full pathname or URL of the media as the first and only
+# argument. This must match the string IINA passed to libmpv in the loadfile
+# command for the watch later file to be found. This is a tool for developers
+# to use when working on watch later related issues.
+#
+# Example use:
+# low-batt@gag other (md5 *$%=)$ ./cat_watch_later_file.sh "$HOME/Movies/big_buck_bunny.mp4"
+# start=212.600000
+# sid=1
+# low-batt@gag other (md5 *$%=)$ 
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m' # No Color
+
+# Must be invoked with one argument.
+if [ "$#" -lt 1 ]
+then
+  echo -e "${RED}Usage: $0 <full pathname or URL of the media>${NC}" >&2
+  exit 1
+fi
+# The argument must not be empty.
+if [ -z "$1" ]
+then
+  echo -e "${RED}Pathname / URL argument cannot be empty${NC}" >&2
+  exit 1
+fi
+# No more than one argument can be supplied.
+if [ "$#" -ne 1 ]
+then
+  echo -e "${RED}Too many arguments${NC}" >&2
+  exit 1
+fi
+
+filename=$(md5 -qs "$1" | awk '{print toupper($0)}')
+path="$HOME/Library/Application Support/com.colliderli.iina/watch_later/$filename"
+
+# The media won't have a file if it is currently being played, if it was played
+# to the end or if the user switched to another file in the playlist, etc.
+if [ ! -f "$path" ]; then
+  echo -e "${GREEN}No watch later file found for this media${NC}" >&2
+  exit
+fi
+
+cat "$path"


### PR DESCRIPTION
This commit will:
- Change the `Utility.mpvWatchLaterMd5` method to match the sum calculated by mpv
- Add a new `ignorePath` parameter to `mpvWatchLaterMd5` in support of the mpv `ignore-path-in-watch-later-config` option
- Add a new `ignorePathInWatchLaterConfig` property to `PlayerCore` that gets and caches the value of the mpv `ignore-path-in-watch-later-config` option
- Change `PlayerCore.refreshCachedVideoInfo` to use the `ignorePathInWatchLaterConfig` property when calling `mpvWatchLaterMd5`
- Remove the call to `mpvWatchLaterMd5` from `PlaybackInfo`
- Change `PlayerCore.openMainWindow` to call `mpvWatchLaterMd5` and set `PlaybackInfo.mpvMd5`
- Change `PlayerCore.fileStarted` to call `mpvWatchLaterMd5` and set `PlaybackInfo.mpvMd5`
- Add a `mpvMd5` parameter to the `PlaybackHistory` initializer and remove the call to `mpvWatchLaterMd5`
- Add an `ignorePath` parameter to `HistoryController.add`
- Change `HistoryController.add` to call `mpvWatchLaterMd5` and pass the sum when constructing the `PlaybackHistory` object
- Change `PlayerCore.fileLoaded` to pass `ignorePathInWatchLaterConfig` when calling `HistoryController.add`
- Add a `cat_watch_later_file.sh` script to `other` that makes it easy for developer to see the contents of a watch later file

This commit will correct the MD5 sum calculation for YouTube videos to match the sum calculated by mpv. The current code is calculating the sum based on the URL path, which for a YouTube video is just `/watch`. This prevents IINA from finding the watch later file and also causes the history file to have only one entry for all YouTube videos.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
