### PR TITLE
Fix display color profile not properly applied, #5912

### DIFF
--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -560,12 +560,14 @@ class PlayerCore: NSObject {
       mpv.setFlag(MPVOption.PlaybackControl.pause, true, level: .verbose)
     }
 
+#if USE_ICC_PROFILE_AUTO // See VideoView.setICCProfile.
     // If this mpv core is being reused icc-profile-auto may have been left set to true. This option
     // MUST be reset to false to avoid a crash that occurs if the mpv OSD is being used. Another way
     // to fix this would be to add this option to the mpv reset-on-next-file option. However the
     // user might override IINA and set that option themselves and not include icc-profile-auto.
     // Better to directly reset icc-profile-auto. See issue #5727 for details.
     mpv.setFlag(MPVOption.GPURendererOptions.iccProfileAuto, false)
+#endif
 
     // Delay force-window until an actual file load to avoid Xcode-launched app startup hanging
     // while mpv tries to create a VO before IINA has entered its normal media-open path.

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -308,18 +308,76 @@ class VideoView: NSView {
     RunLoop.current.add(displayIdleTimer!, forMode: .default)
   }
 
+#if !USE_ICC_PROFILE_AUTO
+  private func findProfilePath() -> String? {
+    guard let displayId = currentDisplay,
+          let uuid = CGDisplayCreateUUIDFromDisplayID(displayId)?.takeRetainedValue() else {
+      return nil
+    }
+    typealias ProfileData = (uuid: CFUUID, profileUrl: URL?)
+    var argResult: ProfileData = (uuid, nil)
+    withUnsafeMutablePointer(to: &argResult) { data in
+      ColorSyncIterateDeviceProfiles({ (dict: CFDictionary?, ptr: UnsafeMutableRawPointer?) -> Bool in
+        if let info = dict as? [String: Any], let current = info["DeviceProfileIsCurrent"] as? Int {
+          let deviceID = info["DeviceID"] as! CFUUID
+          let ptr = ptr!.bindMemory(to: ProfileData.self, capacity: 1)
+          let uuid = ptr.pointee.uuid
+          if current == 1, deviceID == uuid {
+            let profileURL = info["DeviceProfileURL"] as! URL
+            ptr.pointee.profileUrl = profileURL
+            return false
+          }
+        }
+        return true
+      }, data)
+    }
+    guard let iccProfilePath = argResult.profileUrl?.path,
+          FileManager.default.fileExists(atPath: iccProfilePath) else {
+      return nil
+    }
+    return iccProfilePath
+  }
+#endif
+
+  /// Set the ICC profile and adjust the view layer.
+  /// - Important: IINA should be using the mpv
+  ///     [icc-profile-auto](https://mpv.io/manual/stable/#options-icc-profile-auto) option because that allows
+  ///     users to make use of the mpv [icc-profile](https://mpv.io/manual/stable/#options-icc-profile) option
+  ///     in their `mpv.conf` file since setting that option overrides `icc-profile-auto`. But `icc-profile-auto` is not
+  ///     working as reported in mpv issue [#17385](https://github.com/mpv-player/mpv/issues/17385). Until that
+  ///     problem is fixed, IINA must go back to using `icc-profile`. The code to support `icc-profile-auto` can be
+  ///     enabled by setting `USE_ICC_PROFILE_AUTO` in Xcode settings to test a proposed fix to `libmpv`.
   private func setICCProfile() {
     let screenColorSpace = player.mainWindow.window?.screen?.colorSpace
     if !Preference.bool(for: .loadIccProfile) {
       logHDR("Not using ICC profile due to user preference")
+#if USE_ICC_PROFILE_AUTO
       player.mpv.setFlag(MPVOption.GPURendererOptions.iccProfileAuto, false)
-    } else if let screenColorSpace {
-      let name = screenColorSpace.localizedName ?? "unnamed"
-      logHDR("Using the ICC profile of the color space \(name)")
-      // Set MPV_RENDER_PARAM_ICC_PROFILE before enabling icc-profile-auto to true as mpv requires
-      // that parameter be set in the render context when icc-profile-auto is in use.
-      videoLayer.setRenderICCProfile(screenColorSpace)
-      player.mpv.setFlag(MPVOption.GPURendererOptions.iccProfileAuto, true)
+#else
+      player.mpv.setString(MPVOption.GPURendererOptions.iccProfile, "")
+#endif
+    } else {
+#if USE_ICC_PROFILE_AUTO
+      if let screenColorSpace {
+        let name = screenColorSpace.localizedName ?? "unnamed"
+        logHDR("Using the ICC profile of the color space \(name)")
+        // Set MPV_RENDER_PARAM_ICC_PROFILE before enabling icc-profile-auto to true as mpv requires
+        // that parameter be set in the render context when icc-profile-auto is in use.
+        videoLayer.setRenderICCProfile(screenColorSpace)
+        player.mpv.setFlag(MPVOption.GPURendererOptions.iccProfileAuto, true)
+      } else {
+        logHDR("Failed find ICC profile to load", level: .error)
+        player.mpv.setFlag(MPVOption.GPURendererOptions.iccProfileAuto, false)
+      }
+#else
+      if let iccProfilePath = findProfilePath() {
+        logHDR("Loading ICC profile: \(iccProfilePath)")
+        player.mpv.setString(MPVOption.GPURendererOptions.iccProfile, iccProfilePath)
+      } else {
+        logHDR("Failed to find ICC profile to load", level: .error)
+        player.mpv.setString(MPVOption.GPURendererOptions.iccProfile, "")
+      }
+#endif
     }
 
     let sdrColorSpace = screenColorSpace?.cgColorSpace ?? VideoView.SRGB
@@ -491,7 +549,11 @@ extension VideoView {
 
     videoLayer.wantsExtendedDynamicRangeContent = true
     videoLayer.colorspace = CGColorSpace(name: name)
+#if USE_ICC_PROFILE_AUTO // See setICCProfile.
     mpv.setFlag(MPVOption.GPURendererOptions.iccProfileAuto, false)
+#else
+    mpv.setString(MPVOption.GPURendererOptions.iccProfile, "")
+#endif
     mpv.setString(MPVOption.GPURendererOptions.targetPrim, primaries)
     // PQ videos will be display as it was, HLG videos will be converted to PQ
     mpv.setString(MPVOption.GPURendererOptions.targetTrc, "pq")

--- a/iina/ViewLayer.swift
+++ b/iina/ViewLayer.swift
@@ -465,6 +465,7 @@ class ViewLayer: CAOpenGLLayer {
 
   // MARK: - ICC Profile
 
+#if USE_ICC_PROFILE_AUTO // See VideoView.setICCProfile.
   /// Set an ICC profile for use with the mpv [icc-profile-auto](https://mpv.io/manual/stable/#options-icc-profile-auto)
   /// option.
   ///
@@ -500,6 +501,7 @@ class ViewLayer: CAOpenGLLayer {
       }
     }
   }
+#endif // USE_ICC_PROFILE_AUTO
 
   // MARK: - Utils
 


### PR DESCRIPTION
This commit will change IINA to revert back to using the mpv `icc-profile` option instead of the `icc-profile-auto` option as a workaround for mpv issue #17385.

IINA should be using the `icc-profile-auto` option because that allows users to make use of the `icc-profile` option in their mpv.conf files since setting that option overrides `icc-profile-auto`. So this commit adds conditional compilation to allow reverting back to `icc-profile-auto`. The code can be enabled by setting `USE_ICC_PROFILE_AUTO` in Xcode settings to test a proposed fix to libmpv.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] Related issue: #5912
- [ ] Related Design Proposal: # / Not applicable
---
- [ ] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**
