### PR TITLE
Add AirPlay video casting

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -231,6 +231,9 @@
 		845E70B2210CB59D00D06C42 /* ScrollingTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 845E70B1210CB59D00D06C42 /* ScrollingTextField.swift */; };
 		8460FBA91D6497490081841B /* PlaylistViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8460FBA71D6497490081841B /* PlaylistViewController.swift */; };
 		846121BD1F35FCA500ABB39C /* DraggingDetect.swift in Sources */ = {isa = PBXBuildFile; fileRef = 846121BC1F35FCA500ABB39C /* DraggingDetect.swift */; };
+		FFFFFF010000000000FF0B02 /* HLSPackager.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFFFFF010000000000FF0B01 /* HLSPackager.swift */; };
+		FFFFFF010000000000FF0B04 /* HLSFileServer.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFFFFF010000000000FF0B03 /* HLSFileServer.swift */; };
+		FFFFFF010000000000FF0B06 /* AirPlayCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFFFFF010000000000FF0B05 /* AirPlayCoordinator.swift */; };
 		8461BA681E4237C7008BB852 /* youtube-dl in Copy Executables */ = {isa = PBXBuildFile; fileRef = 8461BA671E4237C2008BB852 /* youtube-dl */; settings = {ATTRIBUTES = (CodeSignOnCopy, ); }; };
 		8461C52E1D45FFF6006E91FF /* PlaySliderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8461C52D1D45FFF6006E91FF /* PlaySliderCell.swift */; };
 		8461C5301D462488006E91FF /* VideoTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8461C52F1D462488006E91FF /* VideoTime.swift */; };
@@ -306,6 +309,7 @@
 		84F725561D4783EE000DEF1B /* VolumeSliderCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F725551D4783EE000DEF1B /* VolumeSliderCell.swift */; };
 		84F7258F1D486185000DEF1B /* MPVProperty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84F7258E1D486185000DEF1B /* MPVProperty.swift */; };
 		84FBCB381EEACDDD0076C77C /* FFmpegController.m in Sources */ = {isa = PBXBuildFile; fileRef = 84FBCB371EEACDDD0076C77C /* FFmpegController.m */; };
+		FFFFFF010000000000FF0C02 /* HLSRemuxer.m in Sources */ = {isa = PBXBuildFile; fileRef = FFFFFF010000000000FF0C01 /* HLSRemuxer.m */; };
 		84FBF23E1EF06A90003EA491 /* ThumbnailCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FBF23D1EF06A90003EA491 /* ThumbnailCache.swift */; };
 		8F49C36E213EFB7E0076C4F9 /* MiniPlayerWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8F49C370213EFB7E0076C4F9 /* MiniPlayerWindowController.xib */; };
 		9E47DAC01E3CFA6D00457420 /* DurationDisplayTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E47DABF1E3CFA6D00457420 /* DurationDisplayTextField.swift */; };
@@ -1346,6 +1350,9 @@
 		845E70B1210CB59D00D06C42 /* ScrollingTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ScrollingTextField.swift; sourceTree = "<group>"; };
 		8460FBA71D6497490081841B /* PlaylistViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaylistViewController.swift; sourceTree = "<group>"; };
 		846121BC1F35FCA500ABB39C /* DraggingDetect.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraggingDetect.swift; sourceTree = "<group>"; };
+		FFFFFF010000000000FF0B01 /* HLSPackager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HLSPackager.swift; path = "iina/AirPlay/HLSPackager.swift"; sourceTree = SOURCE_ROOT; };
+		FFFFFF010000000000FF0B03 /* HLSFileServer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = HLSFileServer.swift; path = "iina/AirPlay/HLSFileServer.swift"; sourceTree = SOURCE_ROOT; };
+		FFFFFF010000000000FF0B05 /* AirPlayCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AirPlayCoordinator.swift; path = "iina/AirPlay/AirPlayCoordinator.swift"; sourceTree = SOURCE_ROOT; };
 		8461BA671E4237C2008BB852 /* youtube-dl */ = {isa = PBXFileReference; lastKnownFileType = text; name = "youtube-dl"; path = "deps/executable/youtube-dl"; sourceTree = SOURCE_ROOT; };
 		8461C52D1D45FFF6006E91FF /* PlaySliderCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaySliderCell.swift; sourceTree = "<group>"; };
 		8461C52F1D462488006E91FF /* VideoTime.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = VideoTime.swift; sourceTree = "<group>"; };
@@ -1580,6 +1587,8 @@
 		84F7258E1D486185000DEF1B /* MPVProperty.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MPVProperty.swift; sourceTree = "<group>"; };
 		84FBCB361EEACDDD0076C77C /* FFmpegController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = FFmpegController.h; sourceTree = "<group>"; };
 		84FBCB371EEACDDD0076C77C /* FFmpegController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = FFmpegController.m; sourceTree = "<group>"; };
+		FFFFFF010000000000FF0C01 /* HLSRemuxer.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; name = HLSRemuxer.m; path = "iina/HLSRemuxer.m"; sourceTree = SOURCE_ROOT; };
+		FFFFFF010000000000FF0C03 /* HLSRemuxer.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = HLSRemuxer.h; path = "iina/HLSRemuxer.h"; sourceTree = SOURCE_ROOT; };
 		84FBF23D1EF06A90003EA491 /* ThumbnailCache.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ThumbnailCache.swift; sourceTree = "<group>"; };
 		875FDF9E2157873300F7F7FD /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/PrefUtilsViewController.strings; sourceTree = "<group>"; };
 		875FDFA02157874B00F7F7FD /* ru */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = ru; path = ru.lproj/PrefOSCToolbarSettingsSheetController.strings; sourceTree = "<group>"; };
@@ -3053,6 +3062,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FFFFFF010000000000FF0B02 /* HLSPackager.swift in Sources */,
+				FFFFFF010000000000FF0B04 /* HLSFileServer.swift in Sources */,
+				FFFFFF010000000000FF0B06 /* AirPlayCoordinator.swift in Sources */,
 				E3EC8C432F94330400FBB51E /* Dialog.swift in Sources */,
 				E35306FA214808AB008FE492 /* JavascriptAPIEvent.swift in Sources */,
 				849581F11F02728700D3B359 /* InitialWindowController.swift in Sources */,
@@ -3209,6 +3221,7 @@
 				E392B8CC2FB2263F005F2C24 /* SettingsSearch.swift in Sources */,
 				E3FF5AC02938582F0019CE45 /* JavascriptDevTool.swift in Sources */,
 				84FBCB381EEACDDD0076C77C /* FFmpegController.m in Sources */,
+				FFFFFF010000000000FF0C02 /* HLSRemuxer.m in Sources */,
 				84879A981E0FFC7E0004F894 /* PrefUIViewController.swift in Sources */,
 				84C6D3641EB276E9009BF721 /* PlaybackHistory.swift in Sources */,
 				E3CB258F222799B800A62C47 /* MPVHook.swift in Sources */,

--- a/iina/AirPlay/AirPlayCoordinator.swift
+++ b/iina/AirPlay/AirPlayCoordinator.swift
@@ -1,0 +1,321 @@
+import Foundation
+import AVKit
+import AVFoundation
+
+/// Orchestrates an AirPlay video session.
+///
+/// The stream-copy remux (HLSRemuxer, libavformat in-process) converts the file to a growing
+/// fMP4 HLS playlist, paced to ~real time so the AirPlay receiver plays from near the start
+/// (a full-speed remux would race the playlist to the end and the TV would ride that live
+/// edge). A local LAN server serves it; a hidden AVPlayer with allowsExternalPlayback streams
+/// it to the TV. Playback is a single live stream — reliable, plays from the beginning; the
+/// OSC follows the receiver's position and play/pause is forwarded to it. Seeking is
+/// best-effort within the range remuxed so far. mpv stays paused behind an overlay.
+final class AirPlayCoordinator: NSObject, AVRoutePickerViewDelegate {
+  private weak var player: PlayerCore?
+  private let avPlayer = AVPlayer()
+  private let packager = HLSPackager()
+  private let server = HLSFileServer()
+  private var externalObs: NSKeyValueObservation?
+  private var itemStatusObs: NSKeyValueObservation?
+
+  private(set) var isCasting = false
+  private var isPreparing = false
+  private var resumeMpvOnEnd = false
+  /// Bumped on each prepareCast so a stale cancel timer can't tear down a newer session.
+  private var generation = 0
+  /// Suppresses the external-playback-dropped transient while rebuilding for a track change.
+  private var isRebuilding = false
+  /// Movie time the current remux started from. The output HLS timeline is 0-based, so the
+  /// movie position on the receiver = castStartOffset + avPlayer.currentTime. Seeking beyond
+  /// what's been remuxed re-remuxes from the target and updates this offset.
+  private var castStartOffset: Double = 0
+  /// Debounce token for a pending re-remux (a slider drag issues many seeks; only recast once).
+  private var recastGeneration = 0
+
+  /// Current movie position on the receiver. nil if not casting.
+  var castCurrentSeconds: Double? {
+    guard isCasting else { return nil }
+    let t = avPlayer.currentTime().seconds
+    return t.isFinite ? castStartOffset + t : nil
+  }
+  var isCastPaused: Bool { avPlayer.rate == 0 }
+
+  init(player: PlayerCore) {
+    self.player = player
+    super.init()
+    avPlayer.allowsExternalPlayback = true
+    avPlayer.automaticallyWaitsToMinimizeStalling = true  // buffer before starting playback
+    externalObs = avPlayer.observe(\.isExternalPlaybackActive, options: [.new]) { [weak self] p, _ in
+      DispatchQueue.main.async { self?.externalChanged(active: p.isExternalPlaybackActive) }
+    }
+    NotificationCenter.default.addObserver(self, selector: #selector(playerItemEnded(_:)),
+                                           name: .AVPlayerItemDidPlayToEndTime, object: nil)
+  }
+
+  deinit {
+    NotificationCenter.default.removeObserver(self)
+    endIfActive()
+  }
+
+  func attach(routePicker: AVRoutePickerView) { routePicker.delegate = self }
+
+  // MARK: - AVRoutePickerViewDelegate
+
+  func routePickerViewWillBeginPresentingRoutes(_ routePickerView: AVRoutePickerView) {
+    prepareCast()
+  }
+
+  /// Menu closed — if no route was engaged shortly after, cancel the preparation.
+  func routePickerViewDidEndPresentingRoutes(_ routePickerView: AVRoutePickerView) {
+    let gen = generation
+    DispatchQueue.main.asyncAfter(deadline: .now() + 12.0) { [weak self] in
+      guard let self = self, gen == self.generation else { return }
+      if self.isPreparing && !self.isCasting && !self.avPlayer.isExternalPlaybackActive {
+        NSLog("AirPlay: no route engaged, cancelling preparation")
+        self.teardown()
+      }
+    }
+  }
+
+  // MARK: - Session
+
+  private func prepareCast() {
+    guard !isPreparing, !isCasting, let player = player,
+          let url = player.info.currentURL, url.isFileURL else { return }
+    isPreparing = true
+    generation += 1
+    castStartOffset = 0
+    resumeMpvOnEnd = !player.mpv.getFlag(MPVOption.PlaybackControl.pause)
+    player.mpv.setFlag(MPVOption.PlaybackControl.pause, true)
+    NSLog("AirPlay: prepare \(url.lastPathComponent)")
+    let audioIndex = max(0, (player.info.aid ?? 1) - 1)
+    let subtitleIndex: Int? = player.info.sid.flatMap { $0 >= 1 ? $0 - 1 : nil }
+    runPackager(url: url, audioIndex: audioIndex, subtitleIndex: subtitleIndex)
+  }
+
+  /// Remuxes the file from `castStartOffset` to a paced HLS playlist. `onReady` (first segment)
+  /// is enough to load the item and engage the route. Retries once without subtitles on failure.
+  private func runPackager(url: URL, audioIndex: Int, subtitleIndex: Int?) {
+    packager.start(input: url, startSeconds: castStartOffset, audioIndex: audioIndex, subtitleIndex: subtitleIndex,
+      onReady: { [weak self] result in
+        guard let self = self, self.isPreparing || self.isCasting else { return }
+        switch result {
+        case .failure(let e):
+          if subtitleIndex != nil {
+            NSLog("AirPlay: subtitle remux failed (\(e)); retrying without subtitles")
+            self.packager.stop(); self.packager.cleanup()
+            self.runPackager(url: url, audioIndex: audioIndex, subtitleIndex: nil)
+          } else {
+            NSLog("AirPlay: ffmpeg failed: \(e)")
+            self.teardown()
+          }
+        case .success(let playlist):
+          self.serveAndLoad(playlist)
+        }
+      },
+      onComplete: { _ in NSLog("AirPlay: remux complete (full file available)") })
+  }
+
+  private func serveAndLoad(_ playlist: URL) {
+    DispatchQueue.global(qos: .userInitiated).async {
+      do {
+        let lanURL = try self.server.start(servingFrom: playlist.deletingLastPathComponent(),
+                                           playlist: playlist.lastPathComponent)
+        DispatchQueue.main.async { self.loadItem(lanURL) }
+      } catch {
+        DispatchQueue.main.async {
+          NSLog("AirPlay: server failed: \(error)")
+          self.teardown()
+        }
+      }
+    }
+  }
+
+  /// Loads the playlist (paused). A loaded item — even paused — is what lets the AirPlay route
+  /// engage; we must NOT play() here, or the hidden AVPlayer would emit audio from the Mac
+  /// speakers before a device is selected. Playback (on the TV) starts in beginCastingState.
+  private func loadItem(_ lanURL: URL) {
+    guard isPreparing || isCasting else { server.stop(); return }
+    NSLog("AirPlay: serving \(lanURL); loading item (paused) to engage route")
+    let item = AVPlayerItem(url: lanURL)
+    avPlayer.replaceCurrentItem(with: item)
+    observeItem(item)
+    if avPlayer.isExternalPlaybackActive { beginCastingState() }
+  }
+
+  private func externalChanged(active: Bool) {
+    NSLog("AirPlay: externalPlaybackActive=\(active) rebuilding=\(isRebuilding)")
+    if active {
+      isRebuilding = false
+      if avPlayer.currentItem != nil { beginCastingState() }
+    } else if isCasting && !isRebuilding {
+      endCasting()
+    }
+  }
+
+  /// Enters the casting state and starts playback on the TV (external playback is now active,
+  /// so the audio plays on the TV, not the Mac).
+  private func beginCastingState() {
+    isPreparing = false
+    if !isCasting {
+      isCasting = true
+      player?.mpv.setFlag(MPVOption.PlaybackControl.pause, true)
+      player?.mainWindow.setCastingOverlay(true)
+      NSLog("AirPlay: casting engaged")
+      scheduleReleasePacing()
+    }
+    avPlayer.play()
+    player?.mainWindow.updatePlayButtonState(paused: false)
+  }
+
+  /// Once the receiver has loaded the paced playlist and started near the beginning, stop pacing
+  /// so the rest fills the buffer fast — prevents underrun stalls / audio drift and makes
+  /// forward seeking available. Tied to `generation`, so a re-remux (new session) re-arms it.
+  private func scheduleReleasePacing() {
+    let gen = generation
+    DispatchQueue.main.asyncAfter(deadline: .now() + 8.0) { [weak self] in
+      guard let self = self, self.isCasting, gen == self.generation else { return }
+      NSLog("AirPlay: releasing pacing (fill buffer + enable seek)")
+      self.packager.releasePacing()
+    }
+  }
+
+  private func observeItem(_ item: AVPlayerItem) {
+    itemStatusObs = item.observe(\.status, options: [.new]) { it, _ in
+      if it.status == .failed {
+        NSLog("AirPlay: item failed: \(String(describing: it.error))")
+        return
+      }
+      guard it.status == .readyToPlay else { return }
+      // Turn on the WebVTT subtitle rendition (we mux only the user's selected sub, so the
+      // legible group has a single option).
+      if let group = it.asset.mediaSelectionGroup(forMediaCharacteristic: .legible),
+         let option = group.options.first {
+        it.select(option, in: group)
+        NSLog("AirPlay: subtitle rendition selected (\(group.options.count) option(s))")
+      }
+    }
+  }
+
+  // MARK: - Transport (called from PlayerCore while casting)
+
+  func reloadForTrackChange() {
+    guard isCasting, let player = player, let url = player.info.currentURL, url.isFileURL else { return }
+    castStartOffset = castCurrentSeconds ?? castStartOffset   // rebuild from the current position
+    generation += 1
+    isRebuilding = true
+    DispatchQueue.main.asyncAfter(deadline: .now() + 8.0) { [weak self] in self?.isRebuilding = false }
+    NSLog("AirPlay: track changed, rebuilding from %.1fs", castStartOffset)
+    server.stop(); packager.stop(); packager.cleanup()
+    let audioIndex = max(0, (player.info.aid ?? 1) - 1)
+    let subtitleIndex: Int? = player.info.sid.flatMap { $0 >= 1 ? $0 - 1 : nil }
+    runPackager(url: url, audioIndex: audioIndex, subtitleIndex: subtitleIndex)
+    scheduleReleasePacing()
+  }
+
+  func castSeek(toAbsolute seconds: Double) {
+    guard isCasting, seconds.isFinite else { return }
+    seekToMovieTime(seconds)
+  }
+
+  func castSeek(byRelative delta: Double) {
+    guard isCasting else { return }
+    seekToMovieTime((castCurrentSeconds ?? castStartOffset) + delta)
+  }
+
+  func setCastPaused(_ paused: Bool) {
+    guard isCasting else { return }
+    paused ? avPlayer.pause() : avPlayer.play()
+    player?.mainWindow.updatePlayButtonState(paused: paused)
+  }
+
+  /// Seek to an absolute MOVIE time. Within the range remuxed so far → seek locally (instant).
+  /// Beyond it (or before the current remux start) → re-remux from that position, so the cast
+  /// restarts there. Debounced, so a slider drag re-remuxes only once (to where it settles).
+  private func seekToMovieTime(_ movieSeconds: Double) {
+    let target = max(0, movieSeconds)
+    let local = target - castStartOffset
+    var edge = -1.0
+    if let r = avPlayer.currentItem?.seekableTimeRanges.first?.timeRangeValue {
+      edge = r.start.seconds + r.duration.seconds
+    }
+    if local >= -1, edge.isFinite, local <= edge + 1 {
+      recastGeneration += 1  // cancel any pending recast — this seek is inside the buffer
+      let clamped = max(0, min(local, edge))
+      avPlayer.seek(to: CMTime(seconds: clamped, preferredTimescale: 600))
+    } else {
+      scheduleRecast(toMovie: target)
+    }
+  }
+
+  private func scheduleRecast(toMovie target: Double) {
+    recastGeneration += 1
+    let gen = recastGeneration
+    DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+      guard let self = self, self.isCasting, gen == self.recastGeneration else { return }
+      self.recastFrom(target)
+    }
+  }
+
+  /// Re-remuxes the file from `movieSeconds` and reloads the receiver there (like a track-change
+  /// rebuild, but from a seek position). The output timeline is 0-based; castStartOffset carries
+  /// the movie time so the OSC and later seeks stay in movie time.
+  private func recastFrom(_ movieSeconds: Double) {
+    guard isCasting, let player = player, let url = player.info.currentURL, url.isFileURL else { return }
+    castStartOffset = max(0, movieSeconds)
+    generation += 1
+    isRebuilding = true
+    DispatchQueue.main.asyncAfter(deadline: .now() + 8.0) { [weak self] in self?.isRebuilding = false }
+    NSLog("AirPlay: recasting from %.1fs", castStartOffset)
+    server.stop(); packager.stop(); packager.cleanup()
+    let audioIndex = max(0, (player.info.aid ?? 1) - 1)
+    let subtitleIndex: Int? = player.info.sid.flatMap { $0 >= 1 ? $0 - 1 : nil }
+    runPackager(url: url, audioIndex: audioIndex, subtitleIndex: subtitleIndex)
+    scheduleReleasePacing()
+  }
+
+  @objc private func playerItemEnded(_ note: Notification) {
+    guard isCasting, (note.object as? AVPlayerItem) === avPlayer.currentItem else { return }
+    DispatchQueue.main.async { [weak self] in self?.endCasting() }
+  }
+
+  private func endCasting() {
+    teardown(resumeAt: castCurrentSeconds)   // hand the movie position back to mpv
+  }
+
+  /// Release all cast resources without handing position back to mpv (player stopping /
+  /// switching files). No-op if not casting. Called from PlayerCore.
+  func endIfActive() {
+    guard isCasting || isPreparing else { return }
+    NSLog("AirPlay: ending cast (player stop / file change)")
+    cleanupSession()
+  }
+
+  /// Tears down the session and hands the current position back to mpv.
+  private func teardown(resumeAt: Double? = nil) {
+    let wasActive = isCasting || isPreparing
+    cleanupSession()
+    guard wasActive, let player = player else { return }
+    if let pos = resumeAt, pos > 0 {
+      player.mpv.command(.seek, args: ["\(pos)", "absolute+exact"])
+    }
+    if resumeMpvOnEnd {
+      player.mpv.setFlag(MPVOption.PlaybackControl.pause, false)
+    }
+  }
+
+  private func cleanupSession() {
+    isCasting = false
+    isPreparing = false
+    isRebuilding = false
+    castStartOffset = 0
+    avPlayer.pause()
+    avPlayer.replaceCurrentItem(with: nil)
+    itemStatusObs = nil
+    server.stop()
+    packager.stop()
+    packager.cleanup()
+    player?.mainWindow.setCastingOverlay(false)
+  }
+}

--- a/iina/AirPlay/HLSFileServer.swift
+++ b/iina/AirPlay/HLSFileServer.swift
@@ -1,0 +1,128 @@
+import Foundation
+import Network
+
+/// Minimal HTTP/1.1 static-file server over NWListener, bound to all interfaces,
+/// used to serve a directory of HLS files to an AirPlay receiver on the LAN.
+/// Supports GET and HEAD with optional byte-range requests (needed for fMP4 seeking).
+/// Validated against an LG webOS TV via the scratch spike before integration.
+enum HLSServerError: Error { case noLANAddress, noPort }
+
+final class HLSFileServer {
+  private var listener: NWListener?
+  private let queue = DispatchQueue(label: "iina.airplay.hlsserver")
+  private var rootDir = URL(fileURLWithPath: "/")
+
+  /// Starts serving `dir`; returns the master playlist URL on the Mac's LAN IPv4.
+  func start(servingFrom dir: URL, playlist: String = "out.m3u8") throws -> URL {
+    stop()  // release any previous listener/port before rebinding
+    rootDir = dir
+    let listener = try NWListener(using: .tcp, on: .any)   // OS-assigned ephemeral port
+    self.listener = listener
+    listener.newConnectionHandler = { [weak self] conn in
+      // Each connection gets its own queue: AVPlayer keeps several connections open at once
+      // (playlist + segments, and a second player during the VOD reload). A single shared
+      // serial queue would serialize them and stall later sessions.
+      let connQueue = DispatchQueue(label: "iina.airplay.hlsconn")
+      conn.start(queue: connQueue)
+      self?.receive(conn, buffer: Data())
+    }
+    listener.start(queue: queue)
+    let port = try Self.awaitPort(listener)
+    guard let ip = Self.lanIPv4() else { throw HLSServerError.noLANAddress }
+    return URL(string: "http://\(ip):\(port)/\(playlist)")!
+  }
+
+  func stop() { listener?.cancel(); listener = nil }
+
+  private func receive(_ conn: NWConnection, buffer: Data) {
+    conn.receive(minimumIncompleteLength: 1, maximumLength: 64 * 1024) { [weak self] data, _, done, err in
+      guard let self = self else { return }
+      var buf = buffer
+      if let data = data { buf.append(data) }
+      let sep = Data("\r\n\r\n".utf8)
+      if let r = buf.range(of: sep) {
+        let header = String(data: buf.subdata(in: 0..<r.lowerBound), encoding: .utf8) ?? ""
+        self.respond(conn, header: header)
+      } else if err == nil && !done && buf.count < 16384 {
+        self.receive(conn, buffer: buf)
+      } else { conn.cancel() }
+    }
+  }
+
+  private func respond(_ conn: NWConnection, header: String) {
+    let lines = header.components(separatedBy: "\r\n")
+    let parts = (lines.first ?? "").split(separator: " ")
+    guard parts.count >= 2 else { return status(conn, 400) }
+    let method = String(parts[0])
+    guard method == "GET" || method == "HEAD" else { return status(conn, 405) }
+    var path = String(parts[1])
+    if let q = path.firstIndex(of: "?") { path = String(path[..<q]) }
+    path = path.removingPercentEncoding ?? path
+    let name = (path as NSString).lastPathComponent
+    guard !name.isEmpty, !name.contains("..") else { return status(conn, 400) }
+    guard let body = try? Data(contentsOf: rootDir.appendingPathComponent(name), options: .mappedIfSafe) else {
+      NSLog("AirPlay/server: 404 %@ (dir=%@)", name, rootDir.path)
+      return status(conn, 404)
+    }
+    let type = Self.contentType(for: name)
+    let rangeLine = lines.first { $0.lowercased().hasPrefix("range:") }
+    // HLS playlists change as the remux progresses (live → complete VOD); never let the
+    // client cache them, or it keeps treating a completed stream as live (no duration/seek).
+    let noCache = "Cache-Control: no-cache, no-store, must-revalidate\r\n"
+    if let rl = rangeLine,
+       let (s, e) = Self.parseRange(String(rl.dropFirst(6)).trimmingCharacters(in: .whitespaces), total: body.count) {
+      let slice = body.subdata(in: s..<(e + 1))
+      let head = "HTTP/1.1 206 Partial Content\r\nContent-Type: \(type)\r\n\(noCache)"
+        + "Content-Range: bytes \(s)-\(e)/\(body.count)\r\nContent-Length: \(slice.count)\r\n"
+        + "Accept-Ranges: bytes\r\nConnection: close\r\n\r\n"
+      send(conn, Data(head.utf8) + (method == "HEAD" ? Data() : slice))
+    } else {
+      let head = "HTTP/1.1 200 OK\r\nContent-Type: \(type)\r\n\(noCache)Content-Length: \(body.count)\r\n"
+        + "Accept-Ranges: bytes\r\nConnection: close\r\n\r\n"
+      send(conn, Data(head.utf8) + (method == "HEAD" ? Data() : body))
+    }
+  }
+
+  private func status(_ conn: NWConnection, _ code: Int) {
+    send(conn, Data("HTTP/1.1 \(code)\r\nContent-Length: 0\r\nConnection: close\r\n\r\n".utf8))
+  }
+  private func send(_ conn: NWConnection, _ data: Data) {
+    conn.send(content: data, completion: .contentProcessed { _ in conn.cancel() })
+  }
+
+  static func contentType(for name: String) -> String {
+    if name.hasSuffix(".m3u8") { return "application/vnd.apple.mpegurl" }
+    if name.hasSuffix(".m4s") || name.hasSuffix(".mp4") { return "video/mp4" }
+    if name.hasSuffix(".vtt") { return "text/vtt" }
+    return "application/octet-stream"
+  }
+  static func parseRange(_ h: String, total: Int) -> (Int, Int)? {
+    guard h.hasPrefix("bytes=") else { return nil }
+    let c = h.dropFirst(6).split(separator: "-", maxSplits: 1, omittingEmptySubsequences: false)
+    guard let s = Int(c[0]) else { return nil }
+    let e = (c.count > 1 ? Int(c[1]) : nil).map { min($0, total - 1) } ?? total - 1
+    guard s >= 0, s <= e, e < total else { return nil }
+    return (s, e)
+  }
+  static func awaitPort(_ l: NWListener) throws -> UInt16 {
+    for _ in 0..<200 { if let p = l.port?.rawValue, p != 0 { return p }; usleep(10_000) }
+    throw HLSServerError.noPort
+  }
+  static func lanIPv4() -> String? {
+    var ifaddr: UnsafeMutablePointer<ifaddrs>?
+    guard getifaddrs(&ifaddr) == 0, let first = ifaddr else { return nil }
+    defer { freeifaddrs(ifaddr) }
+    for ptr in sequence(first: first, next: { $0.pointee.ifa_next }) {
+      let flags = Int32(ptr.pointee.ifa_flags)
+      guard (flags & (IFF_UP | IFF_RUNNING)) == (IFF_UP | IFF_RUNNING), (flags & IFF_LOOPBACK) == 0 else { continue }
+      guard ptr.pointee.ifa_addr.pointee.sa_family == UInt8(AF_INET) else { continue }
+      let name = String(cString: ptr.pointee.ifa_name)
+      guard name == "en0" || name == "en1" else { continue }
+      var host = [CChar](repeating: 0, count: Int(NI_MAXHOST))
+      getnameinfo(ptr.pointee.ifa_addr, socklen_t(ptr.pointee.ifa_addr.pointee.sa_len),
+                  &host, socklen_t(host.count), nil, 0, NI_NUMERICHOST)
+      return String(cString: host)
+    }
+    return nil
+  }
+}

--- a/iina/AirPlay/HLSPackager.swift
+++ b/iina/AirPlay/HLSPackager.swift
@@ -1,0 +1,85 @@
+import Foundation
+
+/// Remuxes the current file to a growing fMP4 HLS event playlist using libavformat
+/// in-process (`HLSRemuxer`) — no bundled ffmpeg CLI. Reports ready as soon as the first
+/// segment is written (the remux keeps running in the background).
+final class HLSPackager {
+  enum PackagerError: Error { case notReady }
+
+  private(set) var outputDir: URL?
+  private var remuxer: HLSRemuxer?
+  private var pollTimer: DispatchSourceTimer?
+  private var isStopped = false
+
+  /// Remuxes the whole file to a paced HLS playlist. With `subtitleIndex` the output is a
+  /// master playlist (`master.m3u8`) with a WebVTT subtitle rendition; without it, a single
+  /// media playlist (`out.m3u8`).
+  ///
+  /// - `onReady` fires once the first segment exists (enough to engage the AirPlay route).
+  /// - `onComplete` fires once the remux has finished.
+  func start(input: URL, startSeconds: Double, audioIndex: Int, subtitleIndex: Int?,
+             onReady: @escaping (Result<URL, Error>) -> Void,
+             onComplete: @escaping (URL) -> Void) {
+    isStopped = false
+    let dir = FileManager.default.temporaryDirectory.appendingPathComponent("iina-airplay-\(UUID().uuidString)")
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    outputDir = dir
+    // Subtitle mode emits a master playlist; otherwise a single media playlist.
+    let playlist = dir.appendingPathComponent(subtitleIndex != nil ? "master.m3u8" : "out.m3u8")
+    let initFile = dir.appendingPathComponent("init.mp4")
+
+    let remuxer = HLSRemuxer(input: input.path, outputDir: dir.path, startSeconds: startSeconds,
+                             audioIndex: Int32(audioIndex), subtitleIndex: Int32(subtitleIndex ?? -1))
+    self.remuxer = remuxer
+    remuxer.onFinished = { [weak self] in
+      guard let self = self, !self.isStopped else { return }
+      NSLog("AirPlay/libav: remux finished")
+      onComplete(playlist)
+    }
+    Logger.log("AirPlay/libav: remuxing \(input.lastPathComponent) (audio \(audioIndex), sub \(String(describing: subtitleIndex)))")
+    remuxer.start()
+
+    // Poll until the served playlist exists and a media segment has been written — enough to
+    // load an item and engage the route. (In subtitle mode the master playlist references a
+    // variant, so check for a segment file on disk rather than ".m4s" in the playlist text.)
+    var ticks = 0
+    let timer = DispatchSource.makeTimerSource(queue: DispatchQueue.global())
+    timer.schedule(deadline: .now() + 0.2, repeating: 0.2)
+    timer.setEventHandler { [weak self] in
+      guard let self = self else { timer.cancel(); return }
+      if self.isStopped { timer.cancel(); return }
+      ticks += 1
+      let fm = FileManager.default
+      let hasPlaylist = fm.fileExists(atPath: playlist.path)
+      let hasInit = fm.fileExists(atPath: initFile.path)
+      let hasSegment = ((try? fm.contentsOfDirectory(atPath: dir.path)) ?? []).contains { $0.hasSuffix(".m4s") }
+      if hasPlaylist && hasInit && hasSegment {
+        timer.cancel()
+        Logger.log("AirPlay/libav: first segment ready after ~\(Double(ticks) * 0.2)s")
+        DispatchQueue.main.async { onReady(.success(playlist)) }
+      } else if ticks > 50 {   // ~10s: nothing written → fail (caller retries without subs)
+        timer.cancel()
+        Logger.log("AirPlay/libav: timed out (no segment)", level: .error)
+        DispatchQueue.main.async { onReady(.failure(PackagerError.notReady)) }
+      }
+    }
+    pollTimer = timer
+    timer.resume()
+  }
+
+  /// Stops real-time pacing so the rest of the file is written quickly (fills the receiver's
+  /// buffer, enables forward seeking). Call once playback has started near the beginning.
+  func releasePacing() { remuxer?.releasePacing() }
+
+  func stop() {
+    isStopped = true
+    pollTimer?.cancel(); pollTimer = nil
+    remuxer?.stop()
+    remuxer = nil
+  }
+
+  func cleanup() {
+    if let dir = outputDir { try? FileManager.default.removeItem(at: dir) }
+    outputDir = nil
+  }
+}

--- a/iina/HLSRemuxer.h
+++ b/iina/HLSRemuxer.h
@@ -1,0 +1,46 @@
+//
+//  HLSRemuxer.h
+//  iina
+//
+//  Remuxes a media file to fMP4 HLS in-process using libavformat (the libav* libs IINA
+//  already links) — no bundled ffmpeg CLI. Used by the AirPlay feature.
+//
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface HLSRemuxer : NSObject
+
+/// - Parameters:
+///   - inputPath: source media file.
+///   - outputDir: directory to write `out.m3u8`, `init.mp4`, `seg_%03d.m4s` into.
+///   - audioIndex: 0-based index among the file's audio streams.
+///   - subtitleIndex: 0-based index among the file's subtitle streams, or -1 for none.
+/// - Parameters:
+///   - startSeconds: remux from this position (seeks to the keyframe at/just before it),
+///     keeping original timestamps so the HLS timeline equals the movie time.
+- (instancetype)initWithInput:(NSString *)inputPath
+                    outputDir:(NSString *)outputDir
+                 startSeconds:(double)startSeconds
+                   audioIndex:(int)audioIndex
+                subtitleIndex:(int)subtitleIndex;
+
+/// Called on the main queue once the remux has finished writing the complete playlist
+/// (#EXT-X-ENDLIST present) — i.e. the output is now a full, seekable VOD.
+@property (nonatomic, copy, nullable) void (^onFinished)(void);
+
+/// Begins remuxing on a background queue (returns immediately).
+- (void)start;
+
+/// Stops pacing the remux to real time — the remainder is written as fast as possible to
+/// fill the receiver's buffer (prevents underrun stalls and makes forward seeking available).
+/// Call only after the receiver has started playing near the beginning.
+- (void)releasePacing;
+
+/// Signals the remux to stop as soon as possible.
+- (void)stop;
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/iina/HLSRemuxer.m
+++ b/iina/HLSRemuxer.m
@@ -1,0 +1,434 @@
+//
+//  HLSRemuxer.m
+//  iina
+//
+
+#import "HLSRemuxer.h"
+#import <libavformat/avformat.h>
+#import <libavcodec/avcodec.h>
+#import <libavutil/avutil.h>
+#import <libavutil/channel_layout.h>
+#import <libavutil/samplefmt.h>
+#import <sys/time.h>
+#import <unistd.h>
+
+// AVAudioFifo lives in libavutil but its header isn't in the bundled include set; declare the
+// handful of functions we use (audio transcode buffers samples to the encoder's frame size).
+typedef struct AVAudioFifo AVAudioFifo;
+extern AVAudioFifo *av_audio_fifo_alloc(enum AVSampleFormat sample_fmt, int channels, int nb_samples);
+extern int av_audio_fifo_write(AVAudioFifo *af, void **data, int nb_samples);
+extern int av_audio_fifo_read(AVAudioFifo *af, void **data, int nb_samples);
+extern int av_audio_fifo_size(AVAudioFifo *af);
+extern void av_audio_fifo_free(AVAudioFifo *af);
+
+@interface HLSRemuxer ()
+@property(nonatomic, copy) NSString *inputPath;
+@property(nonatomic, copy) NSString *outputDir;
+@property(nonatomic) double startSeconds;
+@property(nonatomic) int audioIndex;
+@property(nonatomic) int subtitleIndex;
+@property(atomic) BOOL stopped;
+@property(atomic) BOOL pacingOff;
+@end
+
+@implementation HLSRemuxer
+
+- (instancetype)initWithInput:(NSString *)inputPath
+                    outputDir:(NSString *)outputDir
+                 startSeconds:(double)startSeconds
+                   audioIndex:(int)audioIndex
+                subtitleIndex:(int)subtitleIndex {
+  self = [super init];
+  if (self) {
+    _inputPath = [inputPath copy];
+    _outputDir = [outputDir copy];
+    _startSeconds = startSeconds;
+    _audioIndex = audioIndex;
+    _subtitleIndex = subtitleIndex;
+    _stopped = NO;
+  }
+  return self;
+}
+
+- (void)stop {
+  self.stopped = YES;
+}
+
+- (void)releasePacing {
+  self.pacingOff = YES;
+}
+
+- (void)start {
+  dispatch_async(dispatch_get_global_queue(QOS_CLASS_USER_INITIATED, 0), ^{
+    [self runRemux];
+  });
+}
+
+- (void)runRemux {
+  const char *inPath = self.inputPath.fileSystemRepresentation;
+
+  // All locals declared up front so `goto cleanup` never bypasses an initialization.
+  AVFormatContext *ic = NULL;
+  AVFormatContext *oc = NULL;
+  AVDictionary *opts = NULL;
+  AVPacket *pkt = NULL;
+  AVCodecContext *subDecCtx = NULL;
+  AVCodecContext *subEncCtx = NULL;
+  const AVCodec *subDec = NULL;
+  const AVCodec *subEnc = NULL;
+  AVCodecContext *audDecCtx = NULL;
+  AVCodecContext *audEncCtx = NULL;
+  const AVCodec *audDec = NULL;
+  const AVCodec *audEnc = NULL;
+  AVAudioFifo *audFifo = NULL;
+  AVFrame *audDecFrame = NULL;
+  AVPacket *audEncPkt = NULL;
+  BOOL transcodeAudio = NO;
+  int64_t audioNextPts = 0;
+  BOOL haveAudioPts = NO;
+  int outIndexOf[64];
+  int inVideo = -1, inAudio = -1, inSub = -1, audioSeen = 0, subSeen = 0;
+  int outSubIndex = -1;
+  int ret = 0;
+  // Subtitle mode: emit a master playlist + a WebVTT subtitle rendition (transcoded from the
+  // text subtitle). Without subtitles, emit the simple single media playlist (out.m3u8).
+  BOOL wantSub = (self.subtitleIndex >= 0);
+  NSString *outName = wantSub ? @"out_%v.m3u8" : @"out.m3u8";
+  NSString *segName = wantSub ? @"seg_%v_%03d.m4s" : @"seg_%03d.m4s";
+  NSString *outFile = [self.outputDir stringByAppendingPathComponent:outName];
+  NSString *segPattern = [self.outputDir stringByAppendingPathComponent:segName];
+  for (int i = 0; i < 64; i++) outIndexOf[i] = -1;
+
+  ret = avformat_open_input(&ic, inPath, NULL, NULL);
+  if (ret < 0) { NSLog(@"HLSRemuxer: open_input failed (%d)", ret); goto cleanup; }
+  if ((ret = avformat_find_stream_info(ic, NULL)) < 0) {
+    NSLog(@"HLSRemuxer: find_stream_info failed (%d)", ret); goto cleanup;
+  }
+
+  if (self.startSeconds > 0.5) {
+    int64_t ts = (int64_t)(self.startSeconds * AV_TIME_BASE);
+    if (av_seek_frame(ic, -1, ts, AVSEEK_FLAG_BACKWARD) < 0) {
+      NSLog(@"HLSRemuxer: seek to %.1fs failed; starting from 0", self.startSeconds);
+    }
+  }
+
+  for (unsigned i = 0; i < ic->nb_streams; i++) {
+    enum AVMediaType t = ic->streams[i]->codecpar->codec_type;
+    if (t == AVMEDIA_TYPE_VIDEO && inVideo < 0) {
+      inVideo = (int)i;
+    } else if (t == AVMEDIA_TYPE_AUDIO) {
+      if (audioSeen == self.audioIndex) inAudio = (int)i;
+      audioSeen++;
+    } else if (t == AVMEDIA_TYPE_SUBTITLE) {
+      if (wantSub && subSeen == self.subtitleIndex) inSub = (int)i;
+      subSeen++;
+    }
+  }
+  if (inVideo < 0 || inAudio < 0) {
+    NSLog(@"HLSRemuxer: no video(%d)/audio(%d)", inVideo, inAudio); goto cleanup;
+  }
+  // Requested subtitle missing → abort so the caller can retry without subtitles.
+  if (wantSub && inSub < 0) { NSLog(@"HLSRemuxer: subtitle %d not found", self.subtitleIndex); goto cleanup; }
+
+  // Set up the subtitle transcode (text subrip → WebVTT). Text subtitles round-trip through
+  // ASS, so the encoder needs the decoder's ASS subtitle_header.
+  if (wantSub) {
+    subDec = avcodec_find_decoder(ic->streams[inSub]->codecpar->codec_id);
+    if (subDec) subDecCtx = avcodec_alloc_context3(subDec);
+    if (!subDecCtx || avcodec_parameters_to_context(subDecCtx, ic->streams[inSub]->codecpar) < 0
+        || avcodec_open2(subDecCtx, subDec, NULL) < 0) {
+      NSLog(@"HLSRemuxer: subtitle decoder setup failed"); goto cleanup;
+    }
+    subEnc = avcodec_find_encoder(AV_CODEC_ID_WEBVTT);
+    if (subEnc) subEncCtx = avcodec_alloc_context3(subEnc);
+    if (!subEncCtx) { NSLog(@"HLSRemuxer: no webvtt encoder"); goto cleanup; }
+    subEncCtx->time_base = (AVRational){1, 1000};
+    if (subDecCtx->subtitle_header_size > 0) {
+      subEncCtx->subtitle_header = av_malloc(subDecCtx->subtitle_header_size + 1);
+      memcpy(subEncCtx->subtitle_header, subDecCtx->subtitle_header, subDecCtx->subtitle_header_size);
+      subEncCtx->subtitle_header[subDecCtx->subtitle_header_size] = 0;
+      subEncCtx->subtitle_header_size = subDecCtx->subtitle_header_size;
+    }
+    if (avcodec_open2(subEncCtx, subEnc, NULL) < 0) {
+      NSLog(@"HLSRemuxer: subtitle encoder setup failed"); goto cleanup;
+    }
+  }
+
+  // Audio: stream-copy AAC and AC-3 (both play in sync over AirPlay); transcode anything else
+  // (E-AC3, DTS, TrueHD…) to AAC, since e.g. E-AC3 desyncs on the receiver. On any setup
+  // failure, fall back to stream-copy so the cast still works.
+  {
+    enum AVCodecID acodec = ic->streams[inAudio]->codecpar->codec_id;
+    transcodeAudio = (acodec != AV_CODEC_ID_AAC && acodec != AV_CODEC_ID_AC3);
+  }
+  if (transcodeAudio) {
+    audDec = avcodec_find_decoder(ic->streams[inAudio]->codecpar->codec_id);
+    if (audDec) audDecCtx = avcodec_alloc_context3(audDec);
+    if (audDecCtx && avcodec_parameters_to_context(audDecCtx, ic->streams[inAudio]->codecpar) >= 0) {
+      audDecCtx->pkt_timebase = ic->streams[inAudio]->time_base;
+    }
+    audEnc = avcodec_find_encoder(AV_CODEC_ID_AAC);
+    if (audEnc && audDecCtx && avcodec_open2(audDecCtx, audDec, NULL) >= 0) {
+      audEncCtx = avcodec_alloc_context3(audEnc);
+    }
+    if (audEncCtx) {
+      audEncCtx->sample_rate = audDecCtx->sample_rate;
+      // Use a STANDARD channel layout (matching channel count → just a relabel, no downmix):
+      // Apple's AAC decoder rejects PCE-based layouts like "5.1(side)".
+      int nch = audDecCtx->ch_layout.nb_channels;
+      if (nch == 6) { AVChannelLayout l = AV_CHANNEL_LAYOUT_5POINT1_BACK; av_channel_layout_copy(&audEncCtx->ch_layout, &l); }
+      else if (nch == 2) { AVChannelLayout l = AV_CHANNEL_LAYOUT_STEREO; av_channel_layout_copy(&audEncCtx->ch_layout, &l); }
+      else if (nch == 1) { AVChannelLayout l = AV_CHANNEL_LAYOUT_MONO; av_channel_layout_copy(&audEncCtx->ch_layout, &l); }
+      else av_channel_layout_copy(&audEncCtx->ch_layout, &audDecCtx->ch_layout);
+      audEncCtx->sample_fmt = AV_SAMPLE_FMT_FLTP;
+      audEncCtx->bit_rate = 96000LL * audEncCtx->ch_layout.nb_channels;
+      audEncCtx->time_base = (AVRational){1, audEncCtx->sample_rate};
+      audEncCtx->flags |= AV_CODEC_FLAG_GLOBAL_HEADER;   // fMP4 wants the AAC ASC in the init segment
+    }
+    AVDictionary *encOpts = NULL;
+    av_dict_set(&encOpts, "aac_coder", "fast", 0);   // faster encode → the buffer fills quicker
+    int aacOpen = audEncCtx ? avcodec_open2(audEncCtx, audEnc, &encOpts) : -1;
+    av_dict_free(&encOpts);
+    if (aacOpen < 0) {
+      NSLog(@"HLSRemuxer: audio transcode setup failed; streaming audio as-is");
+      transcodeAudio = NO;
+      if (audDecCtx) avcodec_free_context(&audDecCtx);
+      if (audEncCtx) avcodec_free_context(&audEncCtx);
+    } else {
+      audFifo = av_audio_fifo_alloc(AV_SAMPLE_FMT_FLTP, audEncCtx->ch_layout.nb_channels, 1);
+      audDecFrame = av_frame_alloc();
+      audEncPkt = av_packet_alloc();
+      if (!audFifo || !audDecFrame || !audEncPkt) { NSLog(@"HLSRemuxer: audio transcode alloc failed"); transcodeAudio = NO; }
+      NSLog(@"HLSRemuxer: transcoding audio %s → aac", avcodec_get_name(ic->streams[inAudio]->codecpar->codec_id));
+    }
+  }
+
+  if ((ret = avformat_alloc_output_context2(&oc, NULL, "hls", outFile.fileSystemRepresentation)) < 0) {
+    NSLog(@"HLSRemuxer: alloc_output(hls) failed (%d)", ret); goto cleanup;
+  }
+  // Normalize the timeline to start at zero, shifting all streams equally so A/V stay in sync
+  // (prevents the fMP4 segments from starting at odd/negative timestamps).
+  oc->avoid_negative_ts = AVFMT_AVOID_NEG_TS_MAKE_ZERO;
+
+  // Output stream 0 = video (stream copy).
+  {
+    AVStream *out = avformat_new_stream(oc, NULL);
+    if (!out || avcodec_parameters_copy(out->codecpar, ic->streams[inVideo]->codecpar) < 0) {
+      NSLog(@"HLSRemuxer: video stream setup failed"); goto cleanup;
+    }
+    out->codecpar->codec_tag = 0;
+    if (inVideo < 64) outIndexOf[inVideo] = 0;
+  }
+  // Output stream 1 = audio (transcoded to AAC, or stream copy).
+  {
+    AVStream *out = avformat_new_stream(oc, NULL);
+    int ok = out != NULL;
+    if (ok && transcodeAudio) { ok = avcodec_parameters_from_context(out->codecpar, audEncCtx) >= 0; out->time_base = audEncCtx->time_base; }
+    else if (ok) { ok = avcodec_parameters_copy(out->codecpar, ic->streams[inAudio]->codecpar) >= 0; }
+    if (!ok) { NSLog(@"HLSRemuxer: audio stream setup failed"); goto cleanup; }
+    out->codecpar->codec_tag = 0;
+    if (inAudio < 64) outIndexOf[inAudio] = 1;
+  }
+  // Output stream 2 = subtitle (WebVTT), when requested.
+  if (wantSub) {
+    AVStream *out = avformat_new_stream(oc, NULL);
+    if (!out || avcodec_parameters_from_context(out->codecpar, subEncCtx) < 0) {
+      NSLog(@"HLSRemuxer: subtitle stream setup failed"); goto cleanup;
+    }
+    out->codecpar->codec_tag = 0;
+    out->time_base = (AVRational){1, 1000};
+    AVDictionaryEntry *lang = av_dict_get(ic->streams[inSub]->metadata, "language", NULL, 0);
+    if (lang) av_dict_set(&out->metadata, "language", lang->value, 0);
+    outSubIndex = 2;
+    if (inSub < 64) outIndexOf[inSub] = 2;
+  }
+
+  av_dict_set(&opts, "hls_time", "6", 0);
+  av_dict_set(&opts, "hls_playlist_type", "event", 0);
+  av_dict_set(&opts, "hls_segment_type", "fmp4", 0);
+  av_dict_set(&opts, "hls_fmp4_init_filename", "init.mp4", 0);
+  av_dict_set(&opts, "hls_segment_filename", segPattern.fileSystemRepresentation, 0);
+  if (wantSub) {
+    av_dict_set(&opts, "master_pl_name", "master.m3u8", 0);
+    av_dict_set(&opts, "var_stream_map", "v:0,a:0,s:0,sgroup:subs", 0);
+  }
+
+  if (!(oc->oformat->flags & AVFMT_NOFILE)) {
+    if ((ret = avio_open(&oc->pb, outFile.fileSystemRepresentation, AVIO_FLAG_WRITE)) < 0) {
+      NSLog(@"HLSRemuxer: avio_open failed (%d)", ret); goto cleanup;
+    }
+  }
+  if ((ret = avformat_write_header(oc, &opts)) < 0) {
+    NSLog(@"HLSRemuxer: write_header failed (%d)", ret); goto cleanup;
+  }
+
+  pkt = av_packet_alloc();
+  long written = 0;
+  double firstPtsSec = -1;
+  struct timeval startTv;
+  gettimeofday(&startTv, NULL);
+  const double LOOKAHEAD = 30.0;   // initial buffer depth ahead of real time (avoids early underrun)
+  while (!self.stopped && av_read_frame(ic, pkt) >= 0) {
+    int oi = (pkt->stream_index < 64) ? outIndexOf[pkt->stream_index] : -1;
+    if (oi < 0) { av_packet_unref(pkt); continue; }
+    AVStream *in = ic->streams[pkt->stream_index];
+    AVStream *out = oc->streams[oi];
+
+    // Subtitle: decode the text subtitle and re-encode as WebVTT.
+    if (oi == outSubIndex && wantSub) {
+      AVSubtitle sub;
+      int got = 0;
+      if (avcodec_decode_subtitle2(subDecCtx, &sub, &got, pkt) >= 0 && got) {
+        uint8_t buf[16384];
+        int n = avcodec_encode_subtitle(subEncCtx, buf, sizeof(buf), &sub);
+        if (n > 0) {
+          AVPacket *op = av_packet_alloc();
+          if (op && av_new_packet(op, n) == 0) {
+            memcpy(op->data, buf, n);
+            op->stream_index = outSubIndex;
+            op->pts = av_rescale_q(pkt->pts, in->time_base, out->time_base);
+            op->dts = op->pts;
+            op->duration = av_rescale_q(pkt->duration, in->time_base, out->time_base);
+            av_interleaved_write_frame(oc, op);
+          }
+          if (op) av_packet_free(&op);
+        }
+        avsubtitle_free(&sub);
+      }
+      av_packet_unref(pkt);
+      continue;
+    }
+
+    // Audio transcode: decode → buffer to the encoder frame size → AAC-encode. The output PTS
+    // is anchored to the first audio packet's timeline so it stays aligned with the video.
+    if (oi == 1 && transcodeAudio) {
+      if (avcodec_send_packet(audDecCtx, pkt) >= 0) {
+        while (avcodec_receive_frame(audDecCtx, audDecFrame) >= 0) {
+          if (!haveAudioPts && audDecFrame->pts != AV_NOPTS_VALUE) {
+            // The track may have an A/V offset (e.g. this E-AC3 track starts at +1.008s).
+            // Prepend that much silence so the audio aligns with the video and the real audio
+            // lands at its offset — receivers otherwise mis-handle the initial gap (~1s desync).
+            // Reference is the remux start (startSeconds), so this also holds when re-remuxing
+            // from a seek position (audio timeline starts at the same movie time as the video).
+            int64_t startSamples = (int64_t)(self.startSeconds * audEncCtx->sample_rate);
+            int64_t audioFirst = av_rescale_q(audDecFrame->pts, in->time_base, audEncCtx->time_base);
+            int64_t offset = audioFirst - startSamples;
+            audioNextPts = startSamples;
+            if (offset > 0 && offset < 10LL * audEncCtx->sample_rate) {
+              AVFrame *sil = av_frame_alloc();
+              sil->nb_samples = (int)offset;
+              sil->format = AV_SAMPLE_FMT_FLTP;
+              av_channel_layout_copy(&sil->ch_layout, &audEncCtx->ch_layout);
+              sil->sample_rate = audEncCtx->sample_rate;
+              if (av_frame_get_buffer(sil, 0) == 0) {
+                av_samples_set_silence(sil->data, 0, (int)offset,
+                                       audEncCtx->ch_layout.nb_channels, AV_SAMPLE_FMT_FLTP);
+                av_audio_fifo_write(audFifo, (void **)sil->data, (int)offset);
+              }
+              av_frame_free(&sil);
+            }
+            haveAudioPts = YES;
+          }
+          av_audio_fifo_write(audFifo, (void **)audDecFrame->data, audDecFrame->nb_samples);
+          av_frame_unref(audDecFrame);
+        }
+        while (av_audio_fifo_size(audFifo) >= audEncCtx->frame_size) {
+          AVFrame *f = av_frame_alloc();
+          f->nb_samples = audEncCtx->frame_size;
+          f->format = AV_SAMPLE_FMT_FLTP;
+          av_channel_layout_copy(&f->ch_layout, &audEncCtx->ch_layout);
+          f->sample_rate = audEncCtx->sample_rate;
+          if (av_frame_get_buffer(f, 0) == 0) {
+            av_audio_fifo_read(audFifo, (void **)f->data, audEncCtx->frame_size);
+            f->pts = audioNextPts; audioNextPts += audEncCtx->frame_size;
+            if (avcodec_send_frame(audEncCtx, f) >= 0) {
+              while (avcodec_receive_packet(audEncCtx, audEncPkt) >= 0) {
+                av_packet_rescale_ts(audEncPkt, audEncCtx->time_base, out->time_base);
+                audEncPkt->stream_index = 1;
+                av_interleaved_write_frame(oc, audEncPkt);
+                av_packet_unref(audEncPkt);
+              }
+            }
+          }
+          av_frame_free(&f);
+        }
+      }
+      av_packet_unref(pkt);
+      continue;
+    }
+
+    // Pace to ~real time (a live-stream cadence): a full-speed stream-copy races the playlist
+    // to the end of the movie in seconds, so the AirPlay receiver rides a "live edge" that is
+    // nowhere near the start. Throttling on the video PTS keeps the edge near real playback,
+    // so the TV plays from near the beginning. stop() breaks the sleep promptly.
+    if (!self.pacingOff && oi == 0 && pkt->pts != AV_NOPTS_VALUE) {
+      double ptsSec = pkt->pts * av_q2d(in->time_base);
+      if (firstPtsSec < 0) firstPtsSec = ptsSec;
+      struct timeval now;
+      gettimeofday(&now, NULL);
+      double wall = (now.tv_sec - startTv.tv_sec) + (now.tv_usec - startTv.tv_usec) / 1e6;
+      double ahead = (ptsSec - firstPtsSec) - wall - LOOKAHEAD;
+      while (ahead > 0 && !self.stopped && !self.pacingOff) {
+        double chunk = ahead > 0.2 ? 0.2 : ahead;
+        usleep((useconds_t)(chunk * 1e6));
+        ahead -= chunk;
+      }
+    }
+    av_packet_rescale_ts(pkt, in->time_base, out->time_base);
+    pkt->stream_index = oi;
+    pkt->pos = -1;
+    if (av_interleaved_write_frame(oc, pkt) < 0) { av_packet_unref(pkt); break; }
+    written++;
+    av_packet_unref(pkt);
+  }
+  // Flush the audio transcoder (decoder → FIFO → encoder) so the tail isn't dropped.
+  if (transcodeAudio && !self.stopped && audDecCtx && audEncCtx) {
+    avcodec_send_packet(audDecCtx, NULL);
+    while (avcodec_receive_frame(audDecCtx, audDecFrame) >= 0) {
+      av_audio_fifo_write(audFifo, (void **)audDecFrame->data, audDecFrame->nb_samples);
+      av_frame_unref(audDecFrame);
+    }
+    while (av_audio_fifo_size(audFifo) > 0) {
+      int n = av_audio_fifo_size(audFifo);
+      if (n > audEncCtx->frame_size) n = audEncCtx->frame_size;
+      AVFrame *f = av_frame_alloc();
+      f->nb_samples = n; f->format = AV_SAMPLE_FMT_FLTP;
+      av_channel_layout_copy(&f->ch_layout, &audEncCtx->ch_layout);
+      f->sample_rate = audEncCtx->sample_rate;
+      if (av_frame_get_buffer(f, 0) == 0) {
+        av_audio_fifo_read(audFifo, (void **)f->data, n);
+        f->pts = audioNextPts; audioNextPts += n;
+        avcodec_send_frame(audEncCtx, f);
+      }
+      av_frame_free(&f);
+    }
+    avcodec_send_frame(audEncCtx, NULL);
+    while (avcodec_receive_packet(audEncCtx, audEncPkt) >= 0) {
+      av_packet_rescale_ts(audEncPkt, audEncCtx->time_base, oc->streams[1]->time_base);
+      audEncPkt->stream_index = 1;
+      av_interleaved_write_frame(oc, audEncPkt);
+      av_packet_unref(audEncPkt);
+    }
+  }
+  if (oc->pb) av_write_trailer(oc);
+  if (!self.stopped && self.onFinished) {
+    void (^cb)(void) = self.onFinished;
+    dispatch_async(dispatch_get_main_queue(), ^{ cb(); });
+  }
+
+cleanup:
+  av_dict_free(&opts);
+  if (pkt) av_packet_free(&pkt);
+  if (subDecCtx) avcodec_free_context(&subDecCtx);
+  if (subEncCtx) avcodec_free_context(&subEncCtx);
+  if (audDecCtx) avcodec_free_context(&audDecCtx);
+  if (audEncCtx) avcodec_free_context(&audEncCtx);
+  if (audFifo) av_audio_fifo_free(audFifo);
+  if (audDecFrame) av_frame_free(&audDecFrame);
+  if (audEncPkt) av_packet_free(&audEncPkt);
+  if (oc && !(oc->oformat->flags & AVFMT_NOFILE) && oc->pb) avio_closep(&oc->pb);
+  if (oc) avformat_free_context(oc);
+  if (ic) avformat_close_input(&ic);
+}
+
+@end

--- a/iina/Info.plist
+++ b/iina/Info.plist
@@ -605,6 +605,8 @@
 	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
 	<key>NSAppTransportSecurity</key>
 	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
 		<key>NSAllowsArbitraryLoadsInWebContent</key>
 		<true/>
 		<key>NSExceptionDomains</key>

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -9,6 +9,7 @@
 import Cocoa
 import Mustache
 import WebKit
+import AVKit
 
 fileprivate let isMacOS11: Bool = {
   if #unavailable(macOS 12.0) {
@@ -55,6 +56,40 @@ class MainWindowController: PlayerWindowController {
   }
 
   lazy private var _videoView: VideoView = VideoView(frame: window!.contentView!.bounds, player: player)
+
+  /// Overlay shown over the (frozen) video while casting via AirPlay, so the Mac doesn't
+  /// just show a paused frame.
+  lazy var castingOverlayView: NSView = {
+    let v = NSVisualEffectView()
+    v.material = .hudWindow
+    v.blendingMode = .withinWindow
+    v.state = .active
+    v.translatesAutoresizingMaskIntoConstraints = false
+    v.isHidden = true
+    let icon = NSImageView()
+    icon.image = NSImage.sf(["airplayvideo"], withConfiguration: NSImage.SymbolConfiguration(pointSize: 52, weight: .regular))
+    icon.contentTintColor = .white
+    icon.translatesAutoresizingMaskIntoConstraints = false
+    let label = NSTextField(labelWithString: "Playing on AirPlay")
+    label.font = .systemFont(ofSize: 20, weight: .medium)
+    label.textColor = .white
+    label.translatesAutoresizingMaskIntoConstraints = false
+    v.addSubview(icon)
+    v.addSubview(label)
+    NSLayoutConstraint.activate([
+      icon.centerXAnchor.constraint(equalTo: v.centerXAnchor),
+      icon.centerYAnchor.constraint(equalTo: v.centerYAnchor, constant: -18),
+      label.centerXAnchor.constraint(equalTo: v.centerXAnchor),
+      label.topAnchor.constraint(equalTo: icon.bottomAnchor, constant: 12),
+    ])
+    return v
+  }()
+
+  /// Show/hide the AirPlay casting overlay. Called by the AirPlayCoordinator.
+  func setCastingOverlay(_ visible: Bool) {
+    guard loaded else { return }
+    castingOverlayView.isHidden = !visible
+  }
 
   /// Owns the sidebar panels, view controllers, and show/hide/resize logic.
   lazy var sidebars = SidebarController(mainWindow: self)
@@ -350,7 +385,9 @@ class MainWindowController: PlayerWindowController {
       }
     case PK.enableLiveText.rawValue:
       if #available(macOS 13, *), let newValue = change[.newKey] as? Bool {
-        let buttons = fragToolbarView.subviews as! [NSButton]
+        // compactMap (not `as! [NSButton]`) — the toolbar may hold a non-NSButton view
+        // (the AirPlay AVRoutePickerView), which would trap a force cast.
+        let buttons = fragToolbarView.subviews.compactMap { $0 as? NSButton }
         if let btn = buttons.first(where: { $0.tag == Preference.ToolBarButton.liveText.rawValue }) {
           btn.image = newValue ? Preference.ToolBarButton.liveText.alternateImage() : Preference.ToolBarButton.liveText.image()
         }
@@ -477,6 +514,15 @@ class MainWindowController: PlayerWindowController {
 
     // init quick setting view now
     let _ = sidebars.quickSettingView
+
+    // AirPlay casting overlay — above the video, below the OSC/chrome.
+    cv.addSubview(castingOverlayView)
+    NSLayoutConstraint.activate([
+      castingOverlayView.leadingAnchor.constraint(equalTo: cv.leadingAnchor),
+      castingOverlayView.trailingAnchor.constraint(equalTo: cv.trailingAnchor),
+      castingOverlayView.topAnchor.constraint(equalTo: cv.topAnchor),
+      castingOverlayView.bottomAnchor.constraint(equalTo: cv.bottomAnchor),
+    ])
 
     // create translucent views
     oscBottomView = OSCBottomView(mainWindow: self)
@@ -814,9 +860,21 @@ class MainWindowController: PlayerWindowController {
     let effectiveButtons = buttons.filter { $0 != .liveText || Preference.isLiveTextEnabled }
     fragToolbarView.views.forEach { fragToolbarView.removeView($0) }
     let liveTextEnabled = Preference.bool(for: .enableLiveText)
+    let realButtonCount = effectiveButtons.filter { $0 != .airplay }.count
     for buttonType in effectiveButtons {
+      if buttonType == .airplay {
+        // AirPlay uses a system AVRoutePickerView rather than a plain toolbar button.
+        let picker = AVRoutePickerView()
+        picker.translatesAutoresizingMaskIntoConstraints = false
+        picker.isRoutePickerButtonBordered = false
+        Utility.quickConstraints(["H:[v(\(Preference.ToolBarButton.frameSize))]",
+                                  "V:[v(\(Preference.ToolBarButton.frameSize))]"], ["v": picker])
+        fragToolbarView.addView(picker, in: .trailing)
+        player.airPlayCoordinator.attach(routePicker: picker)
+        continue
+      }
       let button = NSButton()
-      OSCToolbarButton.setStyle(of: button, buttonType: buttonType, reducedWidth: effectiveButtons.count > 4)
+      OSCToolbarButton.setStyle(of: button, buttonType: buttonType, reducedWidth: realButtonCount > 4)
       if buttonType == .liveText && liveTextEnabled {
         button.image = Preference.ToolBarButton.liveText.alternateImage()
       }
@@ -828,7 +886,8 @@ class MainWindowController: PlayerWindowController {
   @objc
   private func updateOSCToolbarButtons(_ notification: Notification) {
     func highlight(_ button: Preference.ToolBarButton, _ isHighlighted: Bool) {
-      let buttons = fragToolbarView.subviews as! [NSButton]
+      // subviews may include a non-NSButton (the AirPlay AVRoutePickerView), so filter.
+      let buttons = fragToolbarView.subviews.compactMap { $0 as? NSButton }
       let currentButton = buttons.first(where: { $0.tag == button.rawValue })
       currentButton?.image = isHighlighted ? button.alternateImage() : button.image()
     }
@@ -2858,6 +2917,8 @@ class MainWindowController: PlayerWindowController {
       sidebars.show(sidebar: .plugins)
     case .liveText:
       Preference.set(!Preference.bool(for: .enableLiveText), for: .enableLiveText)
+    case .airplay:
+      break  // handled by the AVRoutePickerView, not a tag-based button action
     }
   }
 

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -226,6 +226,9 @@ class PlayerCore: NSObject {
 
   lazy var info: PlaybackInfo = PlaybackInfo(self)
 
+  /// Coordinates AirPlay video casting (HLS remux -> LAN server -> AVPlayer -> AirPlay).
+  lazy var airPlayCoordinator: AirPlayCoordinator = AirPlayCoordinator(player: self)
+
   var syncUITimer: Timer?
 
   var displayOSD: Bool = true
@@ -890,6 +893,10 @@ class PlayerCore: NSObject {
   // MARK: - MPV commands
 
   func togglePause(_ set: Bool? = nil) {
+    if airPlayCoordinator.isCasting {
+      airPlayCoordinator.setCastPaused(set ?? !airPlayCoordinator.isCastPaused)
+      return
+    }
     info.state == .paused ? resume() : pause()
   }
 
@@ -940,6 +947,11 @@ class PlayerCore: NSObject {
   ///     running when the mpv core is shutdown it may call into mpv triggering a crash.
   func stop() {
     guard info.state != .shutDown else { return }
+    if airPlayCoordinator.isCasting, let pos = airPlayCoordinator.castCurrentSeconds {
+      // Hand the receiver's position back so watch-later saves where the TV actually is.
+      mpv.command(.seek, args: ["\(pos)", "absolute+exact"])
+    }
+    airPlayCoordinator.endIfActive()
     savePlaybackPosition()
 
     // The player may already be stopped in which case the state must not be set to stopping.
@@ -981,6 +993,14 @@ class PlayerCore: NSObject {
   }
 
   func seek(percent: Double, forceExact: Bool = false) {
+    // While casting, seek only the AirPlay receiver — don't touch mpv (it stays paused; no
+    // local seek/playback on the Mac).
+    if airPlayCoordinator.isCasting {
+      if let dur = info.videoDuration?.second, dur > 0 {
+        airPlayCoordinator.castSeek(toAbsolute: percent.clamped(to: 0..<100) / 100 * dur)
+      }
+      return
+    }
     var percent = percent
     // mpv will play next file automatically when seek to EOF.
     // We clamp to a Range to ensure that we don't try to seek to 100%.
@@ -995,6 +1015,11 @@ class PlayerCore: NSObject {
   }
 
   func seek(relativeSecond: Double, option: Preference.SeekOption) {
+    // While casting, seek only the AirPlay receiver — don't touch mpv.
+    if airPlayCoordinator.isCasting {
+      airPlayCoordinator.castSeek(byRelative: relativeSecond)
+      return
+    }
     switch option {
 
     case .relative:
@@ -1020,6 +1045,11 @@ class PlayerCore: NSObject {
   }
 
   func seek(absoluteSecond: Double) {
+    // While casting, seek only the AirPlay receiver — don't touch mpv.
+    if airPlayCoordinator.isCasting {
+      airPlayCoordinator.castSeek(toAbsolute: absoluteSecond)
+      return
+    }
     mpv.command(.seek, args: ["\(absoluteSecond)", "absolute+exact"])
   }
 
@@ -1295,6 +1325,11 @@ class PlayerCore: NSObject {
     }
     mpv.setInt(name, index)
     getSelectedTracks()
+    // If we're casting via AirPlay, rebuild the stream so the new audio/subtitle track
+    // is reflected on the receiver (otherwise the TV keeps the old track).
+    if (forType == .audio || forType == .sub), airPlayCoordinator.isCasting {
+      airPlayCoordinator.reloadForTrackChange()
+    }
   }
 
   func setSpeed(_ speed: Double) {
@@ -2042,6 +2077,7 @@ class PlayerCore: NSObject {
   ///         the player is no longer active.
   func fileStarted(path: String) {
     guard info.state.active else { return }
+    airPlayCoordinator.endIfActive()  // a new file is loading — tear down any active cast
     log("File started")
 
     Task { @MainActor in
@@ -2743,6 +2779,13 @@ class PlayerCore: NSObject {
   ///     milliseconds. Due to this behavior of the `time-pos` property, this method checks to see of the end of the video has been
   ///     reached and if so, sets `videoPosition` to match `videoDuration`.
   private func syncPosition() {
+    // While casting via AirPlay, the receiver (AVPlayer) is the transport master, so the
+    // OSC must reflect its position rather than the (paused) mpv core.
+    if airPlayCoordinator.isCasting, let castSeconds = airPlayCoordinator.castCurrentSeconds {
+      info.videoPosition?.second = castSeconds
+      info.constrainVideoPosition()
+      return
+    }
     if info.isNetworkResource {
       info.videoDuration?.second = mpv.getDouble(MPVProperty.duration)
     }

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -675,7 +675,7 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
   }
 
   @IBAction func playButtonAction(_ sender: NSButton) {
-    player.info.state == .paused ? player.resume() : player.pause()
+    player.togglePause()  // routes to the AirPlay cast while casting, else mpv
   }
 
   @IBAction func muteButtonAction(_ sender: NSButton) {

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -840,6 +840,7 @@ struct Preference {
     case screenshot
     case plugins
     case liveText
+    case airplay
 
     var description: String {
       switch self {
@@ -852,6 +853,7 @@ struct Preference {
       case .screenshot: "screenshot"
       case .plugins: "plugins"
       case .liveText: "liveText"
+      case .airplay: "airplay"
       }
     }
 
@@ -871,6 +873,7 @@ struct Preference {
       case .screenshot: return makeSymbol(["camera.shutter.button", "camera.fill"])
       case .plugins: return makeSymbol(["puzzlepiece.extension", "puzzlepiece"])
       case .liveText: return makeSymbol(["document.viewfinder", "doc.viewfinder", "doc.text.viewfinder"])
+      case .airplay: return makeSymbol(["airplayvideo"])
       }
     }
 
@@ -898,6 +901,7 @@ struct Preference {
       case .screenshot: key = "screenshot"
       case .plugins: key = "plugins"
       case .liveText: key = "live_text"
+      case .airplay: key = "airplay"
       }
       return NSLocalizedString("osc_toolbar.\(key)", comment: key)
     }
@@ -1028,7 +1032,7 @@ struct Preference {
     .controlBarStickToCenter: true,
     .controlBarAutoHideTimeout: Float(2.5),
     .enableControlBarAutoHide: true,
-    .controlBarToolbarButtons: [ToolBarButton.plugins.rawValue, ToolBarButton.pip.rawValue, ToolBarButton.playlist.rawValue, ToolBarButton.settings.rawValue],
+    .controlBarToolbarButtons: [ToolBarButton.plugins.rawValue, ToolBarButton.airplay.rawValue, ToolBarButton.pip.rawValue, ToolBarButton.playlist.rawValue, ToolBarButton.settings.rawValue],
     .oscPosition: OSCPosition.floating.rawValue,
     .disablePlaySliderScrolling: false,
     .disableVolumeSliderScrolling: false,

--- a/iina/iina-Bridging-Header.h
+++ b/iina/iina-Bridging-Header.h
@@ -17,6 +17,7 @@
 #import "FixedFontManager.h"
 #import "ObjcUtils.h"
 #import "FFmpegController.h"
+#import "HLSRemuxer.h"
 
 #import <CommonCrypto/CommonCrypto.h>
 


### PR DESCRIPTION
Casts the current file (including MKV) to an AirPlay 2 receiver — tested on an LG webOS TV.

## Approach
mpv renders through a CAOpenGL layer the system can't AirPlay, so this remuxes the current file in-process to fMP4 HLS using **libavformat** (the `libav*` libraries IINA already links — **no bundled ffmpeg binary**), serves it over a small `NWListener` LAN HTTP server, and streams it to the receiver with an `AVPlayer` (`allowsExternalPlayback`) engaged via an `AVRoutePickerView` in the OSC. While casting, mpv pauses behind a "casting" overlay and AVPlayer is the transport master (OSC position, play/pause, seek, track selection).

## Features
- **Audio** — the selected audio track is honored. AAC/AC-3 are stream-copied; other codecs (E-AC3, DTS, …) are transcoded to AAC with a standard channel layout (Apple's decoder rejects PCE-based layouts), and the track's container A/V offset is preserved as leading silence so audio stays in sync.
- **Subtitles** — the selected text subtitle is transcoded to a WebVTT HLS rendition.
- **Starts from the beginning** — the remux is paced to ~real time so the receiver doesn't ride a live edge that a full-speed stream-copy would race to the end; pacing is released once playback is established to fill the buffer.
- **Seek anywhere** — an instant `AVPlayer` seek within the remuxed range; beyond it, the file is re-remuxed from the target and the cast restarts there.

## Adds
`HLSRemuxer` (libavformat remux), `HLSFileServer` (LAN server), `HLSPackager`, `AirPlayCoordinator`, an `.airplay` OSC toolbar button, and `NSAllowsLocalNetworking`.

Note: casting bypasses mpv for rendering, so mpv-side ASS styling / speed / audio-delay controls don't apply to the cast.
