### PR TITLE
fix: correct hex color parsing in NSColor(mpvColorString:)

### DIFF
--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -441,10 +441,11 @@ extension NSColor {
       var rgb: UInt64 = 0
       scanner.scanHexInt64(&rgb)
 
-      let r = Double((rgb >> 32) & 0xFF) / 255
-      let g = Double((rgb >> 16) & 0xFF) / 255
-      let b = Double((rgb >> 8) & 0xFF) / 255
-      let a = Double(rgb & 0xFF) / 255
+      // mpv hex colors are #RRGGBB (100% opaque) or #AARRGGBB (alpha first).
+      let a = hex.count <= 6 ? 1.0 : Double((rgb >> 24) & 0xFF) / 255.0
+      let r = Double((rgb >> 16) & 0xFF) / 255
+      let g = Double((rgb >> 8) & 0xFF) / 255
+      let b = Double(rgb & 0xFF) / 255
 
       self.init(red: r, green: g, blue: b, alpha: a)
     } else {


### PR DESCRIPTION
`NSColor(mpvColorString:)` decoded mpv hex colors with the wrong bit shifts — `>>32 / >>16 / >>8 / >>0` — which, for a value that fits in the low 32 bits, makes red always `0` and makes a 6-digit `#RRGGBB` (documented as 100% opaque) come out with `alpha == 0`: `#FF8800` (opaque orange) renders as transparent green. This breaks the subtitle color picker in the new sidebar (`SidebarSubtitlesPane.swift:538`) whenever mpv returns a hex color string.

Per the maintainer's own comment and the reference `hexColorToFloat` (`MPVController.swift:1798-1825`), the mpv format is `#RRGGBB` (6 digits, opaque) or `#AARRGGBB` (8 digits, alpha first) — both fit in 32 bits, so the channel must be selected by hex digit count, not a fixed shift.

## Fix
Branch on `hex.count`: `#RRGGBB` → R/G/B from `>>16 / >>8 / >>0` with `alpha = 1.0`; `#AARRGGBB` → same R/G/B plus `alpha` from `>>24`. Matches `hexColorToFloat` 1:1. The float `else`-branch is untouched (it was correct).

## Test plan
A standalone `Scanner` + bit-shift reproducer (pure Foundation) verifies 9 inputs. Before → after (literal):
```
#FF8800    BUGGY(r=0.000 g=1.000 b=0.533 a=0.000)  CORRECT(r=1.000 g=0.533 b=0.000 a=1.000)
#80FF8800  BUGGY(r=0.000 g=1.000 b=0.533 a=0.000)  CORRECT(r=1.000 g=0.533 b=0.000 a=0.502)
#FFFFFF    BUGGY(r=0.000 g=1.000 b=1.000 a=1.000)  CORRECT(r=1.000 g=1.000 b=1.000 a=1.000)
#FF0000    BUGGY(transparent)                      CORRECT(opaque red)
#000000    BUGGY(transparent)                      CORRECT(opaque black)
```
`xcodebuild ... build` — `Extensions.swift` compiles clean. (The only local build error is the pre-existing `LanguageTokenField.swift:131` SDK-API mismatch on this host, unrelated to this file — same note as on #6239.)

## AI disclosure
The code is fully written by AI.

Related Design Proposal: Not applicable