### PR TITLE
Fix mini player volume slider dragging

### DIFF
--- a/iina/VolumeSlider.swift
+++ b/iina/VolumeSlider.swift
@@ -22,6 +22,14 @@ class VolumeSlider: NSSlider {
   
   // MARK: - Mouse / Trackpad events
 
+  /// Keep AppKit's slider tracking path active on macOS versions affected by IINA issue #5768.
+  ///
+  /// Without this explicit override, AppKit may skip mouse tracking for NSSlider subclasses,
+  /// allowing a movable window background to handle the drag instead.
+  override func mouseDown(with event: NSEvent) {
+    super.mouseDown(with: event)
+  }
+
   /// The user is scrolling while the cursor is within the slider.
   ///
   /// With certain kinds of input devices, such as a mouse with a scroll wheel that spins freely, it is easy to accidentally move the cursor


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] Related issue: #
- [ ] Related Design Proposal: Not applicable
---
- [x] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.

**Description:**

Restore the explicit `mouseDown` pass-through for `VolumeSlider`, so AppKit keeps native slider tracking active. This prevents the mini player window background from handling volume-slider drags when album art is hidden.