### PR TITLE
Fix width of the settings sidebar is adjustable, #6299

### DIFF
--- a/iina/SettingsWindow.swift
+++ b/iina/SettingsWindow.swift
@@ -170,6 +170,7 @@ class SettingsWindow: NSWindow {
 
     // Add the sidebar and content view controllers to the split view
     let sidebarSplitItem = NSSplitViewItem(sidebarWithViewController: sidebarViewController)
+    sidebarSplitItem.maximumThickness = 200
     sidebarSplitItem.minimumThickness = 200
     sidebarSplitItem.canCollapse = false
     splitViewController.addSplitViewItem(sidebarSplitItem)


### PR DESCRIPTION
This commit will change the `SettingsWindow` initializer to set the `maximumThickness` of the `sidebarSplitItem` to the same size as is currently assigned to its `minimumThickness`.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] Related issue: #6299
- [ ] Related Design Proposal: # / Not applicable
---
- [ ] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**
