### PR TITLE
Fix mini player control button backgrounds

### DIFF
--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -300,6 +300,8 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     self.closeButtonBackground = NSBox()
     closeButtonBackground.translatesAutoresizingMaskIntoConstraints = false
     closeButtonBackground.boxType = .custom
+    closeButtonBackground.isTransparent = false
+    closeButtonBackground.fillColor = NSColor(calibratedWhite: 0.12, alpha: 1)
     closeButtonBackground.contentViewMargins = .zero
     closeButtonBackground.cornerRadius = 10
     closeButtonBackground.titlePosition = .noTitle
@@ -322,6 +324,7 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
       button!.bezelStyle = .smallSquare
       button!.isBordered = false
       button!.imagePosition = .imageOnly
+      button!.contentTintColor = NSColor(calibratedWhite: 0.76, alpha: 0.82)
       button!.refusesFirstResponder = true
       button!.widthAnchor.constraint(equalTo: button!.heightAnchor, multiplier: 1).isActive = true
       closeButtonBackground.contentView!.addSubview(button!)
@@ -516,8 +519,7 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
   }
 
   private func updateCloseButton() {
-    closeButtonBackground.fillColor = .controlBackgroundColor
-      .withAlphaComponent(isVideoVisible ? 0.9 : 0.2)
+    closeButtonBackground.fillColor = NSColor(calibratedWhite: 0.12, alpha: 1)
     closeButtonSizeConstraint.constant = isVideoVisible ? 13 : 12
     closeButtonSpacingConstraint.constant = isVideoVisible ? 5 : 4
   }

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -32,7 +32,7 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
 
   var backgroundView: NSVisualEffectView!
   var closeButtonView: NSView!
-  var closeButtonBackground: NSBox!
+  var closeButtonBackground: NSVisualEffectView!
   var closeButton: NSButton!
   var closeButtonSizeConstraint: NSLayoutConstraint!
   var closeButtonSpacingConstraint: NSLayoutConstraint!
@@ -297,15 +297,15 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     cv.addSubview(closeButtonView)
     closeButtonView.padding(.top(6), .leading(8))
 
-    self.closeButtonBackground = NSBox()
+    self.closeButtonBackground = NSVisualEffectView()
     closeButtonBackground.translatesAutoresizingMaskIntoConstraints = false
-    closeButtonBackground.boxType = .custom
-    closeButtonBackground.isTransparent = false
-    closeButtonBackground.fillColor = NSColor(calibratedWhite: 0.12, alpha: 1)
-    closeButtonBackground.contentViewMargins = .zero
-    closeButtonBackground.cornerRadius = 10
-    closeButtonBackground.titlePosition = .noTitle
-    closeButtonBackground.borderColor = .clear
+    closeButtonBackground.blendingMode = .withinWindow
+    closeButtonBackground.material = .popover
+    closeButtonBackground.state = .active
+    closeButtonBackground.clipsToBounds = true
+    closeButtonBackground.roundCorners(withRadius: 10)
+    closeButtonBackground.wantsLayer = true
+    closeButtonBackground.layer?.cornerRadius = 10
     closeButtonView.addSubview(closeButtonBackground)
     closeButtonBackground.padding(.all)
 
@@ -324,10 +324,9 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
       button!.bezelStyle = .smallSquare
       button!.isBordered = false
       button!.imagePosition = .imageOnly
-      button!.contentTintColor = NSColor(calibratedWhite: 0.76, alpha: 0.82)
       button!.refusesFirstResponder = true
       button!.widthAnchor.constraint(equalTo: button!.heightAnchor, multiplier: 1).isActive = true
-      closeButtonBackground.contentView!.addSubview(button!)
+      closeButtonBackground.addSubview(button!)
     }
 
     backButton.widthAnchor.constraint(equalTo: closeButton.widthAnchor, multiplier: 1).isActive = true
@@ -519,7 +518,6 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
   }
 
   private func updateCloseButton() {
-    closeButtonBackground.fillColor = NSColor(calibratedWhite: 0.12, alpha: 1)
     closeButtonSizeConstraint.constant = isVideoVisible ? 13 : 12
     closeButtonSpacingConstraint.constant = isVideoVisible ? 5 : 4
   }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] Related issue: N/A
- [ ] Related Design Proposal: N/A
---
- [ ] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**

Fix a regression introduced by eea2d4af092998929d10bff7caa48cd97f30ecac, which left the mini player close and back button backgrounds too transparent and reduced their contrast.

| Nightly Build from `develop` | This PR | v1.4.4 |
| :---: | :---: | :---: |
| ![](https://github.com/user-attachments/assets/92e86d5f-a418-4f68-a07f-dbe521ebdb3f) | ![](https://github.com/user-attachments/assets/53bb7d87-7b0a-48aa-9512-b1835cd82d57) | ![](https://github.com/user-attachments/assets/50354bbc-0e6d-4809-94e6-af918ad37935) |