### PR TITLE
docs: replace SubLingo with SubTandem in plugin lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ IINA is always looking for contributions, whether it's through bug reports, code
 - **[PolyScript](https://github.com/SammoMichael/polyplugin-release)** (`SammoMichael/polyplugin-release`) - Dual subtitles, hover dictionary, and AI-assisted translation for language learning.
 - **[recorder](https://github.com/5thDimensionalVader/recorder-iina)** (`5thDimensionalVader/recorder-iina`) - to clip a video using ffmpeg.
 - **[Skip Intro](https://github.com/pparanoiidd/iina-skip-intro)** (`pparanoiidd/iina-skip-intro`) - Detect and skip intros, recaps and credits.
-- **[SubLingo](https://github.com/janwee-sha/SubLingo)** (`janwee-sha/SubLingo`) - Translate selected local embedded text subtitles and external SRT/ASS subtitles into real-time bilingual subtitles.
+- **[SubTandem](https://github.com/janwee-sha/SubTandem)** (`janwee-sh/SubTandem`) - Translate selected local embedded text subtitles and external SRT/ASS subtitles into real-time bilingual subtitles.
 - **[Trakt Scrobbler](https://github.com/i3p9/iina-trakt-scrobbler)** (`i3p9/iina-trakt-scrobbler`) - Trakt.tv scrobbler plugin for IINA.
 - **[VR2D](https://github.com/fetzu/iina-plugin-vr2d)** (`fetzu/iina-plugin-vr2d`) - Watch 3D VR videos (180°/360°, side-by-side or over-under) flat, with pan, zoom and automatic detection.
 

--- a/plugins.json
+++ b/plugins.json
@@ -120,10 +120,10 @@
     "id": "com.pparanoiidd.skipintro"
   },
   {
-    "name": "SubLingo",
-    "url": "https://github.com/janwee-sha/SubLingo",
+    "name": "SubTandem",
+    "url": "https://github.com/janwee-sha/SubTandem",
     "desc": "Translates the selected local embedded text subtitle or external SRT/ASS subtitle and renders translated subtitles itself in IINA.",
-    "id": "io.sublingo.iina"
+    "id": "io.subtandem.iina"
   },
   {
     "name": "Trakt Scrobbler",


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] Related issue: #
- [x] Related Design Proposal: # / Not applicable
---
- [ ] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**

Replaces the SubLingo entry with SubTandem in both community plugin discovery sources.

The SubLingo name overlaps with other software products, which can cause ambiguity and make the plugin harder to identify. The project has therefore moved to the more distinctive SubTandem name, repository, and plugin identity.

- Updates the README community plugin list used by released IINA versions.
- Updates `plugins.json`, used by the development plugin installer.
- Changes the repository from `janwee-sha/SubLingo` to `janwee-sha/SubTandem`.
- Changes the plugin identifier from `io.sublingo.iina` to `io.subtandem.iina`.

SubTandem is published as a separate plugin identity. This catalog change does not migrate existing SubLingo installations or data.

Public release:
https://github.com/janwee-sha/SubTandem/releases/tag/v0.1.0

No IINA runtime code is changed.

Validation:
- `python3 -m json.tool plugins.json`
- `git diff --check`
- Verified the public repository, release package, repository metadata, and plugin identifier.
