### PR TITLE
ci: authenticate GitHub release API requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,8 @@
 name: CI
 
+permissions:
+  contents: read
+
 on:
   push:
       branches: [develop]
@@ -21,6 +24,7 @@ jobs:
         run: ./other/download_libs.sh $DOWNLOAD_LIBS_ARGS
         env:
           DOWNLOAD_LIBS_ARGS: ${{ github.event_name == 'pull_request' && '--skip-plugins' || '' }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build
         run: xcodebuild -project iina.xcodeproj ONLY_ACTIVE_ARCH=NO -scheme iina -configuration Nightly ${{ matrix.deployment_target }}

--- a/other/download_libs.sh
+++ b/other/download_libs.sh
@@ -214,9 +214,14 @@ fetch_latest_plugin_asset() {
   local repo="$1"
   local response_file
   local status_code
+  local curl_args=()
+
+  if [[ -n "${GITHUB_TOKEN:-}" ]]; then
+    curl_args=(-H "Authorization: Bearer ${GITHUB_TOKEN}")
+  fi
 
   response_file=$(mktemp) || return 1
-  status_code=$(curl -s -L -o "$response_file" -w "%{http_code}" "https://api.github.com/repos/${repo}/releases/latest") || {
+  status_code=$(curl -s -L "${curl_args[@]}" -o "$response_file" -w "%{http_code}" "https://api.github.com/repos/${repo}/releases/latest") || {
     echo -e "${RED}Failed to contact GitHub for ${repo}.${NC}" >&2
     rm -f "$response_file"
     return 1


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**

CI sometimes fails while installing dependencies because the workflow downloads the latest official plugin releases through unauthenticated GitHub API requests. When GitHub rate-limits the runner IP, the dependency install step fails with HTTP 403 before the build can start.

This change passes the workflow `GITHUB_TOKEN` into the dependency install step and uses it when querying GitHub's release API. Authenticated requests have a higher rate limit, which should make plugin downloads more reliable in CI.

Testing performed:

- Ran `bash -n other/download_libs.sh`
- Ran `git diff --check`
- Verified `.github/workflows/ci.yml` can be parsed as YAML