### PR TITLE
fix: prevent stale Live Text overlay during playback

### DIFF
--- a/iina/LiveTextSupport.swift
+++ b/iina/LiveTextSupport.swift
@@ -52,7 +52,7 @@ class LiveTextController {
   }
 
   func clearAnalysis() {
-    guard #available(macOS 13.0, *), isShown else { return }
+    guard #available(macOS 13.0, *), analysisTask != nil || isShown else { return }
     clearAnalysisImpl()
   }
 
@@ -102,6 +102,11 @@ extension LiveTextController: ImageAnalysisOverlayViewDelegate {
         }
         try Task.checkCancellation()
         let analysis = try await ImageAnalyzer().analyze(image, orientation: .up, configuration: .init([.text]))
+        try Task.checkCancellation()
+        guard mainWindow.player.info.state == .paused, Preference.isLiveTextEnabled else {
+          liveTextLog("Discarding image analysis results because Live Text is no longer active")
+          return
+        }
         liveTextLog("Image analysis results acquired")
         await MainActor.run {
           let overlay = self.setupLiveTextOverlay()


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] Related issue: #
- [x] Related Design Proposal: Not applicable
---
- [x] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**

Rapidly toggling pause and playback could leave the Live Text overlay visible while the video was playing. When playback resumed before image analysis finished, `clearAnalysis()` returned early because no overlay existed yet, allowing the stale analysis task to insert one later.

This change cancels an in-flight analysis even when its overlay has not been created, then checks cancellation and the current playback/Live Text state again before presenting analysis results.

Tested with a macOS Debug build (`xcodebuild`): `BUILD SUCCEEDED`.
