### PR TITLE
miniplayer: show OSD and let mpv render the default album art in music mode

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -20,7 +20,6 @@ fileprivate let isMacOS11: Bool = {
 fileprivate let InteractiveModeBottomViewHeight: CGFloat = 60
 
 fileprivate let UIAnimationDuration = 0.25
-fileprivate let OSDAnimationDuration = 0.5
 fileprivate let CropAnimationDuration = 0.2
 
 fileprivate extension NSStackView.VisibilityPriority {
@@ -60,7 +59,6 @@ class MainWindowController: PlayerWindowController {
 
   /** For auto hiding UI after a timeout. */
   var hideControlTimer: Timer?
-  var hideOSDTimer: Timer?
 
   /** For blacking out other screens. */
   var screens: [NSScreen] = []
@@ -93,7 +91,6 @@ class MainWindowController: PlayerWindowController {
   var oscToolbarView: NSStackView!
   var oscSliderView: NSView!
 
-  var osdView: OSDView!
   var additionalInfoView: AdditionalInfoView!
   var bufferIndicatorView: BufferIndicatorView!
   var timePreviewView: TimePreviewView!
@@ -164,8 +161,7 @@ class MainWindowController: PlayerWindowController {
   var isCurrentPressInSecondStage = false
 
   /** Whether current osd needs user interaction to be dismissed */
-  var isShowingPersistentOSD = false
-  var osdContext: Any?
+  // `isShowingPersistentOSD` and `osdContext` are inherited from `PlayerWindowController`.
 
   /** Activated during interactive mode to prevent video view from being compressed */
   var aspectRatioConstraintForInteractiveMode: NSLayoutConstraint?
@@ -244,12 +240,7 @@ class MainWindowController: PlayerWindowController {
   // Animation state
 
   /// Animation state of he hide/show part
-  enum UIAnimationState {
-    case shown, hidden, willShow, willHide
-  }
-
   var animationState: UIAnimationState = .shown
-  var osdAnimationState: UIAnimationState = .hidden
 
   private var osdLastMessage: OSDMessage? = nil
 
@@ -478,7 +469,7 @@ class MainWindowController: PlayerWindowController {
     cv.addSubview(oscBottomView)
     oscFloatingView = OSCFloatingView(mainWindow: self)
     cv.addSubview(oscFloatingView)
-    osdView = OSDView(mainWindow: self)
+    osdView = OSDView()
     cv.addSubview(osdView)
     additionalInfoView = AdditionalInfoView(mainWindow: self)
     cv.addSubview(additionalInfoView)
@@ -2172,92 +2163,7 @@ class MainWindowController: PlayerWindowController {
 
   // MARK: - UI: OSD
 
-  /// Show a message in the on screen display.
-  /// - Parameters:
-  ///   - message: The `OSDMessage` to display.
-  ///   - autoHide: If `true` (the default) the message will be hidden after a timeout.
-  ///   - forcedTimeout: Timeout after which the message will be hidden (overrides user configured timeout).
-  ///   - accessoryView: Custom view to display (if not supplied normal OSD views are used).
-  ///   - context: Additional information associated with the message.
-  /// - Attention: Do not call `displayOSD` directly, call `PlayerCore.sendOSD` instead.
-  /// - Important: As per Apple's [Internationalization and Localization Guide](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/SupportingRight-To-LeftLanguages/SupportingRight-To-LeftLanguages.html)
-  ///     timeline indicators should not flip in a right-to-left language. Thus OSD messages referencing a position within the video
-  ///     must always use a left to right layout.
-  func displayOSD(_ message: OSDMessage, autoHide: Bool = true, forcedTimeout: Float? = nil, accessoryView: NSView? = nil, context: Any? = nil) {
-    guard player.displayOSD || message.alwaysEnabled, !isShowingPersistentOSD else { return }
-
-    if hideOSDTimer != nil {
-      hideOSDTimer!.invalidate()
-      hideOSDTimer = nil
-    }
-    if osdAnimationState != .shown {
-      osdAnimationState = .shown  /// set this before calling `refreshSyncUITimer()`
-      player.refreshSyncUITimer()
-    } else {
-      osdAnimationState = .shown
-    }
-
-    osdView.updateViews(fromMessage: message, player: player)
-
-    osdView.alphaValue = 1
-    osdView.isHidden = false
-    osdView.layoutSubtreeIfNeeded()
-
-    if let accessoryView {
-      isShowingPersistentOSD = true
-      if context != nil {
-        osdContext = context
-      }
-
-      let heightConstraint = NSLayoutConstraint(item: accessoryView, attribute: .height, relatedBy: .greaterThanOrEqual, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: 300)
-      heightConstraint.priority = .defaultLow
-      heightConstraint.isActive = true
-
-      osdView.addAccessoryView(accessoryView)
-
-      // enlarge window if too small
-      let winFrame = window!.frame
-      var newFrame = winFrame
-      if (winFrame.height < 300) {
-        newFrame = winFrame.centeredResize(to: winFrame.size.satisfyMinSizeWithSameAspectRatio(NSSize(width: 500, height: 300)))
-      }
-
-      accessoryView.wantsLayer = true
-      accessoryView.layer?.opacity = 0
-
-      NSAnimationContext.runAnimationGroup({ context in
-        context.duration = AccessibilityPreferences.adjustedDuration(0.3)
-        context.allowsImplicitAnimation = true
-        window!.setFrame(newFrame, display: true)
-        osdView.layoutSubtreeIfNeeded()
-      }, completionHandler: {
-        accessoryView.layer?.opacity = 1
-      })
-    }
-
-    if autoHide {
-      let timeout = forcedTimeout ?? Preference.float(for: .osdAutoHideTimeout)
-      hideOSDTimer = Timer.scheduledTimer(timeInterval: TimeInterval(timeout), target: self, selector: #selector(self.hideOSD), userInfo: nil, repeats: false)
-    }
-  }
-
-  @objc
-  func hideOSD() {
-    NSAnimationContext.runAnimationGroup({ (context) in
-      self.osdAnimationState = .willHide
-      context.duration = OSDAnimationDuration
-      osdView.animator().alphaValue = 0
-    }) {
-      if self.osdAnimationState == .willHide {
-        self.osdAnimationState = .hidden
-        self.osdView.isHidden = true
-        self.osdView.removeAccessoryView()
-      }
-    }
-    isShowingPersistentOSD = false
-    osdContext = nil
-    player.refreshSyncUITimer()
-  }
+  // `displayOSD` and `hideOSD` are inherited from `PlayerWindowController`.
 
   // MARK: - UI: Interactive mode
 

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -50,7 +50,6 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
   var volumeControlContainer: NSView!
   var volumeControlBackground: NSVisualEffectView!
   var volumeContainerTrailingConstraint: NSLayoutConstraint!
-  var defaultAlbumArt: NSView!
   var togglePlaylistButton: NSButton!
   var toggleAlbumArtButton: NSButton!
 
@@ -111,18 +110,6 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     let videoWrapperTopConstraint = videoWrapperView.topAnchor.constraint(equalTo: cv.topAnchor)
     videoWrapperTopConstraint.priority = .defaultHigh
     videoWrapperTopConstraint.isActive = true
-
-    self.defaultAlbumArt = NSView()
-    defaultAlbumArt.translatesAutoresizingMaskIntoConstraints = false
-    defaultAlbumArt.isHidden = false
-    defaultAlbumArt.wantsLayer = true
-    defaultAlbumArt.layer?.contents = #imageLiteral(resourceName: "default-album-art")
-    videoWrapperView.addSubview(defaultAlbumArt)
-    defaultAlbumArt.padding(.top, .leading, .trailing)
-    let videoWrapperShrinkConstraint = videoWrapperView.bottomAnchor.constraint(equalTo: defaultAlbumArt.bottomAnchor)
-    videoWrapperShrinkConstraint.priority = NSLayoutConstraint.Priority(250)
-    videoWrapperShrinkConstraint.isActive = true
-    defaultAlbumArt.widthAnchor.constraint(equalTo: defaultAlbumArt.heightAnchor).isActive = true
 
     // background view
 
@@ -338,6 +325,14 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     closeButtonSpacingConstraint = backButton.topAnchor.constraint(equalTo: closeButton.bottomAnchor, constant: 4)
     closeButtonSpacingConstraint.isActive = true
 
+    // on screen display
+
+    self.osdView = OSDView()
+    cv.addSubview(osdView)
+    osdView.padding(.top(8), .leading(greaterThan: 8), .trailing(greaterThan: 8), .bottom(greaterThan: 8))
+    osdView.setStyle(Preference.liquidGlass(.osd) ? .liquidGlass : .visualEffect)
+    osdView.isHidden = true
+
     setToInitialWindowSize(display: false, animate: false)
 
     // tracking area
@@ -536,7 +531,10 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     guard player.info.isAudio == .isAudio else {
       return player.videoSizeForDisplay
     }
-    let albumArtTrack = player.info.videoTracks.first(where: { $0.isAlbumart })
+    // Prefer the currently selected album art track, which is the one mpv is actually displaying.
+    // The default album art added by IINA also appears as an album art track.
+    let albumArtTrack = player.info.videoTracks.first(where: { $0.isAlbumart && $0.isSelected })
+      ?? player.info.videoTracks.first(where: { $0.isAlbumart })
     if let albumArtTrack,
        let width = albumArtTrack.demuxW,
        let height = albumArtTrack.demuxH,
@@ -545,13 +543,6 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
       return (width, height)
     }
     return (1, 1)
-  }
-
-  func refreshArtworkVisibility() {
-    guard loaded else { return }
-    let albumArtTrack = player.info.videoTracks.first(where: { $0.isAlbumart })
-    let hasSubtitles = (player.info.isSubVisible && player.info.sid != 0) || (player.info.isSecondSubVisible && player.info.secondSid != 0)
-    defaultAlbumArt.isHidden = player.info.isAudio != .isAudio || albumArtTrack != nil || hasSubtitles
   }
 
   func setToInitialWindowSize(display: Bool = true, animate: Bool = true) {

--- a/iina/OSDView.swift
+++ b/iina/OSDView.swift
@@ -16,13 +16,9 @@ class OSDView: TranslucentView {
   var secondaryLabel: NSTextField
   var progressBar: FixedProgressBar
 
-  weak var mainWindow: MainWindowController!
-
   private var accessoryView: NSView?
 
-  init(mainWindow: MainWindowController) {
-    self.mainWindow = mainWindow
-
+  init() {
     self.stackView = NSStackView()
     stackView.translatesAutoresizingMaskIntoConstraints = false
     stackView.orientation = .vertical

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -809,7 +809,6 @@ class PlayerCore: NSObject {
     miniPlayer.videoWrapperView.addSubview(videoView, positioned: .below, relativeTo: nil)
     Utility.quickConstraints(["H:|[v]|", "V:|[v]|"], ["v": videoView])
 
-    miniPlayer.refreshArtworkVisibility()
     let (width, height) = miniPlayer.videoSizeForDisplayInMusicMode()
     let aspect = CGFloat(width) / CGFloat(height)
     miniPlayer.updateVideoViewAspectConstraint(withAspect: aspect)
@@ -821,6 +820,9 @@ class PlayerCore: NSObject {
     }
 
     isInMiniPlayer = true
+
+    // Let mpv render the default album art when the media has no cover art.
+    addDefaultAlbumArtTrackIfNeeded()
 
     // restore layout
     if needRestoreLayout {
@@ -878,6 +880,9 @@ class PlayerCore: NSObject {
     miniPlayer.window?.orderOut(nil)
     isInMiniPlayer = false
 
+    // Keep main window playback unaffected by the default album art.
+    removeDefaultAlbumArtTrack()
+
     mainWindow.pendingShow = true
     if showMainWindow {
       currentController.setupUI()
@@ -889,6 +894,81 @@ class PlayerCore: NSObject {
     mainWindow.liveText.requestAnalysis()
     postNotification(.iinaMusicModeChanged)
     events.emit(.musicModeChanged, data: false)
+  }
+
+  // MARK: - Default album art (music mode)
+
+  /// URL of a file containing IINA's default album art image.
+  ///
+  /// The image is stored in the asset catalog, which mpv cannot access, so the PNG data is written
+  /// to the app support directory on first access.
+  private lazy var defaultAlbumArtURL: URL? = {
+    let url = Utility.appSupportDirUrl.appendingPathComponent("default-album-art.png", isDirectory: false)
+    if FileManager.default.fileExists(atPath: url.path) { return url }
+    guard let image = NSImage(named: "default-album-art"),
+          let tiffData = image.tiffRepresentation,
+          let imageRep = NSBitmapImageRep(data: tiffData),
+          let pngData = imageRep.representation(using: .png, properties: [:]) else {
+      log("Cannot get PNG data of the default album art", level: .error)
+      return nil
+    }
+    do {
+      try pngData.write(to: url)
+    } catch {
+      log("Cannot write the default album art to \(url.path): \(error)", level: .error)
+      return nil
+    }
+    return url
+  }()
+
+  /// Whether the given track is the default album art track added by IINA.
+  private func isDefaultAlbumArtTrack(_ track: MPVTrack) -> Bool {
+    track.isAlbumart && track.externalFilename == defaultAlbumArtURL?.path
+  }
+
+  /// Whether the `video-add` command for the default album art has been issued for the current file.
+  ///
+  /// This prevents issuing duplicate commands before mpv has reported the new track list back to IINA.
+  private var didAddDefaultAlbumArtTrack = false
+
+  /// Load IINA's default album art as an external cover art track in mpv when needed.
+  ///
+  /// This is called when entering music mode and when the track list changes. The track is only
+  /// added when playing audio and no cover art track (embedded or external) exists, so mpv will
+  /// render the default album art in the video view just like embedded cover art.
+  func addDefaultAlbumArtTrackIfNeeded() {
+    guard isInMiniPlayer, info.state.active, info.isAudio == .isAudio,
+          !didAddDefaultAlbumArtTrack,
+          !info.videoTracks.contains(where: { $0.isAlbumart }),
+          let url = defaultAlbumArtURL else { return }
+    log("Adding default album art track", level: .verbose)
+    // The "select" flag is important: "auto" would add the track without selecting it, so mpv
+    // would never display it.
+    mpv.command(.videoAdd, args: [url.path, "select", NSLocalizedString("track.default_album_art", comment: "Default Album Art"), "", "yes"], checkError: false) { [unowned self] code in
+      if code < 0 {
+        self.log("Failed to add the default album art track (error \(code))", level: .error)
+      }
+    }
+    didAddDefaultAlbumArtTrack = true
+  }
+
+  /// Reset `didAddDefaultAlbumArtTrack` if the default album art track is no longer present, e.g.
+  /// because a new file has been loaded and external tracks do not carry over.
+  func resetDefaultAlbumArtTrackIfNeeded() {
+    if didAddDefaultAlbumArtTrack, !info.videoTracks.contains(where: isDefaultAlbumArtTrack) {
+      didAddDefaultAlbumArtTrack = false
+    }
+  }
+
+  /// Remove the default album art track, if present. Called when leaving music mode.
+  private func removeDefaultAlbumArtTrack() {
+    guard info.state.active, let track = info.videoTracks.first(where: isDefaultAlbumArtTrack) else {
+      didAddDefaultAlbumArtTrack = false
+      return
+    }
+    log("Removing default album art track", level: .verbose)
+    mpv.command(.videoRemove, args: [track.id.description], checkError: false)
+    didAddDefaultAlbumArtTrack = false
   }
 
   // MARK: - MPV commands
@@ -2212,7 +2292,7 @@ class PlayerCore: NSObject {
     }
 
     if self.isInMiniPlayer {
-      miniPlayer.refreshArtworkVisibility()
+      addDefaultAlbumArtTrackIfNeeded()
       miniPlayer.handleVideoSizeChange()
     }
 
@@ -2458,9 +2538,6 @@ class PlayerCore: NSObject {
     info.secondSid = Int(mpv.getInt(MPVOption.Subtitles.secondarySid))
     postNotification(.iinaSIDChanged)
     sendOSD(.track(info.currentTrack(.secondSub) ?? .noneSubTrack))
-    if isInMiniPlayer {
-      miniPlayer.refreshArtworkVisibility()
-    }
   }
 
   func secondSubVisibilityChanged(_ visible: Bool) {
@@ -2468,9 +2545,6 @@ class PlayerCore: NSObject {
     info.isSecondSubVisible = visible
     sendOSD(visible ? .secondSubVisible : .secondSubHidden)
     postNotification(.iinaSubVisibilityChanged)
-    if isInMiniPlayer {
-      miniPlayer.refreshArtworkVisibility()
-    }
   }
 
   func sidChanged() {
@@ -2478,9 +2552,6 @@ class PlayerCore: NSObject {
     info.sid = Int(mpv.getInt(MPVOption.TrackSelection.sid))
     postNotification(.iinaSIDChanged)
     sendOSD(.track(info.currentTrack(.sub) ?? .noneSubTrack))
-    if isInMiniPlayer {
-      miniPlayer.refreshArtworkVisibility()
-    }
     Task { @MainActor in
       mainWindow.liveText.clearAnalysis()
       mainWindow.liveText.requestAnalysis()
@@ -2520,9 +2591,6 @@ class PlayerCore: NSObject {
     info.isSubVisible = visible
     sendOSD(visible ? .subVisible : .subHidden)
     postNotification(.iinaSubVisibilityChanged)
-    if isInMiniPlayer {
-      miniPlayer.refreshArtworkVisibility()
-    }
   }
 
   func trackListChanged() {
@@ -2534,6 +2602,7 @@ class PlayerCore: NSObject {
     getTrackInfo()
     getSelectedTracks()
     let audioStatus = info.isAudio
+    let wasInMiniPlayer = isInMiniPlayer
 
     // if need to switch to music mode
     if Preference.bool(for: .autoSwitchToMusicMode) {
@@ -2549,7 +2618,13 @@ class PlayerCore: NSObject {
     }
 
     if isInMiniPlayer {
-      miniPlayer.refreshArtworkVisibility()
+      if wasInMiniPlayer {
+        // Only reevaluate when the mini player was already active. When just switched,
+        // `switchToMiniPlayer` has already handled the default album art and the track info
+        // here would be stale.
+        resetDefaultAlbumArtTrackIfNeeded()
+        addDefaultAlbumArtTrackIfNeeded()
+      }
       miniPlayer.handleVideoSizeChange()
     }
 
@@ -2585,7 +2660,7 @@ class PlayerCore: NSObject {
     postNotification(.iinaVIDChanged)
     sendOSD(.track(info.currentTrack(.video) ?? .noneVideoTrack))
     if isInMiniPlayer {
-      miniPlayer.refreshArtworkVisibility()
+      addDefaultAlbumArtTrackIfNeeded()
       miniPlayer.handleVideoSizeChange()
     }
 
@@ -2855,25 +2930,27 @@ class PlayerCore: NSObject {
 
   func sendOSD(_ osd: OSDMessage, autoHide: Bool = true, forcedTimeout: Float? = nil, accessoryView: NSView? = nil, context: Any? = nil, external: Bool = false) {
     // querying `mainWindow.isWindowLoaded` will initialize mainWindow unexpectedly
-    guard !isInMiniPlayer, mainWindow.loaded, info.state.active,
+    guard mainWindow.loaded, info.state.active,
           Preference.bool(for: .enableOSD) || osd.alwaysEnabled, !osd.isDisabled else { return }
     if info.disableOSDForFileLoading && !external {
       guard case .fileStart = osd else {
         return
       }
     }
+    let target: PlayerWindowController = isInMiniPlayer ? miniPlayer : mainWindow
     DispatchQueue.main.async {
-      self.mainWindow.displayOSD(osd,
-                                 autoHide: autoHide,
-                                 forcedTimeout: forcedTimeout,
-                                 accessoryView: accessoryView,
-                                 context: context)
+      target.displayOSD(osd,
+                        autoHide: autoHide,
+                        forcedTimeout: forcedTimeout,
+                        accessoryView: accessoryView,
+                        context: context)
     }
   }
 
   func hideOSD() {
     DispatchQueue.main.async {
-      self.mainWindow.hideOSD()
+      let target: PlayerWindowController = self.isInMiniPlayer ? self.miniPlayer : self.mainWindow
+      target.hideOSD()
     }
   }
 

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -8,12 +8,27 @@
 
 import Cocoa
 
+fileprivate let OSDAnimationDuration = 0.5
+
 class PlayerWindowController: NSWindowController, NSWindowDelegate {
 
   unowned var player: PlayerCore
-  
+
   var videoView: VideoView {
     fatalError("Subclass must implement")
+  }
+
+  // MARK: - OSD
+
+  var osdView: OSDView!
+  var hideOSDTimer: Timer?
+  var osdAnimationState: UIAnimationState = .hidden
+  var isShowingPersistentOSD = false
+  var osdContext: Any?
+
+  /// Animation state of the hide/show part.
+  enum UIAnimationState {
+    case shown, hidden, willShow, willHide
   }
 
   var menuActionHandler: MainMenuActionHandler!
@@ -686,6 +701,96 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
     }
     log("Forcing drawing, \(reason)")
     videoView.videoLayer.update(force: true)
+  }
+
+  // MARK: - OSD
+
+  /// Show a message in the on screen display.
+  /// - Parameters:
+  ///   - message: The `OSDMessage` to display.
+  ///   - autoHide: If `true` (the default) the message will be hidden after a timeout.
+  ///   - forcedTimeout: Timeout after which the message will be hidden (overrides user configured timeout).
+  ///   - accessoryView: Custom view to display (if not supplied normal OSD views are used).
+  ///   - context: Additional information associated with the message.
+  /// - Attention: Do not call `displayOSD` directly, call `PlayerCore.sendOSD` instead.
+  /// - Important: As per Apple's [Internationalization and Localization Guide](https://developer.apple.com/library/archive/documentation/MacOSX/Conceptual/BPInternational/SupportingRight-To-LeftLanguages/SupportingRight-To-LeftLanguages.html)
+  ///     timeline indicators should not flip in a right-to-left language. Thus OSD messages referencing a position within the video
+  ///     must always use a left to right layout.
+  func displayOSD(_ message: OSDMessage, autoHide: Bool = true, forcedTimeout: Float? = nil, accessoryView: NSView? = nil, context: Any? = nil) {
+    guard player.displayOSD || message.alwaysEnabled, !isShowingPersistentOSD else { return }
+
+    if hideOSDTimer != nil {
+      hideOSDTimer!.invalidate()
+      hideOSDTimer = nil
+    }
+    if osdAnimationState != .shown {
+      osdAnimationState = .shown  /// set this before calling `refreshSyncUITimer()`
+      player.refreshSyncUITimer()
+    } else {
+      osdAnimationState = .shown
+    }
+
+    osdView.updateViews(fromMessage: message, player: player)
+
+    osdView.alphaValue = 1
+    osdView.isHidden = false
+    osdView.layoutSubtreeIfNeeded()
+
+    if let accessoryView {
+      isShowingPersistentOSD = true
+      if context != nil {
+        osdContext = context
+      }
+
+      let heightConstraint = NSLayoutConstraint(item: accessoryView, attribute: .height, relatedBy: .greaterThanOrEqual, toItem: nil, attribute: .notAnAttribute, multiplier: 1, constant: 300)
+      heightConstraint.priority = .defaultLow
+      heightConstraint.isActive = true
+
+      osdView.addAccessoryView(accessoryView)
+
+      // enlarge window if too small
+      let winFrame = window!.frame
+      var newFrame = winFrame
+      if (winFrame.height < 300) {
+        newFrame = winFrame.centeredResize(to: winFrame.size.satisfyMinSizeWithSameAspectRatio(NSSize(width: 500, height: 300)))
+      }
+
+      accessoryView.wantsLayer = true
+      accessoryView.layer?.opacity = 0
+
+      NSAnimationContext.runAnimationGroup({ context in
+        context.duration = AccessibilityPreferences.adjustedDuration(0.3)
+        context.allowsImplicitAnimation = true
+        window!.setFrame(newFrame, display: true)
+        osdView.layoutSubtreeIfNeeded()
+      }, completionHandler: {
+        accessoryView.layer?.opacity = 1
+      })
+    }
+
+    if autoHide {
+      let timeout = forcedTimeout ?? Preference.float(for: .osdAutoHideTimeout)
+      hideOSDTimer = Timer.scheduledTimer(timeInterval: TimeInterval(timeout), target: self, selector: #selector(self.hideOSD), userInfo: nil, repeats: false)
+    }
+  }
+
+  @objc
+  func hideOSD() {
+    guard let osdView else { return }
+    NSAnimationContext.runAnimationGroup({ (context) in
+      self.osdAnimationState = .willHide
+      context.duration = OSDAnimationDuration
+      osdView.animator().alphaValue = 0
+    }) {
+      if self.osdAnimationState == .willHide {
+        self.osdAnimationState = .hidden
+        osdView.isHidden = true
+        osdView.removeAccessoryView()
+      }
+    }
+    isShowingPersistentOSD = false
+    osdContext = nil
+    player.refreshSyncUITimer()
   }
 
   // MARK: - IBActions

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -237,6 +237,7 @@
 "menu.hide_plugins_panel" = "Hide Plugins Panel";
 
 "track.audio" = "Audio";
+"track.default_album_art" = "Default Album Art";
 "track.none" = "<None>";
 "track.sub" = "Subtitle";
 "track.video" = "Video";


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] Related issue: #
- [ ] Related Design Proposal: Not applicable
---
- [x] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**

Music mode never shows the OSD. The OSD view belongs to the main window, which is hidden while the mini player is on screen, so `sendOSD` bails out early on `!isInMiniPlayer` (#6050). That leaves music mode without any feedback for volume, seeking or pausing.

While looking into this I also noticed that when the media has no cover art, the mini player stacks a `defaultAlbumArt` NSView on top of the video view, which needs manual bookkeeping (track list, subtitle visibility) and leaves mpv rendering nothing behind it.

This PR addresses both:

1. The OSD state and the display/hide logic moved from `MainWindowController` down to `PlayerWindowController`, and the mini player creates its own `OSDView`. `sendOSD`/`hideOSD` now route to whichever window is active. Everything the main window OSD supports (progress bar, accessory views, auto-hide timeout, liquid glass style) keeps working.

2. The overlay view is gone. Instead, when entering music mode with a file that has no cover art, IINA adds its default album art as an external cover art track (`video-add <file> select <title> <lang> yes`) and removes the track when leaving music mode. mpv then renders it exactly like embedded cover art, so window sizing follows the image and embedded art still takes priority when present. Files with a real video track are never touched, and main window playback outside music mode is unchanged (the track is removed on switch back and does not survive file loads anyway).

A detail worth mentioning: the flags argument of `video-add` must be `select`. With `auto`, mpv adds the track but never selects it, so nothing is displayed and the track list logic would skip re-adding it.

One side effect I think is a plus: audio files without cover art now provide artwork to the system Now Playing panel, since the default art is a regular external album art track.

Tested with cover-less audio (art shows, single `video-add` in the log), audio with embedded art (no track added) and video files (main window untouched). Built with Xcode against the current develop.

The last commit is a drive-by one-character fix (`GrouopBy` → `GroupBy`) so the typos check passes; it has been failing on develop since 3e9b2813. Happy to move it to a separate PR if preferred.