### PR TITLE
Display screenshot formats in order

### DIFF
--- a/iina/SettingsItem.swift
+++ b/iina/SettingsItem.swift
@@ -577,6 +577,16 @@ struct SettingsItem {
       return self
     }
 
+    func bindToSorted<T>(_ key: Preference.Key, ofType t: T.Type) -> Self
+    where T: RawRepresentable & CaseIterable & InitializingFromKey & Comparable, T.RawValue == Int
+    {
+      self.key = key
+      for c in t.allCases.sorted() {
+        valueTypes.append((c.rawValue, String(describing: c)))
+      }
+      return self
+    }
+
     func bindToCustom<T>(type t: T.Type, block: @escaping (NSPopUpButton) -> Void) -> Self
     where T: RawRepresentable & CaseIterable & InitializingFromKey, T.RawValue == Int
     {

--- a/iina/SettingsPageGeneral.swift
+++ b/iina/SettingsPageGeneral.swift
@@ -178,7 +178,7 @@ class SettingsPageGeneral: SettingsPage {
           .bindTo(.screenshotSaveToFile)
           .extraViews(fileChooseView.textField, fileChooseView.chooseButton)
         SettingsItem.PopupButton()
-          .bindTo(.screenshotFormat, ofType: Preference.ScreenshotFormat.self)
+          .bindToSorted(.screenshotFormat, ofType: Preference.ScreenshotFormat.self)
         SettingsItem.Switch()
           .image(name: "list.clipboard")
           .bindTo(.screenshotCopyToClipboard)
@@ -215,5 +215,11 @@ fileprivate extension Preference {
       case .monthly: "monthly"
       }
     }
+  }
+}
+
+extension Preference.ScreenshotFormat: Comparable {
+  static func <(lhs: Preference.ScreenshotFormat, rhs: Preference.ScreenshotFormat) -> Bool {
+    String(describing: lhs) < String(describing: rhs)
   }
 }

--- a/iina/VerbatimStrings.strings
+++ b/iina/VerbatimStrings.strings
@@ -6,7 +6,7 @@
   Copyright © 2026 lhc. All rights reserved.
 */
 
-"settings.screenShotFormat.items.0" = "PNG";
+"settings.screenShotFormat.items.0" = "PNG (.png)";
 "settings.screenShotFormat.items.1" = "JPEG (.jpg)";
 "settings.screenShotFormat.items.2" = "JPEG (.jpeg)";
 "settings.screenShotFormat.items.3" = "WebP (.webp)";


### PR DESCRIPTION
This commit will:
- Add a `bindToSorted` method to `SettingsItem`
- Add a `Preference.ScreenshotFormat` extension to `SettingsPageGeneral` that implements comparable
- Change `SettingsPageGeneral.sectionScreenshots` to use `bindToSorted` for the screenshot format setting
- Add the missing file extension to the PNG string in `VerbatimStrings`

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] Related issue: #
- [ ] Related Design Proposal: # / Not applicable
---
- [ ] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**
