### PR TITLE
fix: prevent stale Live Text overlay during playback

### DIFF
--- a/iina/LiveTextSupport.swift
+++ b/iina/LiveTextSupport.swift
@@ -69,7 +69,7 @@ class LiveTextController: NSObject {
   }
 
   func clearAnalysis() {
-    guard #available(macOS 13.0, *), isShown else { return }
+    guard #available(macOS 13.0, *), analysisTask != nil || isShown else { return }
     clearAnalysisImpl()
   }
 
@@ -119,6 +119,10 @@ extension LiveTextController: ImageAnalysisOverlayViewDelegate {
         }
         try Task.checkCancellation()
         let analysis = try await ImageAnalyzer().analyze(image, orientation: .up, configuration: .init([.text]))
+        try Task.checkCancellation()
+        guard mainWindow.player.info.state == .paused, Preference.isLiveTextEnabled else {
+          return
+        }
         liveTextLog("Image analysis results acquired")
         await MainActor.run {
           let overlay = self.setupLiveTextOverlay()


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] Related issue: #6101 
- [ ] Related Design Proposal: Not applicable
---
- [x] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**

Rapidly toggling pause and playback could leave the Live Text overlay visible while the video was playing.

When playback resumed before image analysis finished, `clearAnalysis()` returned early because no overlay existed yet. The pending analysis could then complete and insert a stale overlay.

This change cancels pending analysis even when its overlay has not been created. It also rechecks cancellation, playback state, and the Live Text setting before displaying analysis results.