### PR TITLE
Fix crash connecting an external display, #6215

### DIFF
--- a/iina/Display.swift
+++ b/iina/Display.swift
@@ -21,6 +21,9 @@ struct Display: CustomStringConvertible {
     if isBuiltin {
       attributes.append("builtin")
     }
+    if isVirtual {
+      attributes.append("virtual")
+    }
     if CGDisplayIsMain(displayId) != 0 {
       attributes.append("main")
     }
@@ -75,10 +78,11 @@ struct Display: CustomStringConvertible {
     if let mode = CGDisplayCopyDisplayMode(displayId) {
       description += "\n  Mode: \(mode.shortDescription)"
     }
-    let modes = displayModes.reduce("", { result, displayMode in
-      result + "\n    " + displayMode.shortDescription })
-    description += "\n  Native modes:"
-    description += modes
+    if let modes = displayModes?.reduce("", { result, displayMode in
+      result + "\n    " + displayMode.shortDescription }) {
+      description += "\n  Native modes:"
+      description += modes
+    }
     return description
   }
 
@@ -88,10 +92,15 @@ struct Display: CustomStringConvertible {
   let displayId: CGDirectDisplayID
 
   /// Native modes supported by the display.
-  let displayModes: [CGDisplayMode]
+  /// - Note: When waking up, macOS may return a virtual display that does not report any native modes or the modes may be
+  ///         missing because macOS was still in the process of querying the display for information.
+  let displayModes: [CGDisplayMode]?
 
   /// Whether the display is built-in, such as the internal display in portable systems.
   let isBuiltin: Bool
+
+  /// Whether the display is a virtual device.
+  let isVirtual: Bool
 
   /// The model number of the display's monitor.
   let modelNumber: UInt32
@@ -114,6 +123,18 @@ struct Display: CustomStringConvertible {
   /// - Parameter displayId: The
   ///     [CGDirectDisplayID](https://developer.apple.com/documentation/coregraphics/cgdirectdisplayid)
   ///     that identifies the display to create a `Display` object for.
+  /// - Important: Although the Apple documentation for the
+  ///     [CGDisplayCopyAllDisplayModes](https://developer.apple.com/documentation/coregraphics/cgdisplaycopyalldisplaymodes(_:_:))
+  ///     method indicates it only returns `nil` if called with an invalid display ID, that has proven to not be true. Apparently this
+  ///     method will return `nil` when macOS is in the process of querying the display for information. Unfortunately macOS will
+  ///     post [didChangeScreenParametersNotification](https://developer.apple.com/documentation/appkit/nsapplication/didchangescreenparametersnotification)
+  ///     before it has finished querying the display and populating this information. This creates a race condition where IINA may or
+  ///     may not find the display information populated. See issue [#6215](https://github.com/iina/iina/issues/6215)
+  ///     for details.
+  ///
+  ///     Currently this information is only used for logging display attributes to help with debugging problems, so it is acceptable to
+  ///     not populate `displayModes`.  If in the future this information is needed for a feature, such as matching the refresh rate
+  ///     of the display, changes in this area will be needed.
   init(_ displayId: CGDirectDisplayID) {
     self.displayId = displayId
     isBuiltin = CGDisplayIsBuiltin(displayId) != 0
@@ -123,17 +144,24 @@ struct Display: CustomStringConvertible {
     // Obtain all the available modes on the display and filter out all except the native modes.
     // Native modes are of interest as IINA in the future might add support for matching the refresh
     // rate of the display when in full screen mode.
-    let allDisplayModes = CGDisplayCopyAllDisplayModes(displayId, nil) as! [CGDisplayMode]
-    var usableDisplayModes = allDisplayModes
-    usableDisplayModes.removeAll(where: { !$0.isNative })
-    displayModes = usableDisplayModes
-
+    if let allDisplayModes = CGDisplayCopyAllDisplayModes(displayId, nil) as? [CGDisplayMode] {
+      var usableDisplayModes = allDisplayModes
+      usableDisplayModes.removeAll(where: { !$0.isNative })
+      // When waking up, macOS may return a virtual display that does not report any native modes.
+      displayModes = usableDisplayModes.isEmpty ? nil : usableDisplayModes
+    } else {
+      // As discussed above in the comments for this initializer, this method will return nil when
+      // macOS is in the process of querying the display for information.
+      Logger.log("Failed to obtain display modes for display \(displayId)")
+      displayModes = nil
+    }
     // Additional information has to be obtained from the display's info dictionary.
     guard let info = CoreDisplay_DisplayCreateInfoDictionary(displayId)?.takeRetainedValue() as?
             [String: AnyObject] else {
       // Not expected to occur, but we don't want it to be a fatal error if it does occur.
       Logger.log("Failed to create info dictionary for display \(displayId)", level: .error)
       displayBacklight = nil
+      isVirtual = false
       nonReferencePeakHDRLuminance = nil
       nonReferencePeakSDRLuminance = nil
       productName = nil
@@ -143,9 +171,17 @@ struct Display: CustomStringConvertible {
     }
     // It appears the luminance of non-XDR displays is reported using the key DisplayBacklight.
     displayBacklight = info["DisplayBacklight"] as? Int
-    if let productName = info["DisplayProductName"] as? [String: String] {
-      // As the product name is only used in a log message we use the English name.
-      self.productName = productName["en_US"]
+    if let virtual = info["kCGDisplayIsVirtualDevice"] as? Int {
+      isVirtual = virtual == 1
+    } else {
+      isVirtual = false
+    }
+    // As the product name is only used in a log message we use the English name. When waking up,
+    // macOS may return a virtual display that populates all the names with empty strings, so a
+    // check that the name is not empty is required.
+    if let productNames = info["DisplayProductName"] as? [String: String],
+       let name = productNames["en_US"], !name.isEmpty {
+      productName = name
     } else {
       productName = nil
     }

--- a/iina/DisplayController.swift
+++ b/iina/DisplayController.swift
@@ -28,9 +28,6 @@ class DisplayController {
     var result = CGGetOnlineDisplayList(0, nil, &maxDisplays)
     guard checkResult(result, "CGGetOnlineDisplayList") else { return }
 
-    // If there are no new displays there is nothing to do.
-    guard maxDisplays != displays.count else { return }
-
     // Now that we know the number of displays we can allocate the appropriate sized array.
     var displayCount: CGDisplayCount = 0
     var onlineDisplays = [CGDirectDisplayID](repeating: 0, count: Int(maxDisplays))

--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -804,24 +804,38 @@ extension NSScreen {
     }
   }
 
+  /// [CGDirectDisplayID](https://developer.apple.com/documentation/CoreGraphics/CGDirectDisplayID) of the
+  /// display associated with the screen.
+  var displayId: CGDirectDisplayID? {
+    let screenNumberKey = NSDeviceDescriptionKey(rawValue: "NSScreenNumber")
+    return deviceDescription[screenNumberKey] as? CGDirectDisplayID
+  }
+
   /// Log the given `NSScreen` object.
-  ///
+  /// 
   /// Due to issues with multiple monitors and how the screen to use for a window is selected detailed logging has been added in this
   /// area in case additional problems are encountered in the future.
-  /// - parameter label: Label to include in the log message.
-  /// - parameter screen: The `NSScreen` object to log.
-  static func log(_ label: String, _ screen: NSScreen?, subsystem: Logger.Subsystem = .general) {
+  /// - Parameter label: Label to include in the log message.
+  /// - Parameter screen: The `NSScreen` object to log.
+  /// - Parameter details: Whether to include details about the screen (default `true`).
+  /// - Parameter subsystem: The subsystem emitting this message.
+  static func log(_ label: String, _ screen: NSScreen?, details: Bool = true,
+                  subsystem: Logger.Subsystem = .general) {
     guard let screen else {
       Logger.log("\(label): nil", level: .warning, subsystem: subsystem)
       return
     }
+    guard Logger.isEmitting(.debug) else { return }
     var message = "\(label), \(screen.localizedName)"
     if screen == NSScreen.main {
       message += " (main screen)"
     }
-    let screenNumberKey = NSDeviceDescriptionKey(rawValue: "NSScreenNumber")
-    if let displayId = screen.deviceDescription[screenNumberKey] as? CGDirectDisplayID {
+    if let displayId = screen.displayId {
       message += ", on display \(displayId)"
+    }
+    guard details else {
+      Logger.log(message, subsystem: subsystem)
+      return
     }
     message += ":"
     message += "\n  Frame: \(screen.frame), visible \(screen.visibleFrame)"
@@ -829,13 +843,23 @@ extension NSScreen {
     Logger.log(message, subsystem: subsystem)
   }
 
+  /// Log all screens.
+  /// - Parameter subsystem: The subsystem emitting this message.
+  static func logAll(subsystem: Logger.Subsystem = .general) {
+    guard Logger.isEmitting(.debug) else { return }
+    NSScreen.screens.enumerated().forEach { screen in
+      NSScreen.log("NSScreen.screens[\(screen.offset)]", screen.element, subsystem: subsystem)
+    }
+  }
+
   /// Log EDR aspects of the given `NSScreen` object.
-  /// - parameter screen: The `NSScreen` object to log EDR aspects of.
+  /// - Parameter screen: The `NSScreen` object to log EDR aspects of.
   static func logEDR(_ label: String, _ screen: NSScreen?, subsystem: Logger.Subsystem = .general) {
     guard let screen else {
       Logger.log("\(label): nil", level: .warning, subsystem: subsystem)
       return
     }
+    guard Logger.isEmitting(.debug) else { return }
     var message = "\(label), \(screen.localizedName):"
     message += "\n  \(formEDRMessage(screen))"
     Logger.log(message, subsystem: subsystem)

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -718,11 +718,9 @@ class MainWindowController: PlayerWindowController {
       // notification if changes require processing this notification.
       let screensChanged: Bool = {
         guard screens.count == cachedScreens.count else { return true }
-        for i in 0..<screens.count {
-          if screens[i].frame != cachedScreens[i].frame { return true }
-          if screens[i].displayId != cachedScreens[i].displayId { return true }
+        return zip(screens, cachedScreens).contains {
+          $0.frame != $1.frame || $0.displayId != $1.displayId
         }
-        return false
       }()
       guard screensChanged else { return }
       // Update the cached screens

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -64,8 +64,8 @@ class MainWindowController: PlayerWindowController {
 
   /** For blacking out other screens. */
   var screens: [NSScreen] = []
-  var cachedScreenCount = 0
   var blackWindows: [NSWindow] = []
+  var cachedScreens: [NSScreen] = []
 
   lazy var rotation: Int = {
     return player.mpv.getInt(MPVProperty.videoParamsRotate)
@@ -671,7 +671,7 @@ class MainWindowController: PlayerWindowController {
     fadeableViews.update()
 
     // other initialization
-    cachedScreenCount = NSScreen.screens.count
+    cachedScreens = NSScreen.screens
     [pipOverlayView].forEach {
       $0?.state = .active
     }
@@ -707,21 +707,42 @@ class MainWindowController: PlayerWindowController {
 
     addObserver(to: .default, forName: NSApplication.didChangeScreenParametersNotification) { [unowned self] _ in
       // This observer handles a situation that the user connected a new screen or removed a screen
-      let screenCount = NSScreen.screens.count
-      let countChanged = cachedScreenCount != screenCount
-      if fsState.isFullscreen && Preference.bool(for: .blackOutMonitor) && countChanged {
+      let screens = NSScreen.screens
+
+      // Activating extended dynamic range will cause notifications to be posted at a high rate
+      // because the screen's maximumExtendedDynamicRangeColorComponentValue property keeps changing
+      // as the display's brightness ramps up. This can continue to change if the display is
+      // configured to automatically adjust brightness if ambient lighting is changing. Instruments
+      // identified processing these notifications as a performance problem when they occur at a
+      // high rate. Compare the current list of screens to the cached list and only process this
+      // notification if changes require processing this notification.
+      let screensChanged: Bool = {
+        guard screens.count == cachedScreens.count else { return true }
+        for i in 0..<screens.count {
+          if screens[i].frame != cachedScreens[i].frame { return true }
+          if screens[i].displayId != cachedScreens[i].displayId { return true }
+        }
+        return false
+      }()
+      guard screensChanged else { return }
+      // Update the cached screens
+      cachedScreens = screens
+
+      log("Screen parameters have changed")
+      DisplayController.shared.addNewDisplays()
+      NSScreen.logAll(subsystem: subsystem)
+      NSScreen.log("Window is on screen", window.screen, details: false, subsystem: subsystem)
+
+      if fsState.isFullscreen && Preference.bool(for: .blackOutMonitor) {
         removeBlackWindow()
         blackOutOtherMonitors()
       }
-      // Update the cached value
-      cachedScreenCount = screenCount
       videoView.updateDisplayLink()
-      DisplayController.shared.addNewDisplays()
       // In normal full screen mode AppKit will automatically adjust the window frame if the window
       // is moved to a new screen such as when the window is on an external display and that display
       // is disconnected. In legacy full screen mode IINA is responsible for adjusting the window's
       // frame.
-      guard countChanged, fsState.isFullscreen, Preference.bool(for: .useLegacyFullScreen) else { return }
+      guard fsState.isFullscreen, Preference.bool(for: .useLegacyFullScreen) else { return }
       setWindowFrameForLegacyFullScreen()
     }
 
@@ -766,12 +787,8 @@ class MainWindowController: PlayerWindowController {
     window.title = "Window"
 
     // As there have been issues in this area, log details about the screen selection process.
-    NSScreen.log("window.screen", window.screen)
-    NSScreen.screens.enumerated().forEach { screen in
-      if screen.element != window.screen {
-        NSScreen.log("NSScreen.screens[\(screen.offset)]" , screen.element)
-      }
-    }
+    NSScreen.logAll(subsystem: subsystem)
+    NSScreen.log("Window is on screen", window.screen, details: false, subsystem: subsystem)
 
     // If a video is not actively playing then the initial drawing of the view needs to be forced.
     // The forceDraw method will check to see if drawing is actually needed.
@@ -2370,12 +2387,13 @@ class MainWindowController: PlayerWindowController {
   private func determineScreenToUse(_ window: NSWindow) -> NSScreen {
     // If the window is currently showing on a screen, use this screen
     if window.isOnActiveSpace, let currentScreen = window.screen {
-      NSScreen.log("Window is currently showing screen", currentScreen)
+      NSScreen.log("Window is currently showing on screen", currentScreen, subsystem: subsystem)
       return currentScreen
     }
     guard let rectString = UserDefaults.standard.value(forKey: "MainWindowLastPosition") as? String else {
       let selected = window.selectDefaultScreen()
-      NSScreen.log("MainWindowLastPosition not found, using default screen", selected)
+      NSScreen.log("MainWindowLastPosition not found, using default screen", selected,
+                   subsystem: subsystem)
       return selected
     }
     let rect = NSRectFromString(rectString)
@@ -2384,11 +2402,11 @@ class MainWindowController: PlayerWindowController {
       // connected or the arrangement of the screens has changed.
       let selected = window.selectDefaultScreen()
       NSScreen.log("MainWindowLastPosition \(rect.origin) is not within any screens, using default screen",
-                   selected)
+                   selected, subsystem: subsystem)
       return selected
     }
     // Found a screen containing the previous window origin. Use that screen for the window.
-    NSScreen.log("MainWindowLastPosition \(rect.origin) matched", lastScreen)
+    NSScreen.log("MainWindowLastPosition \(rect.origin) matched", lastScreen, subsystem: subsystem)
     return lastScreen
   }
 

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -32,7 +32,7 @@ class VideoView: NSView {
   var hasPlayableFiles: Bool = false
 
   // cached indicator to prevent unnecessary updates of DisplayLink
-  var currentDisplay: UInt32?
+  var currentDisplay: CGDirectDisplayID?
 
   var isIdle = true
   private var displayIdleTimer: Timer?
@@ -239,8 +239,8 @@ class VideoView: NSView {
 
   // This should only be called if the window has changed displays
   func updateDisplayLink() {
-    guard let window, let link, let screen = window.screen else { return }
-    let displayId = screen.deviceDescription[NSDeviceDescriptionKey("NSScreenNumber")] as! UInt32
+    guard let window, let link, let screen = window.screen,
+          let displayId = screen.displayId else { return }
 
     // Do nothing if on the same display
     if (currentDisplay == displayId) { return }


### PR DESCRIPTION
This commit will:
- Change the `Display` initializer to support `CGDisplayCopyAllDisplayModes` returning `nil`
- Change the `displayModes` property to be optional
- Change the `Display.description` property to handle `displayModes` being `nil`
- Add a new `isVirtual` property to `Display` and change the initializer to set it
- Add support for the `isVirtual` property to the `description` property
- Change the initializer to handle product names that are the empty string
- Remove the check in `DisplayController` that requires the number of displays to change
- Add a new `displayId` property to the `NSScreen` extension
- Change `VideoView.updateDisplayLink` to use the new `displayId` property
- Change the `didChangeScreenParametersNotification` observer in `MainWindowController` to properly ignore screen changes IINA does not need to respond to
- Add a new `logAll` method to the `NSScreen` extension
- Change log methods in the `NSScreen` extension to not form messages if the log message will not be emitted
- Add the logger subsystem to calls to `NSScreen` logging methods where missing

The Apple documentation for the `CGDisplayCopyAllDisplayModes` method indicates it only returns `nil` if called with an invalid display ID. As the display ID was known to be valid the code was not expecting the results to be `nil`. According to the ChatGPT analysis posted in the issue macOS will return `nil` or an invalid display mode when macOS is re-probing the display. This commit will correct the crash by updating code to support `CGDisplayCopyAllDisplayModes` returning `nil`.

This commit will also correct problems where IINA was ignoring notifications about screen parameters changing that should have been processed.

This commit will also improve logging of displays and screens. This logging is needed to debug problems involving external displays.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] Related issue: #6215
- [ ] Related Design Proposal: # / Not applicable
---
- [ ] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**
