### PR TITLE
feat: add frame precision to time display

### DIFF
--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -48,6 +48,7 @@
 "osc.100ms" = "100 milliseconds";
 "osc.10ms" = "10 milliseconds";
 "osc.1ms" = "1 millisecond";
+"osc.1frame" = "1 frame";
 
 // QuickSettingViewController.swift
 "quicksetting.item_default" = "Default";

--- a/iina/DurationDisplayTextField.swift
+++ b/iina/DurationDisplayTextField.swift
@@ -9,6 +9,7 @@
 import Foundation
 
 class DurationDisplayTextField: NSTextField {
+  static let framePrecision: UInt = 4
   enum DisplayMode {
     case current
     case duration // displays the duration of the movie
@@ -20,6 +21,7 @@ class DurationDisplayTextField: NSTextField {
   var duration: VideoTime = .zero
   var current: VideoTime = .zero
   var remaining: VideoTime = .zero
+  var frameRate: Double?
 
   override init(frame frameRect: NSRect) {
     super.init(frame: .zero)
@@ -42,23 +44,24 @@ class DurationDisplayTextField: NSTextField {
   }
 
   func updateText(with duration: VideoTime, given current: VideoTime,
-                  and remaining: VideoTime) {
+                  and remaining: VideoTime, frameRate: Double? = nil) {
     self.duration = duration
     self.current = current
     self.remaining = remaining
+    self.frameRate = frameRate
     updateText()
   }
   
   private func updateText() {
-    let precision = DurationDisplayTextField.precision
+    let precision = displayPrecision
     let stringValue: String
     switch mode {
     case .current:
-      stringValue = current.stringRepresentationWithPrecision(precision)
+      stringValue = current.stringRepresentationWithPrecision(precision, frameRate: frameRate)
     case .duration:
-      stringValue = duration.stringRepresentationWithPrecision(precision)
+      stringValue = duration.stringRepresentationWithPrecision(precision, frameRate: frameRate)
     case .remaining:
-      stringValue = "-\(remaining.stringRepresentationWithPrecision(precision))"
+      stringValue = "-\(remaining.stringRepresentationWithPrecision(precision, frameRate: frameRate))"
     }
     self.stringValue = stringValue
   }
@@ -76,7 +79,7 @@ class DurationDisplayTextField: NSTextField {
   }
 
   override func rightMouseDown(with event: NSEvent) {
-    let precision = DurationDisplayTextField.precision
+    let precision = displayPrecision
     let menu = NSMenu(title: "Time label settings")
     menu.addItem(withTitle: NSLocalizedString("osc.precision", comment: "Precision"))
     ["1s", "100ms", "10ms", "1ms"].enumerated().forEach { (index, key) in
@@ -85,7 +88,20 @@ class DurationDisplayTextField: NSTextField {
                    target: self, tag: index,
                    stateOn: precision == index)
     }
+    if let frameRate, frameRate > 0 {
+      menu.addItem(withTitle: NSLocalizedString("osc.1frame", comment: "1 frame"),
+                   action: #selector(self.setPrecision(_:)),
+                   target: self, tag: Int(Self.framePrecision),
+                   stateOn: precision == Self.framePrecision)
+    }
     NSMenu.popUpContextMenu(menu, with: event, for: self)
+  }
+
+  private var displayPrecision: UInt {
+    if DurationDisplayTextField.precision == Self.framePrecision && (frameRate ?? 0) <= 0 {
+      return 3
+    }
+    return DurationDisplayTextField.precision
   }
 
   override func touchesBegan(with event: NSEvent) {

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -634,9 +634,10 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
       log("Video remaining not available", level: .warning)
       return
     }
-    [leftLabel, rightLabel].forEach { $0.updateText(with: duration, given: pos, and: remaining) }
+    let frameRate = player.info.currentTrack(.video)?.demuxFps
+    [leftLabel, rightLabel].forEach { $0.updateText(with: duration, given: pos, and: remaining, frameRate: frameRate) }
     player.touchBarSupport.touchBarPosLabels.forEach { $0.updateText(with: duration, given: pos,
-                                                                     and: remaining) }
+                                                                     and: remaining, frameRate: frameRate) }
     if andProgressBar {
       let percentage = (pos.second / duration.second) * 100
       playSlider.doubleValue = percentage

--- a/iina/VideoTime.swift
+++ b/iina/VideoTime.swift
@@ -28,18 +28,25 @@ class VideoTime {
   /// | 1 | 100 milliseconds |
   /// | 2 | 10 milliseconds |
   /// | 3 | 1 millisecond |
+  /// | 4 | 1 frame |
   /// - Important: The time is also displayed in the macOS
   ///     [Control Center](https://support.apple.com/guide/mac-help/quickly-change-settings-mchl50f94f8f/mac)
   ///     Now Playing module. Now Playing uses 1 second precision. When the IINA OSC is also configured to use 1 second precision
   ///     it is important that the times displayed match. This means IINA **must** use the same rounding method that Now Playing
   ///     uses, [rounding half down](https://en.wikipedia.org/wiki/Rounding#Rounding_half_down).  IINA must
   ///     round 0.5 to 0 and 0.51 to 1.
-  /// - Parameter precision: Precision to use for the seconds portion of the returned string.
-  /// - Returns: A string containing the time in the format "hh:mm:ss.sss", with the number of digits in the fraction controlled by the
-  ///     precision parameter.
-  func stringRepresentationWithPrecision(_ precision: UInt) -> String {
+  /// - Parameter precision: Precision to use for the seconds portion of the returned string. A value of 4 displays the frame number.
+  /// - Parameter frameRate: The video's frame rate, required when `precision` is 4.
+  /// - Returns: A string containing the time in the format "hh:mm:ss.sss", or "hh:mm:ss:FF" when using frame precision.
+  func stringRepresentationWithPrecision(_ precision: UInt, frameRate: Double? = nil) -> String {
     if self == Constants.Time.infinite {
       return "End"
+    }
+
+    if precision == 4, let frameRate, frameRate > 0 {
+      let wholeSeconds = floor(second)
+      let frame = Int(((second - wholeSeconds) * frameRate).rounded(.down))
+      return "\(VideoTime(wholeSeconds).stringRepresentation):\(String(format: "%02d", frame))"
     }
 
     // Whether to include fractional seconds.

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -48,6 +48,7 @@
 "osc.100ms" = "100 milliseconds";
 "osc.10ms" = "10 milliseconds";
 "osc.1ms" = "1 millisecond";
+"osc.1frame" = "1 frame";
 
 // QuickSettingViewController.swift
 "quicksetting.item_default" = "Default";


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] Related issue: #3153
- [ ] Related Design Proposal: Not applicable
---
- [x] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**

Add a “1 frame” precision option to the time display context menu. Video files display `h:mm:ss:CurrentFrame`, where `CurrentFrame` is the frame number within the current second, calculated from the active video track’s frame rate. If frame precision was selected for a video, audio playback temporarily falls back to 1 millisecond precision and restores frame precision when returning to video.

<img width="592" height="226" alt="Screenshot 2026-08-15 at 19 27 15" src="https://github.com/user-attachments/assets/749a1804-40c5-4056-a023-5da3af4d6d22" />
