### PR TITLE
docs: add SubLingo to the Community Plugins list

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,7 @@ IINA is always looking for contributions, whether it's through bug reports, code
 - **[PolyScript](https://github.com/SammoMichael/polyplugin-release)** (`SammoMichael/polyplugin-release`) - Dual subtitles, hover dictionary, and AI-assisted translation for language learning.
 - **[recorder](https://github.com/5thDimensionalVader/recorder-iina)** (`5thDimensionalVader/recorder-iina`) - to clip a video using ffmpeg.
 - **[Skip Intro](https://github.com/pparanoiidd/iina-skip-intro)** (`pparanoiidd/iina-skip-intro`) - Detect and skip intros, recaps and credits.
+- **[SubLingo](https://github.com/janwee-sha/SubLingo)** (`janwee-sha/SubLingo`) - Translate selected local embedded text subtitles and external SRT/ASS subtitles into real-time bilingual subtitles.
 - **[Trakt Scrobbler](https://github.com/i3p9/iina-trakt-scrobbler)** (`i3p9/iina-trakt-scrobbler`) - Trakt.tv scrobbler plugin for IINA.
 - **[VR2D](https://github.com/fetzu/iina-plugin-vr2d)** (`fetzu/iina-plugin-vr2d`) - Watch 3D VR videos (180°/360°, side-by-side or over-under) flat, with pan, zoom and automatic detection.
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] Related issue: Not applicable
- [x] Related Design Proposal: Not applicable
---
- [ ] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**

Adds SubLingo (`janwee-sha/SubLingo`) to the Community Plugins list.

SubLingo translates selected local embedded text subtitles and external SRT/ASS subtitles and renders bilingual translations in real time.

README only: one line, placed after Skip Intro and before Trakt Scrobbler to keep the list alphabetical.