### PR TITLE
refactor(osc): explore QuickTime-style floating controls

### DIFF
--- a/iina/LiveTextSupport.swift
+++ b/iina/LiveTextSupport.swift
@@ -68,7 +68,10 @@ class LiveTextController: NSObject {
   }
 
   func requestAnalysis() {
-    guard #available(macOS 13.0, *), Preference.isLiveTextEnabled, isAvailable else { return }
+    // Seeking temporarily pauses playback. Do not recreate the overlay while the progress
+    // slider is handling that interaction, otherwise it can compete with the OSC for events.
+    guard #available(macOS 13.0, *), Preference.isLiveTextEnabled, isAvailable,
+          !mainWindow.isMouseInSlider else { return }
     requestAnalysisImpl()
   }
 

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -521,10 +521,10 @@ class MainWindowController: PlayerWindowController {
     oscPlayControlView.alignment = .centerY
     oscPlayControlView.spacing = 0
 
-    self.leftArrowButton = NSButton(image: .speedl, target: self, action: #selector(leftButtonAction))
+    self.leftArrowButton = OSCButton(image: .speedl, target: self, action: #selector(leftButtonAction))
     leftArrowButton.maxAcceleratorLevel = 5
 
-    self.rightArrowButton = NSButton(image: .speed, target: self, action: #selector(rightButtonAction))
+    self.rightArrowButton = OSCButton(image: .speed, target: self, action: #selector(rightButtonAction))
     rightArrowButton.maxAcceleratorLevel = 5
 
     [playButton, leftArrowButton, rightArrowButton].forEach { button in
@@ -891,7 +891,7 @@ class MainWindowController: PlayerWindowController {
     oscToolbarView.views.forEach { oscToolbarView.removeView($0) }
     let liveTextEnabled = Preference.bool(for: .enableLiveText)
     for buttonType in effectiveButtons {
-      let button = NSButton()
+      let button = OSCButton()
       OSCToolbarButton.setStyle(of: button, buttonType: buttonType, reducedWidth: false)
       if buttonType == .liveText && liveTextEnabled {
         button.image = Preference.ToolBarButton.liveText.alternateImage()
@@ -1019,8 +1019,27 @@ class MainWindowController: PlayerWindowController {
 
     oscPlayControlMiddleView.spacing = isFloating ? 24: 16
 
+    configureQuickTimeOSC(isFloating)
+
     fadeableViews.update()
     showUI()
+  }
+
+  private func configureQuickTimeOSC(_ enabled: Bool) {
+    playSlider.setQuickTimeStyle(enabled)
+    (volumeSlider as? VolumeSlider)?.setQuickTimeStyle(enabled)
+
+    if enabled {
+      playButton.image = quickTimePlayButtonImage(paused: player.info.state != .playing)
+    } else {
+      playButton.image = NSImage(named: player.info.state == .playing ? "pause" : "play")
+    }
+    updateArrowButtons()
+  }
+
+  private func quickTimePlayButtonImage(paused: Bool) -> NSImage? {
+    .sf(paused ? "play.fill" : "pause.fill",
+        withConfiguration: .init(pointSize: 24, weight: .medium))
   }
 
   // MARK: - Mouse / Trackpad events
@@ -2719,6 +2738,9 @@ class MainWindowController: PlayerWindowController {
 
   override func updatePlayButtonState(paused: Bool) {
     super.updatePlayButtonState(paused: paused)
+    if oscPosition == .floating {
+      playButton.image = quickTimePlayButtonImage(paused: paused)
+    }
     if paused {
       speedValueIndex = AppData.availableSpeedValues.count / 2
     }
@@ -2733,7 +2755,16 @@ class MainWindowController: PlayerWindowController {
   /// [multiLevelAccelerator](https://developer.apple.com/documentation/appkit/nsbutton/buttontype/multilevelaccelerator)
   /// button. This allows the user to control the speed using pressure when using devices that support pressure sensitivity.
   func updateArrowButtons() {
-    if arrowBtnFunction == .playlist {
+    if oscPosition == .floating {
+      let config = NSImage.SymbolConfiguration(pointSize: 23, weight: .semibold)
+      if arrowBtnFunction == .playlist {
+        leftArrowButton.image = .sf("backward.end.fill", withConfiguration: config)
+        rightArrowButton.image = .sf("forward.end.fill", withConfiguration: config)
+      } else {
+        leftArrowButton.image = .sf("backward.fill", withConfiguration: config)
+        rightArrowButton.image = .sf("forward.fill", withConfiguration: config)
+      }
+    } else if arrowBtnFunction == .playlist {
       leftArrowButton.image = #imageLiteral(resourceName: "nextl")
       rightArrowButton.image = #imageLiteral(resourceName: "nextr")
     } else {

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -905,7 +905,7 @@ class MainWindowController: PlayerWindowController {
     oscToolbarView.views.forEach { oscToolbarView.removeView($0) }
     let liveTextEnabled = Preference.bool(for: .enableLiveText)
     for buttonType in effectiveButtons {
-      let button = OSCButton()
+      let button = NSButton()
       OSCToolbarButton.setStyle(of: button, buttonType: buttonType, reducedWidth: false)
       if buttonType == .liveText && liveTextEnabled {
         button.image = Preference.ToolBarButton.liveText.alternateImage()

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -1033,7 +1033,7 @@ class MainWindowController: PlayerWindowController {
       oscBottomMainView.setVisibilityPriority(.detachEarlier, for: oscToolbarView)
     }
 
-    oscPlayControlMiddleView.spacing = isFloating ? 10 : DockedOSCLayout.transportSpacing
+    oscPlayControlMiddleView.spacing = isFloating ? 4 : DockedOSCLayout.transportSpacing
     oscToolbarView.spacing = 0
 
     configureQuickTimeOSC(isFloating)
@@ -1069,7 +1069,7 @@ class MainWindowController: PlayerWindowController {
 
   private func quickTimePlayButtonImage(paused: Bool) -> NSImage? {
     .sf(paused ? "play.fill" : "pause.fill",
-        withConfiguration: .init(pointSize: 24, weight: .medium))
+        withConfiguration: .init(pointSize: 32, weight: .medium))
   }
 
   // MARK: - Mouse / Trackpad events
@@ -2793,7 +2793,7 @@ class MainWindowController: PlayerWindowController {
   /// button. This allows the user to control the speed using pressure when using devices that support pressure sensitivity.
   func updateArrowButtons() {
     if oscPosition == .floating {
-      let config = NSImage.SymbolConfiguration(pointSize: 23, weight: .semibold)
+      let config = NSImage.SymbolConfiguration(pointSize: 27, weight: .semibold)
       if arrowBtnFunction == .playlist {
         leftArrowButton.image = .sf("backward.end.fill", withConfiguration: config)
         rightArrowButton.image = .sf("forward.end.fill", withConfiguration: config)

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -301,7 +301,7 @@ class MainWindowController: PlayerWindowController {
       }
     case PK.showChapterPos.rawValue:
       if let newValue = change[.newKey] as? Bool {
-        (playSlider.cell as! PlaySliderCell).drawChapters = newValue
+        playSlider.drawChapters = newValue
       }
     case PK.verticalScrollAction.rawValue:
       if let newValue = change[.newKey] as? Int {
@@ -1019,7 +1019,7 @@ class MainWindowController: PlayerWindowController {
 
     oscPlayControlMiddleView.spacing = isFloating ? 24: 16
 
-    configureQuickTimeOSC(isFloating)
+    configureQuickTimeOSC(true)
 
     fadeableViews.update()
     showUI()

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -35,6 +35,11 @@ fileprivate let minimumInitialDragDistance: CGFloat = 3.0
 fileprivate let layoutSides: [NSLayoutConstraint.Attribute] = [.top, .bottom, .leading, .trailing]
 
 class MainWindowController: PlayerWindowController {
+  private enum DockedOSCLayout {
+    static let volumeSliderWidth: CGFloat = 70
+    static let playSliderInset: CGFloat = 6
+    static let transportSpacing: CGFloat = 16
+  }
 
   override var windowNibName: NSNib.Name {
     return NSNib.Name("MainWindowController")
@@ -509,7 +514,7 @@ class MainWindowController: PlayerWindowController {
     self.oscVolumeView = NSView()
     oscVolumeView.translatesAutoresizingMaskIntoConstraints = false
 
-    oscVolumeSliderWidthConstraint = volumeSlider.widthAnchor.constraint(equalToConstant: 70)
+    oscVolumeSliderWidthConstraint = volumeSlider.widthAnchor.constraint(equalToConstant: DockedOSCLayout.volumeSliderWidth)
     oscVolumeSliderWidthConstraint.isActive = true
 
     oscVolumeView.addSubview(muteButton)
@@ -585,8 +590,10 @@ class MainWindowController: PlayerWindowController {
       .center(.y, with: playSlider)
     rightLabel.padding(.trailing(2)).spacing(.leading(2), to: playSlider)
       .center(.y, with: playSlider)
-    oscPlaySliderTopConstraint = playSlider.topAnchor.constraint(equalTo: oscSliderView.topAnchor, constant: 4)
-    oscPlaySliderBottomConstraint = oscSliderView.bottomAnchor.constraint(equalTo: playSlider.bottomAnchor, constant: 4)
+    oscPlaySliderTopConstraint = playSlider.topAnchor.constraint(equalTo: oscSliderView.topAnchor,
+                                                                 constant: DockedOSCLayout.playSliderInset)
+    oscPlaySliderBottomConstraint = oscSliderView.bottomAnchor.constraint(equalTo: playSlider.bottomAnchor,
+                                                                          constant: DockedOSCLayout.playSliderInset)
     NSLayoutConstraint.activate([oscPlaySliderTopConstraint, oscPlaySliderBottomConstraint])
 
     // osd
@@ -1026,7 +1033,7 @@ class MainWindowController: PlayerWindowController {
       oscBottomMainView.setVisibilityPriority(.detachEarlier, for: oscToolbarView)
     }
 
-    oscPlayControlMiddleView.spacing = isFloating ? 10 : 16
+    oscPlayControlMiddleView.spacing = isFloating ? 10 : DockedOSCLayout.transportSpacing
     oscToolbarView.spacing = 0
 
     configureQuickTimeOSC(isFloating)
@@ -1042,9 +1049,9 @@ class MainWindowController: PlayerWindowController {
     (rightArrowButton as? OSCButton)?.setQuickTimeStyle(enabled, role: .transport)
     playSlider.setQuickTimeStyle(enabled)
     (volumeSlider as? VolumeSlider)?.setQuickTimeStyle(enabled)
-    oscVolumeSliderWidthConstraint?.constant = enabled ? 80 : 70
-    oscPlaySliderTopConstraint?.constant = enabled ? 4 : 6
-    oscPlaySliderBottomConstraint?.constant = enabled ? 4 : 6
+    oscVolumeSliderWidthConstraint?.constant = enabled ? 80 : DockedOSCLayout.volumeSliderWidth
+    oscPlaySliderTopConstraint?.constant = enabled ? 4 : DockedOSCLayout.playSliderInset
+    oscPlaySliderBottomConstraint?.constant = enabled ? 4 : DockedOSCLayout.playSliderInset
 
     let labelColor = enabled ? NSColor.white.withAlphaComponent(0.68) : NSColor.secondaryLabelColor
     leftLabel.textColor = labelColor
@@ -1118,7 +1125,14 @@ class MainWindowController: PlayerWindowController {
       log("MainWindow mouseDown @ \(event.locationInWindow)", level: .verbose)
     }
     workaroundCursorDefect()
-    // do nothing if it's related to floating OSC
+    if oscPosition == .floating,
+       !oscFloatingView.isHiddenOrHasHiddenAncestor,
+       event.inAnyOf([oscFloatingView]),
+       oscFloatingView.routeMouseDown(event) {
+      mousePosRelatedToWindow = nil
+      return
+    }
+    // do nothing if it's related to floating OSC dragging
     guard !oscFloatingView.isDragging else { return }
     mousePosRelatedToWindow = event.locationInWindow
     let consumedBySidebar = sidebars.handleMouseDown(event, at: event.locationInWindow)

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -586,6 +586,7 @@ class MainWindowController: PlayerWindowController {
     oscSliderView.addSubview(leftLabel)
     oscSliderView.addSubview(rightLabel)
     oscSliderView.addSubview(playSlider)
+    leftLabel.widthAnchor.constraint(equalTo: rightLabel.widthAnchor).isActive = true
     leftLabel.padding(.leading(2)).spacing(.trailing(2), to: playSlider)
       .center(.y, with: playSlider)
     rightLabel.padding(.trailing(2)).spacing(.leading(2), to: playSlider)

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -92,6 +92,9 @@ class MainWindowController: PlayerWindowController {
   var oscVolumeView: NSView!
   var oscToolbarView: NSStackView!
   var oscSliderView: NSView!
+  private var oscVolumeSliderWidthConstraint: NSLayoutConstraint!
+  private var oscPlaySliderTopConstraint: NSLayoutConstraint!
+  private var oscPlaySliderBottomConstraint: NSLayoutConstraint!
 
   var osdView: OSDView!
   var additionalInfoView: AdditionalInfoView!
@@ -506,13 +509,14 @@ class MainWindowController: PlayerWindowController {
     self.oscVolumeView = NSView()
     oscVolumeView.translatesAutoresizingMaskIntoConstraints = false
 
-    volumeSlider.size(width: 70)
+    oscVolumeSliderWidthConstraint = volumeSlider.widthAnchor.constraint(equalToConstant: 70)
+    oscVolumeSliderWidthConstraint.isActive = true
 
     oscVolumeView.addSubview(muteButton)
     oscVolumeView.addSubview(volumeSlider)
     muteButton.size(width: 24, height: 24)
       .padding(.vertical, .leading(4)).spacing(.trailing(4), to: volumeSlider)
-    volumeSlider.size(width: 70).center(.y)
+    volumeSlider.center(.y)
       .padding(.trailing(6))
 
     self.oscPlayControlView = NSStackView()
@@ -557,7 +561,7 @@ class MainWindowController: PlayerWindowController {
     oscPlayControlMiddleView.translatesAutoresizingMaskIntoConstraints = false
     oscPlayControlMiddleView.orientation = .horizontal
     oscPlayControlMiddleView.alignment = .centerY
-    oscPlayControlMiddleView.spacing = 24
+    oscPlayControlMiddleView.spacing = 10
 
     self.oscToolbarView = NSStackView()
     oscToolbarView.translatesAutoresizingMaskIntoConstraints = false
@@ -581,7 +585,9 @@ class MainWindowController: PlayerWindowController {
       .center(.y, with: playSlider)
     rightLabel.padding(.trailing(2)).spacing(.leading(2), to: playSlider)
       .center(.y, with: playSlider)
-    playSlider.padding(.vertical(6))
+    oscPlaySliderTopConstraint = playSlider.topAnchor.constraint(equalTo: oscSliderView.topAnchor, constant: 4)
+    oscPlaySliderBottomConstraint = oscSliderView.bottomAnchor.constraint(equalTo: playSlider.bottomAnchor, constant: 4)
+    NSLayoutConstraint.activate([oscPlaySliderTopConstraint, oscPlaySliderBottomConstraint])
 
     // osd
 
@@ -971,8 +977,11 @@ class MainWindowController: PlayerWindowController {
     switch oscPosition {
     case .floating:
       currentControlBar = oscFloatingView
-      oscPlayControlView.setVisibilityPriority(.detachOnlyIfNecessary, for: oscSpeedLabelLeftContainer)
-      oscPlayControlView.setVisibilityPriority(.detachOnlyIfNecessary, for: oscSpeedLabelRightContainer)
+      // QuickTime's floating controller only shows the three transport buttons. The speed labels
+      // belong to the docked layouts and must not consume width needed by the volume and toolbar
+      // groups.
+      oscPlayControlView.setVisibilityPriority(.notVisible, for: oscSpeedLabelLeftContainer)
+      oscPlayControlView.setVisibilityPriority(.notVisible, for: oscSpeedLabelRightContainer)
       oscFloatingView.oscTopView.addView(oscVolumeView, in: .leading)
       oscFloatingView.oscTopView.addView(oscToolbarView, in: .trailing)
       oscFloatingView.oscTopView.addView(oscPlayControlView, in: .center)
@@ -980,8 +989,8 @@ class MainWindowController: PlayerWindowController {
       // Setting the visibility priority to detach only will cause freeze when resizing the window
       // (and triggering the detach) in macOS 11.
       if !isMacOS11 {
-        oscFloatingView.oscTopView.setVisibilityPriority(.detachOnlyIfNecessary, for: oscVolumeView)
-        oscFloatingView.oscTopView.setVisibilityPriority(.detachOnlyIfNecessary, for: oscToolbarView)
+        oscFloatingView.oscTopView.setVisibilityPriority(.mustHold, for: oscVolumeView)
+        oscFloatingView.oscTopView.setVisibilityPriority(.mustHold, for: oscToolbarView)
         oscFloatingView.oscTopView.setClippingResistancePriority(.defaultLow, for: .horizontal)
       }
       oscFloatingView.oscBottomView.addSubview(oscSliderView)
@@ -1017,17 +1026,31 @@ class MainWindowController: PlayerWindowController {
       oscBottomMainView.setVisibilityPriority(.detachEarlier, for: oscToolbarView)
     }
 
-    oscPlayControlMiddleView.spacing = isFloating ? 24: 16
+    oscPlayControlMiddleView.spacing = isFloating ? 10 : 16
+    oscToolbarView.spacing = 0
 
-    configureQuickTimeOSC(true)
+    configureQuickTimeOSC(isFloating)
 
     fadeableViews.update()
     showUI()
   }
 
   private func configureQuickTimeOSC(_ enabled: Bool) {
+    muteButton.setQuickTimeStyle(enabled)
+    (leftArrowButton as? OSCButton)?.setQuickTimeStyle(enabled, role: .transport)
+    (playButton as? OSCButton)?.setQuickTimeStyle(enabled, role: .primary)
+    (rightArrowButton as? OSCButton)?.setQuickTimeStyle(enabled, role: .transport)
     playSlider.setQuickTimeStyle(enabled)
     (volumeSlider as? VolumeSlider)?.setQuickTimeStyle(enabled)
+    oscVolumeSliderWidthConstraint?.constant = enabled ? 80 : 70
+    oscPlaySliderTopConstraint?.constant = enabled ? 4 : 6
+    oscPlaySliderBottomConstraint?.constant = enabled ? 4 : 6
+
+    let labelColor = enabled ? NSColor.white.withAlphaComponent(0.68) : NSColor.secondaryLabelColor
+    leftLabel.textColor = labelColor
+    rightLabel.textColor = labelColor
+    oscSpeedLabelLeft.textColor = labelColor
+    oscSpeedLabelRight.textColor = labelColor
 
     if enabled {
       playButton.image = quickTimePlayButtonImage(paused: player.info.state != .playing)

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -248,6 +248,7 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
 
     volumeControlContainer.addSubview(volumeSlider)
     volumeSlider.maxValue = Double(Preference.integer(for: .maxVolume))
+    (volumeSlider as? VolumeSlider)?.setQuickTimeStyle(true)
     volumeSlider.size(width: 100)
       .padding(.vertical(12), .leading(45))
 

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -153,6 +153,7 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     leftLabel.widthAnchor.constraint(equalTo: rightLabel.widthAnchor, multiplier: 1).isActive = true
 
     backgroundView.addSubview(playSlider)
+    playSlider.setQuickTimeStyle(true)
     playSlider.padding(.bottom(.bottomPadding))
     playSlider.spacing(.leading(6), to: leftLabel)
     leftLabel.center(.y, with: playSlider)
@@ -193,8 +194,11 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     controlView.padding(.horizontal, .top(.controlTopPadding))
       .size(height: 48)
 
-    let prevBtn = NSButton(image: .nextl, target: self, action: #selector(prevBtnAction))
-    let nextBtn = NSButton(image: .nextr, target: self, action: #selector(nextBtnAction))
+    let symbolConfiguration = NSImage.SymbolConfiguration(pointSize: 24, weight: .medium)
+    let prevBtn = OSCButton(image: .sf("backward.end.fill", withConfiguration: symbolConfiguration)!,
+                            target: self, action: #selector(prevBtnAction))
+    let nextBtn = OSCButton(image: .sf("forward.end.fill", withConfiguration: symbolConfiguration)!,
+                            target: self, action: #selector(nextBtnAction))
 
     self.togglePlaylistButton = NSButton(image: .sf("list.bullet.rectangle")!, target: self, action: #selector(togglePlaylist))
     self.toggleAlbumArtButton = NSButton(image: .sf("photo")!, target: self, action: #selector(toggleVideoView))
@@ -208,8 +212,14 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
       button.isBordered = false
       button.imageScaling = .scaleProportionallyUpOrDown
       button.refusesFirstResponder = true
+      if button !== togglePlaylistButton && button !== toggleAlbumArtButton {
+        button.setButtonType(.momentaryPushIn)
+      }
       controlView.addSubview(button)
     }
+
+    playButton.image = .sf("play.fill", withConfiguration: symbolConfiguration)
+    playButton.alternateImage = .sf("pause.fill", withConfiguration: symbolConfiguration)
 
     playButton.size(width: 28, height: 28)
     nextBtn.size(width: 28, height: 28)

--- a/iina/OSCFloatingView.swift
+++ b/iina/OSCFloatingView.swift
@@ -8,13 +8,119 @@
 
 fileprivate extension LayoutValue {
   static let oscPaddingTop = LayoutValue(14, 10)
-  static let oscPaddingBottom = LayoutValue(8, 5)
+  static let oscPaddingBottom = LayoutValue(16, 10)
 }
 
 /// Button used by the floating OSC so AppKit keeps the native tracking path active.
 class OSCButton: NSButton {
+  enum Role {
+    case standard
+    case transport
+    case primary
+
+    var floatingSize: CGFloat {
+      switch self {
+      case .standard: 24
+      case .transport: 28
+      case .primary: 36
+      }
+    }
+  }
+
+  private var originalImageScaling: NSImageScaling?
+  private var originalImagePosition: NSControl.ImagePosition?
+  private var originalBezelStyle: NSButton.BezelStyle?
+  private var originalIsBordered: Bool?
+  private var originalContentTintColor: NSColor?
+  private var originalConstraintSizes: [ObjectIdentifier: CGFloat] = [:]
+  private var usesQuickTimeStyle = false
+  private var isPressed = false
+  @objc dynamic private var visualScale: CGFloat = 1 {
+    didSet { needsDisplay = true }
+  }
+
+  override class func defaultAnimation(forKey key: NSAnimatablePropertyKey) -> Any? {
+    if key == "visualScale" {
+      return CABasicAnimation()
+    }
+    return super.defaultAnimation(forKey: key)
+  }
+
+  func setQuickTimeStyle(_ enabled: Bool, role: Role = .standard) {
+    if originalImageScaling == nil {
+      originalImageScaling = imageScaling
+      originalImagePosition = imagePosition
+      originalBezelStyle = bezelStyle
+      originalIsBordered = isBordered
+      originalContentTintColor = contentTintColor
+    }
+
+    usesQuickTimeStyle = enabled
+    if enabled {
+      imagePosition = .imageOnly
+      imageScaling = .scaleProportionallyDown
+      bezelStyle = .shadowlessSquare
+      isBordered = false
+      contentTintColor = .white
+    } else {
+      imagePosition = originalImagePosition!
+      imageScaling = originalImageScaling!
+      bezelStyle = originalBezelStyle!
+      isBordered = originalIsBordered!
+      contentTintColor = originalContentTintColor
+      setPressed(false)
+    }
+
+    for constraint in constraints where (constraint.firstItem as? NSButton) === self {
+      guard constraint.secondItem == nil,
+            constraint.firstAttribute == .width || constraint.firstAttribute == .height else { continue }
+      let key = ObjectIdentifier(constraint)
+      if originalConstraintSizes[key] == nil {
+        originalConstraintSizes[key] = constraint.constant
+      }
+      constraint.constant = enabled ? role.floatingSize : originalConstraintSizes[key]!
+    }
+  }
+
   override func mouseDown(with event: NSEvent) {
+    if usesQuickTimeStyle {
+      setPressed(true)
+      super.mouseDown(with: event)
+      setPressed(false)
+      return
+    }
     super.mouseDown(with: event)
+  }
+
+  override func draw(_ dirtyRect: NSRect) {
+    guard usesQuickTimeStyle, visualScale != 1 else {
+      super.draw(dirtyRect)
+      return
+    }
+    NSGraphicsContext.saveGraphicsState()
+    let transform = NSAffineTransform()
+    transform.translateX(by: bounds.midX, yBy: bounds.midY)
+    transform.scale(by: visualScale)
+    transform.translateX(by: -bounds.midX, yBy: -bounds.midY)
+    transform.concat()
+    super.draw(dirtyRect)
+    NSGraphicsContext.restoreGraphicsState()
+  }
+
+  private func setPressed(_ pressed: Bool) {
+    guard isPressed != pressed else { return }
+    isPressed = pressed
+    highlight(pressed)
+    let scale: CGFloat = pressed ? 0.94 : 1
+    guard !Preference.bool(for: .disableAnimations) else {
+      visualScale = scale
+      return
+    }
+    NSAnimationContext.runAnimationGroup { context in
+      context.duration = pressed ? 0.1 : 0.15
+      context.timingFunction = CAMediaTimingFunction(name: pressed ? .easeInEaseOut : .easeOut)
+      animator().visualScale = scale
+    }
   }
 }
 
@@ -71,7 +177,8 @@ private final class OSCFloatingDragSurface: NSView {
 
 
 class OSCFloatingView: TranslucentView {
-  private let width: CGFloat = 460
+  static let preferredWidth: CGFloat = 460
+  private let width = preferredWidth
   weak var mainWindow: MainWindowController!
   private let prefObserver = Preference.Observer()
 
@@ -93,8 +200,7 @@ class OSCFloatingView: TranslucentView {
     let container = OSCFloatingContentView(mainWindow: mainWindow)
     container.translatesAutoresizingMaskIntoConstraints = false
 
-    let cornerRadius: CGFloat = if #available(macOS 26.0, *) { 12 } else { 6 }
-    super.init(liquidGlassCornerRadius: cornerRadius, vevCornerRadius: cornerRadius,
+    super.init(liquidGlassCornerRadius: 24, vevCornerRadius: 20,
                liquidGlassInteractive: true, padding: (0, 0))
 
     let dragSurface = OSCFloatingDragSurface()
@@ -131,6 +237,14 @@ class OSCFloatingView: TranslucentView {
       .addObserver(forName: .iinaSidebarStatusChanged, object: nil, queue: .main) { [weak self] _ in
       self?.initPosition()
     }
+  }
+
+  override func setStyle(_ newStyle: TranslucentView.Style, force: Bool = false) {
+    super.setStyle(newStyle, force: force)
+    guard case .visualEffect = newStyle,
+          let visualEffectView = container as? NSVisualEffectView else { return }
+    visualEffectView.material = .hudWindow
+    visualEffectView.appearance = NSAppearance(named: .darkAqua)
   }
 
   func setupConstraints() {

--- a/iina/OSCFloatingView.swift
+++ b/iina/OSCFloatingView.swift
@@ -11,6 +11,63 @@ fileprivate extension LayoutValue {
   static let oscPaddingBottom = LayoutValue(8, 5)
 }
 
+/// Button used by the floating OSC so AppKit keeps the native tracking path active.
+class OSCButton: NSButton {
+  override func mouseDown(with event: NSEvent) {
+    super.mouseDown(with: event)
+  }
+}
+
+private final class OSCFloatingContentView: NSView {
+  private weak var mainWindow: MainWindowController?
+  weak var dragSurface: NSView?
+
+  init(mainWindow: MainWindowController) {
+    self.mainWindow = mainWindow
+    super.init(frame: .zero)
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  override func hitTest(_ point: NSPoint) -> NSView? {
+    guard bounds.contains(point), let mainWindow else { return nil }
+
+    var controls: [NSView] = mainWindow.oscToolbarView?.subviews ?? []
+    controls.append(contentsOf: [mainWindow.volumeSlider, mainWindow.muteButton,
+                                 mainWindow.leftArrowButton, mainWindow.playButton,
+                                 mainWindow.rightArrowButton, mainWindow.playSlider].compactMap { $0 })
+    for control in controls.reversed()
+      where control.isDescendant(of: self) && !control.isHiddenOrHasHiddenAncestor {
+      let localPoint = control.convert(point, from: self)
+      if control.bounds.contains(localPoint) {
+        return control.hitTest(localPoint) ?? control
+      }
+    }
+
+    return dragSurface
+  }
+}
+
+private final class OSCFloatingDragSurface: NSView {
+  weak var owner: OSCFloatingView?
+
+  override var mouseDownCanMoveWindow: Bool { false }
+
+  override func mouseDown(with event: NSEvent) {
+    owner?.mouseDown(with: event)
+  }
+
+  override func mouseDragged(with event: NSEvent) {
+    owner?.mouseDragged(with: event)
+  }
+
+  override func mouseUp(with event: NSEvent) {
+    owner?.mouseUp(with: event)
+  }
+}
+
 
 class OSCFloatingView: TranslucentView {
   private let width: CGFloat = 460
@@ -32,11 +89,18 @@ class OSCFloatingView: TranslucentView {
   init(mainWindow: MainWindowController) {
     self.mainWindow = mainWindow
 
-    let container = NSView()
+    let container = OSCFloatingContentView(mainWindow: mainWindow)
     container.translatesAutoresizingMaskIntoConstraints = false
 
     let cornerRadius: CGFloat = if #available(macOS 26.0, *) { 12 } else { 6 }
     super.init(liquidGlassCornerRadius: cornerRadius, vevCornerRadius: cornerRadius, padding: (0, 0))
+
+    let dragSurface = OSCFloatingDragSurface()
+    dragSurface.translatesAutoresizingMaskIntoConstraints = false
+    dragSurface.owner = self
+    container.addSubview(dragSurface, positioned: .below, relativeTo: nil)
+    dragSurface.padding(.all)
+    container.dragSurface = dragSurface
 
     self.oscTopView = NSStackView()
     oscTopView.translatesAutoresizingMaskIntoConstraints = false

--- a/iina/OSCFloatingView.swift
+++ b/iina/OSCFloatingView.swift
@@ -218,8 +218,7 @@ class OSCFloatingView: TranslucentView {
     let container = OSCFloatingContentView(mainWindow: mainWindow)
     container.translatesAutoresizingMaskIntoConstraints = false
 
-    super.init(liquidGlassCornerRadius: 24, vevCornerRadius: 20,
-               liquidGlassInteractive: true, padding: (0, 0))
+    super.init(liquidGlassCornerRadius: 24, vevCornerRadius: 20, padding: (0, 0))
 
     let dragSurface = OSCFloatingDragSurface()
     dragSurface.translatesAutoresizingMaskIntoConstraints = false

--- a/iina/OSCFloatingView.swift
+++ b/iina/OSCFloatingView.swift
@@ -21,8 +21,8 @@ class OSCButton: NSButton {
     var floatingSize: CGFloat {
       switch self {
       case .standard: 24
-      case .transport: 28
-      case .primary: 36
+      case .transport: 32
+      case .primary: 48
       }
     }
   }
@@ -61,7 +61,7 @@ class OSCButton: NSButton {
       imageScaling = .scaleProportionallyDown
       bezelStyle = .shadowlessSquare
       isBordered = false
-      contentTintColor = .white
+      contentTintColor = .white.withAlphaComponent(0.84)
     } else {
       imagePosition = originalImagePosition!
       imageScaling = originalImageScaling!

--- a/iina/OSCFloatingView.swift
+++ b/iina/OSCFloatingView.swift
@@ -156,18 +156,6 @@ private final class OSCFloatingContentView: NSView {
     return dragSurface
   }
 
-  @discardableResult
-  func routeMouseDown(_ event: NSEvent) -> Bool {
-    let point = convert(event.locationInWindow, from: nil)
-    guard bounds.contains(point), let targetView = hitTest(point) else { return false }
-    if targetView === self {
-      mouseDown(with: event)
-    } else {
-      targetView.mouseDown(with: event)
-    }
-    return true
-  }
-
   override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
     true
   }

--- a/iina/OSCFloatingView.swift
+++ b/iina/OSCFloatingView.swift
@@ -37,7 +37,8 @@ private final class OSCFloatingContentView: NSView {
     var controls: [NSView] = mainWindow.oscToolbarView?.subviews ?? []
     controls.append(contentsOf: [mainWindow.volumeSlider, mainWindow.muteButton,
                                  mainWindow.leftArrowButton, mainWindow.playButton,
-                                 mainWindow.rightArrowButton, mainWindow.playSlider].compactMap { $0 })
+                                 mainWindow.rightArrowButton, mainWindow.leftLabel,
+                                 mainWindow.rightLabel, mainWindow.playSlider].compactMap { $0 })
     for control in controls.reversed()
       where control.isDescendant(of: self) && !control.isHiddenOrHasHiddenAncestor {
       let localPoint = control.convert(point, from: self)

--- a/iina/OSCFloatingView.swift
+++ b/iina/OSCFloatingView.swift
@@ -155,6 +155,22 @@ private final class OSCFloatingContentView: NSView {
 
     return dragSurface
   }
+
+  @discardableResult
+  func routeMouseDown(_ event: NSEvent) -> Bool {
+    let point = convert(event.locationInWindow, from: nil)
+    guard bounds.contains(point), let targetView = hitTest(point) else { return false }
+    if targetView === self {
+      mouseDown(with: event)
+    } else {
+      targetView.mouseDown(with: event)
+    }
+    return true
+  }
+
+  override func acceptsFirstMouse(for event: NSEvent?) -> Bool {
+    true
+  }
 }
 
 private final class OSCFloatingDragSurface: NSView {
@@ -193,6 +209,20 @@ class OSCFloatingView: TranslucentView {
   var isDragging: Bool = false
 
   private var isAlignFeedbackSent = false
+
+  @discardableResult
+  func routeMouseDown(_ event: NSEvent) -> Bool {
+    let point = convert(event.locationInWindow, from: nil)
+    guard bounds.contains(point), let content else { return false }
+    let contentPoint = content.convert(point, from: self)
+    guard let targetView = content.hitTest(contentPoint) else { return false }
+    if targetView === content {
+      mouseDown(with: event)
+    } else {
+      targetView.mouseDown(with: event)
+    }
+    return true
+  }
 
   init(mainWindow: MainWindowController) {
     self.mainWindow = mainWindow

--- a/iina/OSCFloatingView.swift
+++ b/iina/OSCFloatingView.swift
@@ -93,7 +93,8 @@ class OSCFloatingView: TranslucentView {
     container.translatesAutoresizingMaskIntoConstraints = false
 
     let cornerRadius: CGFloat = if #available(macOS 26.0, *) { 12 } else { 6 }
-    super.init(liquidGlassCornerRadius: cornerRadius, vevCornerRadius: cornerRadius, padding: (0, 0))
+    super.init(liquidGlassCornerRadius: cornerRadius, vevCornerRadius: cornerRadius,
+               liquidGlassInteractive: true, padding: (0, 0))
 
     let dragSurface = OSCFloatingDragSurface()
     dragSurface.translatesAutoresizingMaskIntoConstraints = false

--- a/iina/PlaySlider.swift
+++ b/iina/PlaySlider.swift
@@ -8,15 +8,61 @@
 
 import Cocoa
 
+extension NSSlider {
+  func replaceCellPreservingConfiguration(with replacement: NSSliderCell) {
+    let currentValue = doubleValue
+    let currentMinValue = minValue
+    let currentMaxValue = maxValue
+    let currentAltIncrementValue = altIncrementValue
+    let currentSliderType = sliderType
+    let currentNumberOfTickMarks = numberOfTickMarks
+    let currentTickMarkPosition = tickMarkPosition
+    let currentAllowsTickMarkValuesOnly = allowsTickMarkValuesOnly
+    let currentIsContinuous = isContinuous
+    let currentIsEnabled = isEnabled
+    let currentTarget = target
+    let currentAction = action
+    let currentTag = tag
+    let currentNeutralValue: Double? = if #available(macOS 26.0, *) { neutralValue } else { nil }
+
+    cell = replacement
+    minValue = currentMinValue
+    maxValue = currentMaxValue
+    doubleValue = currentValue
+    altIncrementValue = currentAltIncrementValue
+    sliderType = currentSliderType
+    numberOfTickMarks = currentNumberOfTickMarks
+    tickMarkPosition = currentTickMarkPosition
+    allowsTickMarkValuesOnly = currentAllowsTickMarkValuesOnly
+    isContinuous = currentIsContinuous
+    isEnabled = currentIsEnabled
+    target = currentTarget
+    action = currentAction
+    tag = currentTag
+    if #available(macOS 26.0, *), let currentNeutralValue {
+      neutralValue = currentNeutralValue
+    }
+  }
+}
+
 /// A custom [slider](https://developer.apple.com/design/human-interface-guidelines/macos/selectors/sliders/)
 /// for the onscreen controller.
 ///
 /// This slider adds two thumbs (referred to as knobs in code) to the progress bar slider to show the A and B loop points of the
 /// [mpv](https://mpv.io/manual/stable/) A-B loop feature and allow the loop points to be adjusted. When the feature is
 /// disabled the additional thumbs are hidden.
-/// - Requires: The custom slider cell provided by `PlaySliderCell` **must** be used with this class.
+/// - Note: Floating OSCs use a standard `NSSliderCell`; other layouts retain `PlaySliderCell`.
 /// - Note: Unlike `NSSlider` the `draw` method of this class will do nothing if the view is hidden.
 final class PlaySlider: NSSlider {
+
+  private(set) var usesSystemAppearance = false
+  private var originalTrackFillColor: NSColor?
+  private var legacyCell: PlaySliderCell!
+  private lazy var systemCell: NSSliderCell = {
+    let cell = NSSliderCell()
+    cell.refusesFirstResponder = false
+    return cell
+  }()
 
   /// Knob representing the A loop point for the mpv A-B loop feature.
   var abLoopA: PlaySliderLoopKnob { abLoopAKnob }
@@ -24,8 +70,18 @@ final class PlaySlider: NSSlider {
   /// Knob representing the B loop point for the mpv A-B loop feature.
   var abLoopB: PlaySliderLoopKnob { abLoopBKnob }
 
-  /// The slider's cell correctly typed for convenience.
-  var customCell: PlaySliderCell { cell as! PlaySliderCell }
+  var sliderCell: NSSliderCell { cell as! NSSliderCell }
+  var sliderKnobWidth: CGFloat { (cell as? PlaySliderCell)?.knobWidth ?? sliderCell.knobThickness }
+  var sliderKnobHeight: CGFloat { (cell as? PlaySliderCell)?.knobHeight ?? sliderCell.knobThickness }
+  var sliderKnobRadius: CGFloat { (cell as? PlaySliderCell)?.knobRadius ?? sliderCell.knobThickness / 2 }
+
+  var drawChapters: Bool {
+    get { legacyCell.drawChapters }
+    set {
+      legacyCell.drawChapters = newValue
+      needsDisplay = true
+    }
+  }
 
   /// Range of values the slider is configured to return.
   var range: ClosedRange<Double> { minValue...maxValue }
@@ -44,11 +100,15 @@ final class PlaySlider: NSSlider {
   override init(frame frameRect: NSRect) {
     super.init(frame: frameRect)
     cell = PlaySliderCell()
+    legacyCell = cell as? PlaySliderCell
+    originalTrackFillColor = trackFillColor
     commonInit()
   }
 
   required init?(coder: NSCoder) {
     super.init(coder: coder)
+    legacyCell = cell as? PlaySliderCell
+    originalTrackFillColor = trackFillColor
     commonInit()
   }
 
@@ -62,6 +122,22 @@ final class PlaySlider: NSSlider {
 
     abLoopAKnob = PlaySliderLoopKnob(slider: self, toolTip: "A-B loop A")
     abLoopBKnob = PlaySliderLoopKnob(slider: self, toolTip: "A-B loop B")
+  }
+
+  func setQuickTimeStyle(_ enabled: Bool) {
+    let useSystemAppearance = if #available(macOS 26.0, *) { enabled } else { false }
+    guard usesSystemAppearance != useSystemAppearance else { return }
+
+    replaceCellPreservingConfiguration(with: useSystemAppearance ? systemCell : legacyCell)
+    usesSystemAppearance = useSystemAppearance
+    controlSize = .small
+    trackFillColor = useSystemAppearance ? .white : originalTrackFillColor
+    if #available(macOS 26.0, *) {
+      tintProminence = useSystemAppearance ? .primary : .automatic
+    }
+    abLoopA.updateGeometry()
+    abLoopB.updateGeometry()
+    needsDisplay = true
   }
 
   // MARK: - Drawing
@@ -85,6 +161,9 @@ final class PlaySlider: NSSlider {
   override func draw(_ dirtyRect: NSRect) {
     guard !isHiddenOrHasHiddenAncestor else { return }
     super.draw(dirtyRect)
+    if usesSystemAppearance {
+      drawSystemAppearanceIndicators()
+    }
     abLoopA.needsDisplay = true
     abLoopB.needsDisplay = true
     guard #unavailable(macOS 14) else { return }
@@ -112,7 +191,18 @@ final class PlaySlider: NSSlider {
   /// - Important: _DO NOT REMOVE_ this function thinking it is not needed. Read issue #5768.
   /// - Parameter event: An object encapsulating information about the mouse-down event.
   override func mouseDown(with event: NSEvent) {
+    guard usesSystemAppearance else {
+      super.mouseDown(with: event)
+      return
+    }
+    let player = playerCore
+    let shouldResume = player.info.state != .paused
+    player.pause()
+    player.mainWindow.thumbnailPeekView.isHidden = true
     super.mouseDown(with: event)
+    if shouldResume {
+      player.resume()
+    }
   }
 
   /// The user is scrolling while the cursor is within the slider.
@@ -125,5 +215,48 @@ final class PlaySlider: NSSlider {
   override func scrollWheel(with event: NSEvent) {
     guard !Preference.bool(for: .disablePlaySliderScrolling) else { return }
     super.scrollWheel(with: event)
+  }
+
+  private var playerCore: PlayerCore {
+    (window!.windowController as! PlayerWindowController).player
+  }
+
+  private func drawSystemAppearanceIndicators() {
+    let rect = sliderCell.barRect(flipped: isFlipped)
+    let knobRect = sliderCell.knobRect(flipped: isFlipped)
+    let info = playerCore.info
+
+    NSGraphicsContext.saveGraphicsState()
+    defer { NSGraphicsContext.restoreGraphicsState() }
+    let clip = NSBezierPath(rect: rect)
+    clip.append(NSBezierPath(rect: knobRect.insetBy(dx: -1, dy: -1)).reversed)
+    clip.addClip()
+
+    if info.isNetworkResource,
+       info.cacheTime != 0,
+       let duration = info.videoDuration,
+       duration.second > 0 {
+      let playedX = knobRect.midX
+      let cachedRatio = CGFloat(Double(info.cacheTime) / Double(duration.second)).clamped(to: 0...1)
+      let cachedX = rect.minX + rect.width * cachedRatio
+      if cachedX > playedX {
+        let cacheRect = NSRect(x: playedX, y: rect.midY - 1,
+                               width: cachedX - playedX, height: 2)
+        NSColor.controlAccentColor.withAlphaComponent(0.35).setFill()
+        NSBezierPath(roundedRect: cacheRect, xRadius: 1, yRadius: 1).fill()
+      }
+    }
+
+    guard drawChapters,
+          let totalSeconds = info.videoDuration?.second,
+          totalSeconds > 0,
+          info.chapters.count > 1 else { return }
+    NSColor.separatorColor.withAlphaComponent(0.75).setFill()
+    for chapter in info.chapters.dropFirst() {
+      let ratio = CGFloat(chapter.time.second / totalSeconds).clamped(to: 0...1)
+      let x = round(rect.minX + rect.width * ratio)
+      NSBezierPath(rect: NSRect(x: x - 0.5, y: rect.minY,
+                                width: 1, height: rect.height)).fill()
+    }
   }
 }

--- a/iina/PlaySlider.swift
+++ b/iina/PlaySlider.swift
@@ -167,6 +167,7 @@ final class PlaySlider: NSSlider {
   override func mouseDown(with event: NSEvent) {
     let player = playerCore
     let shouldResume = player.info.state != .paused
+    player.mainWindow.liveText.clearAnalysis()
     player.pause()
     player.mainWindow.thumbnailPeekView.isHidden = true
     super.mouseDown(with: event)

--- a/iina/PlaySlider.swift
+++ b/iina/PlaySlider.swift
@@ -58,11 +58,7 @@ final class PlaySlider: NSSlider {
   private(set) var usesSystemAppearance = false
   private var originalTrackFillColor: NSColor?
   private var legacyCell: PlaySliderCell!
-  private lazy var systemCell: NSSliderCell = {
-    let cell = NSSliderCell()
-    cell.refusesFirstResponder = false
-    return cell
-  }()
+  private var systemCell: NSSliderCell!
 
   /// Knob representing the A loop point for the mpv A-B loop feature.
   var abLoopA: PlaySliderLoopKnob { abLoopAKnob }
@@ -99,15 +95,22 @@ final class PlaySlider: NSSlider {
 
   override init(frame frameRect: NSRect) {
     super.init(frame: frameRect)
-    cell = PlaySliderCell()
-    legacyCell = cell as? PlaySliderCell
+    systemCell = cell as! NSSliderCell
+    legacyCell = PlaySliderCell()
+    legacyCell.refusesFirstResponder = true
+    legacyCell.minValue = 0
+    legacyCell.maxValue = 100
     originalTrackFillColor = trackFillColor
     commonInit()
   }
 
   required init?(coder: NSCoder) {
     super.init(coder: coder)
-    legacyCell = cell as? PlaySliderCell
+    systemCell = cell as! NSSliderCell
+    legacyCell = PlaySliderCell()
+    legacyCell.refusesFirstResponder = true
+    legacyCell.minValue = 0
+    legacyCell.maxValue = 100
     originalTrackFillColor = trackFillColor
     commonInit()
   }
@@ -126,9 +129,11 @@ final class PlaySlider: NSSlider {
 
   func setQuickTimeStyle(_ enabled: Bool) {
     let useSystemAppearance = if #available(macOS 26.0, *) { enabled } else { false }
-    guard usesSystemAppearance != useSystemAppearance else { return }
-
-    replaceCellPreservingConfiguration(with: useSystemAppearance ? systemCell : legacyCell)
+    let desiredCell = useSystemAppearance ? systemCell! : legacyCell!
+    guard usesSystemAppearance != useSystemAppearance || cell !== desiredCell else { return }
+    if cell !== desiredCell {
+      replaceCellPreservingConfiguration(with: desiredCell)
+    }
     usesSystemAppearance = useSystemAppearance
     controlSize = .small
     trackFillColor = useSystemAppearance ? .white : originalTrackFillColor
@@ -138,37 +143,6 @@ final class PlaySlider: NSSlider {
     abLoopA.updateGeometry()
     abLoopB.updateGeometry()
     needsDisplay = true
-  }
-
-  // MARK: - Drawing
-
-  /// Draw the slider.
-  ///
-  /// The [NSSlider](https://developer.apple.com/documentation/appkit/nsslider) method is being overridden
-  /// for two reasons.
-  ///
-  /// With the onscreen controller hidden and a movie playing spindumps showed time being spent drawing the slider even though it
-  /// was not visible. Apparently `NSSlider.draw` is not calling
-  /// [hiddenOrHasHiddenAncestor](https://developer.apple.com/documentation/appkit/nsview/1483473-hiddenorhashiddenancestor)
-  /// to see if drawing can be avoided.  This was noticed under macOS Monterey.  Unknown if Apple addressed this in later macOS
-  /// releases.
-  ///
-  /// The loop knobs are added as subviews to the slider. That should have resulted in the `PlaySliderLoopKnob.draw` method
-  /// being called when the slider was being drawn. Prior to macOS Sonoma that did not occur. The assumption is that the
-  /// [NSSlider](https://developer.apple.com/documentation/appkit/nsslider) `draw` method was not calling
-  /// `super.draw` and that has now been corrected. As a workaround on earlier versions of macOS the loop knob `draw` method
-  /// is called directly.
-  override func draw(_ dirtyRect: NSRect) {
-    guard !isHiddenOrHasHiddenAncestor else { return }
-    super.draw(dirtyRect)
-    if usesSystemAppearance {
-      drawSystemAppearanceIndicators()
-    }
-    abLoopA.needsDisplay = true
-    abLoopB.needsDisplay = true
-    guard #unavailable(macOS 14) else { return }
-    abLoopA.draw(dirtyRect)
-    abLoopB.draw(dirtyRect)
   }
 
   override func viewDidUnhide() {
@@ -191,18 +165,7 @@ final class PlaySlider: NSSlider {
   /// - Important: _DO NOT REMOVE_ this function thinking it is not needed. Read issue #5768.
   /// - Parameter event: An object encapsulating information about the mouse-down event.
   override func mouseDown(with event: NSEvent) {
-    guard usesSystemAppearance else {
-      super.mouseDown(with: event)
-      return
-    }
-    let player = playerCore
-    let shouldResume = player.info.state != .paused
-    player.pause()
-    player.mainWindow.thumbnailPeekView.isHidden = true
     super.mouseDown(with: event)
-    if shouldResume {
-      player.resume()
-    }
   }
 
   /// The user is scrolling while the cursor is within the slider.
@@ -217,46 +180,4 @@ final class PlaySlider: NSSlider {
     super.scrollWheel(with: event)
   }
 
-  private var playerCore: PlayerCore {
-    (window!.windowController as! PlayerWindowController).player
-  }
-
-  private func drawSystemAppearanceIndicators() {
-    let rect = sliderCell.barRect(flipped: isFlipped)
-    let knobRect = sliderCell.knobRect(flipped: isFlipped)
-    let info = playerCore.info
-
-    NSGraphicsContext.saveGraphicsState()
-    defer { NSGraphicsContext.restoreGraphicsState() }
-    let clip = NSBezierPath(rect: rect)
-    clip.append(NSBezierPath(rect: knobRect.insetBy(dx: -1, dy: -1)).reversed)
-    clip.addClip()
-
-    if info.isNetworkResource,
-       info.cacheTime != 0,
-       let duration = info.videoDuration,
-       duration.second > 0 {
-      let playedX = knobRect.midX
-      let cachedRatio = CGFloat(Double(info.cacheTime) / Double(duration.second)).clamped(to: 0...1)
-      let cachedX = rect.minX + rect.width * cachedRatio
-      if cachedX > playedX {
-        let cacheRect = NSRect(x: playedX, y: rect.midY - 1,
-                               width: cachedX - playedX, height: 2)
-        NSColor.controlAccentColor.withAlphaComponent(0.35).setFill()
-        NSBezierPath(roundedRect: cacheRect, xRadius: 1, yRadius: 1).fill()
-      }
-    }
-
-    guard drawChapters,
-          let totalSeconds = info.videoDuration?.second,
-          totalSeconds > 0,
-          info.chapters.count > 1 else { return }
-    NSColor.separatorColor.withAlphaComponent(0.75).setFill()
-    for chapter in info.chapters.dropFirst() {
-      let ratio = CGFloat(chapter.time.second / totalSeconds).clamped(to: 0...1)
-      let x = round(rect.minX + rect.width * ratio)
-      NSBezierPath(rect: NSRect(x: x - 0.5, y: rect.minY,
-                                width: 1, height: rect.height)).fill()
-    }
-  }
 }

--- a/iina/PlaySlider.swift
+++ b/iina/PlaySlider.swift
@@ -95,7 +95,7 @@ final class PlaySlider: NSSlider {
 
   override init(frame frameRect: NSRect) {
     super.init(frame: frameRect)
-    systemCell = cell as! NSSliderCell
+    systemCell = cell as? NSSliderCell
     legacyCell = PlaySliderCell()
     legacyCell.refusesFirstResponder = true
     legacyCell.minValue = 0
@@ -106,7 +106,7 @@ final class PlaySlider: NSSlider {
 
   required init?(coder: NSCoder) {
     super.init(coder: coder)
-    systemCell = cell as! NSSliderCell
+    systemCell = cell as? NSSliderCell
     legacyCell = PlaySliderCell()
     legacyCell.refusesFirstResponder = true
     legacyCell.minValue = 0
@@ -165,7 +165,14 @@ final class PlaySlider: NSSlider {
   /// - Important: _DO NOT REMOVE_ this function thinking it is not needed. Read issue #5768.
   /// - Parameter event: An object encapsulating information about the mouse-down event.
   override func mouseDown(with event: NSEvent) {
+    let player = playerCore
+    let shouldResume = player.info.state != .paused
+    player.pause()
+    player.mainWindow.thumbnailPeekView.isHidden = true
     super.mouseDown(with: event)
+    if shouldResume {
+      player.resume()
+    }
   }
 
   /// The user is scrolling while the cursor is within the slider.
@@ -178,6 +185,10 @@ final class PlaySlider: NSSlider {
   override func scrollWheel(with event: NSEvent) {
     guard !Preference.bool(for: .disablePlaySliderScrolling) else { return }
     super.scrollWheel(with: event)
+  }
+
+  private var playerCore: PlayerCore {
+    (window!.windowController as! PlayerWindowController).player
   }
 
 }

--- a/iina/PlaySliderLoopKnob.swift
+++ b/iina/PlaySliderLoopKnob.swift
@@ -33,9 +33,9 @@ final class PlaySliderLoopKnob: NSView {
 
   // MARK:- Private Properties
 
-  private var cell: PlaySliderCell!
-
-  private let knobHeight: CGFloat
+  private var knobHeight: CGFloat {
+    round(slider.sliderKnobHeight * PlaySliderLoopKnob.knobHeightAdjustment)
+  }
   
   /// Percentage of the height of the primary knob to use for the loop knobs when drawing.
   ///
@@ -55,9 +55,9 @@ final class PlaySliderLoopKnob: NSView {
   /// though the value has remained constant.
   private var x: CGFloat {
     get {
-      let bar = cell.barRect(flipped: isFlipped)
+      let bar = slider.sliderCell.barRect(flipped: isFlipped)
       // The usable width of the bar is reduced by the width of the knob.
-      let effectiveWidth = bar.width - cell.knobWidth
+      let effectiveWidth = bar.width - slider.sliderKnobWidth
       let percentage = CGFloat(doubleValue / slider.span)
       let calculatedX = constrainX(bar.origin.x + percentage * effectiveWidth)
       setFrameOrigin(NSPoint(x: calculatedX, y: frame.origin.y))
@@ -66,9 +66,9 @@ final class PlaySliderLoopKnob: NSView {
     set {
       let constrainedX = constrainX(newValue)
       // Calculate the value selected by the new location.
-      let bar = cell.barRect(flipped: isFlipped)
+      let bar = slider.sliderCell.barRect(flipped: isFlipped)
       // The usable width of the bar is reduced by the width of the knob.
-      let effectiveWidth = bar.width - cell.knobWidth
+      let effectiveWidth = bar.width - slider.sliderKnobWidth
       let percentage = Double((constrainedX - bar.origin.x) / effectiveWidth)
       doubleValue = percentage * slider.span
     }
@@ -83,9 +83,6 @@ final class PlaySliderLoopKnob: NSView {
   ///   - toolTip: The help tag to display for this thumb.
   init(slider: PlaySlider, toolTip: String) {
     self.slider = slider
-    self.cell = slider.customCell
-    // We want loop knobs to be shorter than the primary knob.
-    knobHeight = round(cell.knobHeight * PlaySliderLoopKnob.knobHeightAdjustment)
     // The frame is calculated and set once the superclass is initialized.
     super.init(frame: NSZeroRect)
     self.toolTip = toolTip
@@ -93,9 +90,14 @@ final class PlaySliderLoopKnob: NSView {
     isHidden = true
     // Set the size of the frame to match the size of the slider's knob. The frame origin will be
     // adjusted when the knob is unhidden.
-    let rect = cell.knobRect(flipped: isFlipped)
+    let rect = slider.sliderCell.knobRect(flipped: isFlipped)
     setFrameSize(NSSize(width: rect.width, height: rect.height))
     slider.addSubview(self)
+  }
+
+  func updateGeometry() {
+    setFrameSize(slider.sliderCell.knobRect(flipped: isFlipped).size)
+    needsDisplay = true
   }
 
   required init?(coder: NSCoder) { fatalError("init(coder:) has not been implemented") }
@@ -104,9 +106,9 @@ final class PlaySliderLoopKnob: NSView {
   /// - Parameter x: The proposed x coordinate.
   /// - Returns: The given x coordinate constrained to keep the knob within the bar.
   private func constrainX(_ x: CGFloat) -> CGFloat {
-    let bar = cell.barRect(flipped: isFlipped)
+    let bar = slider.sliderCell.barRect(flipped: isFlipped)
     // The coordinate must be short of the end of the bar to keep the knob within the bar.
-    let maxX = bar.maxX - cell.knobWidth
+    let maxX = bar.maxX - slider.sliderKnobWidth
     return x.clamped(to: bar.minX...maxX)
   }
 
@@ -129,18 +131,19 @@ final class PlaySliderLoopKnob: NSView {
     let adjustedY = rect.origin.y + (rect.height - knobHeight) / 2
     let drawing: NSRect
     if #available(macOS 14, *) {
-      drawing = NSMakeRect(0, adjustedY, cell.knobWidth, knobHeight)
+      drawing = NSMakeRect(0, adjustedY, slider.sliderKnobWidth, knobHeight)
     } else {
       // Round the X position for cleaner drawing
-      drawing = NSMakeRect(round(rect.origin.x), adjustedY, cell.knobWidth, knobHeight)
+      drawing = NSMakeRect(round(rect.origin.x), adjustedY, slider.sliderKnobWidth, knobHeight)
     }
-    let path = NSBezierPath(roundedRect: drawing, xRadius: cell.knobRadius, yRadius: cell.knobRadius)
+    let path = NSBezierPath(roundedRect: drawing, xRadius: slider.sliderKnobRadius,
+                            yRadius: slider.sliderKnobRadius)
     knobColor().setFill()
     path.fill()
   }
 
   private func knobRect() -> NSRect {
-    let rect = cell.knobRect(flipped: isFlipped)
+    let rect = slider.sliderCell.knobRect(flipped: isFlipped)
     return NSMakeRect(x, rect.origin.y, rect.width, rect.height)
   }
 
@@ -177,7 +180,7 @@ final class PlaySliderLoopKnob: NSView {
   override func mouseDown(with event: NSEvent) {
     let clickLocation = slider.convert(event.locationInWindow, from: nil)
     // If this click lands on the play knob then pass the event up the responder chain.
-    if isMousePoint(clickLocation, in: slider.customCell.knobRect(flipped: slider.isFlipped)) {
+    if isMousePoint(clickLocation, in: slider.sliderCell.knobRect(flipped: slider.isFlipped)) {
       super.mouseDown(with: event)
       return
     }

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -198,7 +198,7 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
         self.updateTitle()
     }
 
-    self.playButton = NSButton(image: .play, target: self, action: #selector(playButtonAction))
+    self.playButton = OSCButton(image: .play, target: self, action: #selector(playButtonAction))
     playButton.alternateImage = .pause
 
     self.muteButton = VolumeButton(player: player, target: self, action: #selector(muteButtonAction))

--- a/iina/TranslucentView.swift
+++ b/iina/TranslucentView.swift
@@ -13,6 +13,7 @@ class TranslucentView: NSView {
   }
 
   private var liquidGlassCornerRadius: CGFloat
+  private var liquidGlassInteractive: Bool
   private var vevCornerRadius: CGFloat
   private var padding: (CGFloat, CGFloat)
   var content: NSView?
@@ -20,8 +21,10 @@ class TranslucentView: NSView {
   var style: Style
   private var appliedStyle: Style?
 
-  init(liquidGlassCornerRadius: CGFloat = 16, vevCornerRadius: CGFloat = 8, padding: (CGFloat, CGFloat)) {
+  init(liquidGlassCornerRadius: CGFloat = 16, vevCornerRadius: CGFloat = 8,
+       liquidGlassInteractive: Bool = false, padding: (CGFloat, CGFloat)) {
     self.liquidGlassCornerRadius = liquidGlassCornerRadius
+    self.liquidGlassInteractive = liquidGlassInteractive
     self.vevCornerRadius = vevCornerRadius
     self.padding = padding
     self.style = if #available(macOS 26, *) {
@@ -72,6 +75,9 @@ class TranslucentView: NSView {
       if #available(macOS 26.0, *) {
         let view = NSGlassEffectView()
         view.cornerRadius = liquidGlassCornerRadius
+        if #available(macOS 27.0, *), liquidGlassInteractive {
+          view.effectIsInteractive = true
+        }
         view.translatesAutoresizingMaskIntoConstraints = false
         view.contentView = wrapper
         container = view

--- a/iina/TranslucentView.swift
+++ b/iina/TranslucentView.swift
@@ -13,7 +13,6 @@ class TranslucentView: NSView {
   }
 
   private var liquidGlassCornerRadius: CGFloat
-  private var liquidGlassInteractive: Bool
   private var vevCornerRadius: CGFloat
   private var padding: (CGFloat, CGFloat)
   var content: NSView?
@@ -21,10 +20,8 @@ class TranslucentView: NSView {
   var style: Style
   private var appliedStyle: Style?
 
-  init(liquidGlassCornerRadius: CGFloat = 16, vevCornerRadius: CGFloat = 8,
-       liquidGlassInteractive: Bool = false, padding: (CGFloat, CGFloat)) {
+  init(liquidGlassCornerRadius: CGFloat = 16, vevCornerRadius: CGFloat = 8, padding: (CGFloat, CGFloat)) {
     self.liquidGlassCornerRadius = liquidGlassCornerRadius
-    self.liquidGlassInteractive = liquidGlassInteractive
     self.vevCornerRadius = vevCornerRadius
     self.padding = padding
     self.style = if #available(macOS 26, *) {
@@ -75,9 +72,6 @@ class TranslucentView: NSView {
       if #available(macOS 26.0, *) {
         let view = NSGlassEffectView()
         view.cornerRadius = liquidGlassCornerRadius
-        if #available(macOS 27.0, *), liquidGlassInteractive {
-          view.effectIsInteractive = true
-        }
         view.translatesAutoresizingMaskIntoConstraints = false
         view.contentView = wrapper
         container = view

--- a/iina/VolumeButton.swift
+++ b/iina/VolumeButton.swift
@@ -11,6 +11,7 @@ class VolumeButton: NSButton {
   weak var player: PlayerCore!
 
   private var previousIcon: String?
+  private var usesQuickTimeStyle = false
 
   init(player: PlayerCore, target: AnyObject? = nil, action: Selector? = nil) {
     self.player = player
@@ -37,10 +38,18 @@ class VolumeButton: NSButton {
     previousIcon = res.name
   }
 
+  func setQuickTimeStyle(_ enabled: Bool) {
+    usesQuickTimeStyle = enabled
+    previousIcon = nil
+    update()
+  }
+
   private func volumeIcon() -> (image: NSImage?, name: String) {
+    let pointSize: CGFloat = usesQuickTimeStyle ? 17 : 13
+    let configuration = NSImage.SymbolConfiguration(pointSize: pointSize, weight: .regular)
     guard let player, !player.info.isMuted else {
       let name = "speaker.slash.fill"
-      return (.sf(name), name)
+      return (.sf(name, withConfiguration: configuration), name)
     }
     let volume = Int(player.info.volume)
     guard volume >= 0 else {
@@ -52,7 +61,6 @@ class VolumeButton: NSButton {
     case 34...66: "speaker.wave.2.fill"
     default: "speaker.wave.3.fill"
     }
-    let configuration = NSImage.SymbolConfiguration(pointSize: 13, weight: .regular)
     return (.sf(symbol, withConfiguration: configuration), symbol)
   }
 }

--- a/iina/VolumeButton.swift
+++ b/iina/VolumeButton.swift
@@ -15,6 +15,8 @@ class VolumeButton: NSView {
   var action: Selector?
 
   private var previousIcon: String?
+  private var isPressed = false
+  private var eventMonitor: Any?
 
   init(player: PlayerCore, target: Any? = nil, action: Selector? = nil) {
     self.target = target
@@ -36,9 +38,52 @@ class VolumeButton: NSView {
     fatalError("init(coder:) has not been implemented")
   }
 
+  deinit {
+    if let eventMonitor {
+      NSEvent.removeMonitor(eventMonitor)
+    }
+  }
+
   override func mouseDown(with event: NSEvent) {
-    guard let target, let action else { return }
-    NSApp.sendAction(action, to: target, from: self)
+    guard eventMonitor == nil else { return }
+    setPressed(true)
+    eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDragged, .leftMouseUp]) {
+      [weak self] event in
+      guard let self, event.window === window else { return event }
+
+      let location = convert(event.locationInWindow, from: nil)
+      switch event.type {
+      case .leftMouseDragged:
+        setPressed(bounds.contains(location))
+      case .leftMouseUp:
+        let shouldTrigger = bounds.contains(location)
+        if let eventMonitor {
+          NSEvent.removeMonitor(eventMonitor)
+          self.eventMonitor = nil
+        }
+        setPressed(false)
+        if shouldTrigger, let target, let action {
+          NSApp.sendAction(action, to: target, from: self)
+        }
+      default:
+        break
+      }
+      return nil
+    }
+  }
+
+  private func setPressed(_ pressed: Bool) {
+    guard isPressed != pressed else { return }
+    isPressed = pressed
+    guard !Preference.bool(for: .disableAnimations) else {
+      imageView.alphaValue = pressed ? 0.55 : 1
+      return
+    }
+    NSAnimationContext.runAnimationGroup { context in
+      context.duration = pressed ? 0.06 : 0.14
+      context.timingFunction = CAMediaTimingFunction(name: pressed ? .easeInEaseOut : .easeOut)
+      imageView.animator().alphaValue = pressed ? 0.55 : 1
+    }
   }
 
   func update() {

--- a/iina/VolumeButton.swift
+++ b/iina/VolumeButton.swift
@@ -7,94 +7,33 @@
 //
 
 
-class VolumeButton: NSView {
-  let imageView: NSImageView
+class VolumeButton: NSButton {
   weak var player: PlayerCore!
 
-  var target: Any?
-  var action: Selector?
-
   private var previousIcon: String?
-  private var isPressed = false
-  private var eventMonitor: Any?
 
-  init(player: PlayerCore, target: Any? = nil, action: Selector? = nil) {
+  init(player: PlayerCore, target: AnyObject? = nil, action: Selector? = nil) {
+    self.player = player
+    super.init(frame: .zero)
     self.target = target
     self.action = action
-    self.player = player
-
-    self.imageView = NSImageView()
-    imageView.translatesAutoresizingMaskIntoConstraints = false
-    imageView.imageScaling = .scaleProportionallyDown
-
-    super.init(frame: .zero)
-
     translatesAutoresizingMaskIntoConstraints = false
-    addSubview(imageView)
-    imageView.padding(.all)
+    bezelStyle = .shadowlessSquare
+    isBordered = false
+    imagePosition = .imageOnly
+    imageScaling = .scaleProportionallyDown
+    setButtonType(.momentaryPushIn)
+    refusesFirstResponder = true
   }
-  
+
   required init?(coder: NSCoder) {
     fatalError("init(coder:) has not been implemented")
-  }
-
-  deinit {
-    if let eventMonitor {
-      NSEvent.removeMonitor(eventMonitor)
-    }
-  }
-
-  override func mouseDown(with event: NSEvent) {
-    guard eventMonitor == nil else { return }
-    setPressed(true)
-    eventMonitor = NSEvent.addLocalMonitorForEvents(matching: [.leftMouseDragged, .leftMouseUp]) {
-      [weak self] event in
-      guard let self, event.window === window else { return event }
-
-      let location = convert(event.locationInWindow, from: nil)
-      switch event.type {
-      case .leftMouseDragged:
-        setPressed(bounds.contains(location))
-      case .leftMouseUp:
-        let shouldTrigger = bounds.contains(location)
-        if let eventMonitor {
-          NSEvent.removeMonitor(eventMonitor)
-          self.eventMonitor = nil
-        }
-        setPressed(false)
-        if shouldTrigger, let target, let action {
-          NSApp.sendAction(action, to: target, from: self)
-        }
-      default:
-        break
-      }
-      return nil
-    }
-  }
-
-  private func setPressed(_ pressed: Bool) {
-    guard isPressed != pressed else { return }
-    isPressed = pressed
-    guard !Preference.bool(for: .disableAnimations) else {
-      imageView.alphaValue = pressed ? 0.55 : 1
-      return
-    }
-    NSAnimationContext.runAnimationGroup { context in
-      context.duration = pressed ? 0.06 : 0.14
-      context.timingFunction = CAMediaTimingFunction(name: pressed ? .easeInEaseOut : .easeOut)
-      imageView.animator().alphaValue = pressed ? 0.55 : 1
-    }
   }
 
   func update() {
     let res = volumeIcon()
     guard let icon = res.image, res.name != previousIcon else { return }
-    let useReplace = (previousIcon?.contains("slash") ?? false) || (res.name.contains("slash"))
-    if #available(macOS 15.0, *), useReplace {
-      imageView.setSymbolImage(icon, contentTransition: .replace.offUp)
-    } else {
-      imageView.image = icon
-    }
+    image = icon
     previousIcon = res.name
   }
 

--- a/iina/VolumeSlider.swift
+++ b/iina/VolumeSlider.swift
@@ -8,71 +8,36 @@
 
 import Cocoa
 
-/// A custom [slider](https://developer.apple.com/design/human-interface-guidelines/macos/selectors/sliders/)
-/// for the volume slider in the on screen controller.
+/// An NSSlider subclass used for the volume slider in the on-screen controller.
 class VolumeSlider: NSSlider {
-  private(set) var usesSystemAppearance = false
-  private var originalControlSize: NSControl.ControlSize = .mini
-  private var originalTrackFillColor: NSColor?
-  private var legacyCell: VolumeSliderCell!
-  private lazy var systemCell: NSSliderCell = {
-    let cell = NSSliderCell()
-    cell.refusesFirstResponder = false
-    return cell
-  }()
-
   override init(frame frameRect: NSRect) {
     super.init(frame: frameRect)
-    cell = VolumeSliderCell()
-    legacyCell = cell as? VolumeSliderCell
-    originalControlSize = controlSize
-    originalTrackFillColor = trackFillColor
+    maxValue = Double(Preference.integer(for: .maxVolume))
   }
 
   required init?(coder: NSCoder) {
     super.init(coder: coder)
-    if !(cell is VolumeSliderCell) {
-      cell = VolumeSliderCell()
-    }
-    legacyCell = cell as? VolumeSliderCell
-    originalControlSize = controlSize
-    originalTrackFillColor = trackFillColor
+    maxValue = Double(Preference.integer(for: .maxVolume))
   }
 
   func setQuickTimeStyle(_ enabled: Bool) {
-    let useSystemAppearance = if #available(macOS 26.0, *) { enabled } else { false }
-    guard usesSystemAppearance != useSystemAppearance else { return }
-
-    replaceCellPreservingConfiguration(with: useSystemAppearance ? systemCell : legacyCell)
-    usesSystemAppearance = useSystemAppearance
-    controlSize = useSystemAppearance ? .small : originalControlSize
-    trackFillColor = useSystemAppearance ? .white : originalTrackFillColor
+    controlSize = enabled ? .small : .mini
+    trackFillColor = enabled ? .white : nil
     if #available(macOS 26.0, *) {
-      tintProminence = useSystemAppearance ? .none : .automatic
+      tintProminence = enabled ? .none : .automatic
     }
     needsDisplay = true
   }
 
-  // MARK: - Drawing
-
-  override func draw(_ dirtyRect: NSRect) {
-    super.draw(dirtyRect)
-    guard usesSystemAppearance, maxValue > 100 else { return }
-    let sliderCell = cell as! NSSliderCell
-    let rect = sliderCell.barRect(flipped: isFlipped)
-    let x = round(rect.minX + rect.width * CGFloat(100 / maxValue))
-    NSGraphicsContext.saveGraphicsState()
-    let clip = NSBezierPath(rect: rect)
-    clip.append(NSBezierPath(rect: sliderCell.knobRect(flipped: isFlipped)
-      .insetBy(dx: -1, dy: -1)).reversed)
-    clip.addClip()
-    NSColor.separatorColor.withAlphaComponent(0.8).setFill()
-    NSBezierPath(rect: NSRect(x: x - 0.5, y: rect.minY,
-                              width: 1, height: rect.height)).fill()
-    NSGraphicsContext.restoreGraphicsState()
-  }
-
   // MARK: - Mouse / Trackpad events
+
+  /// Keep AppKit's native slider tracking active on macOS versions affected by IINA issue #5768.
+  ///
+  /// This override intentionally does nothing beyond forwarding the event to AppKit. Without
+  /// it, Tahoe can skip the tracking path for an NSSlider subclass.
+  override func mouseDown(with event: NSEvent) {
+    super.mouseDown(with: event)
+  }
 
   /// The user is scrolling while the cursor is within the slider.
   ///
@@ -85,49 +50,4 @@ class VolumeSlider: NSSlider {
     guard !Preference.bool(for: .disableVolumeSliderScrolling) else { return }
     super.scrollWheel(with: event)
   }
-}
-
-fileprivate class VolumeSliderCell: NSSliderCell {
-  override func awakeFromNib() {
-    minValue = 0
-    maxValue = Double(Preference.integer(for: .maxVolume))
-  }
-
-  override func drawBar(inside rect: NSRect, flipped: Bool) {
-    let knobPos: CGFloat = round(knobRect(flipped: flipped).origin.x)
-    let radius: CGFloat = 1.5
-    let path = NSBezierPath(roundedRect: rect, xRadius: radius, yRadius: radius)
-    let x100 = round(rect.minX + rect.width * CGFloat(100 / maxValue))
-
-    let gapClip: NSBezierPath?
-    if maxValue > 100 {
-      let width: CGFloat = 2
-      let gapRect = NSMakeRect(x100 - width / 2, rect.minY, width, rect.height)
-      gapClip = NSBezierPath(rect: gapRect).reversed
-    } else {
-      gapClip = nil
-    }
-
-    NSGraphicsContext.saveGraphicsState()
-    let clipLeft = NSBezierPath(rect: NSMakeRect(rect.minX, rect.minY, knobPos, rect.height))
-    if let gapClip, x100 < knobPos {
-      clipLeft.append(gapClip)
-    }
-    clipLeft.addClip()
-    NSColor.volumeSliderBarLeft.setFill()
-    path.fill()
-    NSGraphicsContext.restoreGraphicsState()
-
-    NSGraphicsContext.saveGraphicsState()
-    let rightRect = NSMakeRect(rect.minX + knobPos, rect.minY, rect.width - knobPos, rect.height)
-    let clipRight = NSBezierPath(rect: rightRect)
-    if let gapClip, knobPos < x100 {
-      clipRight.append(gapClip)
-    }
-    clipRight.addClip()
-    NSColor.volumeSliderBarRight.setFill()
-    path.fill()
-    NSGraphicsContext.restoreGraphicsState()
-  }
-
 }

--- a/iina/VolumeSlider.swift
+++ b/iina/VolumeSlider.swift
@@ -24,7 +24,7 @@ class VolumeSlider: NSSlider {
     controlSize = enabled ? .small : .mini
     trackFillColor = enabled ? .white : nil
     if #available(macOS 26.0, *) {
-      tintProminence = enabled ? .none : .automatic
+      tintProminence = enabled ? .primary : .automatic
     }
     needsDisplay = true
   }

--- a/iina/VolumeSlider.swift
+++ b/iina/VolumeSlider.swift
@@ -10,21 +10,44 @@ import Cocoa
 
 /// An NSSlider subclass used for the volume slider in the on-screen controller.
 class VolumeSlider: NSSlider {
+  private(set) var usesSystemAppearance = false
+  private var originalControlSize: NSControl.ControlSize = .mini
+  private var originalTrackFillColor: NSColor?
+  private var legacyCell: VolumeSliderCell!
+  private var systemCell: NSSliderCell!
+
   override init(frame frameRect: NSRect) {
     super.init(frame: frameRect)
+    systemCell = cell as? NSSliderCell
+    legacyCell = VolumeSliderCell()
+    cell = legacyCell
+    originalControlSize = controlSize
+    originalTrackFillColor = trackFillColor
     maxValue = Double(Preference.integer(for: .maxVolume))
   }
 
   required init?(coder: NSCoder) {
     super.init(coder: coder)
+    systemCell = cell as? NSSliderCell
+    legacyCell = VolumeSliderCell()
+    cell = legacyCell
+    originalControlSize = controlSize
+    originalTrackFillColor = trackFillColor
     maxValue = Double(Preference.integer(for: .maxVolume))
   }
 
   func setQuickTimeStyle(_ enabled: Bool) {
-    controlSize = enabled ? .small : .mini
-    trackFillColor = enabled ? .white : nil
+    let useSystemAppearance = if #available(macOS 26.0, *) { enabled } else { false }
+    let desiredCell = useSystemAppearance ? systemCell! : legacyCell!
+    guard usesSystemAppearance != useSystemAppearance || cell !== desiredCell else { return }
+    if cell !== desiredCell {
+      replaceCellPreservingConfiguration(with: desiredCell)
+    }
+    usesSystemAppearance = useSystemAppearance
+    controlSize = useSystemAppearance ? .small : originalControlSize
+    trackFillColor = useSystemAppearance ? .white : originalTrackFillColor
     if #available(macOS 26.0, *) {
-      tintProminence = enabled ? .primary : .automatic
+      tintProminence = useSystemAppearance ? .primary : .automatic
     }
     needsDisplay = true
   }
@@ -49,5 +72,39 @@ class VolumeSlider: NSSlider {
   override func scrollWheel(with event: NSEvent) {
     guard !Preference.bool(for: .disableVolumeSliderScrolling) else { return }
     super.scrollWheel(with: event)
+  }
+}
+
+fileprivate final class VolumeSliderCell: NSSliderCell {
+  override func drawBar(inside rect: NSRect, flipped: Bool) {
+    let knobPos = round(knobRect(flipped: flipped).origin.x)
+    let path = NSBezierPath(roundedRect: rect, xRadius: 1.5, yRadius: 1.5)
+    let x100 = round(rect.minX + rect.width * CGFloat(100 / maxValue))
+    let gapClip: NSBezierPath?
+    if maxValue > 100 {
+      let gapRect = NSRect(x: x100 - 1, y: rect.minY, width: 2, height: rect.height)
+      gapClip = NSBezierPath(rect: gapRect).reversed
+    } else {
+      gapClip = nil
+    }
+
+    NSGraphicsContext.saveGraphicsState()
+    let clipLeft = NSBezierPath(rect: NSRect(x: rect.minX, y: rect.minY,
+                                             width: knobPos, height: rect.height))
+    if let gapClip, x100 < knobPos { clipLeft.append(gapClip) }
+    clipLeft.addClip()
+    NSColor.volumeSliderBarLeft.setFill()
+    path.fill()
+    NSGraphicsContext.restoreGraphicsState()
+
+    NSGraphicsContext.saveGraphicsState()
+    let rightRect = NSRect(x: rect.minX + knobPos, y: rect.minY,
+                           width: rect.width - knobPos, height: rect.height)
+    let clipRight = NSBezierPath(rect: rightRect)
+    if let gapClip, knobPos < x100 { clipRight.append(gapClip) }
+    clipRight.addClip()
+    NSColor.volumeSliderBarRight.setFill()
+    path.fill()
+    NSGraphicsContext.restoreGraphicsState()
   }
 }

--- a/iina/VolumeSlider.swift
+++ b/iina/VolumeSlider.swift
@@ -11,15 +11,67 @@ import Cocoa
 /// A custom [slider](https://developer.apple.com/design/human-interface-guidelines/macos/selectors/sliders/)
 /// for the volume slider in the on screen controller.
 class VolumeSlider: NSSlider {
+  private(set) var usesSystemAppearance = false
+  private var originalControlSize: NSControl.ControlSize = .mini
+  private var originalTrackFillColor: NSColor?
+  private var legacyCell: VolumeSliderCell!
+  private lazy var systemCell: NSSliderCell = {
+    let cell = NSSliderCell()
+    cell.refusesFirstResponder = false
+    return cell
+  }()
+
   override init(frame frameRect: NSRect) {
     super.init(frame: frameRect)
-    self.cell = VolumeSliderCell()
+    cell = VolumeSliderCell()
+    legacyCell = cell as? VolumeSliderCell
+    originalControlSize = controlSize
+    originalTrackFillColor = trackFillColor
   }
-  
+
   required init?(coder: NSCoder) {
-    fatalError("init(coder:) has not been implemented")
+    super.init(coder: coder)
+    if !(cell is VolumeSliderCell) {
+      cell = VolumeSliderCell()
+    }
+    legacyCell = cell as? VolumeSliderCell
+    originalControlSize = controlSize
+    originalTrackFillColor = trackFillColor
   }
-  
+
+  func setQuickTimeStyle(_ enabled: Bool) {
+    let useSystemAppearance = if #available(macOS 26.0, *) { enabled } else { false }
+    guard usesSystemAppearance != useSystemAppearance else { return }
+
+    replaceCellPreservingConfiguration(with: useSystemAppearance ? systemCell : legacyCell)
+    usesSystemAppearance = useSystemAppearance
+    controlSize = useSystemAppearance ? .small : originalControlSize
+    trackFillColor = useSystemAppearance ? .white : originalTrackFillColor
+    if #available(macOS 26.0, *) {
+      tintProminence = useSystemAppearance ? .none : .automatic
+    }
+    needsDisplay = true
+  }
+
+  // MARK: - Drawing
+
+  override func draw(_ dirtyRect: NSRect) {
+    super.draw(dirtyRect)
+    guard usesSystemAppearance, maxValue > 100 else { return }
+    let sliderCell = cell as! NSSliderCell
+    let rect = sliderCell.barRect(flipped: isFlipped)
+    let x = round(rect.minX + rect.width * CGFloat(100 / maxValue))
+    NSGraphicsContext.saveGraphicsState()
+    let clip = NSBezierPath(rect: rect)
+    clip.append(NSBezierPath(rect: sliderCell.knobRect(flipped: isFlipped)
+      .insetBy(dx: -1, dy: -1)).reversed)
+    clip.addClip()
+    NSColor.separatorColor.withAlphaComponent(0.8).setFill()
+    NSBezierPath(rect: NSRect(x: x - 0.5, y: rect.minY,
+                              width: 1, height: rect.height)).fill()
+    NSGraphicsContext.restoreGraphicsState()
+  }
+
   // MARK: - Mouse / Trackpad events
 
   /// The user is scrolling while the cursor is within the slider.
@@ -35,42 +87,18 @@ class VolumeSlider: NSSlider {
   }
 }
 
-
 fileprivate class VolumeSliderCell: NSSliderCell {
-  /// Draws the slider’s bar—but not its bezel or knob—inside the specified rectangle.
-  ///
-  /// IINA overrides the
-  /// [NSSliderCell.drawBar](https://developer.apple.com/documentation/appkit/nsslidercell/drawbar(inside:flipped:))
-  /// method in order to:
-  /// - Round the ends of the slider bar (matching the playback position slider)
-  /// - Alter the colors of the bar
-  /// - Leave a small gap that marks the position representing 100% volume, when the `Maximum volume` setting has been used to
-  ///     allow the volume to be set beyond 100%
-  ///
-  /// As merely moving the cursor displays the on screen controller it is desirable that this UI element not be intrusive. For this reason
-  /// the OSC intentionally differs in its appearance from other user interface elements. To make the OSC have a subtle appearance a
-  /// greyscale color scheme is used. In particular it is important to override the use of
-  /// [controlAccentColor](https://developer.apple.com/documentation/appkit/nscolor/controlaccentcolor)
-  /// by [NSSlider](https://developer.apple.com/documentation/appkit/nsslider) as that color is intended to stand
-  /// out and attract attention.
-  /// - Parameters:
-  ///   - rect: The bounds of the slider’s bar, not of its interior rectangle.
-  ///   - flipped: A Boolean value that indicates whether the cell’s control view—that is, the `NSSlider` or `NSMatrix`
-  ///       associated with the` NSSliderCell`—has a flipped coordinate system.
+  override func awakeFromNib() {
+    minValue = 0
+    maxValue = Double(Preference.integer(for: .maxVolume))
+  }
+
   override func drawBar(inside rect: NSRect, flipped: Bool) {
-
-    // The position of the knob, rounded for cleaner drawing.
-    let knobPos: CGFloat = round(knobRect(flipped: flipped).origin.x);
-
-    // Round the slider bar ends like is done for the playback progress slider.
+    let knobPos: CGFloat = round(knobRect(flipped: flipped).origin.x)
     let radius: CGFloat = 1.5
     let path = NSBezierPath(roundedRect: rect, xRadius: radius, yRadius: radius)
-
-    // The position at which volume is set to 100 rounded to obtain a pixel perfect clip line.
     let x100 = round(rect.minX + rect.width * CGFloat(100 / maxValue))
 
-    // If the IINA "Maximum volume" setting has been increased beyond 100 then the slider bar will
-    // be drawn with a small gap at the position that represents 100% volume.
     let gapClip: NSBezierPath?
     if maxValue > 100 {
       let width: CGFloat = 2
@@ -80,11 +108,9 @@ fileprivate class VolumeSliderCell: NSSliderCell {
       gapClip = nil
     }
 
-    // Draw the portion of the slider bar that is to the left of the knob.
     NSGraphicsContext.saveGraphicsState()
     let clipLeft = NSBezierPath(rect: NSMakeRect(rect.minX, rect.minY, knobPos, rect.height))
     if let gapClip, x100 < knobPos {
-      // The gap representing 100% volume is in this portion of the bar.
       clipLeft.append(gapClip)
     }
     clipLeft.addClip()
@@ -92,12 +118,10 @@ fileprivate class VolumeSliderCell: NSSliderCell {
     path.fill()
     NSGraphicsContext.restoreGraphicsState()
 
-    // Draw the portion of the slider bar that is to the right of the knob.
     NSGraphicsContext.saveGraphicsState()
     let rightRect = NSMakeRect(rect.minX + knobPos, rect.minY, rect.width - knobPos, rect.height)
     let clipRight = NSBezierPath(rect: rightRect)
     if let gapClip, knobPos < x100 {
-      // The gap representing 100% volume is in this portion of the bar.
       clipRight.append(gapClip)
     }
     clipRight.addClip()
@@ -105,4 +129,5 @@ fileprivate class VolumeSliderCell: NSSliderCell {
     path.fill()
     NSGraphicsContext.restoreGraphicsState()
   }
+
 }


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] Related issue: N/A
- [x] Related Design Proposal: #6275
---
- [x] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.

**Description:**

This pull request explores a QuickTime-style floating OSC implementation and related control behavior changes.

This is more like an implementation reference than a PR ready to be merged, as there may be many details that have not been tested thoroughly yet, and some elements may require a redesign.

The changes include native playback and volume controls in the floating OSC, improved slider interaction and hit testing, QuickTime-like control proportions, and related mute, volume, and transport behavior adjustments.

<img width="472" height="117" alt="Screenshot 2026-08-21 at 18 09 13" src="https://github.com/user-attachments/assets/898d4851-2d84-4a40-a550-b833253772a8" />