### PR TITLE
fix: correct live text padding variable typo

### DIFF
--- a/iina/LiveTextSupport.swift
+++ b/iina/LiveTextSupport.swift
@@ -58,8 +58,8 @@ class LiveTextController: NSObject {
     let isBottom = Preference.enum(for: .oscPosition) as Preference.OSCPosition == .bottom
     let isCompact = Preference.bool(for: .compactUI)
     let padding: CGFloat = isCompact ? 8 : 14
-    let buttomPadding: CGFloat = isBottom ? (isCompact ? 50 : 64) : padding
-    view.supplementaryInterfaceContentInsets = NSEdgeInsets(top: padding, left: padding, bottom: buttomPadding, right: padding)
+    let bottomPadding: CGFloat = isBottom ? (isCompact ? 50 : 64) : padding
+    view.supplementaryInterfaceContentInsets = NSEdgeInsets(top: padding, left: padding, bottom: bottomPadding, right: padding)
   }
 
   func requestAnalysis() {


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] Related issue: Not applicable
- [ ] Related Design Proposal: Not applicable
---
- [ ] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.

**Description:**

Correct the misspelled live text overlay padding variable.