### PR TITLE
Fix missing validation in new settings window, #6289

### DIFF
--- a/iina/SettingsItem.swift
+++ b/iina/SettingsItem.swift
@@ -822,6 +822,7 @@ struct SettingsItem {
     private var customBindingBlock: ((NSTextField) -> Void)?
     private var isLongText = false
     private var range: ClosedRange<Double>?
+    private var allowsFloats = false
 
     private var cachedStepperValue: Double?
     private var stepper: NSStepper?
@@ -853,8 +854,9 @@ struct SettingsItem {
       return self
     }
 
-    func range(_ range: ClosedRange<Double>) -> Self {
+    func range(_ range: ClosedRange<Double>, allowsFloats: Bool = false) -> Self {
       self.range = range
+      self.allowsFloats = allowsFloats
       return self
     }
 
@@ -875,9 +877,11 @@ struct SettingsItem {
       setControlSize(textField)
       if let range {
         let formatter = NumberFormatter()
+        formatter.allowsFloats = allowsFloats
         formatter.usesGroupingSeparator = false
         formatter.minimum = NSNumber(value: range.lowerBound)
         formatter.maximum = NSNumber(value: range.upperBound)
+        formatter.numberStyle = .decimal
         textField.formatter = formatter
       }
       let stack = NSStackView(views: [textField])
@@ -923,11 +927,19 @@ struct SettingsItem {
     private var valueTypes: [(Int, String)] = []
     private var textField: NSTextField!
     private var trailingLabel: SettingsLocalization.Key?
+    private var range: ClosedRange<Double>?
+    private var allowsFloats = false
 
     private var customBindingInput = false
     private var customBindingBlockInput: ((NSTextField) -> Void)?
     private var customBindingSwitch = false
     private var customBindingBlockSwitch: ((NSSwitch) -> Void)?
+
+    func range(_ range: ClosedRange<Double>, allowsFloats: Bool = false) -> Self {
+      self.range = range
+      self.allowsFloats = allowsFloats
+      return self
+    }
 
     override func getValueViews() -> [NSView] {
       nsSwitch = NSSwitch()
@@ -940,6 +952,15 @@ struct SettingsItem {
       textField.bezelStyle = .roundedBezel
       textField.size(width: 64)
       setControlSize(textField)
+      if let range {
+        let formatter = NumberFormatter()
+        formatter.allowsFloats = allowsFloats
+        formatter.usesGroupingSeparator = false
+        formatter.minimum = NSNumber(value: range.lowerBound)
+        formatter.maximum = NSNumber(value: range.upperBound)
+        formatter.numberStyle = .decimal
+        textField.formatter = formatter
+      }
       if let trailingLabel {
         let label = NSTextField(labelWithString: ui.localized(trailingLabel))
         setControlSize(label)

--- a/iina/SettingsPageAudio.swift
+++ b/iina/SettingsPageAudio.swift
@@ -42,6 +42,7 @@ class SettingsPageAudio: SettingsPage {
         SettingsItem.Input(title: .videoThreadsLabel)
           .image(name: "number")
           .bindTo(.audioThreads)
+          .range(0...16)
           .hasDescription(content: .videoThreadsDesc)
         SettingsItem.General(title: .audioDriverEnableAVFoundationLabel)
           .image(name: "waveform")
@@ -90,6 +91,7 @@ class SettingsPageAudio: SettingsPage {
           .labelKey(.enableInitialVolume)
           .bindInputTo(.initialVolume)
           .bindSwitchTo(.enableInitialVolume)
+          .range(0...1000) // mpv option is a float, but IINA uses integers for volume.
         SettingsItem.Input()
           .bindTo(.maxVolume)
           .range(100...1000)
@@ -106,6 +108,7 @@ class SettingsPageAudio: SettingsPage {
           .withDetailView {
             SettingsItem.Input()
               .bindTo(.replayGainPreamp)
+              .range(-150...150)
               .trailingLabel(.text_dB)
               .hasDescription()
             SettingsItem.Switch()
@@ -115,6 +118,7 @@ class SettingsPageAudio: SettingsPage {
         SettingsItem.Input()
           .image(name: "square.dotted")
           .bindTo(.replayGainFallback)
+          .range(-200...60)
           .trailingLabel(.text_dB)
           .hasDescription()
       }

--- a/iina/SettingsPageNetwork.swift
+++ b/iina/SettingsPageNetwork.swift
@@ -44,7 +44,7 @@ class SettingsPageNetwork: SettingsPage {
               .withHelpLink(AppData.cachePauseInitialHelpLink)
             SettingsItem.Input()
               .bindTo(.cachePauseWait)
-              .range(0...3.4028234663853e+38)
+              .range(0...3.4028234663853e+38, allowsFloats: true)
               .hasDescription()
               .withHelpLink(AppData.cachePauseWaitHelpLink)
             SettingsItem.Input()

--- a/iina/SettingsPageSubtitles.swift
+++ b/iina/SettingsPageSubtitles.swift
@@ -103,8 +103,10 @@ class SettingsPageSubtitles: SettingsPage {
           .withExpandingDetailView {
             SettingsItem.Input()
               .bindTo(.subBlur)
+              .range(0...20, allowsFloats: true)
             SettingsItem.Input()
               .bindTo(.subSpacing)
+              .range(-10...10, allowsFloats: true)
           }
       }
     }
@@ -122,6 +124,7 @@ class SettingsPageSubtitles: SettingsPage {
         SettingsItem.Input()
           .image(name: "arrow.up.and.down")
           .bindTo(.subPos)
+          .range(0...150)
           .trailingLabel(.text_Percent)
       }
 
@@ -293,7 +296,7 @@ fileprivate class SubtitlesFontView: SettingsAccessory.Base {
     fontButton.bind(.title, to: UserDefaults.standard, withKeyPath: Preference.Key.subTextFont.rawValue)
     fontButton.size(height: 25)
 
-    let sizeInput = ui.input(bindTo: .subTextSize)
+    let sizeInput = ui.input(bindTo: .subTextSize, range: 1...9000, allowsFloats: true)
 
     let boldButton = SButton(image: .sf("bold"))
     boldButton.translatesAutoresizingMaskIntoConstraints = false
@@ -346,7 +349,7 @@ fileprivate class SubtitlesBorderView: SettingsAccessory.Base {
     super.init()
 
     let widthLabel = ui.smallLabel(bindTo: .text_Size)
-    let widthInput = ui.input(bindTo: .subBorderSize)
+    let widthInput = ui.input(bindTo: .subBorderSize, range: 0...Double.infinity, allowsFloats: true)
 
     let colorLabel = ui.smallLabel(bindTo: .text_Color)
     let colorWell = ui.colorWell(bindTo: .subBorderColorString)
@@ -382,10 +385,10 @@ fileprivate class SubtitlesMarginView: SettingsAccessory.Base {
     super.init()
 
     let xLabel = ui.smallLabel(bindTo: .text_X)
-    let xInput = ui.input(bindTo: .subMarginX)
+    let xInput = ui.input(bindTo: .subMarginX, range: 0...Double(Int.max))
 
     let yLabel = ui.smallLabel(bindTo: .text_Y)
-    let yInput = ui.input(bindTo: .subMarginY)
+    let yInput = ui.input(bindTo: .subMarginY, range: 0...Double(Int.max))
 
     let stackView = ui.hStack(xLabel, xInput, yLabel, yInput)
 

--- a/iina/SettingsPageUI.swift
+++ b/iina/SettingsPageUI.swift
@@ -141,6 +141,7 @@ class SettingsPageUI: SettingsPage {
           .labelKey(.controlBarAutoHideTimeout)
           .bindInputTo(.controlBarAutoHideTimeout)
           .bindSwitchTo(.enableControlBarAutoHide)
+          .range(0...Double(Int.max), allowsFloats: true)
           .trailingLabel(.text_s)
       }
 
@@ -190,10 +191,12 @@ class SettingsPageUI: SettingsPage {
         SettingsItem.Input(title: .controlBarAutoHideTimeoutLabel)
           .image(name: "timer")
           .bindTo(.osdAutoHideTimeout)
+          .range(0...Double(Int.max), allowsFloats: true)
           .trailingLabel(.text_s)
         SettingsItem.Input()
           .image(name: "textformat.size")
           .bindTo(.osdTextSize)
+          .range(1...500)
           .trailingLabel(.text_pt)
         SettingsItem.Switch()
           .image(name: "info.bubble")
@@ -211,11 +214,13 @@ class SettingsPageUI: SettingsPage {
           .withDetailView {
             SettingsItem.Input()
               .bindTo(.maxThumbnailPreviewCacheSize)
+              .range(0...Double(Int.max))
               .trailingLabel(.text_MB)
             SettingsItem.Switch()
               .bindTo(.enableThumbnailForRemoteFiles)
             SettingsItem.Input()
               .bindTo(.thumbnailWidth)
+              .range(1...2000)
               .trailingLabel(.text_pt)
               .hasDescription()
           }

--- a/iina/SettingsPageVideo.swift
+++ b/iina/SettingsPageVideo.swift
@@ -41,6 +41,7 @@ class SettingsPageVideo: SettingsPage {
         SettingsItem.Input()
           .image(name: "number")
           .bindTo(.videoThreads)
+          .range(0...Double(Int.max))
           .hasDescription()
         SettingsItem.General(title: .hardwareDecoderLabel)
           .image(name: "cpu")
@@ -90,6 +91,7 @@ class SettingsPageVideo: SettingsPage {
           .withDetailView {
             SettingsItem.Input()
               .bindTo(.toneMappingTargetPeak)
+              .range(0...10000)  // mpv option is "auto" or 10...10000, todo align with mpv.
               .trailingLabel(.text_nits)
               .hasDescription()
               .withHelpLink(AppData.targetPeakHelpLink)

--- a/iina/UIHelper.swift
+++ b/iina/UIHelper.swift
@@ -26,13 +26,23 @@ class UIHelper {
     return btn
   }
 
-  func input(bindTo key: Preference.Key, fixedAlignmentRect: Bool = true, isFixedSize: Bool = true) -> NSTextField {
+  func input(bindTo key: Preference.Key, fixedAlignmentRect: Bool = true, isFixedSize: Bool = true,
+             range: ClosedRange<Double>? = nil, allowsFloats: Bool = false) -> NSTextField {
     let input = fixedAlignmentRect ? TextFieldWithFixedAlignmentRect() : NSTextField()
     input.translatesAutoresizingMaskIntoConstraints = false
     input.bezelStyle = .roundedBezel
     input.bind(.value, to: UserDefaults.standard, withKeyPath: key.rawValue)
     if isFixedSize {
       input.size(width: 48, height: 25)
+    }
+    if let range {
+      let formatter = NumberFormatter()
+      formatter.allowsFloats = allowsFloats
+      formatter.usesGroupingSeparator = false
+      formatter.minimum = NSNumber(value: range.lowerBound)
+      formatter.maximum = NSNumber(value: range.upperBound)
+      formatter.numberStyle = .decimal
+      input.formatter = formatter
     }
     return input
   }


### PR DESCRIPTION
This commit will:
- Add an `allowsFloats` parameter to the `SettingsItem.Input.range` function
- Add an `allowsFloats` property to `SettingsItem.Input` to store the new range parameter
- Change `SettingsItem.Input.getValueViews` to set the `allowsFloats` property of the `NumberFormatter` based on the parameter passed when establishing the range
- Change `SettingsItem.Input.getValueViews` to set the `NumberFormatter.numberStyle` property to decimal to permit the use of floating point numbers (when `allowsFloats` is true)
- Add a range function to `SettingsItem.SwitchWithInput` similar to the existing function in `SettingsItem.Input`
- Add range and `allowFloats` parameters to the `UIHelper.input` function
- Change `UIHelper.input` to construct a `NumberFormatter` when a range parameter is given and assign it to the `formatter` property of the `NSTextField` being returned
- Change all text fields in the settings window that accept numbers to reject invalid values

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] Related issue: #6289
- [ ] Related Design Proposal: # / Not applicable
---
- [ ] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**
