### PR TITLE
Fix plugin update checks failing

### DIFF
--- a/iina/JavascriptPlugin.swift
+++ b/iina/JavascriptPlugin.swift
@@ -521,7 +521,8 @@ class JavascriptPlugin: NSObject {
       if let error = lastError {
         throw error
       } else {
-        throw PluginError.cannotDownload("Info.json not found on main or master", "")
+        // Both branches returned 404, so we assume no update is available.
+        return nil
       }
     }
 

--- a/iina/JavascriptPlugin.swift
+++ b/iina/JavascriptPlugin.swift
@@ -489,25 +489,51 @@ class JavascriptPlugin: NSObject {
   }
 
   func checkNewVersion() async throws -> String? {
-    try await withCheckedThrowingContinuation { continuation in
-      guard let ghVersion = githubVersion, let ghRepo = githubRepo else {
-        continuation.resume(returning: nil)
-        return
-      }
-      Just.get("https://raw.githubusercontent.com/\(ghRepo)/master/Info.json", asyncCompletionHandler:  { result in
-        if result.ok,
-           let json = result.json as? [String: Any],
-           let newGHVersion = json["ghVersion"] as? Int,
-           let newVersion = json["version"] as? String {
-          if newGHVersion > ghVersion {
-            continuation.resume(returning: newVersion)
-          } else {
-            continuation.resume(returning: nil)
-          }
-        } else {
-          continuation.resume(throwing: PluginError.cannotDownload(result.description, result.text ?? ""))
+    guard let ghVersion = githubVersion, let ghRepo = githubRepo else {
+      return nil
+    }
+
+    var json: [String: Any]? = nil
+    var lastError: Error? = nil
+
+    for branch in ["main", "master"] {
+      do {
+        json = try await withCheckedThrowingContinuation { continuation in
+          Just.get("https://raw.githubusercontent.com/\(ghRepo)/\(branch)/Info.json", asyncCompletionHandler: { result in
+            if result.ok, let resultJson = result.json as? [String: Any] {
+              continuation.resume(returning: resultJson)
+            } else if result.statusCode == 404 {
+              continuation.resume(returning: nil)
+            } else {
+              continuation.resume(throwing: PluginError.cannotDownload(result.description, result.text ?? ""))
+            }
+          })
         }
-      })
+        if json != nil {
+          break
+        }
+      } catch {
+        lastError = error
+      }
+    }
+
+    guard let json = json else {
+      if let error = lastError {
+        throw error
+      } else {
+        throw PluginError.cannotDownload("Info.json not found on main or master", "")
+      }
+    }
+
+    guard let newGHVersion = json["ghVersion"] as? Int,
+          let newVersion = json["version"] as? String else {
+      throw PluginError.cannotDownload("Invalid Info.json format", "")
+    }
+
+    if newGHVersion > ghVersion {
+      return newVersion
+    } else {
+      return nil
     }
   }
 

--- a/iina/SettingsPagePlugin.swift
+++ b/iina/SettingsPagePlugin.swift
@@ -262,16 +262,29 @@ fileprivate class PluginListView: SettingsAccessory.Base {
         }
 
         var dict: [String: Bool] = [:]
+        var hasError = false
         for plugin in JavascriptPlugin.plugins {
-          let version = try await plugin.checkNewVersion()
-          dict[plugin.identifier] = version != nil
+          do {
+            let version = try await plugin.checkNewVersion()
+            dict[plugin.identifier] = version != nil
+          } catch let error {
+            Logger.log("Error checking update for \(plugin.identifier): \(error)", level: .error)
+            hasError = true
+            dict[plugin.identifier] = false
+          }
         }
         PluginListView.pluginHasUpdate = dict
 
         let numOfUpdates = UInt(dict.values.filter{ $0 }.count)
         Logger.log("Finished checking for plugin updates, \(numOfUpdates) updates found")
 
-        updateView.update(.foundUpdate(numOfUpdates))
+        if numOfUpdates > 0 {
+          updateView.update(.foundUpdate(numOfUpdates))
+        } else if hasError {
+          updateView.update(.error)
+        } else {
+          updateView.update(.foundUpdate(0))
+        }
         self.tableView.reloadData()
       } catch let error {
         Logger.log("Error checking for plugin updates: \(error)", level: .error)


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] This implements/fixes issue #.

---

**Description:**
Fixes the issue where the Plugins settings page displays "Error checking for updates" globally due to individual plugins lacking an `Info.json` file in their `main` or `master` branch.
- Modifies `JavascriptPlugin.swift` to check both `main` and `master` branches for `Info.json` to handle plugins using `main` as their default branch.
- Modifies `checkNewVersion` to safely return `nil` instead of throwing an error when `Info.json` is not found on either branch (treating a missing `Info.json` as having no updates).
- Updates `SettingsPagePlugin.swift` to catch and isolate individual plugin update check failures, preventing a single failure from aborting the entire check process for all plugins.
