### PR TITLE
Enhance S/PDIF output setting

### DIFF
--- a/iina/AppData.swift
+++ b/iina/AppData.swift
@@ -69,6 +69,7 @@ struct AppData {
   static let gainAdjustmentHelpLink = "https://mpv.io/manual/stable/#options-replaygain"
   static let gaplessAudioHelpLink = "https://mpv.io/manual/stable/#options-gapless-audio"
   static let audioDriverHellpLink = "https://mpv.io/manual/stable/#audio-output-drivers-coreaudio"
+  static let spdifOutputHelpLink = "https://mpv.io/manual/stable/#options-audio-spdif"
 
   static let widthWhenNoVideo = 640
   static let heightWhenNoVideo = 360

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -978,6 +978,7 @@
 "settings.$RestoreAllAlertsThat" = "Restore all alerts that have been suppressed using the \"Do not show this message again\" checkbox.";
 "settings.$RestoreSuppressedAlerts" = "Restore Suppressed Alerts";
 "settings.$SPDIFOutput" = "S/PDIF output";
+"settings.$SPDIFOutputWarning" = "List of codecs for which compressed audio passthrough should be used.\n\nWarning: There is not much reason to use this setting. HDMI supports uncompressed multichannel PCM, and lossless DTS-HD decoding is supported via FFmpeg's DCA decoder. Playback may not start if the output device does not support S/PDIF and this setting is enabled.";
 "settings.$Safari" = "Safari";
 "settings.$Screenshots" = "Screenshots";
 "settings.$SetIINAAsTheDefault" = "Set IINA as the Default Application";

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -417,12 +417,25 @@ class MPVController: NSObject {
                   level: .verbose)
     setUserOption(PK.maxVolume, type: .int, forName: MPVOption.Audio.volumeMax, level: .verbose)
 
-    var spdif: [String] = []
-    if Preference.bool(for: PK.spdifAC3) { spdif.append("ac3") }
-    if Preference.bool(for: PK.spdifDTS){ spdif.append("dts") }
-    if Preference.bool(for: PK.spdifDTSHD) { spdif.append("dts-hd") }
-    chkErr(setOptionString(MPVOption.Audio.audioSpdif, spdif.joined(separator: ","),
-                           verboseIfDefault: true))
+    let spdifValue = { (key: Preference.Key) -> String in
+      var spdif: [String] = []
+      if Preference.bool(for: PK.spdifAC3) { spdif.append("ac3") }
+      if Preference.bool(for: PK.spdifDTS){ spdif.append("dts") }
+      if Preference.bool(for: PK.spdifDTSHD) { spdif.append("dts-hd") }
+      if Preference.bool(for: PK.spdifEAC3) { spdif.append("eac3") }
+      if Preference.bool(for: PK.spdifTRUEHD) { spdif.append("truehd") }
+      return spdif.joined(separator: ",")
+    }
+    setUserOption(PK.spdifAC3, type: .other, forName: MPVOption.Audio.audioSpdif,
+                  verboseIfDefault: true, transformer: spdifValue)
+    setUserOption(PK.spdifDTS, type: .other, forName: MPVOption.Audio.audioSpdif,
+                  verboseIfDefault: true, transformer: spdifValue)
+    setUserOption(PK.spdifDTSHD, type: .other, forName: MPVOption.Audio.audioSpdif,
+                  verboseIfDefault: true, transformer: spdifValue)
+    setUserOption(PK.spdifEAC3, type: .other, forName: MPVOption.Audio.audioSpdif,
+                  verboseIfDefault: true, transformer: spdifValue)
+    setUserOption(PK.spdifTRUEHD, type: .other, forName: MPVOption.Audio.audioSpdif,
+                  verboseIfDefault: true, transformer: spdifValue)
 
     setUserOption(PK.audioDevice, type: .string, forName: MPVOption.Audio.audioDevice,
                   verboseIfDefault: true)

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -198,6 +198,8 @@ struct Preference {
     static let spdifAC3 = Key("spdifAC3")
     static let spdifDTS = Key("spdifDTS")
     static let spdifDTSHD = Key("spdifDTSHD")
+    static let spdifEAC3 = Key("spdifEAC3")
+    static let spdifTRUEHD = Key("spdifTRUEHD")
 
     static let audioDevice = Key("audioDevice")
     static let audioDeviceDesc = Key("audioDeviceDesc")
@@ -1131,6 +1133,8 @@ struct Preference {
     .spdifAC3: false,
     .spdifDTS: false,
     .spdifDTSHD: false,
+    .spdifEAC3: false,
+    .spdifTRUEHD: false,
     .audioDevice: "auto",
     .audioDeviceDesc: "Autoselect device",
     .enableInitialVolume: false,
@@ -1461,6 +1465,8 @@ struct Preference {
            .spdifAC3,
            .spdifDTS,
            .spdifDTSHD,
+           .spdifEAC3,
+           .spdifTRUEHD,
            .subBold,
            .subItalic,
            .subScaleWithWindow,

--- a/iina/SettingsLocalization.swift
+++ b/iina/SettingsLocalization.swift
@@ -87,6 +87,7 @@ extension SettingsLocalization.Key {
   static let gaplessAudioLabel = SettingsLocalization.Key("gaplessAudio.label")
   static let preferredAudioDeviceLabel = SettingsLocalization.Key("preferredAudioDevice.label")
   static let text_SPDIFOutput = SettingsLocalization.Key("$SPDIFOutput")
+  static let text_SPDIFOutputWarning = SettingsLocalization.Key("$SPDIFOutputWarning")
   static let text_PreferredLanguage = SettingsLocalization.Key("$PreferredLanguage")
   static let text_dB = SettingsLocalization.Key("$dB")
   static let text_Hardware = SettingsLocalization.Key("$Hardware")

--- a/iina/SettingsPageAudio.swift
+++ b/iina/SettingsPageAudio.swift
@@ -64,6 +64,8 @@ class SettingsPageAudio: SettingsPage {
           .withDetailView(audioOutputDeviceView)
         SettingsItem.General(title: .text_SPDIFOutput)
           .image(name: "audio.jack.stereo")
+          .hasDescription(content: .text_SPDIFOutputWarning)  // For why warning, see issue #6251.
+          .withHelpLink(AppData.spdifOutputHelpLink)
           .withExpandingDetailView {
             SettingsItem.Switch()
               .bindTo(.spdifAC3)
@@ -71,6 +73,10 @@ class SettingsPageAudio: SettingsPage {
               .bindTo(.spdifDTS)
             SettingsItem.Switch()
               .bindTo(.spdifDTSHD)
+            SettingsItem.Switch()
+              .bindTo(.spdifEAC3)
+            SettingsItem.Switch()
+              .bindTo(.spdifTRUEHD)
           }
       }
     }

--- a/iina/VerbatimStrings.strings
+++ b/iina/VerbatimStrings.strings
@@ -24,6 +24,8 @@
 "settings.spdifAC3.label" = "AC3";
 "settings.spdifDTS.label" = "DTS";
 "settings.spdifDTSHD.label" = "DTS-HD";
+"settings.spdifEAC3.label" = "EAC3";
+"settings.spdifTRUEHD.label" = "TRUEHD";
 
 "settings.audioDriverEnableAVFoundation.items.0" = "Core Audio";
 "settings.audioDriverEnableAVFoundation.items.1" = "AVFoundation";

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -978,6 +978,7 @@
 "settings.$RestoreAllAlertsThat" = "Restore all alerts that have been suppressed using the \"Do not show this message again\" checkbox.";
 "settings.$RestoreSuppressedAlerts" = "Restore Suppressed Alerts";
 "settings.$SPDIFOutput" = "S/PDIF output";
+"settings.$SPDIFOutputWarning" = "List of codecs for which compressed audio passthrough should be used.\n\nWarning: There is not much reason to use this setting. HDMI supports uncompressed multichannel PCM, and lossless DTS-HD decoding is supported via FFmpeg's DCA decoder. Playback may not start if the output device does not support S/PDIF and this setting is enabled.";
 "settings.$Safari" = "Safari";
 "settings.$Screenshots" = "Screenshots";
 "settings.$SetIINAAsTheDefault" = "Set IINA as the Default Application";


### PR DESCRIPTION
This commit will:
- In audio settings, add a warning about use of the S/PDIF output setting
- Add a help link to the mpv `audio-spdif` option
- Add the missing codecs `eac3` and `truehd`
- Change `MPVController` to support dynamic changes to this setting

The warning that there is not much reason to use this setting is a slightly modified version of the similar warning in the mpv manual entry for the `audio-spdif` option. The reason why playback might not start is explained in issue #6251.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] Related issue: #
- [ ] Related Design Proposal: # / Not applicable
---
- [ ] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**
