### PR TITLE
fix maximum volume validation

### DIFF
--- a/iina/SettingsItem.swift
+++ b/iina/SettingsItem.swift
@@ -821,6 +821,7 @@ struct SettingsItem {
     private var customBinding = false
     private var customBindingBlock: ((NSTextField) -> Void)?
     private var isLongText = false
+    private var range: ClosedRange<Double>?
 
     private var cachedStepperValue: Double?
     private var stepper: NSStepper?
@@ -852,13 +853,16 @@ struct SettingsItem {
       return self
     }
 
+    func range(_ range: ClosedRange<Double>) -> Self {
+      self.range = range
+      return self
+    }
+
     @objc func stepperValueChanged(sender: NSStepper) {
       guard let cachedStepperValue else { return }
-      if cachedStepperValue < sender.doubleValue {
-        textField.doubleValue += sender.increment
-      } else {
-        textField.doubleValue -= sender.increment
-      }
+      let increment = cachedStepperValue < sender.doubleValue ? sender.increment : -sender.increment
+      let value = textField.doubleValue + increment
+      textField.doubleValue = range.map { value.clamped(to: $0) } ?? value
       self.cachedStepperValue = sender.doubleValue
     }
 
@@ -869,6 +873,13 @@ struct SettingsItem {
       textField.bezelStyle = .roundedBezel
       textField.size(width: 64)
       setControlSize(textField)
+      if let range {
+        let formatter = NumberFormatter()
+        formatter.usesGroupingSeparator = false
+        formatter.minimum = NSNumber(value: range.lowerBound)
+        formatter.maximum = NSNumber(value: range.upperBound)
+        textField.formatter = formatter
+      }
       let stack = NSStackView(views: [textField])
       if let stepper {
         stepper.controlSize = controlSize

--- a/iina/SettingsPageAudio.swift
+++ b/iina/SettingsPageAudio.swift
@@ -86,6 +86,7 @@ class SettingsPageAudio: SettingsPage {
           .bindSwitchTo(.enableInitialVolume)
         SettingsItem.Input()
           .bindTo(.maxVolume)
+          .range(100...1000)
           .hasDescription()
       }
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] Related issue: #6198
- [x] Related Design Proposal: Not applicable
---
- [x] AI was used to write the code in this pull request.
  - [x] The code is fully written by AI / I am an AI agent.
---

**Description:**

the new settings page bound maximum volume directly to user defaults without the 100 to 1000 validation used by the old settings view. invalid values could therefore reach mpv and fail after restart.

this adds an opt-in numeric range to `SettingsItem.Input`, applies it through `NumberFormatter`, and clamps stepper changes at the same bounds. the audio setting now uses the documented 100 to 1000 range.

validation included source parsing, whitespace checks, formatter boundary checks, and stepper boundary checks. a full Nightly build was not completed locally because Swift package dependency resolution exhausted the available disk space before compilation. repository CI will run the project build.
