### PR TITLE
PiP: default to hiding the main window

### DIFF
--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -821,7 +821,7 @@ struct Preference {
     case hide
     case minimize
 
-    static var defaultValue = WindowBehaviorWhenPip.doNothing
+    static var defaultValue = WindowBehaviorWhenPip.hide
 
     init?(key: Key) {
       self.init(rawValue: Preference.integer(for: key))
@@ -1107,7 +1107,7 @@ struct Preference {
     .musicModeShowAlbumArt: true,
     .displayTimeAndBatteryInFullScreen: false,
 
-    .windowBehaviorWhenPip: WindowBehaviorWhenPip.doNothing.rawValue,
+    .windowBehaviorWhenPip: WindowBehaviorWhenPip.hide.rawValue,
     .pauseWhenPip: false,
     .togglePipByMinimizingWindow: false,
     .togglePipByMinimizingWindowForVideoOnly: false,


### PR DESCRIPTION
## Summary

Make Hide the default behavior when entering Picture-in-Picture.

## Rationale

Apple TV on macOS collapses playback into a floating Picture-in-Picture viewer while keeping the source app available to return to. Hiding IINA’s main window provides that native macOS-style behavior without closing the player window or adding a separate Close-source-window mode.

## Scope

- Change the default for new or unset preferences from Do nothing to Hide.
- Preserve any explicit existing user preference, including Do nothing.
- Leave the existing behavior options and PiP lifecycle unchanged.

This is a narrower alternative to #6008, which has been closed.

## Validation

- `git diff --check` passes.
- The source compiles through the build; the full local link step is currently blocked by the unavailable `SvtAv1Enc.4` dependency.