### PR TITLE
Fixed manually installing plugins brings up the old settings page

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -771,7 +771,11 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
 
     // if installing a plugin package
     if let pluginPackageURL = urls.first(where: { $0.pathExtension == "iinaplgz" }) {
-      preferenceWindowController.performAction(.installPlugin(url: pluginPackageURL))
+      if Preference.enableNewSettings {
+        SettingsWindow.default.installPlugin(localPackageURL: pluginPackageURL)
+      } else {
+        preferenceWindowController.performAction(.installPlugin(url: pluginPackageURL))
+      }
       return
     }
 

--- a/iina/SettingsPagePlugin.swift
+++ b/iina/SettingsPagePlugin.swift
@@ -36,6 +36,7 @@ class SettingsPagePlugin: SettingsPage {
   fileprivate lazy var installView: PluginInstallView = .init(page: self)
   fileprivate lazy var listView: PluginListView = .init(page: self)
   fileprivate lazy var updateView: PluginUpdateView = .init(page: self)
+  fileprivate lazy var pluginManager = PluginManager(window: SettingsWindow.default)
 
   override func content() -> [SettingsSection] {
     return sections {
@@ -62,12 +63,18 @@ class SettingsPagePlugin: SettingsPage {
       }
     }
   }
+
+  func installPlugin(localPackageURL url: URL) {
+    Task { @MainActor in
+      await pluginManager.install(localPackageURL: url)
+      self.listView.tableView.reloadData()
+    }
+  }
 }
 
 
 fileprivate class PluginInstallView: SettingsAccessory.Base {
   unowned let page: SettingsPagePlugin
-  private lazy var pluginManager: PluginManager = PluginManager(window: self.view.window!)
 
   init(page: SettingsPagePlugin) {
     self.page = page
@@ -95,10 +102,7 @@ fileprivate class PluginInstallView: SettingsAccessory.Base {
   @IBAction func installPluginFromLocalPackage(_ sender: Any) {
     Utility.quickOpenPanel(title: "Install from local package",
                            chooseDir: false, sheetWindow: view.window, allowedFileTypes: ["iinaplgz"]) { url in
-      Task {
-        await self.pluginManager.install(localPackageURL: url)
-        self.page.listView.tableView.reloadData()
-      }
+      self.page.installPlugin(localPackageURL: url)
     }
   }
 
@@ -113,7 +117,7 @@ fileprivate class PluginInstallView: SettingsAccessory.Base {
       Utility.quickPromptPanel("install_plugin_macos_11", sheetWindow: view.window!) { url in
         if url.isEmpty { return }
         Task { @MainActor in
-          await self.pluginManager.install(gitHubString: url)
+          await self.page.pluginManager.install(gitHubString: url)
         }
       }
     }

--- a/iina/SettingsWindow.swift
+++ b/iina/SettingsWindow.swift
@@ -648,6 +648,14 @@ extension SettingsWindow {
       sidebarList.selectRowIndexes(IndexSet(integer: selectIdx), byExtendingSelection: false)
     }
   }
+
+  func installPlugin(localPackageURL url: URL) {
+    show()
+    navigateTo(page: "plugin")
+    if let pluginPage = pages.first(where: { $0.identifier == "plugin" }) as? SettingsPagePlugin {
+      pluginPage.installPlugin(localPackageURL: url)
+    }
+  }
 }
 
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] Related issue: #
- [ ] Related Design Proposal: # / Not applicable
---
- [x] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**

Fixed an issue where double clicking a `.iinaplgz` file to install a plugin brings up the old settings page.