### PR TITLE
Show OSD even when applied volume is constrained

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1276,9 +1276,15 @@ class PlayerCore: NSObject {
     let maxVolume = Preference.integer(for: .maxVolume)
     let constrainedVolume = volume.clamped(to: 0...Double(maxVolume))
     let appliedVolume = constrain ? constrainedVolume : volume
+    let shouldSendConstrainedVolumeOSD =
+      constrain && volume != constrainedVolume && info.volume == appliedVolume
     info.volume = appliedVolume
     mpv.setDouble(MPVOption.Audio.volume, appliedVolume, level: .verbose)
     Preference.set(constrainedVolume, for: .softVolume)
+    if shouldSendConstrainedVolumeOSD {
+      // mpv won't send MPV_EVENT_PROPERTY_CHANGE if the volume is unchanged.
+      sendOSD(.volume(constrainedVolume))
+    }
   }
 
   func setTrack(_ index: Int, forType: MPVTrack.TrackType) {


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] Related issue: n/a
- [ ] Related Design Proposal: Not applicable
---
- [ ] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**

When the volume is already at 0 or 100, further volume adjustments are clamped to the same value. mpv does not emit a property-change event when the volume isn't changed, so IINA does not display the volume OSD in such cases.

Proposed change: sendOSD directly when the requested volume is constrained and the applied volume is already current. This matches the behavior of other media players like Movist or PotPlayer.

Note that normal volume changes continue to use mpv's property-change event. This won't duplicate OSD notifications.

Testing done:

- Built the Release configuration for arm64 and x86_64.
- At volume 100, pressing volume-up again would now display the volume OSD at 100.
- At volume 0, pressing volume-down again would now display the volume OSD at 0.

(I made the initial change locally back in May 2022. I found this behavior is still unchanged as of today, so I rebased the change and figured I should contribute this back.)

Pls kindly review :)