### PR TITLE
Fix camera housing area no longer black in legacy full screen

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1751,6 +1751,16 @@ class MainWindowController: PlayerWindowController {
     view.setFrameSize(NSMakeSize(view.frame.width, screen.frame.height - unusable))
   }
 
+  /// `setMaterial` unconditionally sets the window's background to follow the current appearance, which would
+  /// undo the forced black background from `setWindowFrameForLegacyFullScreen` if the user changes the theme
+  /// while still in legacy full screen on a screen with a camera housing. Re-force it black in that case.
+  override func setMaterial(_ theme: Preference.Theme?) {
+    super.setMaterial(theme)
+    guard case .fullscreen(let legacy, _) = fsState, legacy,
+          window?.screen?.cameraHousingHeight != nil else { return }
+    window?.backgroundColor = .black
+  }
+
   private func legacyAnimateToFullscreen() {
     guard let window = self.window else { fatalError("make sure the window exists before animating") }
     // call delegate

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1704,6 +1704,9 @@ class MainWindowController: PlayerWindowController {
     window.hasShadow = true
     (window as! MainWindow).forceKeyAndMain = false
     window.level = .normal
+    // Undo the forced black background applied for a camera housing gap (see
+    // setWindowFrameForLegacyFullScreen) now that the content view fills the window again.
+    window.backgroundColor = window.effectiveAppearance.isDark ? .black : .white
 
     restoreDockSettings()
     // restore window frame and aspect ratio
@@ -1740,7 +1743,10 @@ class MainWindowController: PlayerWindowController {
     window.setFrame(screen.frame, display: true, animate: useAnimation)
     guard let unusable = screen.cameraHousingHeight else { return }
     // This screen contains an embedded camera. Shorten the height of the window's content view's
-    // frame to avoid having part of the window obscured by the camera housing.
+    // frame to avoid having part of the window obscured by the camera housing. The window's
+    // background will show through the resulting gap, so force it black regardless of the current
+    // appearance to keep the area around the camera housing blacked out. See issue #6201.
+    window.backgroundColor = .black
     let view = window.contentView!
     view.setFrameSize(NSMakeSize(view.frame.width, screen.frame.height - unusable))
   }


### PR DESCRIPTION
## Summary

On a Mac whose built-in screen has a camera housing, entering legacy full screen with a Light appearance leaves the area around the housing white instead of black (see screenshot in #6201).

Legacy full screen shortens the window's content view to avoid the camera housing (`setWindowFrameForLegacyFullScreen` in `MainWindowController.swift`), so the window's own `backgroundColor` shows through that gap. Commit 0df0243b changed `backgroundColor` from an unconditional `.black` to one that follows the current light/dark appearance (to make the windowed-mode sidebar chrome match the theme), which broke the "always black" assumption legacy full screen depends on for that gap.

This forces the background black specifically while the camera-housing gap is present, and restores the theme-following color when returning to windowed mode.

**Update:** a follow-up commit closes a second gap in the same regression family: `PlayerWindowController.setMaterial()` also unconditionally applies the appearance-following background color, and it fires live whenever the user changes the theme preference (including via the in-window Quick Settings sidebar) — with no regard for full screen state. That means changing the theme while already in legacy full screen on a camera-housing screen would silently re-whiten the gap the first commit had just forced black. `MainWindowController` now overrides `setMaterial` to re-force black in that case.

## Known Limitations

- This only affects Macs with a camera housing (`NSScreen.safeAreaInsets.top > 0`) using legacy full screen with a Light appearance — I don't have such a display, so this remains a code-level fix based on tracing the regression, not a visually confirmed repro. I attempted a manual visual sanity check by temporarily stubbing `cameraHousingHeight` to force the gap on this hardware, but couldn't capture a screenshot to verify pixel color (no Screen Recording permission in this environment) — reviewers with either real camera-housing hardware or that permission are best positioned to confirm visually.
- Scoped to `MainWindowController`; the equivalent codepath for other window controllers doesn't do this content-view shortening.
- Two related, lower-severity gaps in the same area were found but are left out of scope for this PR (happy to file follow-up issues if useful): `InteractiveMode.swift`'s enter/exit also sets an unconditional (non-appearance-aware) background color; and closing the window directly (e.g. Cmd-W) while still in legacy full screen bypasses the normal exit path that restores the theme-following color.

## Test Plan

- [x] Built with `xcodebuild -project iina.xcodeproj ONLY_ACTIVE_ARCH=NO -scheme iina -configuration Nightly` — succeeded
- [ ] Visual confirmation on a camera-housing display with Light appearance + legacy full screen (needs a reviewer with that hardware)

Fixes #6201