### PR TITLE
Use pencil instead of gear for key binding edit icon

### DIFF
--- a/iina/SettingsPageKeyBindings.swift
+++ b/iina/SettingsPageKeyBindings.swift
@@ -539,7 +539,7 @@ fileprivate class KeyMappingCell: NSTableCellView {
       }
 
       self.editButton = createActionButton(
-        symbol: "gearshape.fill", action: #selector(editor.editKeyMappingAction))
+        symbol: "pencil", action: #selector(editor.editKeyMappingAction))
       self.removeButton = createActionButton(
         symbol: "trash.fill", action: #selector(editor.removeKeyMappingAction))
       self.lockHelpButton = createActionButton(


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] Related issue: #
- [ ] Related Design Proposal: # / Not applicable
---
- [ ] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**
I finally tried out the new Settings UI and found the new Key Bindings UI to have very good design. But I was initially confused about how to edit a key binding, because I didn't associate the gear icon with a single-line edit. I really think using a pencil icon is more appropriate? I know this could have been a "discussion" post, but seems more precise to just give feedback in the form of a PR.

(One other point of unrequested feedback: I noticed the whole page scrolls. But would be better if all the elements stayed in position except for the the bindings list (i.e., everything below the Search field and above the separator which lies above the `Display raw values` checkbox.)