### PR TITLE
fix(settings): restore advanced option state

### DIFF
--- a/iina/SettingsItem.swift
+++ b/iina/SettingsItem.swift
@@ -677,13 +677,13 @@ struct SettingsItem {
     }
 
     @objc func switchChanged(_ sender: NSSwitch?) {
-      guard let detailView = renderedDetailView else { return }
-
       let enabled = nsSwitch.state == .on
-      if !isExpandableAndClickable {
-        toggleExpandable(enabled)
+      if let detailView = renderedDetailView {
+        if !isExpandableAndClickable {
+          toggleExpandable(enabled)
+        }
+        setSubControls(detailView, enabled: enabled)
       }
-      setSubControls(detailView, enabled: enabled)
 
       if sender != nil {
         // Only call the callback when the user manually clicked the switch.

--- a/iina/SettingsPageAdvanced.swift
+++ b/iina/SettingsPageAdvanced.swift
@@ -10,6 +10,16 @@ fileprivate let ui = SettingsUIHelper.sharedUI
 
 
 class SettingsPageAdvanced: SettingsPage {
+  private var pageView: NSView?
+  private var advancedSettingsView: NSView?
+  private var advancedSettingsObserver: NSObjectProtocol?
+
+  deinit {
+    if let advancedSettingsObserver {
+      NotificationCenter.default.removeObserver(advancedSettingsObserver)
+    }
+  }
+
   override var identifier: String {
     "advanced"
   }
@@ -26,6 +36,28 @@ class SettingsPageAdvanced: SettingsPage {
     "SettingsAdvancedLocalizable"
   }
 
+  override func pageLoaded() {
+    if let renderedView = advancedSettingsSwitch.renderedView {
+      advancedSettingsView = renderedView
+      var pageView: NSView = renderedView
+      while let superview = pageView.superview, !(superview is NSClipView) {
+        pageView = superview
+      }
+      self.pageView = pageView
+    }
+
+    if advancedSettingsObserver == nil {
+      advancedSettingsObserver = NotificationCenter.default.addObserver(
+        forName: UserDefaults.didChangeNotification,
+        object: UserDefaults.standard,
+        queue: .main
+      ) { [weak self] _ in
+        self?.setAdvancedControlsEnabled(Preference.bool(for: .enableAdvancedSettings))
+      }
+    }
+    setAdvancedControlsEnabled(Preference.bool(for: .enableAdvancedSettings))
+  }
+
   private lazy var fileChooseView: SettingsAccessory.FileChooserView = .init(.userDefinedConfDir)
   private lazy var mpvOptionsEditor: MPVOptionsEditor = MPVOptionsEditor()
   private lazy var openLogFolderBtn: NSButton = {
@@ -34,6 +66,20 @@ class SettingsPageAdvanced: SettingsPage {
     btn.target = self
     btn.action = #selector(openLogFolder)
     return btn
+  }()
+
+  private lazy var advancedSettingsSwitch: SettingsItem.Switch = {
+    let item = SettingsItem.Switch()
+      .bindTo(.enableAdvancedSettings)
+      .image(name: ["flask"])
+      .hasDescription()
+      .withHelpLink(AppData.wikiLink.appending("/MPV-Options-and-Properties"))
+    item.stateChangeCallback = { [weak self] _ in
+      DispatchQueue.main.async {
+        self?.setAdvancedControlsEnabled(Preference.bool(for: .enableAdvancedSettings))
+      }
+    }
+    return item
   }()
 
   override func content() -> [SettingsSection] {
@@ -47,13 +93,22 @@ class SettingsPageAdvanced: SettingsPage {
   private func sectionEnableAdvanced() -> SettingsSection {
     return section {
       SettingsList() {
-        SettingsItem.Switch()
-          .bindTo(.enableAdvancedSettings)
-          .image(name: ["flask"])
-          .hasDescription()
-          .withHelpLink(AppData.wikiLink.appending("/MPV-Options-and-Properties"))
+        advancedSettingsSwitch
       }
     }
+  }
+
+  private func setAdvancedControlsEnabled(_ enabled: Bool) {
+    guard let pageView else { return }
+    setControlsEnabled(in: pageView, enabled: enabled, skipping: advancedSettingsView)
+  }
+
+  private func setControlsEnabled(in view: NSView, enabled: Bool, skipping skippedView: NSView?) {
+    guard view !== skippedView else { return }
+    if let control = view as? NSControl {
+      control.isEnabled = enabled
+    }
+    view.subviews.forEach { setControlsEnabled(in: $0, enabled: enabled, skipping: skippedView) }
   }
 
   private func sectionLogging() -> SettingsSection {

--- a/iina/SettingsPageAdvanced.swift
+++ b/iina/SettingsPageAdvanced.swift
@@ -12,13 +12,7 @@ fileprivate let ui = SettingsUIHelper.sharedUI
 class SettingsPageAdvanced: SettingsPage {
   private var pageView: NSView?
   private var advancedSettingsView: NSView?
-  private var advancedSettingsObserver: NSObjectProtocol?
-
-  deinit {
-    if let advancedSettingsObserver {
-      NotificationCenter.default.removeObserver(advancedSettingsObserver)
-    }
-  }
+  private let prefObserver = Preference.Observer()
 
   override var identifier: String {
     "advanced"
@@ -46,16 +40,9 @@ class SettingsPageAdvanced: SettingsPage {
       self.pageView = pageView
     }
 
-    if advancedSettingsObserver == nil {
-      advancedSettingsObserver = NotificationCenter.default.addObserver(
-        forName: UserDefaults.didChangeNotification,
-        object: UserDefaults.standard,
-        queue: .main
-      ) { [weak self] _ in
-        self?.setAdvancedControlsEnabled(Preference.bool(for: .enableAdvancedSettings))
-      }
+    prefObserver.add(.enableAdvancedSettings, runNow: true) { [weak self] _ in
+      self?.setAdvancedControlsEnabled(Preference.bool(for: .enableAdvancedSettings))
     }
-    setAdvancedControlsEnabled(Preference.bool(for: .enableAdvancedSettings))
   }
 
   private lazy var fileChooseView: SettingsAccessory.FileChooserView = .init(.userDefinedConfDir)


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] Related issue: #
- [ ] Related Design Proposal: Not applicable
---
- [x] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**

When Advanced settings were disabled in the new settings window, controls in the Logging and mpv sections stayed active. This change keeps those sibling controls disabled while preserving the master switch row, including its icon and help button, and restores them when the setting is enabled.