### PR TITLE
Split target peak setting into two settings

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -249,8 +249,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
     // register for url event
     NSAppleEventManager.shared().setEventHandler(self, andSelector: #selector(self.handleURLEvent(event:withReplyEvent:)), forEventClass: AEEventClass(kInternetEventClass), andEventID: AEEventID(kAEGetURL))
 
-    // Check for legacy pref entries and migrate them to their modern equivalents
+    // Check for legacy pref entries and migrate them to their modern equivalents.
     LegacyMigration.shared.migrateLegacyPreferences()
+    LegacyMigration.shared.migrateToneMappingTargetPeak()
 
     // guide window
     switch InfoDictionary.shared.buildType {

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -666,7 +666,7 @@
 "settings.loadIccProfile.desc" = "Load the ICC profile for current display and use it to transform video RGB to screen output. (Only for SDR mode)";
 "settings.loadIccProfile.label" = "Load ICC profile";
 "settings.toneMappingAlgorithm.label" = "Algorithm";
-"settings.toneMappingTargetPeak.desc" = "Measured peak brightness of the display. If set to 0, IINA detects this value. If detection fails, IINA sets the target peak to 400.";
+"settings.toneMappingTargetPeak.desc" = "Measured peak brightness of the display. By default IINA detects this value. If detection fails, target peak will be set to an appropriate value based on the transfer characteristics of the display. Enable this setting to manually specify the display's brightness.";
 "settings.toneMappingTargetPeak.label" = "Target peak";
 "settings.videoThreads.desc" = "Default: 0 (Auto)";
 "settings.videoThreads.label" = "Number of threads";

--- a/iina/Extensions.swift
+++ b/iina/Extensions.swift
@@ -10,6 +10,19 @@ import Cocoa
 import CryptoKit
 import MediaPlayer
 
+extension Array {
+
+  /// Form a string containing the contents of this array suitable for use in a log message.
+  /// - Parameter indent: Number of spaces to indent each line.
+  /// - Returns: Contents of this array formatted for inclusion in a log message.
+  func toStringForLog(indent: Int = 2) -> String {
+    guard !isEmpty else { return "" }
+    let prefix = "\n" + String(repeating: " ", count: indent)
+    let sorted = sorted(by: { "\($0)" < "\($1)" })
+    return prefix + sorted.compactMap({ "\($0)" }).joined(separator: prefix)
+  }
+}
+
 extension CGPoint {
   /**
    Uses the Pythagorean theorem to calculate the distance between two points.
@@ -29,6 +42,32 @@ extension CGPoint {
    */
   func distance(to: CGPoint) -> CGFloat {
     return sqrt(pow(self.x - to.x, 2) + pow(self.y - to.y, 2))
+  }
+}
+
+extension Dictionary where Key: StringProtocol {
+
+  /// Form a string containing the contents of this dictionary suitable for use in a log message.
+  /// - Parameter indent: Number of spaces to indent each line.
+  /// - Returns: Contents of this dictionary formatted for inclusion in a log message.
+  func toStringForLog(indent: Int = 2) -> String {
+    guard !isEmpty else { return "" }
+    var message = ""
+    let prefix = "\n" + String(repeating: " ", count: indent)
+    let sorted = self.sorted( by: { $0.0 < $1.0 })
+    for (key, value) in sorted {
+      message += prefix + key + ": "
+      if let dict = value as? [String: Any] {
+        message += dict.toStringForLog(indent: indent + 2)
+        continue
+      }
+      if let array = value as? [Any] {
+        message += array.toStringForLog(indent: indent + 2)
+        continue
+      }
+      message += "\(value)"
+    }
+    return message
   }
 }
 

--- a/iina/LegacyMigration.swift
+++ b/iina/LegacyMigration.swift
@@ -78,4 +78,46 @@ class LegacyMigration {
     }
   }
 
+  /// Migrate the legacy tone mapping target peak setting.
+  ///
+  /// Previous versions of IINA used a single `toneMappingTargetPeak` setting that treated `0` as an indicator that IINA should
+  /// detect the value to use for the mpv [target-peak](https://mpv.io/manual/stable/#options-target-peak) option.
+  /// This mpv option can be set to the keyword `auto` (default) or an integer in the range 10 to 10,000 representing the peak
+  /// brightness of the display in nits. To avoid the awkwardness of having a special value to represent `auto`, as of IINA 1.5.0 this
+  /// setting has been replaced by two separate settings:
+  /// - `enableToneMappingTargetPeakOverride`
+  ///
+  ///   When `true` this setting indicates the user wants to override the automatic determination of the `target-peak` value and
+  ///   manually specify the number of nits to use.
+  /// - `toneMappingTargetPeakOverride`
+  ///
+  ///   This setting provides the `target-peak` value to use when automatic mode has been disabled.
+  ///
+  /// If this function finds `enableToneMappingTargetPeakOverride` has not been set it will set the value of the new settings
+  /// appropriately based on the value of the legacy `toneMappingTargetPeak` setting.
+  func migrateToneMappingTargetPeak() {
+    let appID = InfoDictionary.shared.bundleIdentifier
+    guard let persistedPrefKeys = UserDefaults.standard.persistentDomain(forName: appID)?.keys else {
+      // Internal error, should not occur.
+      Logger.log("""
+        Aborting legacy tone mapping target peak setting migration: failed to find settings domain \
+        for \"\(appID)\"!
+        """, level: .error)
+      return
+    }
+    guard !persistedPrefKeys.contains(Preference.Key.enableToneMappingTargetPeakOverride.rawValue)
+    else { return }
+    Logger.log("Migrating tone mapping target peak setting")
+    let targetPeak = Preference.integer(for: .toneMappingTargetPeak)
+    if targetPeak == 0 {
+      Preference.set(false, for: .enableToneMappingTargetPeakOverride)
+      Logger.log("Set enableToneMappingTargetPeakOverride to false")
+    } else {
+      Preference.set(true, for: .enableToneMappingTargetPeakOverride)
+      Logger.log("Set enableToneMappingTargetPeakOverride to true")
+      Preference.set(targetPeak, for: .toneMappingTargetPeakOverride)
+      Logger.log("Set toneMappingTargetPeakOverride to \(targetPeak)")
+    }
+    Logger.log("Migrated tone mapping target peak setting")
+  }
 }

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -874,6 +874,16 @@ class MPVController: NSObject {
     return mpv_set_property_string(mpv, name, value)
   }
 
+  @discardableResult
+  func setStringToDefault(_ name: String, level: Logger.Level = .debug) -> Int32 {
+    guard let value = MPVOptionDefaults.shared.getString(name) else {
+      log("Failed to obtain default for option: \(name)", level: .error)
+      return MPV_ERROR_OPTION_NOT_FOUND.rawValue
+    }
+    log("Set property to default: \(name)=\(value)", level: level)
+    return mpv_set_property_string(mpv, name, value)
+  }
+
   func getEnum<T: MPVOptionValue>(_ name: String) -> T {
     guard let value = getString(name) else {
       return T.defaultValue

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -50,9 +50,11 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
   
   internal var observedPrefKeys: [Preference.Key] = [
     .enableToneMapping,
+    .enableToneMappingTargetPeakOverride,
     .toneMappingTargetPeak,
     .loadIccProfile,
     .toneMappingAlgorithm,
+    .toneMappingTargetPeakOverride,
     .themeMaterial,
     .showRemainingTime,
     .alwaysFloatOnTop,
@@ -75,9 +77,11 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
     
     switch keyPath {
     case PK.enableToneMapping.rawValue,
+      PK.enableToneMappingTargetPeakOverride.rawValue,
       PK.toneMappingTargetPeak.rawValue,
       PK.loadIccProfile.rawValue,
-      PK.toneMappingAlgorithm.rawValue:
+      PK.toneMappingAlgorithm.rawValue,
+      PK.toneMappingTargetPeakOverride.rawValue:
       videoView.refreshEdrMode()
     case PK.themeMaterial.rawValue:
       if let newValue = change[.newKey] as? Int {

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -187,7 +187,10 @@ struct Preference {
     static let loadIccProfile = Key("loadIccProfile")
     static let enableHdrSupport = Key("enableHdrSupport")
     static let enableToneMapping = Key("enableToneMapping")
+    /// Legacy setting, now only used when migrating to replacement settings.
     static let toneMappingTargetPeak = Key("toneMappingTargetPeak")
+    static let enableToneMappingTargetPeakOverride = Key("enableToneMappingTargetPeakOverride")
+    static let toneMappingTargetPeakOverride = Key("toneMappingTargetPeakOverride")
     static let toneMappingAlgorithm = Key("toneMappingAlgorithm")
 
     static let audioDriverEnableAVFoundation = Key("audioDriverEnableAVFoundation")
@@ -1128,6 +1131,8 @@ struct Preference {
     .enableHdrSupport: true,
     .enableToneMapping: false,
     .toneMappingTargetPeak: 0,
+    .enableToneMappingTargetPeakOverride: false,
+    .toneMappingTargetPeakOverride: 400,
     .toneMappingAlgorithm: ToneMappingAlgorithmOption.defaultValue.rawValue,
     .audioDriverEnableAVFoundation: false,
     .audioThreads: 0,
@@ -1416,6 +1421,7 @@ struct Preference {
            .disableOSDSeekMsg,
            .disableOSDSpeedMsg,
            .disablePlaySliderScrolling,
+           .enableToneMappingTargetPeakOverride,
            .disableVolumeSliderScrolling,
            .displayInLetterBox,
            .displayKeyBindingRawValues,

--- a/iina/SettingsItem.swift
+++ b/iina/SettingsItem.swift
@@ -956,7 +956,7 @@ struct SettingsItem {
       nsSwitch.controlSize = .mini
       nsSwitch.action = #selector(switchChanged)
       nsSwitch.target = self
-      textField = NSTextField()
+      textField = TextFieldWithSwitch(nsSwitch)
       textField.translatesAutoresizingMaskIntoConstraints = false
       textField.controlSize = controlSize
       textField.bezelStyle = .roundedBezel
@@ -1413,5 +1413,39 @@ class SettingsAccessory {
         Preference.set(csv, for: key)
       }
     }
+  }
+}
+
+/// A [NSTextField](https://developer.apple.com/documentation/appkit/nstextfield) controlled by a
+/// [NSSwitch](https://developer.apple.com/documentation/appkit/nsswitch).
+class TextFieldWithSwitch: NSTextField {
+
+  /// A Boolean value that indicates whether the receiver reacts to mouse events.
+  ///
+  /// This text field may be part of a subordinate setting. Disabling a primary setting must disable subordinate settings. However
+  /// enabling a primary setting can only enable this text field if the switch that controls it is also enabled.
+  override var isEnabled: Bool {
+    get { super.isEnabled }
+    set {
+      guard newValue else {
+        super.isEnabled = false
+        return
+      }
+      guard nsSwitch.state == .on else { return }
+      super.isEnabled = true
+    }
+  }
+
+  /// [NSSwitch](https://developer.apple.com/documentation/appkit/nsswitch) that controls whether this
+  /// [NSTextField](https://developer.apple.com/documentation/appkit/nstextfield) can be enabled.
+  private let nsSwitch: NSSwitch
+
+  init(_ nsSwitch: NSSwitch) {
+    self.nsSwitch = nsSwitch
+    super.init(frame: NSRect.zero)
+  }
+
+  required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
   }
 }

--- a/iina/SettingsPageVideo.swift
+++ b/iina/SettingsPageVideo.swift
@@ -89,9 +89,11 @@ class SettingsPageVideo: SettingsPage {
           .bindTo(.enableToneMapping)
           .withHelpLink(AppData.toneMappingHelpLink)
           .withDetailView {
-            SettingsItem.Input()
-              .bindTo(.toneMappingTargetPeak)
-              .range(0...10000)  // mpv option is "auto" or 10...10000, todo align with mpv.
+            SettingsItem.SwitchWithInput()
+              .labelKey(.toneMappingTargetPeak)
+              .bindInputTo(.toneMappingTargetPeakOverride)
+              .bindSwitchTo(.enableToneMappingTargetPeakOverride)
+              .range(10...10000)  // mpv option is "auto" or 10...10000.
               .trailingLabel(.text_nits)
               .hasDescription()
               .withHelpLink(AppData.targetPeakHelpLink)

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -505,38 +505,47 @@ extension VideoView {
   /// - [target-peak](https://mpv.io/manual/stable/#options-target-peak)
   /// - [tone-mapping](https://mpv.io/manual/stable/#options-tone-mapping)
   ///
-  /// If the IINA `Target peak` setting is set to `0` then this method will attempt to determine peak brightness of the display.
+  /// Otherwise these options will be set to their default values.
   private func setToneMappingForHDR() {
-    guard let mpv = player.mpv, Preference.bool(for: .enableToneMapping) else { return }
-    var targetPeak = Preference.integer(for: .toneMappingTargetPeak)
-    // If the target peak is set to zero then IINA attempts to determine peak brightness of the
-    // display.
-    if targetPeak == 0 {
+    guard let mpv = player.mpv else { return }
+    guard Preference.bool(for: .enableToneMapping) else {
+      // Reset options to their defaults.
+      mpv.setStringToDefault(MPVOption.GPURendererOptions.targetPeak)
+      mpv.setStringToDefault(MPVOption.GPURendererOptions.toneMapping)
+      return
+    }
+    var targetPeak = "auto"
+    if Preference.bool(for: .enableToneMappingTargetPeakOverride) {
+      targetPeak = String(Preference.integer(for: .toneMappingTargetPeakOverride))
+    } else {
+      // In auto mode mpv will use the target display's peak brightness, if available. Otherwise
+      // mpv will apply an appropriate value based on the transfer characteristics of the display.
+      // However, mpv is currently missing code for querying the display under macOS. So IINA
+      // attempts to determine peak brightness of the display itself and only uses mpv auto mode
+      // if unable to obtain the display's brightness.
       if let displayInfo = CoreDisplay_DisplayCreateInfoDictionary(currentDisplay!)?.takeRetainedValue()
-                as? [String: AnyObject] {
+          as? [String: AnyObject] {
         logHDR("Successfully obtained information about the display")
         // Apple Silicon Macs use the key NonReferencePeakHDRLuminance.
         if let hdrLuminance = displayInfo["NonReferencePeakHDRLuminance"] as? Int {
           logHDR("Found NonReferencePeakHDRLuminance: \(hdrLuminance)")
-          targetPeak = hdrLuminance
+          targetPeak = String(hdrLuminance)
         } else if let hdrLuminance = displayInfo["DisplayBacklight"] as? Int {
           // Intel Macs use the key DisplayBacklight.
           logHDR("Found DisplayBacklight: \(hdrLuminance)")
-          targetPeak = hdrLuminance
+          targetPeak = String(hdrLuminance)
         } else {
-          logHDR("Didn't find NonReferencePeakHDRLuminance or DisplayBacklight, assuming HDR400")
-          logHDR("Display info dictionary: \(displayInfo)")
-          targetPeak = 400
+          logHDR("Didn't find NonReferencePeakHDRLuminance or DisplayBacklight, using mpv auto mode")
+          logHDR("Display info dictionary:" + displayInfo.toStringForLog(), level: .verbose)
         }
       } else {
-        logHDR("Unable to obtain display information, assuming HDR400", level: .warning)
-        targetPeak = 400
+        logHDR("Unable to obtain display information, using mpv auto mode", level: .warning)
       }
     }
-    let algorithm = Preference.string(for: .toneMappingAlgorithm,
-                                      ofType: Preference.ToneMappingAlgorithmOption.self)
+    let algorithm = String(describing: Preference.enum(for: .toneMappingAlgorithm) as
+                           Preference.ToneMappingAlgorithmOption)
     logHDR("Will enable tone mapping: target-peak=\(targetPeak) algorithm=\(algorithm)")
-    mpv.setInt(MPVOption.GPURendererOptions.targetPeak, targetPeak)
+    mpv.setString(MPVOption.GPURendererOptions.targetPeak, targetPeak)
     mpv.setString(MPVOption.GPURendererOptions.toneMapping, algorithm)
   }
 
@@ -545,8 +554,16 @@ extension VideoView {
   /// If tone mapping is enabled then this method will set the following mpv options back to their default value (`auto`):
   /// - [target-peak](https://mpv.io/manual/stable/#options-target-peak)
   /// - [tone-mapping](https://mpv.io/manual/stable/#options-tone-mapping)
+  ///
+  /// Otherwise these options will be set to their default values.
   private func setToneMappingForSDR() {
-    guard let mpv = player.mpv, Preference.bool(for: .enableToneMapping) else { return }
+    guard let mpv = player.mpv else { return }
+    guard Preference.bool(for: .enableToneMapping) else {
+      // Reset options to their defaults.
+      mpv.setStringToDefault(MPVOption.GPURendererOptions.targetPeak)
+      mpv.setStringToDefault(MPVOption.GPURendererOptions.toneMapping)
+      return
+    }
     logHDR("Will enable tone mapping: target-peak=auto algorithm=auto")
     mpv.setString(MPVOption.GPURendererOptions.targetPeak, "auto")
     mpv.setString(MPVOption.GPURendererOptions.toneMapping, "auto")
@@ -554,7 +571,7 @@ extension VideoView {
 
   // MARK: - Utils
 
-  func logHDR(_ message: String, level: Logger.Level = .debug) {
+  func logHDR(_ message: @autoclosure () -> String, level: Logger.Level = .debug) {
     Logger.log(message, level: level, subsystem: hdrSubsystem)
   }
 

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -666,7 +666,7 @@
 "settings.loadIccProfile.desc" = "Load the ICC profile for current display and use it to transform video RGB to screen output. (Only for SDR mode)";
 "settings.loadIccProfile.label" = "Load ICC profile";
 "settings.toneMappingAlgorithm.label" = "Algorithm";
-"settings.toneMappingTargetPeak.desc" = "Measured peak brightness of the display. If set to 0, IINA detects this value. If detection fails, IINA sets the target peak to 400.";
+"settings.toneMappingTargetPeak.desc" = "Measured peak brightness of the display. By default IINA detects this value. If detection fails, target peak will be set to an appropriate value based on the transfer characteristics of the display. Enable this setting to manually specify the display's brightness.";
 "settings.toneMappingTargetPeak.label" = "Target peak";
 "settings.videoThreads.desc" = "Default: 0 (Auto)";
 "settings.videoThreads.label" = "Number of threads";


### PR DESCRIPTION
This commit will:
- Add an `enableToneMappingTargetPeakOverride` setting
- Add a `toneMappingTargetPeakOverride` setting
- Add a `migrateToneMappingTargetPeak` method to `LegacyMigration` that splits the existing setting into the two new settings
- Change `SettingsPageVideo.sectionColor` to eliminate use of zero to represent automatic detection using the new settings
- Add a `TextFieldWithSwitch` class to `SettingsItem` to support subordinate `SwitchWithInput` settings
- Change `VideoView.requestEdrMode` to use the new settings and defer to mpv when unable to determine the display brightness
- Change the target peak setting's description to reflect the change in behavior

These changes will eliminate the inelegant use of a special value (0) to represent automatic detection of target peak by altering the setting to be a manual override of the default automatic behavior.

These changes will also remove the code that assumes the display's brightness is 400 nits when unable to obtain the brightness capabilities of the display. Instead when this happens, IINA will defer to mpv by setting `target-peak` to `auto`. This moves IINA closer to alignment with mpv.

In auto mode mpv will attempt to detect the target display's peak brightness. However mpv is currently missing code to do that under macOS. For now, IINA's code to detect the display's brightness is still needed.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] Related issue: #
- [ ] Related Design Proposal: # / Not applicable
---
- [ ] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**
