### PR TITLE
history: fix typo in toolbar item identifier

### DIFF
--- a/iina/HistoryWindowController.swift
+++ b/iina/HistoryWindowController.swift
@@ -576,7 +576,7 @@ class HistoryWindowController: NSWindowController, NSOutlineViewDelegate, NSOutl
 
 extension HistoryWindowController: NSToolbarDelegate {
   private static let clear = NSToolbarItem.Identifier("Clear")
-  private static let groupBy = NSToolbarItem.Identifier("GrouopBy")
+  private static let groupBy = NSToolbarItem.Identifier("GroupBy")
   private static let expandCollapse = NSToolbarItem.Identifier("ExpandCollapse")
   private static let searchField = NSToolbarItem.Identifier("SearchField")
   private static let toolbarItems = [groupBy, expandCollapse, .space, clear, .space, searchField]


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] Related issue: #
- [ ] Related Design Proposal: # / Not applicable
---
- [ ] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**
Fixes the `GrouopBy` typo, which has been miss-spelled since https://github.com/iina/iina/commit/3e9b281350277a78f532ef17808976d8efb673d5, but has been detected only yet by `typos`.