### PR TITLE
Fix missing setting for disabling hiding of the OSC, #6273

### DIFF
--- a/iina/SettingsPageUI.swift
+++ b/iina/SettingsPageUI.swift
@@ -136,9 +136,11 @@ class SettingsPageUI: SettingsPage {
         SettingsItem.PopupButton()
           .image(name: "forward.fill")
           .bindTo(.arrowButtonAction, ofType: Preference.ArrowButtonAction.self)
-        SettingsItem.Input()
+        SettingsItem.SwitchWithInput()
           .image(name: "timer")
-          .bindTo(.controlBarAutoHideTimeout)
+          .labelKey(.controlBarAutoHideTimeout)
+          .bindInputTo(.controlBarAutoHideTimeout)
+          .bindSwitchTo(.enableControlBarAutoHide)
           .trailingLabel(.text_s)
       }
 


### PR DESCRIPTION
This commit will change `SettingsPageUI.sectionOSC` to use `SwitchWithInput` for the `Auto hide after` setting so that hiding can be disabled as permitted with the old settings window.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] Related issue: #6273
- [ ] Related Design Proposal: # / Not applicable
---
- [ ] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**
