### PR TITLE
Keep window size and position when rotating the video

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -2537,16 +2537,24 @@ class PlayerCore: NSObject {
     guard info.state.loaded else { return }
     var dwidth = mpv.getInt(MPVProperty.dwidth)
     var dheight = mpv.getInt(MPVProperty.dheight)
-    if info.rotation == 90 || info.rotation == 270 {
+    // Read the rotation synchronously. The video-rotate change notification updates
+    // info.rotation asynchronously, so it can still hold the previous value here.
+    let rotation = mpv.getInt(MPVOption.Video.videoRotate)
+    info.rotation = rotation
+    if rotation == 90 || rotation == 270 {
       swap(&dwidth, &dheight)
     }
     if dwidth != info.displayWidth! || dheight != info.displayHeight! {
       // filter the last video-reconfig event before quit
       if dwidth == 0 && dheight == 0 && mpv.getFlag(MPVProperty.coreIdle) { return }
+      // If the new size is the transpose of the old one, the video was rotated in 90°
+      // steps. Only update the window's aspect ratio, keeping its size and position,
+      // instead of resizing it as if a new video was opened (#1172).
+      let rotationChangedOnly = dwidth == info.displayHeight! && dheight == info.displayWidth!
       // video size changed
       info.displayWidth = dwidth
       info.displayHeight = dheight
-      notifyWindowVideoSizeChanged()
+      notifyWindowVideoSizeChanged(keepWindowSize: rotationChangedOnly)
     }
   }
 
@@ -2708,8 +2716,12 @@ class PlayerCore: NSObject {
     )
   }
 
-  func notifyWindowVideoSizeChanged() {
-    currentController.handleVideoSizeChange()
+  func notifyWindowVideoSizeChanged(keepWindowSize: Bool = false) {
+    if keepWindowSize && !isInMiniPlayer {
+      mainWindow.handleVideoSizeChange(keepWindowSize: true)
+    } else {
+      currentController.handleVideoSizeChange()
+    }
     if currentController.pendingShow {
       currentController.pendingShow = false
       currentController.showWindow(self)


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] Related issue: #1172
- [x] Related Design Proposal: Not applicable
---
- [x] AI was used to write the code in this pull request.
  - [x] The code is fully written by AI / I am an AI agent.
---

**Description:**

Rotating the video resets the player window: every 90° step goes down the same path as a video size change, so the window snaps back to the default scale for the video and gets re-centered, discarding whatever size and position the user had set. Rotating a video you're watching in a small corner window suddenly gives you a full-size window in the middle of the screen.

There is also a race in `onVideoReconfig`: it reads `info.rotation`, which is updated by the `video-rotate` property notification on a separate async hop to the main queue, so whether the reconfig sees the old or the new rotation depends on event timing.

This PR:

- reads `video-rotate` synchronously in `onVideoReconfig`, so the dwidth/dheight normalization no longer races with the property notification
- treats a reconfig whose new display size is the transpose of the previous one as a rotation, and routes it to the existing `handleVideoSizeChange(keepWindowSize: true)` path, so the window flips its aspect ratio in place (same area, same center) instead of being resized and re-centered

Not affected: initial sizing when opening a file (still driven by the resize preferences), playlist navigation, the mini player, and files with rotation metadata. Rotating a metadata-rotated file in place also works, e.g. a file with 270° metadata rotated by 90° flips back to landscape without moving the window.

CC @lhc70000 @low-batt