### PR TITLE
fix: make playlist shuffle reversible (#718)

### DIFF
--- a/iina/PlaybackInfo.swift
+++ b/iina/PlaybackInfo.swift
@@ -235,6 +235,14 @@ class PlaybackInfo {
   ///     To avoid the need to lock multiple locks the cache properties are always accessed while holding the playlist lock. The cache
   ///     properties are private to force all access to be through class methods that properly coordinate thread access.
   @Atomic var playlist: [MPVPlaylistItem] = []
+
+  /// Whether the playlist is currently shuffled via the shuffle button.
+  ///
+  /// Tracks whether a `playlist-shuffle` is in effect so it can be reverted with
+  /// `playlist-unshuffle`. Reset to `false` whenever the playlist is otherwise modified (a new
+  /// media is opened, items added/removed/moved), because an unshuffle is no longer valid then.
+  /// See `PlayerCore.toggleShuffle()` and issue #718.
+  var isShuffled = false
   private var cachedVideoDurationAndProgress: [String: (duration: Double?, progress: Double?)] = [:]
   private var cachedMetadata: [String: (title: String?, album: String?, artist: String?)] = [:]
 

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -537,6 +537,7 @@ class PlayerCore: NSObject {
     info.audioTracks = []
     info.chapters = []
     info.playlist = []
+    info.isShuffled = false
     info.subTracks = []
     info.thumbnails = []
     info.thumbnailsReady = false
@@ -1268,7 +1269,17 @@ class PlayerCore: NSObject {
   }
 
   func toggleShuffle() {
-    mpv.command(.playlistShuffle)
+    // Make shuffling reversible (issue #718). mpv's `playlist-unshuffle` restores the
+    // order that existed before the matching `playlist-shuffle`, so track the state and
+    // toggle between the two commands. `info.isShuffled` is reset to `false` whenever the
+    // playlist is otherwise modified, since an unshuffle would no longer be valid then.
+    if info.isShuffled {
+      mpv.command(.playlistUnshuffle)
+      info.isShuffled = false
+    } else {
+      mpv.command(.playlistShuffle)
+      info.isShuffled = true
+    }
     postNotification(.iinaPlaylistChanged)
   }
 
@@ -1484,6 +1495,7 @@ class PlayerCore: NSObject {
 
   func appendToPlaylist(_ path: String, silent: Bool = false) {
     mpv.playlistAppend(path)
+    info.isShuffled = false
     if !silent {
       postNotification(.iinaPlaylistChanged)
     }
@@ -1491,12 +1503,14 @@ class PlayerCore: NSObject {
 
   func playlistMove(_ from: Int, to: Int) {
     mpv.playlistMove(from, to: to)
+    info.isShuffled = false
     postNotification(.iinaPlaylistChanged)
   }
 
   func playlistReorder(newPlaylist: [MPVPlaylistItem]) {
     guard Set(info.playlist) == Set(newPlaylist) else { return }
     if info.playlist == newPlaylist { return }
+    info.isShuffled = false
     mpv.command(.playlistClear)
     guard let currentPlaying = newPlaylist.firstIndex(where: { $0.isPlaying } ) else {
       for item in newPlaylist {
@@ -1517,6 +1531,7 @@ class PlayerCore: NSObject {
 
   func addToPlaylist(paths: [String], at index: Int = -1) {
     getPlaylist()
+    info.isShuffled = false
     for path in paths {
       mpv.playlistAppend(path)
     }
@@ -1531,6 +1546,7 @@ class PlayerCore: NSObject {
 
   func playlistRemove(_ index: Int) {
     mpv.playlistRemove(index)
+    info.isShuffled = false
     postNotification(.iinaPlaylistChanged)
   }
 
@@ -1541,11 +1557,13 @@ class PlayerCore: NSObject {
       mpv.playlistRemove(i - count)
       count += 1
     }
+    info.isShuffled = false
     postNotification(.iinaPlaylistChanged)
   }
 
   func clearPlaylist() {
     mpv.command(.playlistClear)
+    info.isShuffled = false
     postNotification(.iinaPlaylistChanged)
   }
 
@@ -2019,6 +2037,7 @@ class PlayerCore: NSObject {
       DispatchQueue.main.async { [self] in
         log("Running on_before_start_file hook: shuffling playlist")
         mpv.command(.playlistShuffle)
+        info.isShuffled = true
         /// will cancel this file load sequence (so `fileLoaded` will not be called), then will start loading item at index 0
         mpv.command(.playlistPlayIndex, args: ["0"])
         next()

--- a/iina/SidebarPlaylistPane.swift
+++ b/iina/SidebarPlaylistPane.swift
@@ -70,6 +70,7 @@ class SidebarPlaylistPane: NSView, SidebarPane {
     loopBtn.setButtonType(.momentaryPushIn)
     updateLoopBtnStatus()
     shuffleBtn = makeButton("shuffle", "shuffle", #selector(shuffleBtnAction))
+    updateShuffleBtnStatus()
     sortBtn = makeButton("sort", "arrow.up.arrow.down", #selector(sortBtnAction))
     addBtn = makeButton("add", "plus", #selector(addToPlaylistBtnAction))
     removeBtn = makeButton("remove", "minus", #selector(removeBtnAction))
@@ -151,6 +152,7 @@ class SidebarPlaylistPane: NSView, SidebarPane {
     player.observe(.iinaPlaylistChanged) { [unowned self] _ in
       playlistTotalLengthIsReady = false
       updateTable()
+      updateShuffleBtnStatus()
     }
 
     player.observe(.iinaLoopStatusChanged) { [unowned self] _ in
@@ -163,6 +165,7 @@ class SidebarPlaylistPane: NSView, SidebarPane {
   private func update() {
     updateTable()
     updateLoopBtnStatus()
+    updateShuffleBtnStatus()
   }
 
   private func updateTable() {
@@ -179,6 +182,12 @@ class SidebarPlaylistPane: NSView, SidebarPane {
     case .file: .sf("custom.repeat.1.rectangle.fill")
     default:    .sf("custom.repeat.rectangle.fill")
     }
+  }
+
+  /// Tint the shuffle button while a shuffle is in effect, so it reads as a toggle (issue #718).
+  func updateShuffleBtnStatus() {
+    guard player.info.state.active else { return }
+    shuffleBtn.contentTintColor = player.info.isShuffled ? .controlAccentColor : nil
   }
 
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements/fixes issue #718.

---

**Description:**

Right now the shuffle button in the playlist just calls `playlist-shuffle`
every time it's pressed. Once you click it there's no way back to the
original order short of reloading everything, which is what #718 has been
asking about for a while.

This makes the button a toggle:

- First press shuffles the playlist (`playlist-shuffle`).
- Second press restores the previous order (`playlist-unshuffle`).

mpv already gives us `playlist-unshuffle`, which puts the list back exactly
the way it was before the last shuffle, so I lean on that instead of trying
to snapshot and rebuild the order by hand. To make the state visible, the
button now tints while a shuffle is active, the same way the loop button
next to it reflects its state.

A few details:

- The shuffled state is a single `isShuffled` flag on `PlaybackInfo`.
- It's reset to `false` whenever the playlist changes for another reason
  (new media opened, items added / removed / moved), since an unshuffle
  wouldn't match the list after that. The next press then just does a fresh
  shuffle.
- Advancing to the next track during normal playback doesn't touch the flag,
  so a shuffled playlist stays shuffled (and the button stays lit) as it
  plays through.
- The `--shuffle` command-line path also sets the flag, so a playlist that
  was shuffled at launch shows the button as active.

Tested by opening a folder and toggling shuffle on/off (order restores
correctly), and by editing the playlist after shuffling to confirm the
button clears and the next press re-shuffles rather than doing a stale
unshuffle.
