### PR TITLE
fix: use pushed_at instead of updated_at for plugin update time in the new settings page

### DIFF
--- a/iina/PluginStorePanel.swift
+++ b/iina/PluginStorePanel.swift
@@ -323,6 +323,7 @@ struct GitHubRepo: Codable {
   let language: String?
   let htmlUrl: URL
   let updatedAt: Date
+  let pushedAt: Date?
   let owner: Owner
 
   struct Owner: Codable {
@@ -340,6 +341,7 @@ struct GitHubRepo: Codable {
     case language
     case htmlUrl = "html_url"
     case updatedAt = "updated_at"
+    case pushedAt = "pushed_at"
     case owner
   }
 }
@@ -497,7 +499,7 @@ struct RepoDetailView: View {
       .font(.callout)
       .foregroundColor(.secondary)
 
-      Text("Updated \(Self.relativeFormatter.localizedString(for: repo.updatedAt, relativeTo: Date()))")
+      Text("Updated \(Self.relativeFormatter.localizedString(for: repo.pushedAt ?? repo.updatedAt, relativeTo: Date()))")
         .font(.caption)
         .foregroundColor(.secondary)
     }

--- a/iina/PluginStorePanel.swift
+++ b/iina/PluginStorePanel.swift
@@ -499,16 +499,32 @@ struct RepoDetailView: View {
       .font(.callout)
       .foregroundColor(.secondary)
 
-      Text("Updated \(Self.relativeFormatter.localizedString(for: repo.pushedAt ?? repo.updatedAt, relativeTo: Date()))")
+      Text(formatUpdateDate(repo.pushedAt ?? repo.updatedAt))
         .font(.caption)
         .foregroundColor(.secondary)
     }
     .frame(maxWidth: .infinity, alignment: .leading)
   }
 
+  private func formatUpdateDate(_ date: Date) -> String {
+    let days = Calendar.current.dateComponents([.day], from: date, to: Date()).day ?? 0
+    if days < 30 {
+      return "Updated \(Self.relativeFormatter.localizedString(for: date, relativeTo: Date()))"
+    } else {
+      return "Updated on \(Self.absoluteFormatter.string(from: date))"
+    }
+  }
+
   private static let relativeFormatter: RelativeDateTimeFormatter = {
     let f = RelativeDateTimeFormatter()
     f.unitsStyle = .full
+    return f
+  }()
+
+  private static let absoluteFormatter: DateFormatter = {
+    let f = DateFormatter()
+    f.dateStyle = .medium
+    f.timeStyle = .none
     return f
   }()
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**

This PR fixes a misleading "Updated X time ago" string for Community Plugins in the Plugin Store Panel of the new settings page.

Previously, `PluginStorePanel.swift` used the `updated_at` field from the GitHub repository API to display the relative update time. However, `updated_at` reflects the repository's last activity (which can include events like receiving a star or modifying an issue label), which does not reliably correspond to the last code push. This discrepancy often caused confusion for users and plugin authors, as the time shown inside IINA did not match the "Updated on..." time typically displayed on the GitHub website (which uses `pushed_at`).

To resolve this, we now attempt to decode the `pushed_at` field from the GitHub API payload. The UI uses `pushed_at` as the primary timestamp for relative date calculation, falling back to `updated_at` if `pushed_at` is unavailable. This fallback design ensures robustness: in rare edge cases (e.g., completely empty repositories), the GitHub API might not return a `pushed_at` field. By making `pushedAt` optional and using the nil-coalescing operator (`repo.pushedAt ?? repo.updatedAt`), we guarantee that the UI accurately displays the push time under normal circumstances, while gracefully degrading to `updated_at` when necessary, preventing crashes or missing timestamps.

### Examples

GitHub Website Time (`pushed_at`):
<img width="285" height="117" alt="Screenshot 2026-06-13 at 20 52 15" src="https://github.com/user-attachments/assets/d9f88c38-8b7c-4602-be3d-ddf0e779ff9a" />

Comparison of how it looks in IINA:

| Before (`updated_at`) | After (`pushed_at`) |
| --- | --- |
| ![](https://github.com/user-attachments/assets/1461451a-9365-4860-ac3a-98b5d90d278e) | ![](https://github.com/user-attachments/assets/c9035149-37d0-4e76-9c91-06696794280b) |