### PR TITLE
Restore standard sidebar material in the new settings page

### DIFF
--- a/iina/SettingsWindow.swift
+++ b/iina/SettingsWindow.swift
@@ -84,11 +84,8 @@ class SettingsWindow: NSWindow {
     let sidebarViewController = NSViewController()
     sidebarViewController.view = NSView()
     sidebarViewController.view.wantsLayer = true
-    let sidebarBackground = if #available(macOS 26, *) {
-      NSGlassEffectView()
-    } else {
-      NSVisualEffectView()
-    }
+    let sidebarBackground = NSVisualEffectView()
+    sidebarBackground.material = .sidebar
     sidebarViewController.view.addSubview(sidebarBackground)
     sidebarBackground.translatesAutoresizingMaskIntoConstraints = false
     sidebarBackground.padding(.all)
@@ -886,4 +883,3 @@ fileprivate extension String {
     self.replacingOccurrences(of: "\\s+$", with: "", options: .regularExpression)
   }
 }
-


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] Related issue: #
- [x] Related Design Proposal: #6250
---
- [ ] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.

**Description:**

Restored sidebar to the standard `.sidebar` material as the original `NSGlassEffectView` adds redundant round corners on the top & bottom right corners and to better match current system appearance.
