### PR TITLE
Fix filename being stored as title in history

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -2171,7 +2171,14 @@ class PlayerCore: NSObject {
     if let url = info.currentURL {
       let duration = info.videoDuration ?? .zero
       let mediaTitle = mpv.getString(MPVProperty.mediaTitle)
-      HistoryController.shared.add(url, duration: duration.second, title: mediaTitle,
+      // Unfortunately the mpv media-title property returns the filename when there isn't a title.
+      // Don't store a title unless the media actually has one.
+      let titleToUse: String? = {
+        guard let mediaTitle else { return nil }
+        guard mediaTitle != url.lastPathComponent else { return nil }
+        return mediaTitle
+      }()
+      HistoryController.shared.add(url, duration: duration.second, title: titleToUse,
                                    ignorePathInWatchLaterConfig)
       if Preference.bool(for: .recordRecentFiles) && Preference.bool(for: .trackAllFilesInRecentOpenMenu) {
         AppDelegate.shared.noteNewRecentDocumentURL(url)


### PR DESCRIPTION
This commit will change `PlayerCore.fileLoaded` to check if the mpv property `media-title` value matches the filename of the media and if so, do not store it as the title in the history entry.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
