### PR TITLE
Fix legacy full screen ignoring "Always float on top" preference

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1703,7 +1703,8 @@ class MainWindowController: PlayerWindowController {
     window.styleMask.insert(.titled)
     window.hasShadow = true
     (window as! MainWindow).forceKeyAndMain = false
-    window.level = .normal
+    // Restore level based on current on-top preference instead of unconditionally dropping it.
+    super.setWindowFloatingOnTop(isOntop, updateOnTopStatus: false)
 
     restoreDockSettings()
     // restore window frame and aspect ratio
@@ -1755,7 +1756,10 @@ class MainWindowController: PlayerWindowController {
     window.styleMask.remove(.titled)
     window.hasShadow = false
     (window as! MainWindow).forceKeyAndMain = true
-    window.level = .floating
+    // Respect the user's on-top preference instead of always floating. Call super directly
+    // (not self) because MainWindowController's override of setWindowFloatingOnTop no-ops
+    // while fsState.isFullscreen is true, which it already is by this point in the transition.
+    super.setWindowFloatingOnTop(isOntop, updateOnTopStatus: false)
 
     // cancel aspect ratio
     window.resizeIncrements = NSSize(width: 1, height: 1)


### PR DESCRIPTION
## Summary

Fixes #5644. With **legacy full screen** on, entering full screen always set the window to floating, and exiting always dropped it back to normal — no matter what "Always float on top while playing" was set to. So even with that preference off, the window would stay on top of everything after switching apps (e.g. Cmd+Tab) while in full screen.

Both spots now go through the same `setWindowFloatingOnTop` path the rest of the app uses, so the window level actually follows the preference instead of being hardcoded.

## Known limitations (not introduced or fixed by this PR, flagging for visibility)

- If you pause/resume while already in legacy full screen, the on-top state can go stale until you exit — pre-existing, separate issue.
- On multi-monitor setups, the full-screen black-out overlay on other monitors isn't reordered on app switch — pre-existing, separate issue.
- Native (non-legacy) full screen already drops on-top on entry since it uses its own Space; legacy full screen now behaves slightly differently on purpose, since it doesn't move to a new Space.

## Test plan

- [x] Enabled legacy full screen, disabled "Always float on top", entered full screen, Cmd+Tab'd away — other app now comes to the front.
- [x] Exited full screen — window doesn't float when it shouldn't.
- [x] Re-enabled "Always float on top" — full screen and windowed floating both still work as before.
- [x] Native full screen unaffected.