### PR TITLE
Fix RTL language window controls overlap sidebar, #6192

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -128,6 +128,7 @@
 		519872FF26879B9B00F84BCC /* AccessibilityPreferences.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519872FE26879B9B00F84BCC /* AccessibilityPreferences.swift */; };
 		519CCABD2BFFAEF10079DCAF /* HardwareDecodeCapabilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = 519CCABC2BFFAEF10079DCAF /* HardwareDecodeCapabilities.swift */; };
 		51AC1CAB2A9FBF3700DF7079 /* OpenSubClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51AC1CAA2A9FBF3700DF7079 /* OpenSubClient.swift */; };
+		51BDDFB3301E97EE00E249CE /* CommonWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51BDDFB2301E97EE00E249CE /* CommonWindow.swift */; };
 		51C1BA3A291CA76700C1208A /* InfoDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C1BA39291CA76700C1208A /* InfoDictionary.swift */; };
 		51C889D52C42FF7F007B2584 /* PlayerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51C889D42C42FF7F007B2584 /* PlayerState.swift */; };
 		51CA83E22E35AD6300A44B22 /* MPVAudioDevice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51CA83E12E35AD6300A44B22 /* MPVAudioDevice.swift */; };
@@ -1049,6 +1050,7 @@
 		519CCABC2BFFAEF10079DCAF /* HardwareDecodeCapabilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HardwareDecodeCapabilities.swift; sourceTree = "<group>"; };
 		51A0F0F629FA2C8E000130CF /* Beta.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Beta.xcconfig; sourceTree = "<group>"; };
 		51AC1CAA2A9FBF3700DF7079 /* OpenSubClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OpenSubClient.swift; sourceTree = "<group>"; };
+		51BDDFB2301E97EE00E249CE /* CommonWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommonWindow.swift; sourceTree = "<group>"; };
 		51C1BA39291CA76700C1208A /* InfoDictionary.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = InfoDictionary.swift; sourceTree = "<group>"; };
 		51C3ED782C234BFA004546F9 /* imgutils.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = imgutils.h; sourceTree = "<group>"; };
 		51C889D42C42FF7F007B2584 /* PlayerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerState.swift; sourceTree = "<group>"; };
@@ -2112,6 +2114,7 @@
 		84A0BAA31D2FAEA000BC8DA1 /* Views */ = {
 			isa = PBXGroup;
 			children = (
+				51BDDFB2301E97EE00E249CE /* CommonWindow.swift */,
 				E31E62FA2FD38516005527B2 /* LayoutValue.swift */,
 				84A0BA931D2F9E9600BC8DA1 /* MainMenu.xib */,
 				E38BD4AE20054BD9007635FC /* MainWindow.swift */,
@@ -2955,6 +2958,7 @@
 				34C4D19C2FC58482006B829F /* LiveTextSupport.swift in Sources */,
 				511BF43E2E1305C800E9721E /* MiniPlaySlider.swift in Sources */,
 				E34BC2AC2C27DAE900A94680 /* SettingsHelper.swift in Sources */,
+				51BDDFB3301E97EE00E249CE /* CommonWindow.swift in Sources */,
 				842904E21F0EC01600478376 /* AutoFileMatcher.swift in Sources */,
 				8466BE181D5CDD0300039D03 /* QuickSettingViewController.swift in Sources */,
 				84A0BA9E1D2FAD4000BC8DA1 /* MainWindowController.swift in Sources */,

--- a/iina/Base.lproj/AboutWindowController.xib
+++ b/iina/Base.lproj/AboutWindowController.xib
@@ -30,7 +30,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="About" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" titlebarAppearsTransparent="YES" titleVisibility="hidden" id="F0z-JX-Cv5">
+        <window title="About" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" titlebarAppearsTransparent="YES" titleVisibility="hidden" id="F0z-JX-Cv5" customClass="CommonWindow" customModule="IINA" customModuleProvider="target">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" fullSizeContentView="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="196" y="240" width="640" height="400"/>

--- a/iina/Base.lproj/FilterWindowController.xib
+++ b/iina/Base.lproj/FilterWindowController.xib
@@ -31,7 +31,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Filters" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="F0z-JX-Cv5" userLabel="Filters Window">
+        <window title="Filters" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" animationBehavior="default" id="F0z-JX-Cv5" userLabel="Filters Window" customClass="CommonWindow" customModule="IINA" customModuleProvider="target">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="608" y="562" width="640" height="382"/>
@@ -455,7 +455,7 @@
             </constraints>
             <point key="canvasLocation" x="-563" y="281"/>
         </customView>
-        <window title="New Filter" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="NewFilterWindow" animationBehavior="default" id="8Eh-v2-bbh" userLabel="New Filter Window">
+        <window title="New Filter" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" restorable="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="NewFilterWindow" animationBehavior="default" id="8Eh-v2-bbh" userLabel="New Filter Window" customClass="CommonWindow" customModule="IINA" customModuleProvider="target">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="283" y="305" width="620" height="400"/>
@@ -612,7 +612,7 @@ DQ
                 <outlet property="view" destination="RNP-NG-UVn" id="IxR-CL-PuL"/>
             </connections>
         </viewController>
-        <window title="Save Filter" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="SaveFilterWindow" animationBehavior="default" id="hsA-Hq-fPV" userLabel="Save Filter Window">
+        <window title="Save Filter" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="SaveFilterWindow" animationBehavior="default" id="hsA-Hq-fPV" userLabel="Save Filter Window" customClass="CommonWindow" customModule="IINA" customModuleProvider="target">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="163" y="199" width="403" height="230"/>
@@ -735,7 +735,7 @@ Gw
             </view>
             <point key="canvasLocation" x="-735" y="618"/>
         </window>
-        <window title="Edit Filter" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="EditFilterWindow" animationBehavior="default" id="Zxl-uQ-3ud" userLabel="Edit Filter Window">
+        <window title="Edit Filter" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" frameAutosaveName="EditFilterWindow" animationBehavior="default" id="Zxl-uQ-3ud" userLabel="Edit Filter Window" customClass="CommonWindow" customModule="IINA" customModuleProvider="target">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" resizable="YES"/>
             <windowPositionMask key="initialPositionMask" leftStrut="YES" rightStrut="YES" topStrut="YES" bottomStrut="YES"/>
             <rect key="contentRect" x="163" y="199" width="393" height="240"/>

--- a/iina/Base.lproj/GuideWindowController.xib
+++ b/iina/Base.lproj/GuideWindowController.xib
@@ -16,7 +16,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="F0z-JX-Cv5">
+        <window title="Window" allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" visibleAtLaunch="NO" animationBehavior="default" id="F0z-JX-Cv5" customClass="CommonWindow" customModule="IINA" customModuleProvider="target">
             <windowStyleMask key="styleMask" titled="YES" closable="YES"/>
             <rect key="contentRect" x="196" y="240" width="740" height="540"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1417"/>

--- a/iina/Base.lproj/InitialWindowController.xib
+++ b/iina/Base.lproj/InitialWindowController.xib
@@ -26,7 +26,7 @@
         </customObject>
         <customObject id="-1" userLabel="First Responder" customClass="FirstResponder"/>
         <customObject id="-3" userLabel="Application" customClass="NSObject"/>
-        <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" frameAutosaveName="IINAWelcomeWindow" animationBehavior="default" titlebarAppearsTransparent="YES" id="F0z-JX-Cv5">
+        <window allowsToolTipsWhenApplicationIsInactive="NO" autorecalculatesKeyViewLoop="NO" releasedWhenClosed="NO" frameAutosaveName="IINAWelcomeWindow" animationBehavior="default" titlebarAppearsTransparent="YES" id="F0z-JX-Cv5" customClass="CommonWindow" customModule="IINA" customModuleProvider="target">
             <windowStyleMask key="styleMask" titled="YES" closable="YES" miniaturizable="YES" fullSizeContentView="YES"/>
             <rect key="contentRect" x="931" y="455" width="640" height="400"/>
             <rect key="screenRect" x="0.0" y="0.0" width="2560" height="1415"/>

--- a/iina/CommonWindow.swift
+++ b/iina/CommonWindow.swift
@@ -1,0 +1,117 @@
+//
+//  CommonWindow.swift
+//  iina
+//
+//  Created by low-batt on 8/1/26.
+//  Copyright © 2026 lhc. All rights reserved.
+//
+
+import Cocoa
+
+/// Common base class for IINA windows.
+class CommonWindow: NSWindow {
+
+  /// Whether the window uses a [toolbar](https://developer.apple.com/documentation/appkit/nstoolbar) with the
+  /// [unified](https://developer.apple.com/documentation/appkit/nswindow/toolbarstyle-swift.enum/unified)
+  /// style.
+  private let usesUnifiedToolbar: Bool
+
+  /// The direction the window’s title bar lays text out, either left to right or right to left.
+  ///
+  /// As discussed in the
+  /// [windowTitlebarLayoutDirection](https://developer.apple.com/documentation/appkit/nswindow/windowtitlebarlayoutdirection)
+  /// documentation the value returned by the `NSWindow` implementation is based on the macOS primary system language. If in
+  /// macOS settings IINA has been configured with a language with a different directionality than the primary system language then
+  /// layout will be inconsistent and can cause objects to overlap. This implementation returns the layout direction of the view
+  /// containing the window close button to make layout consistent. See issue
+  /// [#6192](https://github.com/iina/iina/issues/6192).
+  /// - Important: Apparently  the AppKit `NSWindow` implementation does not use the value of this property when laying out
+  ///     the title bar if the window uses a [toolbar](https://developer.apple.com/documentation/appkit/nstoolbar)
+  ///     with the
+  ///     [unified](https://developer.apple.com/documentation/appkit/nswindow/toolbarstyle-swift.enum/unified)
+  ///     style where the toolbar appears next to the window title. The layout provided by AppKit  in this case expects the standard
+  ///     window buttons to be located based on the direction of the primary system language instead of this property. Unfortunately
+  ///     this behavior means this workaround can not be used for such windows. This affects the `Inspector`, `Log Viewer`
+  ///     and `Playback History` windows.
+  override var windowTitlebarLayoutDirection: NSUserInterfaceLayoutDirection {
+    guard !usesUnifiedToolbar, let button = standardWindowButton(.closeButton),
+          let view = button.superview else {
+      return super.windowTitlebarLayoutDirection
+    }
+    return view.userInterfaceLayoutDirection
+  }
+
+  /// Initializes the window with the specified values.
+  ///
+  /// This initializer ensures the
+  /// [isReleasedWhenClosed](https://developer.apple.com/documentation/appkit/nswindow/isreleasedwhenclosed)
+  /// property is set to `false` as the Apple documentation for the `NSWindow`
+  /// [initializer](https://developer.apple.com/documentation/appkit/nswindow/init(contentrect:stylemask:backing:defer:))
+  /// warns is required for Swift clients to avoid release the window too many times. This is done as a precaution as this property is
+  /// ignored for windows owned by window controllers.
+  /// - Parameters:
+  ///   - contentRect: Origin and size of the window’s content area in screen coordinates. Note that the window server limits
+  ///       window position coordinates to ±16,000 and sizes to 10,000.
+  ///   - style: The window’s style. It can be `NSBorderlessWindowMask`, or it can contain any of the options described in
+  ///       [NSWindow.StyleMask](https://developer.apple.com/documentation/appkit/nswindow/stylemask-swift.struct)
+  ///       combined using the C bitwise OR operator. Borderless windows display none of the usual peripheral elements and are
+  ///       generally useful only for display or caching purposes; you should normally not need to create them. Also, note that a
+  ///       window’s style mask should include `NSTitledWindowMask` if it includes any of the others.
+  ///   - backingStoreType: Specifies how the drawing done in the window is buffered by the window device, and possible
+  ///       values are described in
+  ///       [NSWindow.BackingStoreType](https://developer.apple.com/documentation/appkit/nswindow/backingstoretype).
+  ///   - flag: Specifies whether the window server creates a window device for the window immediately. When
+  ///       [true](https://developer.apple.com/documentation/Swift/true), the window server defers creating the
+  ///       window device until the window is moved onscreen. All display messages sent to the window or its views are postponed
+  ///       until the window is created, just before it’s moved onscreen.
+  /// - Important: If the window will use a
+  ///     [toolbar](https://developer.apple.com/documentation/appkit/nstoolbar) with the
+  ///     [unified](https://developer.apple.com/documentation/appkit/nswindow/toolbarstyle-swift.enum/unified)
+  ///     style where the toolbar appears next to the window title then the other initializer **must be** used.
+  override init(contentRect: NSRect, styleMask style: NSWindow.StyleMask,
+                backing backingStoreType: NSWindow.BackingStoreType, defer flag: Bool) {
+    usesUnifiedToolbar = false
+    super.init(contentRect: contentRect, styleMask: style, backing: backingStoreType, defer: flag)
+    isReleasedWhenClosed = false
+  }
+  
+  /// Initializes the window with the specified values.
+  ///
+  /// This initializer ensures the
+  /// [isReleasedWhenClosed](https://developer.apple.com/documentation/appkit/nswindow/isreleasedwhenclosed)
+  /// property is set to `false` as the Apple documentation for the `NSWindow`
+  /// [initializer](https://developer.apple.com/documentation/appkit/nswindow/init(contentrect:stylemask:backing:defer:))
+  /// warns is required for Swift clients to avoid release the window too many times. This is done as a precaution as this property is
+  /// ignored for windows owned by window controllers.
+  /// - Parameters:
+  ///   - contentRect: Origin and size of the window’s content area in screen coordinates. Note that the window server limits
+  ///       window position coordinates to ±16,000 and sizes to 10,000.
+  ///   - style: The window’s style. It can be `NSBorderlessWindowMask`, or it can contain any of the options described in
+  ///       [NSWindow.StyleMask](https://developer.apple.com/documentation/appkit/nswindow/stylemask-swift.struct)
+  ///       combined using the C bitwise OR operator. Borderless windows display none of the usual peripheral elements and are
+  ///       generally useful only for display or caching purposes; you should normally not need to create them. Also, note that a
+  ///       window’s style mask should include `NSTitledWindowMask` if it includes any of the others.
+  ///   - backingStoreType: Specifies how the drawing done in the window is buffered by the window device, and possible
+  ///       values are described in
+  ///       [NSWindow.BackingStoreType](https://developer.apple.com/documentation/appkit/nswindow/backingstoretype).
+  ///   - flag: Specifies whether the window server creates a window device for the window immediately. When
+  ///       [true](https://developer.apple.com/documentation/Swift/true), the window server defers creating the
+  ///       window device until the window is moved onscreen. All display messages sent to the window or its views are postponed
+  ///       until the window is created, just before it’s moved onscreen.
+  ///   - usesUnifiedToolbar: Specifies whether the window will use a
+  ///       [toolbar](https://developer.apple.com/documentation/appkit/nstoolbar) with the
+  ///       [unified](https://developer.apple.com/documentation/appkit/nswindow/toolbarstyle-swift.enum/unified)
+  ///       style where the toolbar appears next to the window title.
+  /// - Important: Windows that will use a
+  ///     [toolbar](https://developer.apple.com/documentation/appkit/nstoolbar) with the
+  ///     [unified](https://developer.apple.com/documentation/appkit/nswindow/toolbarstyle-swift.enum/unified)
+  ///     style where the toolbar appears next to the window title **must** use this initializer and pass `true` for the
+  ///     `usesUnifiedToolbar` parameter. For more discussion see the `windowTitlebarLayoutDirection` property.
+  init(contentRect: NSRect, styleMask style: NSWindow.StyleMask,
+       backing backingStoreType: NSWindow.BackingStoreType, defer flag: Bool,
+       usesUnifiedToolbar: Bool) {
+    self.usesUnifiedToolbar = usesUnifiedToolbar
+    super.init(contentRect: contentRect, styleMask: style, backing: backingStoreType, defer: flag)
+    isReleasedWhenClosed = false
+  }
+}

--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -854,6 +854,18 @@ extension NSScreen {
   }
 }
 
+#if DEBUG
+extension NSUserInterfaceLayoutDirection: @retroactive CustomStringConvertible {
+  public var description: String {
+    switch self {
+    case .leftToRight: return "leftToRight"
+    case .rightToLeft: return "rightToLeft"
+    @unknown default: return String(self.rawValue)
+    }
+  }
+}
+#endif
+
 extension NSWindow {
 
   /// Return the screen to use by default for this window.

--- a/iina/HistoryWindowController.swift
+++ b/iina/HistoryWindowController.swift
@@ -68,11 +68,12 @@ class HistoryWindowController: NSWindowController, NSOutlineViewDelegate, NSOutl
   private var historyDataKeys: [String] = []
 
   init() {
-    let window = NSWindow(
+    let window = CommonWindow(
       contentRect: NSRect(x: 0, y: 0, width: 800, height: 600),
       styleMask: [.titled, .closable, .resizable, .miniaturizable],
       backing: .buffered,
-      defer: false
+      defer: false,
+      usesUnifiedToolbar: true
     )
     window.title = NSLocalizedString("history_window.title", comment: "Playback History")
     window.setFrameAutosaveName("PlaybackHistoryWindow")

--- a/iina/LogWindowController.swift
+++ b/iina/LogWindowController.swift
@@ -78,11 +78,12 @@ class LogWindowController: NSWindowController, NSMenuDelegate, NSToolbarDelegate
   private var hasSetup = false
 
   convenience init() {
-    let window = NSWindow(
+    let window = CommonWindow(
         contentRect: NSRect(origin: .zero, size: NSSize(width: 800, height: 500)),
         styleMask: [.titled, .closable, .miniaturizable, .resizable],
         backing: .buffered,
-        defer: false
+        defer: false,
+        usesUnifiedToolbar: true
     )
     window.minSize = NSMakeSize(800, 500)
     window.title = NSLocalizedString("logwindow.title", comment: "Log Viewer")

--- a/iina/MainWindow.swift
+++ b/iina/MainWindow.swift
@@ -8,7 +8,7 @@
 
 import Cocoa
 
-class MainWindow: NSWindow {
+class MainWindow: CommonWindow {
   var forceKeyAndMain = false
 
   override func keyDown(with event: NSEvent) {

--- a/iina/MiniPlayerWindow.swift
+++ b/iina/MiniPlayerWindow.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-class MiniPlayerWindow: NSWindow {
+class MiniPlayerWindow: CommonWindow {
 
   override func keyDown(with event: NSEvent) {
     if menu?.performKeyEquivalent(with: event) == true {

--- a/iina/SettingsWindow.swift
+++ b/iina/SettingsWindow.swift
@@ -29,7 +29,7 @@ fileprivate extension NSView {
   }
 }
 
-class SettingsWindow: NSWindow {
+class SettingsWindow: CommonWindow {
   static let `default`: SettingsWindow = SettingsWindow([
     SettingsPageGeneral(),
     SettingsPageUI(),
@@ -75,8 +75,6 @@ class SettingsWindow: NSWindow {
     super.init(contentRect: NSRect(x: 0, y: 0, width: 600, height: 480),
                styleMask: [.closable, .miniaturizable, .resizable, .titled, .fullSizeContentView],
                backing: .buffered, defer: false)
-
-    self.isReleasedWhenClosed = false
 
     let splitViewController = NSSplitViewController()
     self.contentViewController = splitViewController


### PR DESCRIPTION
This commit will:
- Add a `CommonWindow` class
- Change the following classes to use the new `CommonWindow` class:
  - `HistoryWindowController`
  - `LogWindowController`
  - `MainWindow`
  - `MiniPlayerWindow`
  - `SettingsWindow`
- Change the following XIBs to use the new `CommonWindow` class:
  - `AboutWindowController`
  - `FilterWindowController`
  - `GuideWindowController`
  - `InitialWindowController`
- Add a `NSUserInterfaceLayoutDirection` extension for debugging that provides a textual representation of the enum constants

The new `CommonWindow` class overrides the `windowTitlebarLayoutDirection` property with an implementation that returns the layout direction of the view containing the window close button, instead of the implementation provided by `NSWindow` that uses the primary system language. This will cause `NSWindow` to position the standard window buttons as they would appear if in the macOS system settings the language assigned to IINA matched the primary system language, correcting the overlap reported in issue #6192.

However the AppKit `NSWindow` implementation does not use the value of the `windowTitlebarLayoutDirection` property when laying out the title bar if the window uses a toolbar with the unified style where the toolbar appears next to the window title. This affects the `Inspector`, `Log Viewer` and `Playback History` windows. Due to this unfortunate AppKit behavior these windows will continue to have their standard window buttons positioned based on the primary system language. This also applies to windows created by plugins as they might use a unified toolbar.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] Related issue: #6192
- [ ] Related Design Proposal: # / Not applicable
---
- [ ] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**
