### PR TITLE
Fix saving downloaded secondary subtitles

### DIFF
--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -422,15 +422,15 @@ extension MainMenuActionHandler {
   }
 
   @objc func saveDownloadedSub(_ sender: NSMenuItem) {
-    let selected = player.info.$subTracks.withLock { $0.filter { $0.id == player.info.sid } }
-    guard selected.count > 0 else {
-      Utility.showAlert("sub.no_selected")
-
-      return
+    let selectedIDs = [player.info.sid, player.info.secondSid].compactMap { $0 }
+    let selected = player.info.$subTracks.withLock { tracks in
+      selectedIDs.compactMap { id in
+        tracks.first {
+          $0.id == id && $0.externalFilename?.contains("/var/") == true
+        }
+      }.first
     }
-    let sub = selected[0]
-    // make sure it's a downloaded sub
-    guard let path = sub.externalFilename, path.contains("/var/") else {
+    guard let path = selected?.externalFilename else {
       Utility.showAlert("sub.no_selected")
       return
     }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] Related issue: #5977
- [x] Related Design Proposal: Not applicable
---
- [x] AI was used to write the code in this pull request.
  - [x] The code is fully written by AI / I am an AI agent.
---

**Description:**

Fixes #5977.

`Save Downloaded Subtitle` only checked the primary subtitle ID. This keeps the existing primary-first behavior, then checks the selected secondary subtitle and saves the first selected track whose external path is in `/var/`.

Verification:

- Initially reproduced on `develop` at `a25ed139` with primary subtitles disabled and a downloaded secondary subtitle. Before the change, the command showed `Please select a downloaded subtitle first`; after the change, the save panel opened with the secondary subtitle filename.
- Revalidated the unchanged one-file patch on current `develop` at `bbaf86e7` as detached commit `25556a0` (parent `bbaf86e7`) and built the Debug arm64 app successfully from a clean worktree.
- Loaded an isolated synthetic video plus distinct primary and secondary SRT canaries, then exercised separate primary-only and secondary-only save paths.
- With primary `<none>` and secondary `#2 secondary-canary.srt`, the save panel defaulted to `secondary-canary.srt`; IINA confirmed the save, and the written 71-byte file was byte-for-byte identical to the secondary source (`SHA-256 45c32e5462a13e78f266d19efec2aaa127a2c085ec6cbff57e60812b897c0f7a`).
- With primary `#1 primary-canary.srt` and secondary `<none>`, the save panel defaulted to `primary-canary.srt`; IINA confirmed the save, and the written 69-byte file was byte-for-byte identical to the primary source (`SHA-256 853f9b763c43b005e1deb3b5a1d0f6c12c333b0ba4a188ba10b16eba32c6f9f6`).
- The revalidation worktree remained clean after the build and both runtime save tests.

The remote PR head remains `2af7d9d` on its earlier base; this current-base runtime revalidation did not force-push the branch or replace the existing CI results.

Codex was used for code-path inspection, patch drafting, build orchestration, and the isolated runtime save/hash verification. The final change remains a one-file diff, and this PR is left as a draft for author review.
