### PR TITLE
fix(sidebar): prevent inner scroll views from stealing vertical scroll focus

### DIFF
--- a/iina/SidebarTrackSelector.swift
+++ b/iina/SidebarTrackSelector.swift
@@ -33,7 +33,6 @@ class TrackSelector: NSScrollView, NSTableViewDelegate, NSTableViewDataSource {
     wantsLayer = true
     layer?.cornerRadius = 8
     size(height: 98)
-    verticalScrollElasticity = .automatic
 
     player.observe(.iinaTracklistChanged) { [weak self] _ in
       self?.tableView.reloadData()
@@ -45,9 +44,13 @@ class TrackSelector: NSScrollView, NSTableViewDelegate, NSTableViewDataSource {
     }
   }
 
-  private var isTrackingCurrentGesture = false
-  private var isTouchActive = false
-  private var lastTouchEndedTimestamp: TimeInterval = 0
+  private enum ScrollGestureState {
+    case idle
+    case trackingTouch
+    case trackingMomentumCandidate(touchEndedTimestamp: TimeInterval)
+  }
+
+  private var scrollGestureState = ScrollGestureState.idle
 
   override func scrollWheel(with event: NSEvent) {
     // If the content is small enough to fit in the view, it doesn't need to scroll.
@@ -62,25 +65,31 @@ class TrackSelector: NSScrollView, NSTableViewDelegate, NSTableViewDataSource {
     // are not trapped when this view scrolls under the cursor mid-gesture.
     if event.hasPreciseScrollingDeltas && (event.phase != [] || event.momentumPhase != []) {
       if event.phase == .mayBegin || event.phase == .began {
-        isTrackingCurrentGesture = true
-        isTouchActive = true
+        scrollGestureState = .trackingTouch
       } else if event.phase == .changed {
-        if !isTouchActive {
-          isTrackingCurrentGesture = false
+        if case .trackingTouch = scrollGestureState {
+          // Continue handling the gesture that began over this view.
+        } else {
+          scrollGestureState = .idle
         }
       } else if event.phase == .ended || event.phase == .cancelled {
-        isTouchActive = false
-        lastTouchEndedTimestamp = event.timestamp
+        if case .idle = scrollGestureState {
+          // Keep forwarding gestures that began outside this view.
+        } else {
+          scrollGestureState = .trackingMomentumCandidate(touchEndedTimestamp: event.timestamp)
+        }
       } else if event.momentumPhase == .began {
-        if !isTrackingCurrentGesture || (event.timestamp - lastTouchEndedTimestamp) >= 0.1 {
-          isTrackingCurrentGesture = false
+        if case let .trackingMomentumCandidate(touchEndedTimestamp) = scrollGestureState,
+           event.timestamp - touchEndedTimestamp < 0.1 {
+          // Treat promptly following momentum as part of the tracked gesture.
+        } else {
+          scrollGestureState = .idle
         }
       } else if event.momentumPhase == .ended || event.momentumPhase == .cancelled {
-        isTrackingCurrentGesture = false
-        isTouchActive = false
+        scrollGestureState = .idle
       }
 
-      if !isTrackingCurrentGesture {
+      if case .idle = scrollGestureState {
         nextResponder?.scrollWheel(with: event)
         return
       }

--- a/iina/SidebarTrackSelector.swift
+++ b/iina/SidebarTrackSelector.swift
@@ -33,6 +33,7 @@ class TrackSelector: NSScrollView, NSTableViewDelegate, NSTableViewDataSource {
     wantsLayer = true
     layer?.cornerRadius = 8
     size(height: 98)
+    verticalScrollElasticity = .automatic
 
     player.observe(.iinaTracklistChanged) { [weak self] _ in
       self?.tableView.reloadData()
@@ -42,6 +43,50 @@ class TrackSelector: NSScrollView, NSTableViewDelegate, NSTableViewDataSource {
         self?.tableView.reloadData()
       }
     }
+  }
+
+  private var isTrackingCurrentGesture = false
+  private var isTouchActive = false
+  private var lastTouchEndedTimestamp: TimeInterval = 0
+
+  override func scrollWheel(with event: NSEvent) {
+    // If the content is small enough to fit in the view, it doesn't need to scroll.
+    // In this case, strictly forward ALL scroll events to the parent (the sidebar)
+    // so it doesn't trap the cursor and cause "focus stealing".
+    if let documentView = documentView, documentView.bounds.height <= contentView.bounds.height {
+      nextResponder?.scrollWheel(with: event)
+      return
+    }
+
+    // Ensure gestures that started outside this view (e.g. over the parent sidebar)
+    // are not trapped when this view scrolls under the cursor mid-gesture.
+    if event.hasPreciseScrollingDeltas && (event.phase != [] || event.momentumPhase != []) {
+      if event.phase == .mayBegin || event.phase == .began {
+        isTrackingCurrentGesture = true
+        isTouchActive = true
+      } else if event.phase == .changed {
+        if !isTouchActive {
+          isTrackingCurrentGesture = false
+        }
+      } else if event.phase == .ended || event.phase == .cancelled {
+        isTouchActive = false
+        lastTouchEndedTimestamp = event.timestamp
+      } else if event.momentumPhase == .began {
+        if !isTrackingCurrentGesture || (event.timestamp - lastTouchEndedTimestamp) >= 0.1 {
+          isTrackingCurrentGesture = false
+        }
+      } else if event.momentumPhase == .ended || event.momentumPhase == .cancelled {
+        isTrackingCurrentGesture = false
+        isTouchActive = false
+      }
+
+      if !isTrackingCurrentGesture {
+        nextResponder?.scrollWheel(with: event)
+        return
+      }
+    }
+
+    super.scrollWheel(with: event)
   }
   
   required init?(coder: NSCoder) {

--- a/iina/SidebarVideoPane.swift
+++ b/iina/SidebarVideoPane.swift
@@ -257,36 +257,56 @@ fileprivate class HorizontalScrollViewWithIndicator: NSView {
       parent.indicatorDirection = hasLeading ? .leading : hasTrailing ? .trailing : .hidden
     }
 
-    /// Translate vertical scrolling events to horizontal for mouse control
+    private var isVerticalGesture = false
+    private var isTrackingCurrentGesture = false
+    private var isTouchActive = false
+    private var lastTouchEndedTimestamp: TimeInterval = 0
+
     override func scrollWheel(with event: NSEvent) {
-      if event.scrollingDeltaX != 0 {
-        super.scrollWheel(with: event)
+      // If the horizontal options are few enough to fully fit without scrolling,
+      // strictly forward ALL scroll events to the parent (the sidebar).
+      if let documentView = documentView, documentView.bounds.width <= contentView.bounds.width {
+        nextResponder?.scrollWheel(with: event)
         return
       }
-
-      guard let cg = event.cgEvent?.copy() else {
-        super.scrollWheel(with: event)
-        return
+      
+      // For trackpad gestures, lock the scroll axis at the beginning of the swipe,
+      // and ensure gestures that started outside this view (e.g. over the parent sidebar)
+      // are not trapped when this view scrolls under the cursor mid-gesture.
+      if event.hasPreciseScrollingDeltas && (event.phase != [] || event.momentumPhase != []) {
+        if event.phase == .began || event.phase == .mayBegin {
+          isTrackingCurrentGesture = true
+          isTouchActive = true
+          if event.scrollingDeltaX != 0 || event.scrollingDeltaY != 0 {
+            isVerticalGesture = abs(event.scrollingDeltaY) > abs(event.scrollingDeltaX)
+          } else {
+            // If deltas are zero (e.g. at .mayBegin), default to vertical because 
+            // the main sidebar vertical scrolling is the primary user interaction.
+            isVerticalGesture = true
+          }
+        } else if event.phase == .changed {
+          if !isTouchActive {
+            isTrackingCurrentGesture = false
+          }
+        } else if event.phase == .ended || event.phase == .cancelled {
+          isTouchActive = false
+          lastTouchEndedTimestamp = event.timestamp
+        } else if event.momentumPhase == .began {
+          if !isTrackingCurrentGesture || (event.timestamp - lastTouchEndedTimestamp) >= 0.1 {
+            isTrackingCurrentGesture = false
+          }
+        } else if event.momentumPhase == .ended || event.momentumPhase == .cancelled {
+          isTrackingCurrentGesture = false
+          isTouchActive = false
+        }
+        
+        if !isTrackingCurrentGesture || isVerticalGesture {
+          nextResponder?.scrollWheel(with: event)
+          return
+        }
       }
 
-      let lineV = cg.getDoubleValueField(.scrollWheelEventDeltaAxis1)
-      cg.setDoubleValueField(.scrollWheelEventDeltaAxis1, value: 0)
-      cg.setDoubleValueField(.scrollWheelEventDeltaAxis2, value: lineV)
-
-      let pxV = cg.getDoubleValueField(.scrollWheelEventPointDeltaAxis1)
-      cg.setDoubleValueField(.scrollWheelEventPointDeltaAxis1, value: 0)
-      cg.setDoubleValueField(.scrollWheelEventPointDeltaAxis2, value: pxV)
-
-      let fpV = cg.getDoubleValueField(.scrollWheelEventFixedPtDeltaAxis1)
-      cg.setDoubleValueField(.scrollWheelEventFixedPtDeltaAxis1, value: 0)
-      cg.setDoubleValueField(.scrollWheelEventFixedPtDeltaAxis2, value: fpV)
-
-      guard let swapped = NSEvent(cgEvent: cg) else {
-        super.scrollWheel(with: event)
-        return
-      }
-
-      super.scrollWheel(with: swapped)
+      super.scrollWheel(with: event)
     }
   }
 }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] Related issue: #
- [ ] Related Design Proposal: Not applicable
---
- [x] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**

### Problem
When scrolling vertically in the sidebar (e.g., across Video, Audio, and Subtitles panes), interacting with embedded scrollable views like track selectors (`TrackSelector`) and horizontal option controls (`HorizontalScrollViewWithIndicator`) caused several annoying user experience issues:
1. **Focus Stealing & Stuttering**: When swiping vertically from the outer sidebar background, if the mouse cursor slid over an embedded track list or horizontal control mid-gesture, the inner view would intercept the scroll events, causing the outer sidebar scroll to abruptly halt.
2. **Loss of Momentum & Scroll Freezing**: When an external swipe passed over an embedded view, previous attempts to forward events failed to properly pass through touch termination (`.ended`, `.cancelled`) and momentum phases (`momentumPhase`). This broke AppKit's native gesture state machine, causing the scroll to freeze without inertia until the user moved the mouse cursor out of the sidebar.
3. **Missing Elasticity**: Embedded track selector lists lacked native macOS rubber-band bouncing when they had enough items to be scrollable.

https://github.com/user-attachments/assets/dd3334d4-ab00-44fd-9435-81f3d54194de

### Solution & Changes
This PR resolves these issues by implementing robust touch origin tracking and full-lifecycle event forwarding:

* **Touch Origin State Machine (`isTouchActive` & `isTrackingCurrentGesture`)**: 
  * Trackpad gestures are monitored from their initiation (`.mayBegin`/`.began`). A gesture is only tracked and handled by an embedded view if the touch physically originated inside that view.
  * If an external gesture (or a vertical swipe over a horizontal control) slides under the cursor mid-swipe (`.changed`), the view recognizes that it did not initiate the gesture (`!isTouchActive`) and immediately relinquishes control.
* **Full-Lifecycle Event Forwarding**: 
  * For any gesture that started outside the view, **ALL** associated event phases—including `.changed`, `.ended`, `.cancelled`, and the entire `momentumPhase` sequence (`.began`/`.changed`/`.ended`)—are cleanly forwarded to the parent `nextResponder` (`SidebarScrollView`).
  * This guarantees that the parent scroll view receives uninterrupted event streams, eliminating scroll freezing and preserving silky-smooth native momentum and elasticity.
* **Restored Rubber-Band Elasticity**: 
  * Re-enabled `verticalScrollElasticity = .automatic` on `TrackSelector`, allowing scrollable track lists to bounce natively when reaching the top or bottom, without interfering with outer sidebar scrolling.

https://github.com/user-attachments/assets/d9d33d2e-49e0-4dc0-859d-1b6c3b78d5a4

https://github.com/user-attachments/assets/b6c0b2db-07b9-4faa-afcf-b0af42f6291e
