### PR TITLE
chore: add bilingual audio to plugin list

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -6,6 +6,12 @@
     "id": "com.yorkyang2333.anime4k"
   },
   {
+    "name": "Bilingual Audio",
+    "url": "https://github.com/glechic/iina-bilingual-audio",
+    "desc": "Play two audio tracks with left/right channel separation for bilingual viewing.",
+    "id": "com.bilingual-audio.iina-plugin"
+  },
+  {
     "name": "Bookmarks",
     "url": "https://github.com/wyattowalsh/iina-plugin-bookmarks",
     "desc": "Save and manage video timestamps.",


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
Add bilingual audio to plugin list
A plugin that lets two people watch the same movie together, each hearing it in their own language — one track plays through the left speaker, the other through the right.