### PR TITLE
Fix Inspector window flashing white when closed

### DIFF
--- a/iina/InspectorWindowController.swift
+++ b/iina/InspectorWindowController.swift
@@ -87,6 +87,11 @@ class InspectorWindowController: NSWindowController, NSWindowDelegate, NSTableVi
   override func windowDidLoad() {
     super.windowDidLoad()
 
+    // This is a HUD/utility panel, not a document window. The default close animation
+    // doesn't handle the HUD chrome correctly and flashes white; `.utilityWindow` is the
+    // animation Apple documents for exactly this panel style.
+    window?.animationBehavior = .utilityWindow
+
     watchProperties = Preference.array(for: .watchProperties) as! [String]
     watchTableView.delegate = self
     watchTableView.dataSource = self


### PR DESCRIPTION
## Summary

Closes the Inspector window (Cmd-I) with Cmd-W (or the red close button) and you'll see the whole panel flash white for a frame before it disappears.

The Inspector is the only HUD-style panel in IINA (`utility` + `HUD` style mask in `InspectorWindowController.xib`), but it never set an explicit `animationBehavior`, so it defaulted to `.default` — the standard document-window close animation. That animation renders a bitmap snapshot of the window to fade/shrink it out, and it doesn't account for HUD chrome, so the layer-backed content view's transparent backing shows through as white for that one frame.

`NSWindow.AnimationBehavior.utilityWindow` is the behavior Apple documents for inspector/HUD-style panels specifically, so this sets that in `windowDidLoad()` instead of leaving it at the document-window default.

## Known Limitations

- This only touches the close animation; the window's default opening/miniaturize animation was already fine.
- No other window in the app uses the HUD style, so this fix is scoped to `InspectorWindowController` only.

## Test Plan

- [x] Built with `xcodebuild -project iina.xcodeproj ONLY_ACTIVE_ARCH=NO -scheme iina -configuration Nightly` — succeeded
- [x] Opened Inspector (Cmd-I) during playback and closed it with Cmd-W repeatedly — no white flash
- [x] Confirmed the Inspector still opens, updates live, and resizes normally (no regression from the animation change)

Fixes #6143