### PR TITLE
fix: carry sub-second rollover in VideoTime time formatting

### DIFF
--- a/iina/VideoTime.swift
+++ b/iina/VideoTime.swift
@@ -58,7 +58,15 @@ class VideoTime {
     let m_ = m < 10 ? "0\(m)" : "\(m)"
     let s_: String
     if precise {
-      s_ = String(format: "%0\(precision + 3).\(precision)f", fmod(second, 60))
+      let secondsField = String(format: "%0\(precision + 3).\(precision)f", fmod(second, 60))
+      if secondsField.hasPrefix("60") {
+        let carried = rounded + 60
+        let ch = carried / 3600, crem = carried % 3600, cm = crem / 60
+        let ch_ = ch > 0 ? "\(ch):" : ""
+        let cm_ = cm < 10 ? "0\(cm)" : "\(cm)"
+        return ch_ + cm_ + ":" + String(format: "%0\(precision + 3).\(precision)f", 0.0)
+      }
+      s_ = secondsField
     } else {
       let s = remaining % 60
       s_ = s < 10 ? "0\(s)" : "\(s)"


### PR DESCRIPTION
`VideoTime.stringRepresentationWithPrecision(_:)` renders an invalid `60` in the seconds field when sub-second precision (100ms / 10ms / 1ms) rounds a fractional minute up: `59.97s` at precision 1 shows `00:60.0` instead of `01:00.0`, and at the hour boundary `3599.97s` shows `59:60.0` instead of `1:00:00.0`. During normal playback at any sub-second precision the time label flickers `00:59.9 ↔ 00:60.0` once per minute.

## Root cause
In the `precise` branch (`precision ∈ {1,2,3}`), the hour/minute decomposition comes from the truncated integer `Int(second)` (`rounded`), but the seconds field is formatted from the **original** `second` via `fmod(second, 60)`. When `second ∈ [60 − ½·10^−precision, 60)`, `fmod` is the same near-60 value and `%N.Nf` rounds it **up** to `"60.…"` while `h`/`m` were frozen one short. The `precision == 0` branch is correct — it rounds via `roundedHalfDown()` first, baking the carry in. The bug is isolated to the fractional branch added in `4e3226d8`; #5358 only touched the `precision == 0` branch.

## Fix
Inside the existing `if precise { … }` block (~7 lines): keep the `String(format: "%0…f", fmod(second, 60))` call; when the resulting field starts with `"60"` (the only possible rollover, since `fmod` is `< 60`), recompute `h`/`m` from `rounded + 60` and reset the seconds field to all-zeros at the same precision. Byte-for-byte identical to today's output for every non-rollover input.

## Test plan
A standalone reproducer (`fmod` + `String(format:)`, pure Foundation — no mpv/GUI) sweeps the rollover inputs across all four precision levels. Red before the fix:
```
sec=59.9700   p=1  00:60.0      sec=59.9960   p=2  00:60.00
sec=59.9996   p=3  00:60.000    sec=3599.9700 p=1  59:60.0
```
Green after the fix: `01:00.0`, `01:00.00`, `01:00.000`, `1:00:00.0`. Control cases unchanged (`59.4`/1→`00:59.4`, `59.949`/2→`00:59.95`, `0.0`→`00:00.0`, `3600.0`/2→`1:00:00.00`). A dense no-regression sweep over `second ∈ [0, 3h)` at 1ms resolution reports `Bad divergences: 0` (the fix changes output only where the old value contained `":60."`).

`xcodebuild -project iina.xcodeproj -scheme iina -configuration Nightly ONLY_ACTIVE_ARCH=NO CODE_SIGNING_ALLOWED=NO build` — succeeds. Reachable: default precision is 0 (`Preference.swift:1083`), so latent by default; activates via the time-label right-click precision menu and the **Jump To…** dialog (which seeds at precision 3).