### PR TITLE
Allow removing downloaded subtitles from the sidebar

### DIFF
--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -57,7 +57,8 @@
 "quicksetting.hdr" = "HDR";
 "quicksetting.hide" = "Hide";
 "quicksetting.reset_speed" = "Reset speed to 1x";
-"quicksetting.sub_remove_downloaded" = "Remove Downloaded Subtitle";
+"quicksetting.sub_remove" = "Remove Subtitle Track";
+"quicksetting.sub_remove_unavailable" = "Embedded subtitles cannot be removed";
 
 // EQ Presets
 "eq.preset.flat" = "Flat";

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -57,6 +57,7 @@
 "quicksetting.hdr" = "HDR";
 "quicksetting.hide" = "Hide";
 "quicksetting.reset_speed" = "Reset speed to 1x";
+"quicksetting.sub_remove_downloaded" = "Remove Downloaded Subtitle";
 
 // EQ Presets
 "eq.preset.flat" = "Flat";

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -404,6 +404,8 @@ extension MainMenuActionHandler {
     // return if last search is not finished
     guard let url = player.info.currentURL, !player.isSearchingOnlineSubtitle else { return }
 
+    let providerID = sender.representedObject as? String ?? Preference.string(for: .onlineSubProvider)
+    let removeDownloadedFilesWhenUnloaded = !(providerID?.hasPrefix("plugin:") ?? false)
     player.isSearchingOnlineSubtitle = true
     OnlineSubtitle.search(forFile: url, player: player, providerID: sender.representedObject as? String) { urls in
       if urls.isEmpty {
@@ -411,7 +413,7 @@ extension MainMenuActionHandler {
       } else {
         for url in urls {
           Logger.log("Saved subtitle to \(url.path)")
-          self.player.loadExternalSubFile(url)
+          self.player.loadExternalSubFile(url, removeWhenUnloaded: removeDownloadedFilesWhenUnloaded)
         }
         self.player.sendOSD(.downloadedSub(
           urls.map({ $0.lastPathComponent }).joined(separator: "\n")

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1454,6 +1454,18 @@ class PlayerCore: NSObject {
     }
   }
 
+  func subRemove(id: Int? = nil) -> Bool {
+    let args = id.map { [String($0)] } ?? []
+    var result = true
+    mpv.command(.subRemove, args: args, checkError: false, level: .verbose, returnValueCallback: { code in
+      if code < 0 {
+        result = false
+        self.log("Failed removing subtitle track #\(id ?? 0): error code \(code)", level: .error)
+      }
+    })
+    return result
+  }
+
   func reloadAllSubs() {
     let currentSubName = info.currentTrack(.sub)?.externalFilename
     info.$subTracks.withLock {

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -135,6 +135,7 @@ class PlayerCore: NSObject {
   // MARK: - Fields
 
   private var observers: [NSObjectProtocol] = []
+  @Atomic private var temporarySubtitleFiles = Set<URL>()
 
   lazy var subsystem = Logger.makeSubsystem("player\(label!)", ["play.circle"])
 
@@ -1427,7 +1428,16 @@ class PlayerCore: NSObject {
     mpv.setFlag(MPVOption.Subtitles.secondarySubVisibility, newState)
   }
 
-  func loadExternalSubFile(_ url: URL, delay: Bool = false, suppressError: Bool = false) {
+  func loadExternalSubFile(_ url: URL, delay: Bool = false, suppressError: Bool = false,
+                           removeWhenUnloaded: Bool = false) {
+    let standardizedURL = url.standardizedFileURL
+    if removeWhenUnloaded {
+      $temporarySubtitleFiles.withLock {
+        $0.insert(standardizedURL)
+        return ()
+      }
+    }
+
     var track: MPVTrack?
     info.$subTracks.withLock { track = $0.first(where: { $0.externalFilename == url.path }) }
     if let track = track {
@@ -1437,6 +1447,12 @@ class PlayerCore: NSObject {
 
     mpv.command(.subAdd, args: [url.path], checkError: false, level: .verbose) { code in
       if code < 0 {
+        if removeWhenUnloaded {
+          self.$temporarySubtitleFiles.withLock {
+            $0.remove(standardizedURL)
+            return ()
+          }
+        }
         self.log("Unsupported sub: \(url.path)", level: .error)
         // only show alert when the subtitle is added manually
         guard !suppressError else { return }
@@ -1464,6 +1480,28 @@ class PlayerCore: NSObject {
       }
     })
     return result
+  }
+
+  private func cleanupTemporarySubtitleFiles() {
+    let loadedURLs = info.$subTracks.withLock { tracks in
+      Set(tracks.compactMap { $0.externalFilename }.map {
+        URL(fileURLWithPath: $0).standardizedFileURL
+      })
+    }
+    let trackedURLs = $temporarySubtitleFiles.withLock { Set($0) }
+    let unloadedURLs = trackedURLs.subtracting(loadedURLs)
+
+    for url in unloadedURLs {
+      do {
+        try FileManager.default.removeItem(at: url)
+        log("Removed temporary subtitle file \(url.path)", level: .verbose)
+      } catch CocoaError.fileNoSuchFile {
+        // Ignore if the temporary subtitle file was already cleaned up.
+      } catch {
+        log("Failed removing temporary subtitle file \(url.path): \(error.localizedDescription)", level: .warning)
+      }
+    }
+    $temporarySubtitleFiles.withLock { $0.subtract(unloadedURLs) }
   }
 
   func reloadAllSubs() {
@@ -2520,6 +2558,7 @@ class PlayerCore: NSObject {
     guard info.state.active else { return }
     log("Track list changed")
     getTrackInfo()
+    cleanupTemporarySubtitleFiles()
     getSelectedTracks()
     let audioStatus = info.isAudio
 

--- a/iina/SidebarTrackSelector.swift
+++ b/iina/SidebarTrackSelector.swift
@@ -108,49 +108,35 @@ class TrackSelector: NSScrollView, NSTableViewDelegate, NSTableViewDataSource, N
     menu.removeAllItems()
 
     let clickedRow = tableView.clickedRow
-    guard clickedRow > 0,
-          let track = player.info.trackList(trackType)[at: clickedRow - 1],
-          isRemovableDownloadedSubtitle(track) else { return }
+    guard clickedRow > 0, let track = player.info.trackList(trackType)[at: clickedRow - 1] else { return }
 
-    menu.addItem(
-      withTitle: NSLocalizedString(
-        "quicksetting.sub_remove_downloaded",
-        comment: "Remove Downloaded Subtitle"
-      ),
-      action: #selector(removeDownloadedSubtitleFromMenu(_:)),
-      target: self,
-      obj: track
-    )
-  }
-
-  @objc private func removeDownloadedSubtitleFromMenu(_ sender: NSMenuItem) {
-    guard let track = sender.representedObject as? MPVTrack,
-          isRemovableDownloadedSubtitle(track),
-          let filename = track.externalFilename,
-          player.subRemove(id: track.id) else { return }
-
-    do {
-      try FileManager.default.removeItem(at: URL(fileURLWithPath: filename))
-    } catch CocoaError.fileNoSuchFile {
-      // Ignore if the temporary subtitle file was already cleaned up.
-    } catch {
-      player.log(
-        "Failed removing downloaded subtitle file \(filename): \(error.localizedDescription)",
-        level: .warning
+    if track.isExternal {
+      menu.addItem(
+        withTitle: NSLocalizedString(
+          "quicksetting.sub_remove",
+          comment: "Remove Subtitle Track"
+        ),
+        action: #selector(removeSubtitleFromMenu(_:)),
+        target: self,
+        obj: track
       )
+    } else {
+      let item = menu.addItem(
+        withTitle: NSLocalizedString(
+          "quicksetting.sub_remove_unavailable",
+          comment: "Embedded subtitles cannot be removed"
+        ),
+        action: nil,
+        target: nil
+      )
+      item.isEnabled = false
     }
-
-    player.getTrackInfo()
-    player.getSelectedTracks()
-    player.postNotification(.iinaTracklistChanged)
   }
 
-  private func isRemovableDownloadedSubtitle(_ track: MPVTrack) -> Bool {
-    guard track.isExternal, let filename = track.externalFilename else { return false }
-
-    let temporaryDirectory = Utility.tempDirURL.standardizedFileURL.pathComponents
-    let subtitleFile = URL(fileURLWithPath: filename).standardizedFileURL.pathComponents
-    return subtitleFile.starts(with: temporaryDirectory)
+  @objc private func removeSubtitleFromMenu(_ sender: NSMenuItem) {
+    guard let track = sender.representedObject as? MPVTrack,
+          track.isExternal,
+          player.subRemove(id: track.id) else { return }
   }
 
   private func makeCell(identifier: NSUserInterfaceItemIdentifier, columnID: NSUserInterfaceItemIdentifier) -> CellView {

--- a/iina/SidebarTrackSelector.swift
+++ b/iina/SidebarTrackSelector.swift
@@ -6,11 +6,12 @@
 //  Copyright © 2026 lhc. All rights reserved.
 //
 
-class TrackSelector: NSScrollView, NSTableViewDelegate, NSTableViewDataSource {
+class TrackSelector: NSScrollView, NSTableViewDelegate, NSTableViewDataSource, NSMenuDelegate {
   private let trackType: MPVTrack.TrackType
   private unowned let player: PlayerCore
 
   private var tableView: NSTableView
+  private var contextMenu: NSMenu?
 
   init(_ trackType: MPVTrack.TrackType, player: PlayerCore, observedKeys: [Notification.Name]) {
     self.player = player
@@ -26,6 +27,14 @@ class TrackSelector: NSScrollView, NSTableViewDelegate, NSTableViewDataSource {
     tableView.headerView = nil
     tableView.backgroundColor = .clear
     tableView.gridStyleMask = [.solidHorizontalGridLineMask]
+
+    if trackType == .sub || trackType == .secondSub {
+      let menu = NSMenu(title: "Subtitle Actions")
+      menu.delegate = self
+      menu.autoenablesItems = false
+      contextMenu = menu
+      tableView.menu = menu
+    }
 
     translatesAutoresizingMaskIntoConstraints = false
     documentView = tableView
@@ -93,6 +102,55 @@ class TrackSelector: NSScrollView, NSTableViewDelegate, NSTableViewDataSource {
     }
     player.setTrack(trackId, forType: trackType)
     tableView.deselectAll(nil)
+  }
+
+  func menuNeedsUpdate(_ menu: NSMenu) {
+    menu.removeAllItems()
+
+    let clickedRow = tableView.clickedRow
+    guard clickedRow > 0,
+          let track = player.info.trackList(trackType)[at: clickedRow - 1],
+          isRemovableDownloadedSubtitle(track) else { return }
+
+    menu.addItem(
+      withTitle: NSLocalizedString(
+        "quicksetting.sub_remove_downloaded",
+        comment: "Remove Downloaded Subtitle"
+      ),
+      action: #selector(removeDownloadedSubtitleFromMenu(_:)),
+      target: self,
+      obj: track
+    )
+  }
+
+  @objc private func removeDownloadedSubtitleFromMenu(_ sender: NSMenuItem) {
+    guard let track = sender.representedObject as? MPVTrack,
+          isRemovableDownloadedSubtitle(track),
+          let filename = track.externalFilename,
+          player.subRemove(id: track.id) else { return }
+
+    do {
+      try FileManager.default.removeItem(at: URL(fileURLWithPath: filename))
+    } catch CocoaError.fileNoSuchFile {
+      // Ignore if the temporary subtitle file was already cleaned up.
+    } catch {
+      player.log(
+        "Failed removing downloaded subtitle file \(filename): \(error.localizedDescription)",
+        level: .warning
+      )
+    }
+
+    player.getTrackInfo()
+    player.getSelectedTracks()
+    player.postNotification(.iinaTracklistChanged)
+  }
+
+  private func isRemovableDownloadedSubtitle(_ track: MPVTrack) -> Bool {
+    guard track.isExternal, let filename = track.externalFilename else { return false }
+
+    let temporaryDirectory = Utility.tempDirURL.standardizedFileURL.pathComponents
+    let subtitleFile = URL(fileURLWithPath: filename).standardizedFileURL.pathComponents
+    return subtitleFile.starts(with: temporaryDirectory)
   }
 
   private func makeCell(identifier: NSUserInterfaceItemIdentifier, columnID: NSUserInterfaceItemIdentifier) -> CellView {

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -57,7 +57,8 @@
 "quicksetting.hdr" = "HDR";
 "quicksetting.hide" = "Hide";
 "quicksetting.reset_speed" = "Reset speed to 1x";
-"quicksetting.sub_remove_downloaded" = "Remove Downloaded Subtitle";
+"quicksetting.sub_remove" = "Remove Subtitle Track";
+"quicksetting.sub_remove_unavailable" = "Embedded subtitles cannot be removed";
 
 // EQ Presets
 "eq.preset.flat" = "Flat";

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -57,6 +57,7 @@
 "quicksetting.hdr" = "HDR";
 "quicksetting.hide" = "Hide";
 "quicksetting.reset_speed" = "Reset speed to 1x";
+"quicksetting.sub_remove_downloaded" = "Remove Downloaded Subtitle";
 
 // EQ Presets
 "eq.preset.flat" = "Flat";


### PR DESCRIPTION
## Summary

- add a context menu to subtitle track rows in the sidebar
- expose removal for downloaded subtitle temp tracks
- remove the mpv subtitle track and matching temporary file

<img width="395" height="555" alt="image" src="https://github.com/user-attachments/assets/a950d3c7-d75b-4143-b634-f6d20979e870" />

## Verification

- `xcodebuild -project iina.xcodeproj -scheme iina -configuration Debug -sdk macosx build CODE_SIGNING_ALLOWED=NO`
- clean single-commit history based on the latest `develop`