### PR TITLE
Save playback position before playlist navigation

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -1593,6 +1593,9 @@ class PlayerCore: NSObject {
   /// - Parameter pos: Position of the entry in the playlist to be played.
   func playFileInPlaylist(_ pos: Int) {
     mainWindow.videoView.displayActive()
+    // mpv only saves the watch-later file on quit or a loadfile replacement. Switching
+    // playlist entries bypasses both paths, so save the current entry before replacing it.
+    savePlaybackPosition()
     if !mpv.getFlag(MPVOption.PlaybackControl.pause) {
       log("Pausing playback before playing entry at index \(pos) in the playlist")
       mpv.setFlag(MPVOption.PlaybackControl.pause, true, level: .verbose)
@@ -1622,6 +1625,8 @@ class PlayerCore: NSObject {
       seek(absoluteSecond: 0)
     } else {
       mainWindow.videoView.displayActive()
+      // playlist-next and playlist-prev do not cause mpv to save the watch-later file.
+      savePlaybackPosition()
       if !mpv.getFlag(MPVOption.PlaybackControl.pause) {
         log("Pausing playback before playing \(nextMedia ? "next" : "previous") entry in playlist")
         mpv.setFlag(MPVOption.PlaybackControl.pause, true, level: .verbose)


### PR DESCRIPTION
mpv only saves watch-later data on quit or loadfile replacement.

Switching playlist entries via `playlist-next`, `playlist-prev`, or direct selection bypasses those paths, so the current entry can lose its resume position.

Save the playback position immediately before replacing the active playlist item.