### PR TITLE
Fix plugin URL parsing without file-system permission

### DIFF
--- a/iina/JavascriptAPI.swift
+++ b/iina/JavascriptAPI.swift
@@ -74,6 +74,10 @@ class JavascriptAPI: NSObject {
       }
     }
 
+    if !forceLocalPath, let scheme = URL(string: path)?.scheme, scheme != "file" {
+      return (path, false)
+    }
+
     return whenPermitted(to: .accessFileSystem) {
       var absPath = path
       if let player = player, path.hasPrefix("@current/") {
@@ -95,7 +99,7 @@ class JavascriptAPI: NSObject {
         absPath.hasPrefix(pluginInstance.plugin.dataURL.path) ||
         absPath.hasPrefix(pluginInstance.plugin.tmpURL.path)
       )
-    }!
+    } ?? (nil, false)
   }
 
   private func trackPath(_ path: String, type: MPVTrack.TrackType) -> String? {


### PR DESCRIPTION
## Description

Fix `parsePath` so non-file URLs can be opened when `forceLocalPath` is false, without requiring the plugin's `file-system` permission.

Local paths and `file:` URLs remain permission-gated. Permission denial now returns a nil path instead of force-unwrapping the result and crashing.

Fixes #6230

## Testing

- Full Nightly configuration build succeeded.
- Verified HTTPS and RTSP URLs bypass file-system permission.
- Verified absolute paths, tilde paths, and `file:` URLs remain protected.
- Used a temporary macOS 12 deployment-target override because the installed Xcode 27 beta no longer accepts IINA's macOS 11 target.

AI tooling assisted with code analysis and build verification. I reviewed and validated the final change.
