### PR TITLE
docs: add VR2D to the Community Plugins list

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ IINA is always looking for contributions, whether it's through bug reports, code
 - **[recorder](https://github.com/5thDimensionalVader/recorder-iina)** (`5thDimensionalVader/recorder-iina`) - to clip a video using ffmpeg.
 - **[Skip Intro](https://github.com/pparanoiidd/iina-skip-intro)** (`pparanoiidd/iina-skip-intro`) - Detect and skip intros, recaps and credits.
 - **[Trakt Scrobbler](https://github.com/i3p9/iina-trakt-scrobbler)** (`i3p9/iina-trakt-scrobbler`) - Trakt.tv scrobbler plugin for IINA.
+- **[VR2D](https://github.com/fetzu/iina-plugin-vr2d)** (`fetzu/iina-plugin-vr2d`) - Watch 3D VR videos (180°/360°, side-by-side or over-under) flat, with pan, zoom and automatic detection.
 
 
 > 💡 **Want to build your own plugin?**


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] Related issues: #4272, #1620, #5419 
- [x] Related Design Proposal: Not applicable
---
- [x] AI was used to write the code in this pull request.
  - [x] The code is fully written by AI / ~~I am an AI agent~~.
---

**Description:**

Adds VR2D (`fetzu/iina-plugin-vr2d`) to the Community Plugins list.

It plays 3D VR video — 180°/360° equirectangular, equi-angular cubemap and 180–220° fisheye, side-by-side or over-under — as a flat rectilinear view you can pan and zoom, working out how the source is packed from file naming conventions, the container's stereo flag and the frame geometry. Reprojection is a `crop` + `v360` filter chain, so it uses only what mpv already ships with.

README only: one line, placed after Trakt Scrobbler to keep the section alphabetical.

**AI usage:** this one-line change and the plugin itself were written with Claude. The plugin lives in its own repository under the MIT licence and vendors no third-party code, so nothing here affects IINA's GPLv3 licensing.
