### PR TITLE
liquid glass OSC with a modern corner radius

### DIFF
--- a/iina/OSCFloatingView.swift
+++ b/iina/OSCFloatingView.swift
@@ -35,7 +35,7 @@ class OSCFloatingView: TranslucentView {
     let container = NSView()
     container.translatesAutoresizingMaskIntoConstraints = false
 
-    let cornerRadius: CGFloat = if #available(macOS 26.0, *) { 12 } else { 6 }
+    let cornerRadius: CGFloat = if #available(macOS 26.0, *) { 22 } else { 6 }
     super.init(liquidGlassCornerRadius: cornerRadius, vevCornerRadius: cornerRadius, padding: (0, 0))
 
     self.oscTopView = NSStackView()


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] This implements issue #6186

The new corner radius is `22`.

<img width="3024" height="1264" alt="Image" src="https://github.com/user-attachments/assets/c9d4842d-f211-4754-9a60-d8b29f9bf4a3" />