### PR TITLE
Improve subtitle matching by prioritizing longer filenames

### DIFF
--- a/iina/AutoFileMatcher.swift
+++ b/iina/AutoFileMatcher.swift
@@ -48,6 +48,15 @@ class AutoFileMatcher {
     filesGroupedByMediaType[.video]! + filesGroupedByMediaType[.audio]!
   }
 
+  private var mediaFilesForSubtitleMatching: [FileInfo] {
+    mediaFiles.sorted {
+      if $0.filename.count == $1.filename.count {
+        return $0.filename.localizedStandardCompare($1.filename) == .orderedAscending
+      }
+      return $0.filename.count > $1.filename.count
+    }
+  }
+
   private func getAllMediaFiles() throws {
     // get all files in current directory
     guard let files = try? fm.contentsOfDirectory(at: currentFolder, includingPropertiesForKeys: nil, options: searchOptions) else { return }
@@ -203,7 +212,8 @@ class AutoFileMatcher {
     let subAutoLoadOption: Preference.IINAAutoLoadAction = Preference.enum(for: .subAutoLoadIINA)
     guard subAutoLoadOption != .disabled else { return }
 
-    for video in mediaFiles {
+    // Match more specific filenames first so a prefix cannot claim their subtitles.
+    for video in mediaFilesForSubtitleMatching {
       var matchedSubs = Set<FileInfo>()
       log("Matching for \(video.filename)")
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] Related issue: #
- [ ] Related Design Proposal: Not applicable
---
- [x] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**

Fix automatic subtitle matching when one media filename is a prefix of another.

Match longer media filenames first during subtitle assignment. For example, this prevents`abc.wav` from claiming `abc_jp.lrc` before `abc_jp.wav` is processed, while preserving the existing “subtitle filename contains media filename” behavior.