### PR TITLE
add Detached Playlist to the plugin list

### DIFF
--- a/plugins.json
+++ b/plugins.json
@@ -36,6 +36,12 @@
     "id": "com.danmaku-cosmos.iina-plugin"
   },
   {
+    "name": "Detached Playlist",
+    "url": "https://github.com/HowDidTheCatGetSoFat/iina-detached-playlist",
+    "desc": "Show the playlist in a separate floating window.",
+    "id": "com.fxd0h.detached-playlist"
+  },
+  {
     "name": "Episode Info",
     "url": "https://github.com/Zain-Imam/iina-episode-info",
     "desc": "TMDB episode/movie info overlay on pause, with built-in subtitle search.",


### PR DESCRIPTION
adds my plugin to the list. it puts the playlist in its own window instead of
the sidebar, with the same playlist and chapters tabs the built in one has and
a duration on every row.

repo: https://github.com/HowDidTheCatGetSoFat/iina-detached-playlist

it has a v1.0.0 release with an iinaplgz asset, and Info.json carries ghRepo
and ghVersion so the update check works.

disclosure: per the AI usage section in CONTRIBUTING, i used an AI assistant
while building the plugin and drafting this description. the entry in this PR i
checked by hand, the id matches Info.json and the release has the iinaplgz
asset attached.