### PR TITLE
Add custom floating video window mode

### DIFF
--- a/.github/workflows/build-iina.yml
+++ b/.github/workflows/build-iina.yml
@@ -1,0 +1,32 @@
+name: Build IINA
+
+on:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: codex/custom-floating-window
+
+      - name: Install dependencies
+        run: ./other/download_libs.sh --skip-plugins
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build
+        run: xcodebuild -project iina.xcodeproj ONLY_ACTIVE_ARCH=NO -scheme iina -configuration Nightly
+
+      - name: Archive
+        run: |
+          APP=$(find /Users/runner/Library/Developer/Xcode/DerivedData -name "IINA.app" -type d -maxdepth 5 | head -1)
+          echo "Found: $APP"
+          tar cvJf ~/iina.tar.xz -C "$(dirname "$APP")" IINA.app
+
+      - name: Save artifacts
+        uses: actions/upload-artifact@v6
+        with:
+          name: IINA
+          path: ~/iina.tar.xz

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ permissions:
   contents: read
 
 on:
+  workflow_dispatch:
   push:
       branches: [develop]
   pull_request:

--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -183,6 +183,7 @@
 		51C889D52C42FF7F007B2584 /* PlayerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C889D42C42FF7F007B2584 /* PlayerState.swift */; };
 		51CA83E22E35AD6300A44B22 /* MPVAudioDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51CA83E12E35AD6300A44B22 /* MPVAudioDevice.swift */; };
 		51CACB9529D500290034CEE5 /* VideoPIPViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51CACB9429D500290034CEE5 /* VideoPIPViewController.swift */; };
+		51CACB9729D500290034CEE5 /* CustomFloatingWindowController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51CACB9629D500290034CEE5 /* CustomFloatingWindowController.swift */; };
 		51DE55C92A6646710050AD06 /* Sysctl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51DE55C82A6646710050AD06 /* Sysctl.swift */; };
 		51E63DFB29CFB031008AFC20 /* PlaySlider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E63DFA29CFB031008AFC20 /* PlaySlider.swift */; };
 		51E63DFD29CFB04C008AFC20 /* PlaySliderLoopKnob.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E63DFC29CFB04B008AFC20 /* PlaySliderLoopKnob.swift */; };
@@ -1211,6 +1212,7 @@
 		51C889D42C42FF7F007B2584 /* PlayerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerState.swift; sourceTree = "<group>"; };
 		51CA83E12E35AD6300A44B22 /* MPVAudioDevice.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MPVAudioDevice.swift; sourceTree = "<group>"; };
 		51CACB9429D500290034CEE5 /* VideoPIPViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VideoPIPViewController.swift; sourceTree = "<group>"; };
+		51CACB9629D500290034CEE5 /* CustomFloatingWindowController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CustomFloatingWindowController.swift; sourceTree = "<group>"; };
 		51DE55C82A6646710050AD06 /* Sysctl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Sysctl.swift; sourceTree = "<group>"; };
 		51E63DFA29CFB031008AFC20 /* PlaySlider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaySlider.swift; sourceTree = "<group>"; };
 		51E63DFC29CFB04B008AFC20 /* PlaySliderLoopKnob.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PlaySliderLoopKnob.swift; sourceTree = "<group>"; };
@@ -2391,6 +2393,7 @@
 				D1B4E24D2A3AFC9100E36F1D /* MiniPlayerWindow.swift */,
 				84CFC92523F8DDE000381E5B /* PlayerWindowController.swift */,
 				51CACB9429D500290034CEE5 /* VideoPIPViewController.swift */,
+				51CACB9629D500290034CEE5 /* CustomFloatingWindowController.swift */,
 				84D123B31ECAA405004E0D53 /* TouchBarSupport.swift */,
 				8400D5C81E1AB2F1006785F5 /* MainWindowController.xib */,
 				E39EDD822CE2EB9600978036 /* PluginViewController.xib */,
@@ -3425,6 +3428,7 @@
 				841B14281E941DFF00744AB8 /* TimeLabelOverflowedStackView.swift in Sources */,
 				E33BA5C7204BD9FE0069A0F6 /* SubChooseViewController.swift in Sources */,
 				51CACB9529D500290034CEE5 /* VideoPIPViewController.swift in Sources */,
+				51CACB9729D500290034CEE5 /* CustomFloatingWindowController.swift in Sources */,
 				512B8FDD2BC2376E00AF41BF /* OutlineView.swift in Sources */,
 				8460FBA91D6497490081841B /* PlaylistViewController.swift in Sources */,
 				51096C0B2CD88BEC00702C31 /* MPVOptionDefaults.swift in Sources */,

--- a/iina/AppData.swift
+++ b/iina/AppData.swift
@@ -95,6 +95,8 @@ struct Constants {
     static let none = NSLocalizedString("quicksetting.item_none", comment: "None")
     static let pip = NSLocalizedString("menu.pip", comment: "Enter Picture-in-Picture")
     static let exitPIP = NSLocalizedString("menu.exit_pip", comment: "Exit Picture-in-Picture")
+    static let customFloatingWindow = NSLocalizedString("menu.custom_floating_window", comment: "Toggle Floating Video Window")
+    static let exitCustomFloatingWindow = NSLocalizedString("menu.exit_custom_floating_window", comment: "Exit Floating Video Window")
     static let miniPlayer = NSLocalizedString("menu.mini_player", comment: "Enter Music Mode")
     static let exitMiniPlayer = NSLocalizedString("menu.exit_mini_player", comment: "Exit Music Mode")
     static let custom = NSLocalizedString("menu.crop_custom", comment: "Custom crop size")

--- a/iina/Base.lproj/KeyBinding.strings
+++ b/iina/Base.lproj/KeyBinding.strings
@@ -38,6 +38,7 @@
 "iina.mirror" = "Mirror";
 
 "iina.toggle-pip" = "Toggle Picture-in-Picture";
+"iina.toggle-custom-floating-window" = "Toggle Floating Video Window";
 "iina.toggle-music-mode" = "Toggle Music Mode";
 "iina.open-file" = "Open file";
 "iina.open-url" = "Open URL";

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -196,7 +196,8 @@
 "menu.exit_fullscreen" = "Exit Full Screen";
 "menu.pip" = "Enter Picture-in-Picture";
 "menu.exit_pip" = "Exit Picture-in-Picture";
-"menu.mini_player" = "Enter Music Mode";
+"menu.custom_floating_window" = "Toggle Floating Video Window";
+"menu.exit_custom_floating_window" = "Exit Floating Video Window";"menu.mini_player" = "Enter Music Mode";
 "menu.exit_mini_player" = "Exit Music Mode";
 "menu.pause" = "Pause";
 "menu.resume" = "Resume";

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -197,7 +197,8 @@
 "menu.pip" = "Enter Picture-in-Picture";
 "menu.exit_pip" = "Exit Picture-in-Picture";
 "menu.custom_floating_window" = "Toggle Floating Video Window";
-"menu.exit_custom_floating_window" = "Exit Floating Video Window";"menu.mini_player" = "Enter Music Mode";
+"menu.exit_custom_floating_window" = "Exit Floating Video Window";
+"menu.mini_player" = "Enter Music Mode";
 "menu.exit_mini_player" = "Exit Music Mode";
 "menu.pause" = "Pause";
 "menu.resume" = "Resume";

--- a/iina/CustomFloatingWindowController.swift
+++ b/iina/CustomFloatingWindowController.swift
@@ -32,7 +32,7 @@ class CustomFloatingWindowController: NSWindowController, NSWindowDelegate {
     let contentView = NSView(frame: NSRect(origin: .zero, size: initialFrame.size))
     let window = CustomFloatingPanel(
       contentRect: initialFrame,
-      styleMask: [.titled, .closable, .resizable, .miniaturizable, .nonactivatingPanel],
+      styleMask: [.borderless, .resizable, .nonactivatingPanel],
       backing: .buffered,
       defer: false
     )
@@ -43,6 +43,7 @@ class CustomFloatingWindowController: NSWindowController, NSWindowDelegate {
     window.hidesOnDeactivate = false
     window.isReleasedWhenClosed = false
     window.backgroundColor = .black
+    window.isMovableByWindowBackground = true
     window.minSize = NSSize(width: 240, height: 135)
     window.aspectRatio = initialFrame.size
 

--- a/iina/CustomFloatingWindowController.swift
+++ b/iina/CustomFloatingWindowController.swift
@@ -32,7 +32,7 @@ class CustomFloatingWindowController: NSWindowController, NSWindowDelegate {
     let contentView = NSView(frame: NSRect(origin: .zero, size: initialFrame.size))
     let window = CustomFloatingPanel(
       contentRect: initialFrame,
-      styleMask: [.borderless, .resizable],
+      styleMask: [.borderless, .resizable, .nonactivatingPanel],
       backing: .buffered,
       defer: false
     )

--- a/iina/CustomFloatingWindowController.swift
+++ b/iina/CustomFloatingWindowController.swift
@@ -32,7 +32,7 @@ class CustomFloatingWindowController: NSWindowController, NSWindowDelegate {
     let contentView = NSView(frame: NSRect(origin: .zero, size: initialFrame.size))
     let window = CustomFloatingPanel(
       contentRect: initialFrame,
-      styleMask: [.borderless, .nonactivatingPanel],
+      styleMask: [.borderless, .resizable],
       backing: .buffered,
       defer: false
     )

--- a/iina/CustomFloatingWindowController.swift
+++ b/iina/CustomFloatingWindowController.swift
@@ -39,7 +39,13 @@ class CustomFloatingWindowController: NSWindowController, NSWindowDelegate {
     window.title = title
     window.contentView = contentView
     window.level = .screenSaver
-    window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle, .stationary, .transient]
+    var collectionBehavior: NSWindow.CollectionBehavior = [.canJoinAllSpaces, .ignoresCycle, .transient]
+    if #available(macOS 13.0, *) {
+      collectionBehavior.insert(.canJoinAllApplications)
+    } else {
+      collectionBehavior.insert(.fullScreenAuxiliary)
+    }
+    window.collectionBehavior = collectionBehavior
     window.hidesOnDeactivate = false
     window.isReleasedWhenClosed = false
     window.isOpaque = false

--- a/iina/CustomFloatingWindowController.swift
+++ b/iina/CustomFloatingWindowController.swift
@@ -11,30 +11,44 @@ protocol CustomFloatingWindowControllerDelegate: AnyObject {
   func customFloatingWindowWillClose(_ controller: CustomFloatingWindowController)
 }
 
+class CustomFloatingPanel: NSPanel {
+
+  override var canBecomeKey: Bool {
+    true
+  }
+
+  override var canBecomeMain: Bool {
+    true
+  }
+}
+
 class CustomFloatingWindowController: NSWindowController, NSWindowDelegate {
 
   weak var delegate: CustomFloatingWindowControllerDelegate?
   private let videoView: VideoView
 
-  init(videoView: VideoView, title: String, initialFrame: NSRect) {
+  init(videoView: VideoView, title: String, initialFrame: NSRect, nextResponder: NSResponder?) {
     self.videoView = videoView
     let contentView = NSView(frame: NSRect(origin: .zero, size: initialFrame.size))
-    let window = NSWindow(
+    let window = CustomFloatingPanel(
       contentRect: initialFrame,
-      styleMask: [.titled, .closable, .resizable, .miniaturizable],
+      styleMask: [.titled, .closable, .resizable, .miniaturizable, .nonactivatingPanel],
       backing: .buffered,
       defer: false
     )
     window.title = title
     window.contentView = contentView
-    window.level = .iinaFloating
-    window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+    window.level = .screenSaver
+    window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle, .stationary, .transient]
+    window.hidesOnDeactivate = false
     window.isReleasedWhenClosed = false
     window.backgroundColor = .black
     window.minSize = NSSize(width: 240, height: 135)
+    window.aspectRatio = initialFrame.size
 
     super.init(window: window)
     window.delegate = self
+    window.nextResponder = nextResponder
     attachVideoView(to: contentView)
   }
 

--- a/iina/CustomFloatingWindowController.swift
+++ b/iina/CustomFloatingWindowController.swift
@@ -32,7 +32,7 @@ class CustomFloatingWindowController: NSWindowController, NSWindowDelegate {
     let contentView = NSView(frame: NSRect(origin: .zero, size: initialFrame.size))
     let window = CustomFloatingPanel(
       contentRect: initialFrame,
-      styleMask: [.borderless, .resizable, .nonactivatingPanel],
+      styleMask: [.borderless, .nonactivatingPanel],
       backing: .buffered,
       defer: false
     )
@@ -42,7 +42,9 @@ class CustomFloatingWindowController: NSWindowController, NSWindowDelegate {
     window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary, .ignoresCycle, .stationary, .transient]
     window.hidesOnDeactivate = false
     window.isReleasedWhenClosed = false
-    window.backgroundColor = .black
+    window.isOpaque = false
+    window.backgroundColor = .clear
+    window.hasShadow = false
     window.isMovableByWindowBackground = true
     window.minSize = NSSize(width: 240, height: 135)
     window.aspectRatio = initialFrame.size

--- a/iina/CustomFloatingWindowController.swift
+++ b/iina/CustomFloatingWindowController.swift
@@ -1,0 +1,59 @@
+//
+//  CustomFloatingWindowController.swift
+//  iina
+//
+//  Copyright © 2026 lhc. All rights reserved.
+//
+
+import Cocoa
+
+protocol CustomFloatingWindowControllerDelegate: AnyObject {
+  func customFloatingWindowWillClose(_ controller: CustomFloatingWindowController)
+}
+
+class CustomFloatingWindowController: NSWindowController, NSWindowDelegate {
+
+  weak var delegate: CustomFloatingWindowControllerDelegate?
+  private let videoView: VideoView
+
+  init(videoView: VideoView, title: String, initialFrame: NSRect) {
+    self.videoView = videoView
+    let contentView = NSView(frame: NSRect(origin: .zero, size: initialFrame.size))
+    let window = NSWindow(
+      contentRect: initialFrame,
+      styleMask: [.titled, .closable, .resizable, .miniaturizable],
+      backing: .buffered,
+      defer: false
+    )
+    window.title = title
+    window.contentView = contentView
+    window.level = .iinaFloating
+    window.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+    window.isReleasedWhenClosed = false
+    window.backgroundColor = .black
+    window.minSize = NSSize(width: 240, height: 135)
+
+    super.init(window: window)
+    window.delegate = self
+    attachVideoView(to: contentView)
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  func windowWillClose(_ notification: Notification) {
+    delegate?.customFloatingWindowWillClose(self)
+  }
+
+  private func attachVideoView(to contentView: NSView) {
+    contentView.addSubview(videoView)
+    videoView.translatesAutoresizingMaskIntoConstraints = false
+    NSLayoutConstraint.activate([
+      videoView.topAnchor.constraint(equalTo: contentView.topAnchor),
+      videoView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor),
+      videoView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor),
+      videoView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor)
+    ])
+  }
+}

--- a/iina/IINACommand.swift
+++ b/iina/IINACommand.swift
@@ -11,6 +11,7 @@ import Foundation
 enum IINACommand: String {
 
   case togglePIP = "toggle-pip"
+  case toggleCustomFloatingWindow = "toggle-custom-floating-window"
   case openFile = "open-file"
   case openURL = "open-url"
 

--- a/iina/KeyBindingDataLoader.swift
+++ b/iina/KeyBindingDataLoader.swift
@@ -53,6 +53,7 @@ class KeyBindingDataLoader {
     KBI("sub-panel", type: .iinaCmd),
     KBI("playlist-panel", type: .iinaCmd),
     KBI("chapter-panel", type: .iinaCmd),
+    KBI("toggle-custom-floating-window", type: .iinaCmd),
     KBI.separator(),
     KBI("open-file", type: .iinaCmd),
     KBI("open-url", type: .iinaCmd),
@@ -185,4 +186,3 @@ class KeyBindingDataLoader {
   }
 
 }
-

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -88,6 +88,10 @@ extension MainMenuActionHandler {
     }
   }
 
+  @objc func menuToggleCustomFloatingWindow(_ sender: NSMenuItem) {
+    player.mainWindow.toggleCustomFloatingWindow()
+  }
+
   @objc func menuStop(_ sender: NSMenuItem) {
     // FIXME: handle stop
     player.sendOSD(.stop)

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -252,6 +252,12 @@ class MainWindowController: PlayerWindowController {
     case intermediate
   }
 
+  enum CustomFloatingWindowStatus {
+    case notInCustomFloatingWindow
+    case inCustomFloatingWindow
+    case intermediate
+  }
+
   enum InteractiveMode {
     case crop
     case freeSelecting
@@ -439,6 +445,9 @@ class MainWindowController: PlayerWindowController {
   }
 
   var pipVideo: NSViewController!
+  var customFloatingWindowController: CustomFloatingWindowController?
+  var customFloatingWindowStatus = CustomFloatingWindowStatus.notInCustomFloatingWindow
+  var isWindowHiddenDueToCustomFloatingWindow = false
 
   // MARK: - Initialization
 
@@ -746,6 +755,15 @@ class MainWindowController: PlayerWindowController {
     cv.addSubview(videoView, positioned: .below, relativeTo: nil)
     videoView.translatesAutoresizingMaskIntoConstraints = false
     setupVideoViewConstraints()
+  }
+
+  func detachVideoViewFromWindow() {
+    guard let cv = window?.contentView else { return }
+    layoutSides.forEach {
+      videoViewConstraints[$0].flatMap(cv.removeConstraint)
+      videoViewConstraints[$0] = nil
+    }
+    videoView.removeFromSuperview()
   }
 
   private func setupVideoViewConstraints() {
@@ -1298,6 +1316,9 @@ class MainWindowController: PlayerWindowController {
     if pipStatus == .inPIP {
       exitPIP()
     }
+    if customFloatingWindowStatus == .inCustomFloatingWindow {
+      exitCustomFloatingWindow(restoreMainWindow: false)
+    }
     // stop playing
     if case .fullscreen(legacy: true, priorWindowedFrame: _) = fsState {
       restoreDockSettings()
@@ -1622,6 +1643,7 @@ class MainWindowController: PlayerWindowController {
 
     switch fsState {
     case .windowed:
+      guard customFloatingWindowStatus == .notInCustomFloatingWindow else { return }
       guard !player.isInMiniPlayer else { return }
       if Preference.bool(for: .useLegacyFullScreen) {
         log("Will enter legacy full screen mode")
@@ -2952,6 +2974,8 @@ class MainWindowController: PlayerWindowController {
     switch cmd {
     case .toggleMusicMode:
       player.switchToMiniPlayer()
+    case .toggleCustomFloatingWindow:
+      toggleCustomFloatingWindow()
     default:
       break
     }
@@ -3172,5 +3196,98 @@ extension MainWindowController: PIPViewControllerDelegate {
       state.contentDuration = duration
       state.setPlaybackRate(playing ? player.info.playSpeed : 0, elapsedTime: elapsed, timeControlStatus: playing ? 2 : 0)
     }
+  }
+}
+
+// MARK: - Custom Floating Window
+
+extension MainWindowController: CustomFloatingWindowControllerDelegate {
+
+  func toggleCustomFloatingWindow() {
+    switch customFloatingWindowStatus {
+    case .notInCustomFloatingWindow:
+      enterCustomFloatingWindow()
+    case .inCustomFloatingWindow:
+      exitCustomFloatingWindow()
+    case .intermediate:
+      return
+    }
+  }
+
+  func enterCustomFloatingWindow() {
+    guard customFloatingWindowStatus == .notInCustomFloatingWindow,
+          let window = window,
+          !fsState.isFullscreen,
+          player.info.state.active else { return }
+
+    if pipStatus == .inPIP {
+      exitPIP()
+    }
+
+    customFloatingWindowStatus = .intermediate
+    showUI()
+    detachVideoViewFromWindow()
+
+    let controller = CustomFloatingWindowController(
+      videoView: videoView,
+      title: window.title,
+      initialFrame: initialCustomFloatingWindowFrame()
+    )
+    controller.delegate = self
+    customFloatingWindowController = controller
+
+    controller.showWindow(self)
+    controller.window?.makeKeyAndOrderFront(self)
+    window.orderOut(self)
+    isWindowHiddenDueToCustomFloatingWindow = true
+
+    customFloatingWindowStatus = .inCustomFloatingWindow
+  }
+
+  func exitCustomFloatingWindow() {
+    exitCustomFloatingWindow(restoreMainWindow: true)
+  }
+
+  private func exitCustomFloatingWindow(restoreMainWindow: Bool) {
+    guard customFloatingWindowStatus == .inCustomFloatingWindow else { return }
+    customFloatingWindowStatus = .intermediate
+    customFloatingWindowController?.delegate = nil
+    customFloatingWindowController?.close()
+    customFloatingWindowController = nil
+    finishExitingCustomFloatingWindow(restoreMainWindow: restoreMainWindow)
+  }
+
+  func customFloatingWindowWillClose(_ controller: CustomFloatingWindowController) {
+    guard customFloatingWindowController === controller,
+          customFloatingWindowStatus == .inCustomFloatingWindow else { return }
+    customFloatingWindowStatus = .intermediate
+    customFloatingWindowController = nil
+    finishExitingCustomFloatingWindow(restoreMainWindow: true)
+  }
+
+  private func finishExitingCustomFloatingWindow(restoreMainWindow: Bool) {
+    addVideoViewToWindow()
+    if restoreMainWindow && isWindowHiddenDueToCustomFloatingWindow {
+      window?.makeKeyAndOrderFront(self)
+    }
+    if isWindowHiddenDueToCustomFloatingWindow {
+      isWindowHiddenDueToCustomFloatingWindow = false
+    }
+    customFloatingWindowStatus = .notInCustomFloatingWindow
+    forceDraw("exited custom floating window")
+  }
+
+  private func initialCustomFloatingWindowFrame() -> NSRect {
+    let screenFrame = window?.screen?.visibleFrame ?? NSScreen.main?.visibleFrame ?? .zero
+    let (videoWidth, videoHeight) = player.videoSizeForDisplay
+    let aspectSize = NSSize(width: videoWidth, height: videoHeight)
+    let maxSize = NSSize(width: min(screenFrame.width * 0.36, 520), height: min(screenFrame.height * 0.36, 320))
+    var size = aspectSize.shrink(toSize: maxSize)
+    size = size.satisfyMinSizeWithSameAspectRatio(NSSize(width: 240, height: 135))
+    let origin = NSPoint(
+      x: screenFrame.maxX - size.width - 24,
+      y: screenFrame.minY + 24
+    )
+    return NSRect(origin: origin, size: size)
   }
 }

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -3231,7 +3231,8 @@ extension MainWindowController: CustomFloatingWindowControllerDelegate {
     let controller = CustomFloatingWindowController(
       videoView: videoView,
       title: window.title,
-      initialFrame: initialCustomFloatingWindowFrame()
+      initialFrame: initialCustomFloatingWindowFrame(),
+      nextResponder: menuActionHandler
     )
     controller.delegate = self
     customFloatingWindowController = controller

--- a/iina/MainWindowMenuActions.swift
+++ b/iina/MainWindowMenuActions.swift
@@ -88,6 +88,10 @@ extension MainWindowController {
     }
   }
 
+  @objc func menuToggleCustomFloatingWindow(_ sender: NSMenuItem) {
+    toggleCustomFloatingWindow()
+  }
+
   @objc func menuToggleFullScreen(_ sender: NSMenuItem) {
     toggleWindowFullScreen()
   }

--- a/iina/MainWindowMenuActions.swift
+++ b/iina/MainWindowMenuActions.swift
@@ -77,6 +77,7 @@ extension MainWindowController {
   }
 
   @objc func menuTogglePIP(_ sender: NSMenuItem) {
+    guard customFloatingWindowStatus == .notInCustomFloatingWindow else { return }
     switch pipStatus {
     case .notInPIP:
       enterPIP()

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -292,7 +292,8 @@ class MenuController: NSObject, NSMenuDelegate {
     // -- screen
     fullScreen.action = #selector(MainWindowController.menuToggleFullScreen(_:))
     pictureInPicture.action = #selector(MainWindowController.menuTogglePIP(_:))
-    let floatingItem = NSMenuItem(title: Constants.String.customFloatingWindow, action: #selector(MainMenuActionHandler.menuToggleCustomFloatingWindow(_:)), keyEquivalent: "")
+    let floatingItem = NSMenuItem(title: Constants.String.customFloatingWindow, action: #selector(menuToggleCustomFloatingWindow(_:)), keyEquivalent: "")
+    floatingItem.target = self
     floatingItem.tag = -2
     let pictureInPictureIndex = videoMenu.index(of: pictureInPicture)
     videoMenu.insertItem(floatingItem, at: pictureInPictureIndex >= 0 ? pictureInPictureIndex + 1 : videoMenu.numberOfItems)
@@ -529,6 +530,7 @@ class MenuController: NSObject, NSMenuDelegate {
     let isInCustom = player.mainWindow.customFloatingWindowStatus == .inCustomFloatingWindow
     customFloatingWindowMenuItem?.title = Constants.String.customFloatingWindow
     customFloatingWindowMenuItem?.state = isInCustom ? .on : .off
+    customFloatingWindowMenuItem?.isEnabled = player.info.state.active || isInCustom
     miniPlayer.title = player.isInMiniPlayer ? Constants.String.exitMiniPlayer : Constants.String.miniPlayer
     delogo.state = isDelogo ? .on : .off
   }
@@ -869,6 +871,10 @@ class MenuController: NSObject, NSMenuDelegate {
       menuItem.representedObject = filter.filterString
       menu.addItem(menuItem)
     }
+  }
+
+  @objc func menuToggleCustomFloatingWindow(_ sender: NSMenuItem) {
+    PlayerCore.active.mainWindow.toggleCustomFloatingWindow()
   }
 
   func updateKeyEquivalentsFrom(_ keyBindings: [KeyMapping]) {

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -292,7 +292,7 @@ class MenuController: NSObject, NSMenuDelegate {
     // -- screen
     fullScreen.action = #selector(MainWindowController.menuToggleFullScreen(_:))
     pictureInPicture.action = #selector(MainWindowController.menuTogglePIP(_:))
-    let floatingItem = NSMenuItem(title: Constants.String.customFloatingWindow, action: #selector(MainWindowController.menuToggleCustomFloatingWindow(_:)), keyEquivalent: "")
+    let floatingItem = NSMenuItem(title: Constants.String.customFloatingWindow, action: #selector(MainMenuActionHandler.menuToggleCustomFloatingWindow(_:)), keyEquivalent: "")
     floatingItem.tag = -2
     let pictureInPictureIndex = videoMenu.index(of: pictureInPicture)
     videoMenu.insertItem(floatingItem, at: pictureInPictureIndex >= 0 ? pictureInPictureIndex + 1 : videoMenu.numberOfItems)
@@ -527,7 +527,8 @@ class MenuController: NSObject, NSMenuDelegate {
     fullScreen.title = isInFullScreen ? Constants.String.exitFullScreen : Constants.String.fullScreen
     pictureInPicture?.title = isInPIP ? Constants.String.exitPIP : Constants.String.pip
     let isInCustom = player.mainWindow.customFloatingWindowStatus == .inCustomFloatingWindow
-    customFloatingWindowMenuItem?.title = isInCustom ? Constants.String.exitCustomFloatingWindow : Constants.String.customFloatingWindow
+    customFloatingWindowMenuItem?.title = Constants.String.customFloatingWindow
+    customFloatingWindowMenuItem?.state = isInCustom ? .on : .off
     miniPlayer.title = player.isInMiniPlayer ? Constants.String.exitMiniPlayer : Constants.String.miniPlayer
     delogo.state = isDelogo ? .on : .off
   }

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -294,7 +294,8 @@ class MenuController: NSObject, NSMenuDelegate {
     pictureInPicture.action = #selector(MainWindowController.menuTogglePIP(_:))
     let floatingItem = NSMenuItem(title: Constants.String.customFloatingWindow, action: #selector(MainWindowController.menuToggleCustomFloatingWindow(_:)), keyEquivalent: "")
     floatingItem.tag = -2
-    videoMenu.insertItem(floatingItem, at: videoMenu.index(of: pictureInPicture) + 1)
+    let pictureInPictureIndex = videoMenu.index(of: pictureInPicture)
+    videoMenu.insertItem(floatingItem, at: pictureInPictureIndex >= 0 ? pictureInPictureIndex + 1 : videoMenu.numberOfItems)
     customFloatingWindowMenuItem = floatingItem
     alwaysOnTop.action = #selector(MainWindowController.menuAlwaysOnTop(_:))
     lockAspectRatio.action = #selector(MainWindowController.menuLockAspectRatio(_:))
@@ -870,7 +871,7 @@ class MenuController: NSObject, NSMenuDelegate {
   }
 
   func updateKeyEquivalentsFrom(_ keyBindings: [KeyMapping]) {
-    let settings: [(NSMenuItem, Bool, [String], Bool, ClosedRange<Double>?, String?)] = [
+    var settings: [(NSMenuItem, Bool, [String], Bool, ClosedRange<Double>?, String?)] = [
       (showCurrentFileInFinder, true, [IINACommand.showCurrentFileInFinder.rawValue], false, nil, nil),
       (deleteCurrentFile, true, [IINACommand.deleteCurrentFile.rawValue], false, nil, nil),
       (savePlaylist, true, [IINACommand.saveCurrentPlaylist.rawValue], false, nil, nil),
@@ -888,7 +889,6 @@ class MenuController: NSObject, NSMenuDelegate {
       (fitToScreen, true, [IINACommand.fitToScreen.rawValue], false, nil, nil),
       (miniPlayer, true, [IINACommand.toggleMusicMode.rawValue], false, nil, nil),
       (pictureInPicture, true, [IINACommand.togglePIP.rawValue], false, nil, nil),
-      (customFloatingWindowMenuItem!, true, [IINACommand.toggleCustomFloatingWindow.rawValue], false, nil, nil),
       (cycleVideoTracks, false, ["cycle", "video"], false, nil, nil),
       (cycleAudioTracks, false, ["cycle", "audio"], false, nil, nil),
       (cycleSubtitles, false, ["cycle", "sub"], false, nil, nil),
@@ -938,6 +938,9 @@ class MenuController: NSObject, NSMenuDelegate {
       (alwaysOnTop, false, ["cycle", "ontop"], false, nil, nil),
       (fullScreen, false, ["cycle", "fullscreen"], false, nil, nil),
     ]
+    if let customFloatingWindowMenuItem = customFloatingWindowMenuItem {
+      settings.append((customFloatingWindowMenuItem, true, [IINACommand.toggleCustomFloatingWindow.rawValue], false, nil, nil))
+    }
 
     var otherActionsMenuItems: [NSMenuItem] = []
 

--- a/iina/MenuController.swift
+++ b/iina/MenuController.swift
@@ -138,6 +138,7 @@ class MenuController: NSObject, NSMenuDelegate {
   @IBOutlet weak var fitToScreen: NSMenuItem!
   @IBOutlet weak var fullScreen: NSMenuItem!
   @IBOutlet weak var pictureInPicture: NSMenuItem!
+  var customFloatingWindowMenuItem: NSMenuItem?
   @IBOutlet weak var alwaysOnTop: NSMenuItem!
   @IBOutlet weak var lockAspectRatio: NSMenuItem!
   @IBOutlet weak var aspectMenu: NSMenu!
@@ -291,6 +292,10 @@ class MenuController: NSObject, NSMenuDelegate {
     // -- screen
     fullScreen.action = #selector(MainWindowController.menuToggleFullScreen(_:))
     pictureInPicture.action = #selector(MainWindowController.menuTogglePIP(_:))
+    let floatingItem = NSMenuItem(title: Constants.String.customFloatingWindow, action: #selector(MainWindowController.menuToggleCustomFloatingWindow(_:)), keyEquivalent: "")
+    floatingItem.tag = -2
+    videoMenu.insertItem(floatingItem, at: videoMenu.index(of: pictureInPicture) + 1)
+    customFloatingWindowMenuItem = floatingItem
     alwaysOnTop.action = #selector(MainWindowController.menuAlwaysOnTop(_:))
     lockAspectRatio.action = #selector(MainWindowController.menuLockAspectRatio(_:))
 
@@ -520,6 +525,8 @@ class MenuController: NSObject, NSMenuDelegate {
     deinterlace.state = player.info.deinterlace ? .on : .off
     fullScreen.title = isInFullScreen ? Constants.String.exitFullScreen : Constants.String.fullScreen
     pictureInPicture?.title = isInPIP ? Constants.String.exitPIP : Constants.String.pip
+    let isInCustom = player.mainWindow.customFloatingWindowStatus == .inCustomFloatingWindow
+    customFloatingWindowMenuItem?.title = isInCustom ? Constants.String.exitCustomFloatingWindow : Constants.String.customFloatingWindow
     miniPlayer.title = player.isInMiniPlayer ? Constants.String.exitMiniPlayer : Constants.String.miniPlayer
     delogo.state = isDelogo ? .on : .off
   }
@@ -881,6 +888,7 @@ class MenuController: NSObject, NSMenuDelegate {
       (fitToScreen, true, [IINACommand.fitToScreen.rawValue], false, nil, nil),
       (miniPlayer, true, [IINACommand.toggleMusicMode.rawValue], false, nil, nil),
       (pictureInPicture, true, [IINACommand.togglePIP.rawValue], false, nil, nil),
+      (customFloatingWindowMenuItem!, true, [IINACommand.toggleCustomFloatingWindow.rawValue], false, nil, nil),
       (cycleVideoTracks, false, ["cycle", "video"], false, nil, nil),
       (cycleAudioTracks, false, ["cycle", "audio"], false, nil, nil),
       (cycleSubtitles, false, ["cycle", "sub"], false, nil, nil),

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -591,13 +591,7 @@ class PlayerCore: NSObject {
         inputConfPath = currentConfigFilePath
       }
     }
-    var bindings = KeyMapping.parseInputConf(at: inputConfPath) ?? KeyMapping.parseInputConf(at: iinaDefaultConfPath)!
-    let customBinding = KeyMapping(rawKey: "Ctrl+Alt+Meta+p", rawAction: "toggle-custom-floating-window", isIINACommand: true)
-    let key = customBinding.normalizedMpvKey
-    if !bindings.contains(where: { $0.normalizedMpvKey == key }) {
-      bindings.append(customBinding)
-    }
-    setKeyBindings(bindings)
+    setKeyBindings(KeyMapping.parseInputConf(at: inputConfPath) ?? KeyMapping.parseInputConf(at: iinaDefaultConfPath)!)
   }
 
   static func setKeyBindings(_ keyMappings: [KeyMapping]) {

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -591,7 +591,13 @@ class PlayerCore: NSObject {
         inputConfPath = currentConfigFilePath
       }
     }
-    setKeyBindings(KeyMapping.parseInputConf(at: inputConfPath) ?? KeyMapping.parseInputConf(at: iinaDefaultConfPath)!)
+    var bindings = KeyMapping.parseInputConf(at: inputConfPath) ?? KeyMapping.parseInputConf(at: iinaDefaultConfPath)!
+    let customBinding = KeyMapping(rawKey: "Ctrl+Alt+Meta+p", rawAction: "toggle-custom-floating-window", isIINACommand: true)
+    let key = customBinding.normalizedMpvKey
+    if !bindings.contains(where: { $0.normalizedMpvKey == key }) {
+      bindings.append(customBinding)
+    }
+    setKeyBindings(bindings)
   }
 
   static func setKeyBindings(_ keyMappings: [KeyMapping]) {

--- a/iina/config/iina-default-input.conf
+++ b/iina/config/iina-default-input.conf
@@ -48,7 +48,7 @@ Meta+2 set window-scale 2
 #@iina Meta+= bigger-window
 
 #@iina Ctrl+Meta+p toggle-pip
-#@iina Ctrl+Alt+Meta+p toggle-custom-floating-window
+@iina Ctrl+Alt+Meta+p toggle-custom-floating-window
 #@iina Shift+Meta+r show-current-file-in-finder
 Ctrl+Meta+f cycle fullscreen
 Ctrl+Meta+t cycle ontop

--- a/iina/config/iina-default-input.conf
+++ b/iina/config/iina-default-input.conf
@@ -48,6 +48,7 @@ Meta+2 set window-scale 2
 #@iina Meta+= bigger-window
 
 #@iina Ctrl+Meta+p toggle-pip
+#@iina Ctrl+Alt+Meta+p toggle-custom-floating-window
 #@iina Shift+Meta+r show-current-file-in-finder
 Ctrl+Meta+f cycle fullscreen
 Ctrl+Meta+t cycle ontop

--- a/iina/config/iina-default-input.conf
+++ b/iina/config/iina-default-input.conf
@@ -48,7 +48,7 @@ Meta+2 set window-scale 2
 #@iina Meta+= bigger-window
 
 #@iina Ctrl+Meta+p toggle-pip
-@iina Ctrl+Alt+Meta+p toggle-custom-floating-window
+#@iina Ctrl+Alt+Meta+p toggle-custom-floating-window
 #@iina Shift+Meta+r show-current-file-in-finder
 Ctrl+Meta+f cycle fullscreen
 Ctrl+Meta+t cycle ontop

--- a/iina/config/input.conf
+++ b/iina/config/input.conf
@@ -32,7 +32,7 @@
 #@iina Shift+Meta+c chapter-panel
 #@iina Shift+Meta+m toggle-music-mode
 #@iina Ctrl+Meta+p toggle-pip
-@iina Ctrl+Alt+Meta+p toggle-custom-floating-window
+#@iina Ctrl+Alt+Meta+p toggle-custom-floating-window
 #@iina Shift+Meta+r show-current-file-in-finder
 
 MBTN_LEFT     ignore              # don't do anything

--- a/iina/config/input.conf
+++ b/iina/config/input.conf
@@ -32,6 +32,7 @@
 #@iina Shift+Meta+c chapter-panel
 #@iina Shift+Meta+m toggle-music-mode
 #@iina Ctrl+Meta+p toggle-pip
+#@iina Ctrl+Alt+Meta+p toggle-custom-floating-window
 #@iina Shift+Meta+r show-current-file-in-finder
 
 MBTN_LEFT     ignore              # don't do anything

--- a/iina/config/input.conf
+++ b/iina/config/input.conf
@@ -32,7 +32,7 @@
 #@iina Shift+Meta+c chapter-panel
 #@iina Shift+Meta+m toggle-music-mode
 #@iina Ctrl+Meta+p toggle-pip
-#@iina Ctrl+Alt+Meta+p toggle-custom-floating-window
+@iina Ctrl+Alt+Meta+p toggle-custom-floating-window
 #@iina Shift+Meta+r show-current-file-in-finder
 
 MBTN_LEFT     ignore              # don't do anything

--- a/iina/en.lproj/KeyBinding.strings
+++ b/iina/en.lproj/KeyBinding.strings
@@ -38,6 +38,7 @@
 "iina.mirror" = "Mirror";
 
 "iina.toggle-pip" = "Toggle Picture-in-Picture";
+"iina.toggle-custom-floating-window" = "Toggle Floating Video Window";
 "iina.toggle-music-mode" = "Toggle Music Mode";
 "iina.open-file" = "Open file";
 "iina.open-url" = "Open URL";

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -199,7 +199,8 @@
 "menu.pip" = "Enter Picture-in-Picture";
 "menu.exit_pip" = "Exit Picture-in-Picture";
 "menu.custom_floating_window" = "Toggle Floating Video Window";
-"menu.exit_custom_floating_window" = "Exit Floating Video Window";"menu.mini_player" = "Enter Music Mode";
+"menu.exit_custom_floating_window" = "Exit Floating Video Window";
+"menu.mini_player" = "Enter Music Mode";
 "menu.exit_mini_player" = "Exit Music Mode";
 "menu.pause" = "Pause";
 "menu.resume" = "Resume";

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -198,7 +198,8 @@
 "menu.exit_fullscreen" = "Exit Full Screen";
 "menu.pip" = "Enter Picture-in-Picture";
 "menu.exit_pip" = "Exit Picture-in-Picture";
-"menu.mini_player" = "Enter Music Mode";
+"menu.custom_floating_window" = "Toggle Floating Video Window";
+"menu.exit_custom_floating_window" = "Exit Floating Video Window";"menu.mini_player" = "Enter Music Mode";
 "menu.exit_mini_player" = "Exit Music Mode";
 "menu.pause" = "Pause";
 "menu.resume" = "Resume";


### PR DESCRIPTION
## Summary
- add a custom floating video window mode that moves the existing video view into an IINA-managed floating NSWindow
- expose the mode through a new `toggle-custom-floating-window` IINA command and key binding entry
- keep the existing system Picture-in-Picture path unchanged

## Notes
This is intended as a first-pass alternative to macOS system PiP for users who want a freely positionable floating video window. The first version uses a standard floating window shell; a custom borderless/hover-controls UI can be layered on in follow-up work.

## Validation
- `git diff --check`
- `plutil -lint iina.xcodeproj/project.pbxproj`

`xcodebuild` was not run locally because the current machine only has Command Line Tools selected, not a full Xcode installation (`xcodebuild requires Xcode`).