### PR TITLE
feat: automatically show subtitles for audio files

### DIFF
--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -1182,7 +1182,7 @@ struct Preference {
     .enableLogging: false,
     .logLevel: Logger.Level.debug.rawValue,
     .displayKeyBindingRawValues: false,
-    .userOptions: [[String]](),
+    .userOptions: [["sub-visibility", "yes"], ["subs-with-matching-audio", "yes"]],
     .useUserDefinedConfDir: false,
     .userDefinedConfDir: "~/.config/mpv/",
     .iinaEnablePluginSystem: false,


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)

---

**Description:**
This is a small improvement to PR #6030. It adds `sub-visibility=yes` and `subs-with-matching-audio=yes` to the default `userOptions` in `Preference.swift`. This ensures that subtitles are automatically loaded and visible by default when playing audio-only files, so users no longer have to manually toggle them on.