### PR TITLE
Add audio channel routing

### DIFF
--- a/iina/AppData.swift
+++ b/iina/AppData.swift
@@ -129,6 +129,7 @@ struct Constants {
     static let flip = "iina_flip"
     static let mirror = "iina_mirror"
     static let audioEq = "iina_aeq"
+    static let audioChannelRouting = "iina_audio_channel_routing"
     static let delogo = "iina_delogo"
   }
 }

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -8,6 +8,51 @@
 
 import Cocoa
 
+fileprivate enum AudioChannelRoutingFilterBuilder {
+  static func makePanGraph() -> String? {
+    let mode = Preference.enum(for: .audioChannelRoutingMode) as Preference.AudioChannelRoutingMode
+    switch mode {
+    case .assignment:
+      guard let leftSource = validatedSource(Preference.string(for: .audioChannelRoutingLeftSource)),
+            let rightSource = validatedSource(Preference.string(for: .audioChannelRoutingRightSource)) else {
+        return nil
+      }
+      return "pan=stereo|c0=\(leftSource)|c1=\(rightSource)"
+
+    case .customDownmix:
+      let entries = Preference.audioChannelRoutingMatrixEntries()
+      return "pan=stereo|c0=\(expression(for: entries.map { ($0.source, $0.leftGain) }))|c1=\(expression(for: entries.map { ($0.source, $0.rightGain) }))"
+    }
+  }
+
+  private static func validatedSource(_ source: String?) -> String? {
+    guard let source,
+          Preference.audioChannelRoutingSources.contains(where: { $0.id == source }) else {
+      return nil
+    }
+    return source
+  }
+
+  private static func expression(for gains: [(source: String, gain: Double)]) -> String {
+    let terms = gains.compactMap { source, gain -> String? in
+      guard abs(gain) > Double.leastNonzeroMagnitude else { return nil }
+      let magnitude = abs(gain)
+      let term = magnitude == 1 ? source : "\(magnitude.prettyFormat())*\(source)"
+      return gain < 0 ? "-\(term)" : term
+    }
+
+    guard !terms.isEmpty else {
+      return "0*\(Preference.audioChannelRoutingSources[0].id)"
+    }
+
+    var result = terms[0]
+    for term in terms.dropFirst() {
+      result += term.hasPrefix("-") ? term : "+\(term)"
+    }
+    return result
+  }
+}
+
 class PlayerCore: NSObject {
 
   /// Minimum value to set a mpv loop point to.
@@ -66,12 +111,15 @@ class PlayerCore: NSObject {
 
   static var playerCores: [PlayerCore] = []
   static private var playerCoreCounter = 0
+  static private let audioChannelRoutingPreferenceObserver = Preference.Observer()
+  static private var isObservingAudioChannelRoutingPreferences = false
 
   static private func findIdlePlayerCore() -> PlayerCore? {
     playerCores.first { $0.info.state == .idle && !$0.backgroundTaskInUse }
   }
 
   static private func createPlayerCore() -> PlayerCore {
+    observeAudioChannelRoutingPreferences()
     let pc = PlayerCore()
     pc.label = "\(playerCoreCounter)"
     playerCores.append(pc)
@@ -79,6 +127,23 @@ class PlayerCore: NSObject {
     pc.loadPlugins()
     playerCoreCounter += 1
     return pc
+  }
+
+  static private func observeAudioChannelRoutingPreferences() {
+    guard !isObservingAudioChannelRoutingPreferences else { return }
+    isObservingAudioChannelRoutingPreferences = true
+    audioChannelRoutingPreferenceObserver.addAll([
+      .audioChannelRoutingEnabled,
+      .audioChannelRoutingMode,
+      .audioChannelRoutingLeftSource,
+      .audioChannelRoutingRightSource,
+      .audioChannelRoutingMatrix,
+      .spdifAC3,
+      .spdifDTS,
+      .spdifDTSHD
+    ]) { _ in
+      PlayerCore.playerCores.forEach { $0.applyAudioChannelRoutingFilter() }
+    }
   }
 
   static func activeOrNewForMenuAction(isAlternative: Bool) -> PlayerCore {
@@ -662,6 +727,7 @@ class PlayerCore: NSObject {
       log("Audio device configured in settings not found, will default to auto:\n  \(audioDevice)")
       setAudioDevice("auto")
     }
+    applyAudioChannelRoutingFilter()
   }
 
   func initVideo() {
@@ -1812,6 +1878,39 @@ class PlayerCore: NSObject {
     return result
   }
 
+  private func removeAudioChannelRoutingFilters() {
+    let filters = mpv.getFilters(MPVProperty.af)
+    for index in filters.indices.reversed() where filters[index].label == Constants.FilterName.audioChannelRouting {
+      let filter = filters[index]
+      removeAudioFilter(filter, index)
+    }
+  }
+
+  func applyAudioChannelRoutingFilter() {
+    guard info.state != .stopping, info.state != .shuttingDown, info.state != .shutDown else {
+      return
+    }
+    removeAudioChannelRoutingFilters()
+
+    guard Preference.bool(for: .audioChannelRoutingEnabled) else { return }
+    guard !Preference.bool(for: .spdifAC3),
+          !Preference.bool(for: .spdifDTS),
+          !Preference.bool(for: .spdifDTSHD) else {
+      log("Audio channel routing is enabled but ignored while SPDIF passthrough is enabled",
+          level: .warning)
+      return
+    }
+    guard let graph = AudioChannelRoutingFilterBuilder.makePanGraph() else {
+      log("Failed to build audio channel routing filter", level: .warning)
+      return
+    }
+
+    let filter = MPVFilter(name: "lavfi",
+                           label: Constants.FilterName.audioChannelRouting,
+                           paramString: "[\(graph)]")
+    addAudioFilter(filter)
+  }
+
   /// Remove an audio filter based on its position in the list of filters.
   ///
   /// Removing a filter based on its position within the filter list is the preferred way to do it as per discussion with the mpv project.
@@ -2393,6 +2492,7 @@ class PlayerCore: NSObject {
     // restart even while paused. See issue #5337.
     syncUI(.time)
     reloadSavedIINAfilters()
+    applyAudioChannelRoutingFilter()
 
     // The new video's size is guaranteed to be available. Reset the flags used for window resizing.
     // We can't put this in MPV_EVENT_VIDEO_RECONFIG because it can be emitted with the old video's size

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -212,6 +212,12 @@ struct Preference {
 
     static let gaplessAudio = Key("gaplessAudio")
 
+    static let audioChannelRoutingEnabled = Key("audioChannelRoutingEnabled")
+    static let audioChannelRoutingMode = Key("audioChannelRoutingMode")
+    static let audioChannelRoutingLeftSource = Key("audioChannelRoutingLeftSource")
+    static let audioChannelRoutingRightSource = Key("audioChannelRoutingRightSource")
+    static let audioChannelRoutingMatrix = Key("audioChannelRoutingMatrix")
+
     static let userEQPresets = Key("userEQPresets")
 
     // Subtitle
@@ -953,6 +959,65 @@ struct Preference {
     }
   }
 
+  enum AudioChannelRoutingMode: Int, InitializingFromKey, CaseIterable {
+    case assignment = 0
+    case customDownmix
+
+    static var defaultValue = AudioChannelRoutingMode.assignment
+
+    init?(key: Key) {
+      self.init(rawValue: Preference.integer(for: key))
+    }
+
+    var description: String {
+      switch self {
+      case .assignment: "assignment"
+      case .customDownmix: "custom"
+      }
+    }
+  }
+
+  static let audioChannelRoutingSources: [(id: String, title: String)] = [
+    ("FL", "Front left"),
+    ("FR", "Front right"),
+    ("FC", "Center"),
+    ("LFE", "LFE"),
+    ("BL", "Back left"),
+    ("BR", "Back right"),
+    ("SL", "Side left"),
+    ("SR", "Side right")
+  ]
+
+  static let audioChannelRoutingDefaultMatrix =
+    "FL:1:0,FR:0:1,FC:0:0,LFE:0:0,BL:0:0,BR:0:0,SL:0:0,SR:0:0"
+
+  static func audioChannelRoutingMatrixEntries() -> [(source: String, leftGain: Double, rightGain: Double)] {
+    let fallback = Dictionary(uniqueKeysWithValues: audioChannelRoutingSources.map { ($0.id, (0.0, 0.0)) })
+    let stored = Preference.string(for: .audioChannelRoutingMatrix) ?? audioChannelRoutingDefaultMatrix
+    var parsed = fallback
+
+    for entry in stored.split(separator: ",") {
+      let parts = entry.split(separator: ":", omittingEmptySubsequences: false).map(String.init)
+      guard parts.count == 3,
+            audioChannelRoutingSources.contains(where: { $0.id == parts[0] }),
+            let left = Double(parts[1]),
+            let right = Double(parts[2]) else { continue }
+      parsed[parts[0]] = (left, right)
+    }
+
+    return audioChannelRoutingSources.map { source in
+      let gains = parsed[source.id] ?? (0, 0)
+      return (source.id, gains.0, gains.1)
+    }
+  }
+
+  static func setAudioChannelRoutingMatrixEntries(_ entries: [(source: String, leftGain: Double, rightGain: Double)]) {
+    let value = entries.map { entry in
+      "\(entry.source):\(entry.leftGain.prettyFormat()):\(entry.rightGain.prettyFormat())"
+    }.joined(separator: ",")
+    Preference.set(value, for: .audioChannelRoutingMatrix)
+  }
+
   enum DefaultRepeatMode: Int, InitializingFromKey, CaseIterable {
     case playlist = 0
     case file
@@ -1129,6 +1194,11 @@ struct Preference {
     .replayGainClip: false,
     .replayGainFallback: 0,
     .gaplessAudio: GaplessAudioOption.weak.rawValue,
+    .audioChannelRoutingEnabled: false,
+    .audioChannelRoutingMode: AudioChannelRoutingMode.assignment.rawValue,
+    .audioChannelRoutingLeftSource: "FL",
+    .audioChannelRoutingRightSource: "FR",
+    .audioChannelRoutingMatrix: audioChannelRoutingDefaultMatrix,
 
     .subAutoLoadIINA: IINAAutoLoadAction.iina.rawValue,
     .subAutoLoadPriorityString: "",
@@ -1376,6 +1446,7 @@ struct Preference {
            .alwaysFloatOnTop,
            .alwaysOpenInNewWindow,
            .alwaysShowOnTopIcon,
+           .audioChannelRoutingEnabled,
            .audioDriverEnableAVFoundation,
            .autoRepeat,
            .autoSearchOnlineSub,
@@ -1499,6 +1570,9 @@ struct Preference {
       case .gaplessAudio:
         defaultAsString = String(describing: GaplessAudioOption.defaultValue)
         valueAsString = String(describing: Preference.enum(for: key) as GaplessAudioOption)
+      case .audioChannelRoutingMode:
+        defaultAsString = String(describing: AudioChannelRoutingMode.defaultValue)
+        valueAsString = String(describing: Preference.enum(for: key) as AudioChannelRoutingMode)
       case .hardwareDecoder:
         defaultAsString = String(describing: HardwareDecoderOption.defaultValue)
         valueAsString = String(describing: Preference.enum(for: key) as HardwareDecoderOption)

--- a/iina/SettingsLocalization.swift
+++ b/iina/SettingsLocalization.swift
@@ -92,6 +92,11 @@ extension SettingsLocalization.Key {
   static let text_Hardware = SettingsLocalization.Key("$Hardware")
   static let text_AudioOther = SettingsLocalization.Key("$Other")
   static let text_Volume = SettingsLocalization.Key("$Volume")
+  static let audioChannelRoutingModeLabel = SettingsLocalization.Key("audioChannelRoutingMode.label")
+  static let text_OutputChannel1 = SettingsLocalization.Key("$OutputChannel1")
+  static let text_OutputChannel2 = SettingsLocalization.Key("$OutputChannel2")
+  static let text_SourceChannel = SettingsLocalization.Key("$SourceChannel")
+  static let text_Reset = SettingsLocalization.Key("$Reset")
 
   // Subtitles
   static let subAutoLoadSearchPath = SettingsLocalization.Key("subAutoLoadSearchPath.label")

--- a/iina/SettingsPageAudio.swift
+++ b/iina/SettingsPageAudio.swift
@@ -31,6 +31,7 @@ class SettingsPageAudio: SettingsPage {
   override func content() -> [SettingsSection] {
     return sections {
       sectionHardware()
+      sectionChannelRouting()
       sectionVolume()
       sectionOther()
     }
@@ -72,6 +73,19 @@ class SettingsPageAudio: SettingsPage {
             SettingsItem.Switch()
               .bindTo(.spdifDTSHD)
           }
+      }
+    }
+  }
+
+  private func sectionChannelRouting() -> SettingsSection {
+    return section {
+      SettingsList {
+        SettingsItem.Switch()
+          .image(name: "arrow.triangle.branch")
+          .bindTo(.audioChannelRoutingEnabled)
+          .bindExpandableView()
+          .hasDescription()
+          .withExpandingDetailView(AudioChannelRoutingView())
       }
     }
   }
@@ -135,6 +149,205 @@ class SettingsPageAudio: SettingsPage {
           )
       }
     }
+  }
+}
+
+
+fileprivate class AudioChannelRoutingView: NSObject, SettingsContainer, NSTextFieldDelegate {
+  lazy var itemID = SettingsContainerUUID.next()
+
+  let view = NSView()
+  private let modePopUp = NSPopUpButton()
+  private let leftSourcePopUp = NSPopUpButton()
+  private let rightSourcePopUp = NSPopUpButton()
+  private let assignmentStack = NSStackView()
+  private let matrixStack = NSStackView()
+  private var matrixFields: [String: (left: NSTextField, right: NSTextField)] = [:]
+  private var builtView: NSView?
+
+  func makeView() -> NSView {
+    if let builtView {
+      return builtView
+    }
+
+    view.translatesAutoresizingMaskIntoConstraints = false
+
+    let modeRow = row(label: ui.localized(.audioChannelRoutingModeLabel), control: modePopUp)
+    configureModePopUp()
+
+    configureSourcePopUp(leftSourcePopUp, selected: Preference.string(for: .audioChannelRoutingLeftSource))
+    configureSourcePopUp(rightSourcePopUp, selected: Preference.string(for: .audioChannelRoutingRightSource))
+    leftSourcePopUp.action = #selector(sourcePopUpChanged(_:))
+    rightSourcePopUp.action = #selector(sourcePopUpChanged(_:))
+
+    assignmentStack.translatesAutoresizingMaskIntoConstraints = false
+    assignmentStack.orientation = .vertical
+    assignmentStack.spacing = 6
+    assignmentStack.addArrangedSubview(row(label: ui.localized(.text_OutputChannel1), control: leftSourcePopUp))
+    assignmentStack.addArrangedSubview(row(label: ui.localized(.text_OutputChannel2), control: rightSourcePopUp))
+
+    matrixStack.translatesAutoresizingMaskIntoConstraints = false
+    matrixStack.orientation = .vertical
+    matrixStack.spacing = 6
+    buildMatrixRows()
+
+    let contentStack = NSStackView(views: [modeRow, assignmentStack, matrixStack])
+    contentStack.translatesAutoresizingMaskIntoConstraints = false
+    contentStack.orientation = .vertical
+    contentStack.alignment = .leading
+    contentStack.spacing = 10
+    view.addSubview(contentStack)
+    contentStack.padding(.top(topConstraintOffset), .leading(SettingsSubList.indent), .trailing(8), .bottom(8))
+
+    updateModeVisibility()
+    builtView = view
+    view.tag = itemID
+    return view
+  }
+
+  func registerSearchEntry(context: SettingsSearch.Context) {
+    context.add(itemID, ui.localized(.audioChannelRoutingModeLabel), isMain: true)
+    context.add(itemID, ui.localized(.text_OutputChannel1))
+    context.add(itemID, ui.localized(.text_OutputChannel2))
+    context.add(itemID, ui.localized(.text_SourceChannel))
+  }
+
+  private func configureModePopUp() {
+    modePopUp.translatesAutoresizingMaskIntoConstraints = false
+    modePopUp.controlSize = .small
+    modePopUp.target = self
+    modePopUp.action = #selector(modePopUpChanged(_:))
+    modePopUp.removeAllItems()
+    for mode in Preference.AudioChannelRoutingMode.allCases {
+      modePopUp.addItem(withTitle: ui.localized(.init("audioChannelRoutingMode.items.\(mode.rawValue)")))
+      modePopUp.lastItem?.tag = mode.rawValue
+    }
+    modePopUp.selectItem(withTag: Preference.integer(for: .audioChannelRoutingMode))
+  }
+
+  private func configureSourcePopUp(_ popUp: NSPopUpButton, selected: String?) {
+    popUp.translatesAutoresizingMaskIntoConstraints = false
+    popUp.controlSize = .small
+    popUp.target = self
+    popUp.removeAllItems()
+    for source in Preference.audioChannelRoutingSources {
+      popUp.addItem(withTitle: "\(source.title) (\(source.id))")
+      popUp.lastItem?.representedObject = source.id
+    }
+    if let selected,
+       let item = popUp.itemArray.first(where: { $0.representedObject as? String == selected }) {
+      popUp.select(item)
+    }
+  }
+
+  private func buildMatrixRows() {
+    let header = NSStackView()
+    header.translatesAutoresizingMaskIntoConstraints = false
+    header.orientation = .horizontal
+    header.alignment = .centerY
+    header.spacing = 8
+    header.addArrangedSubview(headerLabel(ui.localized(.text_SourceChannel), width: 120))
+    header.addArrangedSubview(headerLabel(ui.localized(.text_OutputChannel1), width: 62))
+    header.addArrangedSubview(headerLabel(ui.localized(.text_OutputChannel2), width: 62))
+    matrixStack.addArrangedSubview(header)
+
+    for entry in Preference.audioChannelRoutingMatrixEntries() {
+      let sourceTitle = Preference.audioChannelRoutingSources.first(where: { $0.id == entry.source })?.title ?? entry.source
+      let leftField = gainField(entry.leftGain, source: entry.source, output: "left")
+      let rightField = gainField(entry.rightGain, source: entry.source, output: "right")
+      matrixFields[entry.source] = (leftField, rightField)
+
+      let row = NSStackView(views: [
+        headerLabel("\(sourceTitle) (\(entry.source))", width: 120),
+        leftField,
+        rightField
+      ])
+      row.translatesAutoresizingMaskIntoConstraints = false
+      row.orientation = .horizontal
+      row.alignment = .centerY
+      row.spacing = 8
+      matrixStack.addArrangedSubview(row)
+    }
+
+    let resetButton = NSButton(title: ui.localized(.text_Reset), target: self, action: #selector(resetMatrix))
+    resetButton.controlSize = .small
+    matrixStack.addArrangedSubview(resetButton)
+  }
+
+  private func row(label title: String, control: NSView) -> NSStackView {
+    let label = headerLabel(title, width: 120)
+    let stack = NSStackView(views: [label, control])
+    stack.translatesAutoresizingMaskIntoConstraints = false
+    stack.orientation = .horizontal
+    stack.alignment = .centerY
+    stack.spacing = 8
+    return stack
+  }
+
+  private func headerLabel(_ title: String, width: CGFloat) -> NSTextField {
+    let label = NSTextField(labelWithString: title)
+    label.translatesAutoresizingMaskIntoConstraints = false
+    label.controlSize = .small
+    label.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+    label.setContentCompressionResistancePriority(.defaultLow, for: .horizontal)
+    label.widthAnchor.constraint(equalToConstant: width).isActive = true
+    return label
+  }
+
+  private func gainField(_ value: Double, source: String, output: String) -> NSTextField {
+    let field = NSTextField()
+    field.translatesAutoresizingMaskIntoConstraints = false
+    field.controlSize = .small
+    field.font = .systemFont(ofSize: NSFont.smallSystemFontSize)
+    field.alignment = .right
+    field.stringValue = value.prettyFormat()
+    field.identifier = NSUserInterfaceItemIdentifier("\(source).\(output)")
+    field.delegate = self
+    field.widthAnchor.constraint(equalToConstant: 62).isActive = true
+    return field
+  }
+
+  @objc private func modePopUpChanged(_ sender: NSPopUpButton) {
+    Preference.set(sender.selectedTag(), for: .audioChannelRoutingMode)
+    updateModeVisibility()
+  }
+
+  @objc private func sourcePopUpChanged(_ sender: NSPopUpButton) {
+    guard let source = sender.selectedItem?.representedObject as? String else { return }
+    Preference.set(source, for: sender == leftSourcePopUp ? .audioChannelRoutingLeftSource : .audioChannelRoutingRightSource)
+  }
+
+  @objc private func resetMatrix() {
+    Preference.set(Preference.audioChannelRoutingDefaultMatrix, for: .audioChannelRoutingMatrix)
+    refreshMatrixFields()
+  }
+
+  func controlTextDidEndEditing(_ obj: Notification) {
+    saveMatrixFields()
+  }
+
+  private func updateModeVisibility() {
+    let mode = Preference.enum(for: .audioChannelRoutingMode) as Preference.AudioChannelRoutingMode
+    assignmentStack.isHidden = mode != .assignment
+    matrixStack.isHidden = mode != .customDownmix
+  }
+
+  private func refreshMatrixFields() {
+    for entry in Preference.audioChannelRoutingMatrixEntries() {
+      matrixFields[entry.source]?.left.stringValue = entry.leftGain.prettyFormat()
+      matrixFields[entry.source]?.right.stringValue = entry.rightGain.prettyFormat()
+    }
+  }
+
+  private func saveMatrixFields() {
+    let entries = Preference.audioChannelRoutingSources.map { source -> (String, Double, Double) in
+      let fields = matrixFields[source.id]
+      let left = Double(fields?.left.stringValue ?? "") ?? 0
+      let right = Double(fields?.right.stringValue ?? "") ?? 0
+      return (source.id, left, right)
+    }
+    Preference.setAudioChannelRoutingMatrixEntries(entries)
+    refreshMatrixFields()
   }
 }
 

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -684,6 +684,11 @@
 "settings.gaplessAudio.items.2" = "Strong";
 "settings.gaplessAudio.items.2.desc" = "The audio device is opened using parameters chosen for the first file played and is then kept open for gapless playback. Following files may be resampled.";
 "settings.gaplessAudio.label" = "Gapless audio";
+"settings.audioChannelRoutingEnabled.desc" = "Route or mix multichannel audio into stereo before it reaches the selected audio device. Disabled while SPDIF passthrough is enabled.";
+"settings.audioChannelRoutingEnabled.label" = "Audio channel routing";
+"settings.audioChannelRoutingMode.items.0" = "Assign channels";
+"settings.audioChannelRoutingMode.items.1" = "Custom downmix";
+"settings.audioChannelRoutingMode.label" = "Mode";
 "settings.maxVolume.desc" = "(100-1000)";
 "settings.maxVolume.label" = "Maximum volume";
 "settings.preferredAudioDevice.label" = "Preferred audio device";
@@ -698,6 +703,10 @@
 "settings.replayGainFallback.label" = "Fallback";
 "settings.replayGainPreamp.desc" = "Pre-amplification gain to apply to the ReplayGain gain.";
 "settings.replayGainPreamp.label" = "Preamp gain";
+"settings.$OutputChannel1" = "Output 1";
+"settings.$OutputChannel2" = "Output 2";
+"settings.$Reset" = "Reset";
+"settings.$SourceChannel" = "Source";
 
 // Settings - Control
 "settings.doubleClickAction.items.0" = "None";


### PR DESCRIPTION
## Summary
- add an Audio settings control for stereo channel assignment and custom downmix gains
- apply routing through a labeled mpv lavfi/pan audio filter without replacing user audio filters
- update active players when routing preferences change and skip routing while SPDIF passthrough is enabled

## Validation
- git diff --check
- xcodebuild -project iina.xcodeproj -scheme iina -configuration Debug -destination "platform=macOS" build (local build reached CompileAssetCatalog, then failed because local asset tooling supports SVG template format 5.0 while repo assets use format 7.0; GitHub CI uses Xcode 26.5)
