### PR TITLE
ui: fix live text overlay shown when in pip

### DIFF
--- a/iina/InteractiveMode.swift
+++ b/iina/InteractiveMode.swift
@@ -139,7 +139,9 @@ class InteractiveModeController: NSObject {
     ])
 
     then()
-    if !isPausedPriorToInteractiveMode {
+    if isPausedPriorToInteractiveMode {
+      mainWindow.liveText.requestAnalysis()
+    } else {
       player.resume()
     }
   }

--- a/iina/LiveTextSupport.swift
+++ b/iina/LiveTextSupport.swift
@@ -32,6 +32,11 @@ class LiveTextController: NSObject {
   var isShown: Bool {
     overlayView != nil
   }
+  var isAvailable: Bool {
+    mainWindow.pipStatus == .notInPIP
+      && !mainWindow.interactiveMode.isActive
+      && !mainWindow.player.isInMiniPlayer
+  }
   private var wasUIHiddenByLiveText: Bool = false
 
   init(mainWindow: MainWindowController) {
@@ -63,8 +68,7 @@ class LiveTextController: NSObject {
   }
 
   func requestAnalysis() {
-    guard #available(macOS 13.0, *), Preference.isLiveTextEnabled,
-          !mainWindow.interactiveMode.isActive else { return }
+    guard #available(macOS 13.0, *), Preference.isLiveTextEnabled, isAvailable else { return }
     requestAnalysisImpl()
   }
 
@@ -121,6 +125,10 @@ extension LiveTextController: ImageAnalysisOverlayViewDelegate {
         let analysis = try await ImageAnalyzer().analyze(image, orientation: .up, configuration: .init([.text]))
         liveTextLog("Image analysis results acquired")
         await MainActor.run {
+          guard self.isAvailable else {
+            liveTextLog("Image analysis results discarded as live text cannot be displayed")
+            return
+          }
           let overlay = self.setupLiveTextOverlay()
           overlay.analysis = analysis
           overlay.frame = videoViewContainer.bounds

--- a/iina/LiveTextSupport.swift
+++ b/iina/LiveTextSupport.swift
@@ -73,7 +73,7 @@ class LiveTextController: NSObject {
   }
 
   func clearAnalysis() {
-    guard #available(macOS 13.0, *), isShown else { return }
+    guard #available(macOS 13.0, *), analysisTask != nil || isShown else { return }
     clearAnalysisImpl()
   }
 
@@ -123,10 +123,11 @@ extension LiveTextController: ImageAnalysisOverlayViewDelegate {
         }
         try Task.checkCancellation()
         let analysis = try await ImageAnalyzer().analyze(image, orientation: .up, configuration: .init([.text]))
+        try Task.checkCancellation()
         liveTextLog("Image analysis results acquired")
         await MainActor.run {
-          guard self.isAvailable else {
-            liveTextLog("Image analysis results discarded as live text cannot be displayed")
+          guard self.isAvailable, self.mainWindow.player.info.state == .paused else {
+            liveTextLog("Image analysis results discarded due to change of player state")
             return
           }
           let overlay = self.setupLiveTextOverlay()

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -3036,6 +3036,7 @@ extension MainWindowController: PIPViewControllerDelegate {
   func enterPIP() {
     guard pipStatus != .inPIP else { return }
     pipStatus = .inPIP
+    liveText.clearAnalysis()
     showUI()
 
     pipVideo = NSViewController()
@@ -3101,6 +3102,7 @@ extension MainWindowController: PIPViewControllerDelegate {
 
     isWindowMiniaturizedDueToPip = false
     isWindowHidden = false
+    liveText.requestAnalysis()
     player.events.emit(.pipChanged, data: false)
     NotificationCenter.default.post(name: .iinaPIPStatusChanged, object: self, userInfo: ["enable": false])
   }

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -803,6 +803,7 @@ class PlayerCore: NSObject {
     miniPlayer.playlistWrapperView.addSubview(playlistView.view)
     playlistView.view.padding(.all)
     // move video view
+    mainWindow.liveText.clearAnalysis()
     videoView.removeFromSuperview()
     miniPlayer.videoWrapperView.addSubview(videoView, positioned: .below, relativeTo: nil)
     Utility.quickConstraints(["H:|[v]|", "V:|[v]|"], ["v": videoView])
@@ -884,6 +885,7 @@ class PlayerCore: NSObject {
     }
 
     mainWindow.forceDraw("exited music mode")
+    mainWindow.liveText.requestAnalysis()
     postNotification(.iinaMusicModeChanged)
     events.emit(.musicModeChanged, data: false)
   }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] Related issue: #
- [x] Related Design Proposal: Not applicable
---
- [ ] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**
This commit cleans up the logic regarding the live text availability. `LiveTextController.isAvailable` defines when the live text is able to show on the video view. It is set to false when the player is in:
- Interactive mode
- Music mode
- Picture-in-Picture mode

After the changes, the player will cleanup old live text overlay (if exists) before entering those modes, and try to create new live text overlay (if paused) after exiting the modes.

Also incorporated changes from #6206.