### PR TITLE
ux: only show sub loading error when manually added

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1433,7 +1433,7 @@ class PlayerCore: NSObject {
     mpv.setFlag(MPVOption.Subtitles.secondarySubVisibility, newState)
   }
 
-  func loadExternalSubFile(_ url: URL, delay: Bool = false) {
+  func loadExternalSubFile(_ url: URL, delay: Bool = false, suppressError: Bool = false) {
     var track: MPVTrack?
     info.$subTracks.withLock { track = $0.first(where: { $0.externalFilename == url.path }) }
     if let track = track {
@@ -1444,6 +1444,8 @@ class PlayerCore: NSObject {
     mpv.command(.subAdd, args: [url.path], checkError: false, level: .verbose) { code in
       if code < 0 {
         self.log("Unsupported sub: \(url.path)", level: .error)
+        // only show alert when the subtitle is added manually
+        guard !suppressError else { return }
         // if another modal panel is shown, popping up an alert now will cause some infinite loop.
         if delay {
           DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 0.5) {
@@ -2092,7 +2094,7 @@ class PlayerCore: NSObject {
             guard !loadedSubs.contains(sub) else { continue }
             loadedSubs.insert(sub)
             try checkTicket(currentTicket)
-            loadExternalSubFile(sub)
+            loadExternalSubFile(sub, suppressError: true)
           }
           // set sub to the first one
           try checkTicket(currentTicket)


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #6145.

---

**Description:**
Don't show the alert when the subtitle file failed to load unless the subtitle file is added manually.

Steps to reproduce:
- Have a .lrc file (mpv cannot load)
- Make a video file the same filename as the .lrc file
- Open the video file, IINA will try to load the .lrc file since they have same filename
- The alert will show up

I was also pretty annoyed by this behavior. I think it's acceptable to silently ignore the subtitles that cannot be loaded by mpv if its loaded automatically. The alert is still preserved if the sub is added manually.