### PR TITLE
Remove deprecated OpenGL surface properties to suppress Xcode compiler warnings

### DIFF
--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -70,8 +70,6 @@ class VideoView: NSView {
 
     // other settings
     autoresizingMask = [.width, .height]
-    wantsBestResolutionOpenGLSurface = true
-    wantsExtendedDynamicRangeOpenGLSurface = true
 
     // dragging init
     registerForDraggedTypes([.nsFilenames, .nsURL, .string])

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -70,6 +70,11 @@ class VideoView: NSView {
 
     // other settings
     autoresizingMask = [.width, .height]
+    // Unlike upstream mpv (video/out/mac/view.swift), IINA intentionally omits setting
+    // `wantsBestResolutionOpenGLSurface` and `wantsExtendedDynamicRangeOpenGLSurface` on NSView.
+    // They were deprecated in macOS 10.14 and are redundant here because VideoView hosts a
+    // custom CAOpenGLLayer (`ViewLayer`), where high-resolution Retina scaling is managed via
+    // `contentsScale` and EDR mode is configured via `wantsExtendedDynamicRangeContent`.
 
     // dragging init
     registerForDraggedTypes([.nsFilenames, .nsURL, .string])


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] Related issue: #
- [ ] Related Design Proposal: Not applicable
---
- [ ] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**

Fixes compiler deprecation warnings in `VideoView.swift` as `VideoView` hosts a `CAOpenGLLayer` (`ViewLayer`), and Retina high-resolution scaling and HDR / EDR content dynamic range are managed directly via `CAOpenGLLayer` properties (`contentsScale` and `wantsExtendedDynamicRangeContent`):
- `'wantsBestResolutionOpenGLSurface' was deprecated in macOS 10.14: Use NSOpenGLView instead.`
- `'wantsExtendedDynamicRangeOpenGLSurface' was deprecated in macOS 10.14: Use NSOpenGLView instead.`