### PR TITLE
fix: crash in iina-plugin new when using the --url flag

### DIFF
--- a/iina-plugin/main.swift
+++ b/iina-plugin/main.swift
@@ -71,7 +71,7 @@ func handlePluginCommand(_ args: [String]) -> Bool {
 // MARK: - Commands
 
 func createPlugin(_ args: ArraySlice<String>) -> Bool {
-  var args = args
+  var args = Array(args)
   var userTemplateURL: String?
   var idxToBeDropped: [Int] = []
   for (idx, arg) in args.enumerated() {
@@ -80,7 +80,7 @@ func createPlugin(_ args: ArraySlice<String>) -> Bool {
       idxToBeDropped.append(idx)
     }
   }
-  for idx in idxToBeDropped {
+  for idx in idxToBeDropped.reversed() {
     args.remove(at: idx)
   }
   


### PR DESCRIPTION
The documented `iina-plugin new --url=… <name>` flag crashed on every run (`Fatal error: Index out of bounds`) since the feature was added (~3 years, commit 1af17db7). createPlugin receives an ArraySlice from dropFirst() (startIndex > 0) but enumerated()+remove(at:) assume a 0 base, so the first --url flag's idx=0 is below the slice startIndex. A second fault dropped indices forward, breaking the multi-flag case too.

## Fix
`var args = Array(args)` (normalize base to 0) + `for idx in idxToBeDropped.reversed()` (drop highest first so earlier indices stay valid). 2 lines.

## Test plan
Standalone reproducer over `["new","--url=…","name"].dropFirst()` traps today; after the fix all 4 cases pass (url-first, name-first, no-url, two-url-flags).

## AI disclosure
The code is fully written by AI.

Related Design Proposal: Not applicable