### PR TITLE
Settings: split pasted mpv options into key and value

### DIFF
--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -888,6 +888,7 @@
 "settings.$About" = "About";
 "settings.$Accessibility" = "Accessibility";
 "settings.$AdditionalMpvOptions" = "Additional mpv options";
+"settings.$AdditionalMpvOptions.desc" = "Paste an option in the key=value format to fill in both fields automatically.";
 "settings.$Advanced" = "Advanced";
 "settings.$Align" = "Align";
 "settings.$AlwaysWhenPlaying" = "Always when playing a new file";

--- a/iina/SettingsLocalization.swift
+++ b/iina/SettingsLocalization.swift
@@ -148,6 +148,7 @@ extension SettingsLocalization.Key {
 
   // Advanced
   static let text_AdditionalMpvOptions = SettingsLocalization.Key("$AdditionalMpvOptions")
+  static let text_AdditionalMpvOptions_desc = SettingsLocalization.Key("$AdditionalMpvOptions.desc")
   static let text_OpenLogDirectory = SettingsLocalization.Key("$OpenLogDirectory")
   static let text_Logging = SettingsLocalization.Key("$Logging")
   static let text_MPVSettings = SettingsLocalization.Key("$MPVSettings")

--- a/iina/SettingsPageAdvanced.swift
+++ b/iina/SettingsPageAdvanced.swift
@@ -115,6 +115,7 @@ class SettingsPageAdvanced: SettingsPage {
       SettingsList {
         SettingsItem.General(title: .text_AdditionalMpvOptions)
           .image(name: ["document.badge.gearshape", "doc.badge.gearshape"])
+          .hasDescription(content: .text_AdditionalMpvOptions_desc)
           .extraViews(mpvOptionsEditor.delBtn, mpvOptionsEditor.addBtn)
         SettingsItem.Custom()
           .view(mpvOptionsEditor.view)

--- a/iina/SettingsPageAdvanced.swift
+++ b/iina/SettingsPageAdvanced.swift
@@ -202,7 +202,7 @@ fileprivate class MPVOptionsEditor: SettingsAccessory.Base, NSTableViewDelegate,
   }
 
   private static func parsePastedOption(_ string: String) -> [String]? {
-    let parts = string.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+    let parts = string.split(separator: "=", omittingEmptySubsequences: false)
     guard parts.count == 2 else { return nil }
 
     let whitespaceAndNewlines = CharacterSet.whitespacesAndNewlines

--- a/iina/SettingsPageAdvanced.swift
+++ b/iina/SettingsPageAdvanced.swift
@@ -20,20 +20,17 @@ private final class MPVOptionFieldEditor: NSTextView {
   }
 }
 
-private final class MPVOptionTextFieldCell: NSTextFieldCell {
-  private let optionFieldEditor: MPVOptionFieldEditor = {
+private final class MPVOptionsTableView: NSTableView {
+  let optionFieldEditor: MPVOptionFieldEditor = {
     let editor = MPVOptionFieldEditor()
     editor.isFieldEditor = true
     return editor
   }()
+}
 
-  var pasteHandler: ((String) -> Bool)? {
-    get { optionFieldEditor.pasteHandler }
-    set { optionFieldEditor.pasteHandler = newValue }
-  }
-
+private final class MPVOptionTextFieldCell: NSTextFieldCell {
   override func fieldEditor(for controlView: NSView) -> NSTextView? {
-    return optionFieldEditor
+    return (controlView as? MPVOptionsTableView)?.optionFieldEditor
   }
 }
 
@@ -133,7 +130,7 @@ class SettingsPageAdvanced: SettingsPage {
 fileprivate class MPVOptionsEditor: SettingsAccessory.Base, NSTableViewDelegate, NSTableViewDataSource {
   private static let dragType = NSPasteboard.PasteboardType("com.colliderli.iina.mpv-option-row")
 
-  let tableView: NSTableView = NSTableView()
+  let tableView: MPVOptionsTableView = MPVOptionsTableView()
   let scrollView: NSScrollView = NSScrollView()
   let addBtn: NSButton = NSButton()
   let delBtn: NSButton = NSButton()
@@ -155,6 +152,7 @@ fileprivate class MPVOptionsEditor: SettingsAccessory.Base, NSTableViewDelegate,
     tableView.registerForDraggedTypes([MPVOptionsEditor.dragType])
     tableView.delegate = self
     tableView.dataSource = self
+    tableView.optionFieldEditor.pasteHandler = { [weak self] in self?.pasteOption($0) ?? false }
     let columnKey = NSTableColumn(identifier: .key)
     columnKey.title = "Key"
     columnKey.minWidth = 140
@@ -163,7 +161,6 @@ fileprivate class MPVOptionsEditor: SettingsAccessory.Base, NSTableViewDelegate,
     keyCell.isSelectable = true
     keyCell.lineBreakMode = .byTruncatingTail
     keyCell.font = monoFont
-    keyCell.pasteHandler = { [weak self] in self?.pasteOption($0) ?? false }
     columnKey.dataCell = keyCell
     tableView.addTableColumn(columnKey)
     let columnValue = NSTableColumn(identifier: .value)
@@ -173,7 +170,6 @@ fileprivate class MPVOptionsEditor: SettingsAccessory.Base, NSTableViewDelegate,
     valueCell.isSelectable = true
     valueCell.lineBreakMode = .byTruncatingTail
     valueCell.font = monoFont
-    valueCell.pasteHandler = { [weak self] in self?.pasteOption($0) ?? false }
     columnValue.dataCell = valueCell
     tableView.addTableColumn(columnValue)
     tableView.columnAutoresizingStyle = .sequentialColumnAutoresizingStyle

--- a/iina/SettingsPageAdvanced.swift
+++ b/iina/SettingsPageAdvanced.swift
@@ -8,6 +8,34 @@
 
 fileprivate let ui = SettingsUIHelper.sharedUI
 
+private final class MPVOptionFieldEditor: NSTextView {
+  var pasteHandler: ((String) -> Bool)?
+
+  override func paste(_ sender: Any?) {
+    guard let string = NSPasteboard.general.string(forType: .string),
+          pasteHandler?(string) == true else {
+      super.paste(sender)
+      return
+    }
+  }
+}
+
+private final class MPVOptionTextFieldCell: NSTextFieldCell {
+  private let optionFieldEditor: MPVOptionFieldEditor = {
+    let editor = MPVOptionFieldEditor()
+    editor.isFieldEditor = true
+    return editor
+  }()
+
+  var pasteHandler: ((String) -> Bool)? {
+    get { optionFieldEditor.pasteHandler }
+    set { optionFieldEditor.pasteHandler = newValue }
+  }
+
+  override func fieldEditor(for controlView: NSView) -> NSTextView? {
+    return optionFieldEditor
+  }
+}
 
 class SettingsPageAdvanced: SettingsPage {
   override var identifier: String {
@@ -130,11 +158,23 @@ fileprivate class MPVOptionsEditor: SettingsAccessory.Base, NSTableViewDelegate,
     let columnKey = NSTableColumn(identifier: .key)
     columnKey.title = "Key"
     columnKey.minWidth = 140
-    (columnKey.dataCell as? NSCell)?.font = monoFont
+    let keyCell = MPVOptionTextFieldCell()
+    keyCell.isEditable = true
+    keyCell.isSelectable = true
+    keyCell.lineBreakMode = .byTruncatingTail
+    keyCell.font = monoFont
+    keyCell.pasteHandler = { [weak self] in self?.pasteOption($0) ?? false }
+    columnKey.dataCell = keyCell
     tableView.addTableColumn(columnKey)
     let columnValue = NSTableColumn(identifier: .value)
     columnValue.title = "Value"
-    (columnValue.dataCell as? NSCell)?.font = monoFont
+    let valueCell = MPVOptionTextFieldCell()
+    valueCell.isEditable = true
+    valueCell.isSelectable = true
+    valueCell.lineBreakMode = .byTruncatingTail
+    valueCell.font = monoFont
+    valueCell.pasteHandler = { [weak self] in self?.pasteOption($0) ?? false }
+    columnValue.dataCell = valueCell
     tableView.addTableColumn(columnValue)
     tableView.columnAutoresizingStyle = .sequentialColumnAutoresizingStyle
     tableView.rowHeight = 18
@@ -162,6 +202,30 @@ fileprivate class MPVOptionsEditor: SettingsAccessory.Base, NSTableViewDelegate,
   private func saveToUserDefaults() {
     Preference.set(options, for: .userOptions)
     UserDefaults.standard.synchronize()
+  }
+
+  private static func parsePastedOption(_ string: String) -> [String]? {
+    let parts = string.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
+    guard parts.count == 2 else { return nil }
+
+    let whitespaceAndNewlines = CharacterSet.whitespacesAndNewlines
+    let key = String(parts[0]).trimmingCharacters(in: whitespaceAndNewlines)
+    let value = String(parts[1]).trimmingCharacters(in: whitespaceAndNewlines)
+    guard !key.isEmpty, !value.isEmpty else { return nil }
+    return [key, value]
+  }
+
+  private func pasteOption(_ string: String) -> Bool {
+    guard let option = Self.parsePastedOption(string),
+          options.indices.contains(tableView.editedRow) else { return false }
+
+    let row = tableView.editedRow
+    guard tableView.abortEditing() else { return false }
+    options[row] = option
+    tableView.reloadData(forRowIndexes: IndexSet(integer: row),
+                         columnIndexes: IndexSet(integersIn: 0..<tableView.numberOfColumns))
+    saveToUserDefaults()
+    return true
   }
 
   @objc func addOptionAction(_ sender: AnyObject) {

--- a/iina/SettingsPageAdvanced.swift
+++ b/iina/SettingsPageAdvanced.swift
@@ -202,7 +202,7 @@ fileprivate class MPVOptionsEditor: SettingsAccessory.Base, NSTableViewDelegate,
   }
 
   private static func parsePastedOption(_ string: String) -> [String]? {
-    let parts = string.split(separator: "=", omittingEmptySubsequences: false)
+    let parts = string.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
     guard parts.count == 2 else { return nil }
 
     let whitespaceAndNewlines = CharacterSet.whitespacesAndNewlines

--- a/iina/SettingsPageAdvanced.swift
+++ b/iina/SettingsPageAdvanced.swift
@@ -202,12 +202,11 @@ fileprivate class MPVOptionsEditor: SettingsAccessory.Base, NSTableViewDelegate,
   }
 
   private static func parsePastedOption(_ string: String) -> [String]? {
-    let parts = string.split(separator: "=", maxSplits: 1, omittingEmptySubsequences: false)
-    guard parts.count == 2 else { return nil }
+    guard let separator = string.firstIndex(of: "=") else { return nil }
 
     let whitespaceAndNewlines = CharacterSet.whitespacesAndNewlines
-    let key = String(parts[0]).trimmingCharacters(in: whitespaceAndNewlines)
-    let value = String(parts[1]).trimmingCharacters(in: whitespaceAndNewlines)
+    let key = String(string[..<separator]).trimmingCharacters(in: whitespaceAndNewlines)
+    let value = String(string[string.index(after: separator)...]).trimmingCharacters(in: whitespaceAndNewlines)
     guard !key.isEmpty, !value.isEmpty else { return nil }
     return [key, value]
   }

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -888,6 +888,7 @@
 "settings.$About" = "About";
 "settings.$Accessibility" = "Accessibility";
 "settings.$AdditionalMpvOptions" = "Additional mpv options";
+"settings.$AdditionalMpvOptions.desc" = "Paste an option in the key=value format to fill in both fields automatically.";
 "settings.$Advanced" = "Advanced";
 "settings.$Align" = "Align";
 "settings.$AlwaysWhenPlaying" = "Always when playing a new file";


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] Related issue: #
- [ ] Related Design Proposal: Not applicable
---
- [x] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**

Automatically split pasted mpv options into the Key and Value columns in the new settings page.

For example, pasting `hr-seek-framedrop=yes` into either cell now sets:
- Key: `hr-seek-framedrop`
- Value: `yes`