### PR TITLE
Tear down plugin resources on disable, reload, and shutdown

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -526,6 +526,12 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
       window.close()
     }
 
+    // Let window-will-close listeners finish first, then deactivate all plugin
+    // instances before returning to the run loop to wait for player shutdown.
+    // Ordinary window closure keeps its player and plugins available for reuse.
+    PlayerCore.playerCores.forEach { $0.clearPlugins() }
+    JavascriptPlugin.plugins.forEach { $0.globalInstance?.tearDown() }
+
     // Check if there are any players that are not shutdown. If all players are already shutdown
     // then application termination can proceed immediately. This will happen if there is only one
     // player and shutdown was initiated by sending a quit command directly to mpv through it's IPC

--- a/iina/JavascriptAPI.swift
+++ b/iina/JavascriptAPI.swift
@@ -40,14 +40,20 @@ class JavascriptAPI: NSObject {
   }
 
   func permitted(to permission: JavascriptPlugin.Permission) -> Bool {
-    return pluginInstance.plugin.permissions.contains(permission)
+    guard let instance = pluginInstance, instance.isActive else { return false }
+    return instance.plugin.permissions.contains(permission)
   }
 
   func extraSetup() { }
   func cleanUp(_ instance: JavascriptPluginInstance) { }
 
-  func createPromise(_ block: @escaping @convention(block) (JSValue, JSValue) -> Void) -> JSValue {
-    return context.objectForKeyedSubscript("Promise")!.construct(withArguments: [JSValue(object: block, in: context)!])
+  func createPromise(_ block: @escaping (JavascriptPluginCallback) -> Void) -> JSValue {
+    dispatchPrecondition(condition: .onQueue(.main))
+    let executor: @convention(block) (JSValue, JSValue) -> Void = { [weak pluginInstance] resolve, reject in
+      guard let instance = pluginInstance, instance.isActive else { return }
+      block(instance.makeCallback([resolve, reject]))
+    }
+    return context.objectForKeyedSubscript("Promise")!.construct(withArguments: [JSValue(object: executor, in: context)!])
   }
 
   /// Expand the magic strings such as `@tmp` and `@data` in the path.

--- a/iina/JavascriptAPIEvent.swift
+++ b/iina/JavascriptAPIEvent.swift
@@ -24,6 +24,8 @@ class JavascriptAPIEvent: JavascriptAPI, JavascriptAPIEventExportable {
   private var addedListeners: [(String, EventController.Name)] = []
 
   @objc func on(_ event: String, _ callback: JSValue) -> String? {
+    dispatchPrecondition(condition: .onQueue(.main))
+    guard let instance = pluginInstance, instance.isActive else { return nil }
     let splitted = event.split(separator: ".")
     let isEventListener = splitted.count == 2
     let isPropertyChangedListener = splitted.count == 3 && splitted[2] == "changed"
@@ -38,7 +40,7 @@ class JavascriptAPIEvent: JavascriptAPI, JavascriptAPIEventExportable {
       player!.mpv.observe(property: eventName)
     }
     let name = EventController.Name(event)
-    let id = player!.events.addListener(JavascriptAPIEventCallback(callback), for: name)
+    let id = player!.events.addListener(JavascriptAPIEventCallback(callback, instance: pluginInstance), for: name)
     addedListeners.append((id, name))
     return id
   }
@@ -59,18 +61,23 @@ class JavascriptAPIEvent: JavascriptAPI, JavascriptAPIEventExportable {
 
 class JavascriptAPIEventCallback: EventCallable {
   private var callback: JSValue?
+  private weak var instance: JavascriptPluginInstance?
 
-  init(_ callback: JSValue) {
+  init(_ callback: JSValue, instance: JavascriptPluginInstance) {
     self.callback = callback
+    self.instance = instance
   }
 
   func call(withArguments args: [Any]) {
-    callback?.call(withArguments: args.map { arg in
-      if let rect = arg as? CGRect {
-        return JSValue(rect: rect, in: callback!.context)!
-      } else {
-        return arg
-      }
-    })
+    guard let instance, instance.isActive else { return }
+    instance.withActiveContext {
+      callback?.call(withArguments: args.map { arg in
+        if let rect = arg as? CGRect {
+          return JSValue(rect: rect, in: callback!.context)!
+        } else {
+          return arg
+        }
+      })
+    }
   }
 }

--- a/iina/JavascriptAPIHttp.swift
+++ b/iina/JavascriptAPIHttp.swift
@@ -23,6 +23,37 @@ fileprivate typealias JustRequestFunc = (URLComponentsConvertible, [String : Any
 }
 
 class JavascriptAPIHttp: JavascriptAPI, JavascriptAPIHttpExportable {
+  // Just's async result does not expose its task until completion. Keep its request
+  // encoding, but use an instance-owned session so teardown can cancel pending IO.
+  private let session = URLSession(configuration: .default)
+  // Main-owned registry. Each write owns a separate, irrevocable cancellation
+  // token so a new instance cannot revive an old instance's pending download.
+  private var downloads: [UUID: JavascriptPluginDownload] = [:]
+  private let downloadQueue = DispatchQueue(label: "com.colliderli.iina.plugin.download", qos: .utility)
+
+  override func cleanUp(_ instance: JavascriptPluginInstance) {
+    dispatchPrecondition(condition: .onQueue(.main))
+    downloads.values.forEach { $0.cancel() }
+    downloads.removeAll()
+    session.invalidateAndCancel()
+  }
+
+  private func perform(_ method: HTTPMethod, url: String, params: [String: String],
+                       data: [String: Any], headers: [String: String],
+                       completion: @escaping (HTTPResult) -> Void) {
+    let builder = HTTP(session: session)
+    guard let request = builder.synthesizeRequest(method, url: url, params: params,
+      data: data, json: nil, headers: .init(dictionary: headers), files: [:], auth: nil,
+      timeout: nil, urlQuery: nil, requestBody: nil) else {
+      completion(HTTPResult(data: nil, response: nil,
+                           error: URLError(.badURL), task: nil))
+      return
+    }
+    session.dataTask(with: request) { data, response, error in
+      completion(HTTPResult(data: data, response: response, error: error, task: nil))
+    }.resume()
+  }
+
 
   @objc func get(_ url: String, _ options: [String: Any]?) -> JSValue? {
     return request(.get, url: url, options: options)
@@ -45,10 +76,11 @@ class JavascriptAPIHttp: JavascriptAPI, JavascriptAPIHttpExportable {
   }
 
   @objc func xmlrpc(_ location: String) -> JavascriptAPIXmlrpc? {
+    guard let instance = pluginInstance, instance.isActive else { return nil }
     guard hostIsValid(location) else {
       return nil
     }
-    return JavascriptAPIXmlrpc(context: context, pluginInstance: pluginInstance, location: location)
+    return JavascriptAPIXmlrpc(context: context, pluginInstance: pluginInstance, location: location, session: session)
   }
 
   func download(_ url: String, _ dest: String, _ options: [String: Any]?) -> JSValue? {
@@ -68,23 +100,26 @@ class JavascriptAPIHttp: JavascriptAPI, JavascriptAPIHttpExportable {
       let params = options?["params"] as? [String: String]
       let headers = options?["headers"] as? [String: String]
       let data = options?["data"] as? [String: Any]
-      return createPromise { resolve, reject in
-        Just.request(method, url: url,
-                     params: params ?? [:],
-                     data: data ?? [:],
-                     headers: headers ?? [:],
-                     asyncCompletionHandler:  { [unowned self] response in
-          if (response.ok) {
-            do {
-              try response.content?.write(to: URL(fileURLWithPath: destPath))
-            } catch {
-              self.throwError(withMessage: "Unable to write to the destination.")
+      return createPromise { reply in
+        let operation = JavascriptPluginDownload(stagingDirectory: self.pluginInstance.plugin.tmpURL)
+        self.downloads[operation.id] = operation
+        let queue = self.downloadQueue
+        self.perform(method, url: url,
+                     params: params ?? [:], data: data ?? [:], headers: headers ?? [:]) { [weak self] response in
+          queue.async {
+            var writeError = false
+            if response.ok, let content = response.content {
+              do { try operation.write(content, to: URL(fileURLWithPath: destPath)) }
+              catch { writeError = true }
             }
-            resolve.call(withArguments: [])
-          } else {
-            reject.call(withArguments: [response.toDict()])
+            DispatchQueue.main.async {
+              self?.downloads.removeValue(forKey: operation.id)
+              if writeError { reply.reject(["Unable to write to the destination."]) }
+              else if response.ok { reply.resolve([]) }
+              else { reply.reject([response.toDict()]) }
+            }
           }
-        })
+        }
       }
     }
   }
@@ -99,13 +134,14 @@ class JavascriptAPIHttp: JavascriptAPI, JavascriptAPIHttpExportable {
       let params = options?["params"] as? [String: String]
       let headers = options?["headers"] as? [String: String]
       let data = options?["data"] as? [String: Any]
-      return createPromise { resolve, reject in
-        Just.request(method, url: url,
+      return createPromise { reply in
+        self.perform(method, url: url,
                      params: params ?? [:],
                      data: data ?? [:],
                      headers: headers ?? [:],
-                     asyncCompletionHandler:  { response in
-          (response.ok ? resolve : reject).call(withArguments: [response.toDict()])
+                     completion: { response in
+          if response.ok { reply.resolve([response.toDict()]) }
+          else { reply.reject([response.toDict()]) }
         })
       }
     }
@@ -131,21 +167,21 @@ class JavascriptAPIHttp: JavascriptAPI, JavascriptAPIHttpExportable {
 class JavascriptAPIXmlrpc: JavascriptAPI, JavascriptAPIXmlrpcExportable {
   private let xmlrpc: JustXMLRPC
 
-  init(context: JSContext, pluginInstance: JavascriptPluginInstance, location: String) {
-    self.xmlrpc = JustXMLRPC(location)
+  init(context: JSContext, pluginInstance: JavascriptPluginInstance, location: String, session: URLSession) {
+    self.xmlrpc = JustXMLRPC(location, session: session)
     super.init(context: context, pluginInstance: pluginInstance)
   }
 
   @objc func call(_ method: String, _ args: [Any]) -> JSValue? {
-    return createPromise { resolve, reject in
+    return createPromise { reply in
       self.xmlrpc.call(method, args) { response in
         switch response {
         case .ok(let returnValue):
-          resolve.call(withArguments: [returnValue])
+          reply.resolve([returnValue])
         case .failure:
-          reject.call(withArguments: [])
+          reply.reject([])
         case .error(let err):
-          reject.call(withArguments: [[
+          reply.reject([[
             "httpCode": err.httpCode,
             "reason": err.reason,
             "description": err.readableDescription,
@@ -164,5 +200,119 @@ fileprivate extension HTTPResult {
       "data": json,
       "text": text
     ]
+  }
+}
+
+/// Stages the body off main, then writes through the destination as Data.write
+/// does: preserve existing inodes/permissions and follow symbolic links. Once
+/// publication starts, cancellation or an IO error may leave a partial file.
+/// Cancellation owns removal of the staging name; it never joins the writer.
+/// Destination mutation is serialized with cancellation one syscall at a time,
+/// so no further bytes can be published after cancel returns. Filesystem syscall
+/// latency is not bounded, even though body IO never runs on main.
+final class JavascriptPluginDownload {
+  let id = UUID()
+  private let lock = NSLock()
+  private var cancelled = false
+  private var started = false
+  private var stagingPath: String?
+  private let stagingDirectory: URL
+
+  init(stagingDirectory: URL) {
+    self.stagingDirectory = stagingDirectory
+  }
+
+  func cancel() {
+    lock.lock()
+    defer { lock.unlock() }
+    cancelled = true
+    removeStagingFile()
+  }
+
+  // Caller holds lock. The writer retains its fd, not the directory entry: an
+  // unlinked file disappears on process exit even if the writer never resumes.
+  private func removeStagingFile() {
+    if let path = stagingPath {
+      if unlink(path) == 0 || errno == ENOENT { stagingPath = nil }
+    }
+  }
+
+  private func checkCancellation() throws {
+    lock.lock()
+    let stopped = cancelled
+    lock.unlock()
+    if stopped { throw URLError(.cancelled) }
+  }
+
+  private func createStagingFile() throws -> Int32 {
+    lock.lock()
+    defer { lock.unlock() }
+    guard !cancelled, !started else { throw URLError(.cancelled) }
+    started = true
+    let path = stagingDirectory.appendingPathComponent(".iina-download-\(id.uuidString)").path
+    let fd = open(path, O_RDWR | O_CREAT | O_EXCL | O_CLOEXEC, S_IRUSR | S_IWUSR)
+    guard fd >= 0 else { throw URLError(.cannotCreateFile) }
+    // Creation and ownership are indivisible with respect to cancellation.
+    stagingPath = path
+    return fd
+  }
+
+  private func openDestination(_ destination: URL) throws -> Int32 {
+    lock.lock()
+    defer { lock.unlock() }
+    guard !cancelled else { throw URLError(.cancelled) }
+    // O_TRUNC preserves the existing inode and mode, follows symlinks (including
+    // dangling links), and applies the process umask/parent ACL for a new file.
+    let fd = open(destination.path, O_WRONLY | O_CREAT | O_TRUNC | O_CLOEXEC, 0o666)
+    guard fd >= 0 else { throw URLError(.cannotCreateFile) }
+    return fd
+  }
+
+  func write(_ data: Data, to destination: URL) throws {
+    dispatchPrecondition(condition: .notOnQueue(.main))
+    let fd = try createStagingFile()
+    defer {
+      close(fd)
+      lock.lock()
+      removeStagingFile()
+      lock.unlock()
+    }
+    try data.withUnsafeBytes { bytes in
+      var offset = 0
+      while offset < bytes.count {
+        try checkCancellation()
+        let count = Darwin.write(fd, bytes.baseAddress!.advanced(by: offset), min(256 * 1024, bytes.count - offset))
+        if count < 0 && errno == EINTR { continue }
+        guard count > 0 else { throw URLError(.cannotWriteToFile) }
+        offset += count
+      }
+    }
+    guard lseek(fd, 0, SEEK_SET) >= 0 else { throw URLError(.cannotOpenFile) }
+    let output = try openDestination(destination)
+    defer { close(output) }
+    var buffer = [UInt8](repeating: 0, count: 256 * 1024)
+    while true {
+      try checkCancellation()
+      let count = read(fd, &buffer, buffer.count)
+      if count < 0 && errno == EINTR { continue }
+      guard count >= 0 else { throw URLError(.cannotDecodeContentData) }
+      if count == 0 { break }
+      try buffer.withUnsafeBytes { bytes in
+        var offset = 0
+        while offset < count {
+          lock.lock()
+          if cancelled {
+            lock.unlock()
+            throw URLError(.cancelled)
+          }
+          let written = Darwin.write(output, bytes.baseAddress!.advanced(by: offset), count - offset)
+          let code = errno
+          lock.unlock()
+          if written < 0 && code == EINTR { continue }
+          guard written > 0 else { throw URLError(.cannotWriteToFile) }
+          offset += written
+        }
+      }
+    }
   }
 }

--- a/iina/JavascriptAPIMpv.swift
+++ b/iina/JavascriptAPIMpv.swift
@@ -67,6 +67,8 @@ class JavascriptAPIMpv: JavascriptAPI, JavascriptAPIMpvExportable {
   }
 
   @objc func addHook(_ name: String, _ priority: Int, _ callback: JSValue) {
+    dispatchPrecondition(condition: .onQueue(.main))
+    guard let instance = pluginInstance, instance.isActive else { return }
     let hook = MPVHookValue(withIdentifier: identifier, jsContext: context, jsBlock: callback, owner: self)
     player!.mpv.addHook(MPVHook(name), priority: Int32(priority), hook: hook)
   }

--- a/iina/JavascriptAPIOverlay.swift
+++ b/iina/JavascriptAPIOverlay.swift
@@ -35,24 +35,27 @@ class JavascriptAPIOverlay: JavascriptAPI, JavascriptAPIOverlayExportable, WKScr
   func show() {
     guard pluginInstance != nil else { return }
     guard pluginInstance.overlayViewLoaded && permitted(to: .displayVideoOverlay) else { return }
-    DispatchQueue.main.async {
-      self.pluginInstance.overlayView.isHidden = false
+    DispatchQueue.main.async { [weak self] in
+      guard let self, let instance = self.pluginInstance, instance.isActive else { return }
+      instance.overlayView.isHidden = false
     }
   }
 
   func hide() {
     guard pluginInstance != nil else { return }
     guard pluginInstance.overlayViewLoaded && permitted(to: .displayVideoOverlay) else { return }
-    DispatchQueue.main.async {
-      self.pluginInstance.overlayView.isHidden = true
+    DispatchQueue.main.async { [weak self] in
+      guard let self, let instance = self.pluginInstance, instance.isActive else { return }
+      instance.overlayView.isHidden = true
     }
   }
 
   func setOpacity(_ opacity: Float) {
     guard pluginInstance != nil else { return }
     guard pluginInstance.overlayViewLoaded && permitted(to: .displayVideoOverlay) else { return }
-    DispatchQueue.main.async {
-      self.pluginInstance.overlayView.alphaValue = CGFloat(opacity)
+    DispatchQueue.main.async { [weak self] in
+      guard let self, let instance = self.pluginInstance, instance.isActive else { return }
+      instance.overlayView.alphaValue = CGFloat(opacity)
     }
   }
 
@@ -68,9 +71,10 @@ class JavascriptAPIOverlay: JavascriptAPI, JavascriptAPIOverlayExportable, WKScr
     let rootURL = pluginInstance.plugin.root
     let url = rootURL.appendingPathComponent(path)
     
-    DispatchQueue.main.async {
-      self.pluginInstance.overlayView.loadFileURL(url, allowingReadAccessTo: rootURL)
-      self.pluginInstance.overlayViewLoaded = true
+    DispatchQueue.main.async { [weak self] in
+      guard let self, let instance = self.pluginInstance, instance.isActive else { return }
+      instance.overlayView.loadFileURL(url, allowingReadAccessTo: rootURL)
+      instance.overlayViewLoaded = true
       self.inSimpleMode = false
     }
     messageHub.clearListeners()

--- a/iina/JavascriptAPIUtils.swift
+++ b/iina/JavascriptAPIUtils.swift
@@ -36,6 +36,15 @@ fileprivate extension Process {
 }
 
 class JavascriptAPIUtils: JavascriptAPI, JavascriptAPIUtilsExportable {
+  // Registry is main-owned; each child serializes its IO and cancellation.
+  private var processes: [UUID: JavascriptPluginProcess] = [:]
+
+  override func cleanUp(_ instance: JavascriptPluginInstance) {
+    dispatchPrecondition(condition: .onQueue(.main))
+    processes.values.forEach { $0.cancel() }
+    processes.removeAll()
+  }
+
   func keychainWrite(_ service: String, _ name: String, _ password: String) -> Any {
     if service.isEmpty {
       return false
@@ -102,7 +111,7 @@ class JavascriptAPIUtils: JavascriptAPI, JavascriptAPIUtilsExportable {
       return nil
     }
 
-    return createPromise { [unowned self] resolve, reject in
+    return createPromise { [unowned self] reply in
       var path = ""
       var args = args
       if !file.contains("/") {
@@ -138,7 +147,7 @@ class JavascriptAPIUtils: JavascriptAPI, JavascriptAPIUtilsExportable {
         }
         // make sure the file exists
         guard FileManager.default.fileExists(atPath: path) else {
-          reject.call(withArguments: [-1, "Cannot find the binary \(file)"])
+          reply.reject([-1, "Cannot find the binary \(file)"])
           return
         }
       }
@@ -150,7 +159,7 @@ class JavascriptAPIUtils: JavascriptAPI, JavascriptAPIUtilsExportable {
         do {
           try FileManager.default.setAttributes([.posixPermissions: NSNumber(integerLiteral: 0o755)], ofItemAtPath: path)
         } catch {
-          reject.call(withArguments: [-2, "The binary is not executable, and execute permission cannot be added"])
+          reply.reject([-2, "The binary is not executable, and execute permission cannot be added"])
           return
         }
       }
@@ -166,47 +175,25 @@ class JavascriptAPIUtils: JavascriptAPI, JavascriptAPIUtilsExportable {
       process.standardOutput = stdout
       process.standardError = stderr
 
-      var stdoutContent = ""
-      var stderrContent = ""
-      var stdoutHook: JSValue?
-      var stderrHook: JSValue?
-      if let hookVal = stdoutHook_, hookVal.isObject {
-        stdoutHook = hookVal
+      let hooks = [stdoutHook_, stderrHook_].map { value -> JavascriptPluginCallback? in
+        guard let value, value.isObject else { return nil }
+        return pluginInstance.makeCallback([value], once: false)
       }
-      if let hookVal = stderrHook_, hookVal.isObject {
-        stderrHook = hookVal
-      }
-
-      stdout.fileHandleForReading.readabilityHandler = { file in
-        guard let output = String(data: file.availableData, encoding: .utf8) else { return }
-        stdoutContent += output
-        stdoutHook?.call(withArguments: [output])
-      }
-      stderr.fileHandleForReading.readabilityHandler = { file in
-        guard let output = String(data: file.availableData, encoding: .utf8) else { return }
-        stderrContent += output
-        stderrHook?.call(withArguments: [output])
-      }
-      Logger.log("Executing \(path) \(args.joined(separator: " "))", subsystem: pluginInstance.subsystem)
-      do {
-        try process.run()
-      } catch {
-        reject.call(withArguments: ["Execution failed reporting: \(error.localizedDescription)"])
-        return
-      }
-
-      self.pluginInstance.queue.async {
-        process.waitUntilExit()
-        stderr.fileHandleForReading.readabilityHandler = nil
-        stdout.fileHandleForReading.readabilityHandler = nil
-        DispatchQueue.main.async {
-          resolve.call(withArguments: [[
-            "status": process.terminationStatus,
-            "stdout": stdoutContent,
-            "stderr": stderrContent
-          ] as [String: Any]])
+      let id = UUID()
+      let operation = JavascriptPluginProcess(process: process, pipes: [stdout, stderr], hooks: hooks) { [weak self] result in
+        dispatchPrecondition(condition: .onQueue(.main))
+        self?.processes.removeValue(forKey: id)
+        hooks.forEach { $0?.cancel() }
+        switch result {
+        case .success(let output): reply.resolve([output])
+        case .failure(let error): reply.reject(["Execution failed reporting: \(error.localizedDescription)"])
         }
       }
+      guard let instance = pluginInstance, instance.isActive else { return }
+      processes[id] = operation
+      Logger.log("Executing \(path) \(args.joined(separator: " "))", subsystem: pluginInstance.subsystem)
+      operation.start()
+
     }
   }
 
@@ -237,9 +224,9 @@ class JavascriptAPIUtils: JavascriptAPI, JavascriptAPIUtilsExportable {
   func chooseFile(_ title: String, _ options: [String: Any]) -> Any {
     let chooseDir = options["chooseDir"] as? Bool ?? false
     let allowedFileTypes = options["allowedFileTypes"] as? [String]
-    return createPromise { resolve, reject in
+    return createPromise { reply in
       Utility.quickOpenPanel(title: title, chooseDir: chooseDir, allowedFileTypes: allowedFileTypes) { result in
-        resolve.call(withArguments: [result.path])
+        reply.resolve([result.path])
       }
     }
   }
@@ -271,5 +258,116 @@ class JavascriptAPIUtils: JavascriptAPI, JavascriptAPIUtilsExportable {
 
   func preferredLocalizations() -> Any {
     return Bundle.main.preferredLocalizations
+  }
+}
+
+/// Owns the direct child and its pipe readers independently of JavaScript delivery.
+/// All IO state is confined to `queue`; completion runs on the main queue.
+private final class JavascriptPluginProcess {
+  private let process: Process
+  private let pipes: [Pipe]
+  private let hooks: [JavascriptPluginCallback?]
+  private let completion: (Result<[String: Any], Error>) -> Void
+  private let queue = DispatchQueue(label: "com.colliderli.iina.plugin.exec")
+  private var sources: [DispatchSourceRead] = []
+  private var output = [Data(), Data()]
+  private var closed = [false, false]
+  private var exited = false
+  private var cancelled = false
+  private var completed = false
+
+  init(process: Process, pipes: [Pipe], hooks: [JavascriptPluginCallback?],
+       completion: @escaping (Result<[String: Any], Error>) -> Void) {
+    self.process = process
+    self.pipes = pipes
+    self.hooks = hooks
+    self.completion = completion
+  }
+
+  func start() {
+    queue.async { [self] in startOnQueue() }
+  }
+
+  private func startOnQueue() {
+    // Install readers before launch, but resume them only after Process has inherited
+    // the pipes. A failed launch closes both ends without waiting for an exit event.
+    for (index, pipe) in pipes.enumerated() {
+      let handle = pipe.fileHandleForReading
+      let fd = handle.fileDescriptor
+      _ = fcntl(fd, F_SETFL, fcntl(fd, F_GETFL) | O_NONBLOCK)
+      let source = DispatchSource.makeReadSource(fileDescriptor: fd, queue: queue)
+      source.setEventHandler { [self] in drain(index) }
+      source.setCancelHandler { handle.closeFile() }
+      sources.append(source)
+    }
+    process.terminationHandler = { [self] _ in
+      queue.async { [self] in
+        exited = true
+        // Drain data already in the pipes before reporting completion. Descendants
+        // do not own this exec call; do not wait for them to close inherited writers.
+        for index in pipes.indices { drain(index); close(index) }
+        finishIfReady()
+      }
+    }
+    do {
+      try process.run()
+      sources.forEach { $0.resume() }
+    } catch {
+      completed = true
+      process.terminationHandler = nil
+      sources.forEach { $0.setEventHandler(handler: nil); $0.resume(); $0.cancel() }
+      pipes.forEach { $0.fileHandleForWriting.closeFile() }
+      DispatchQueue.main.async { [completion] in completion(.failure(error)) }
+    }
+  }
+
+  func cancel() {
+    queue.async { [self] in
+      guard !completed, !cancelled else { return }
+      cancelled = true
+      // Detach readers even if the child refuses termination. Never wait on the UI.
+      for index in pipes.indices { close(index) }
+      if process.isRunning { process.terminate() }
+      queue.asyncAfter(deadline: .now() + 1) { [self] in
+        if process.isRunning { kill(process.processIdentifier, SIGKILL) }
+      }
+      finishIfReady()
+    }
+  }
+
+  private func drain(_ index: Int) {
+    guard !closed[index] else { return }
+    var bytes = [UInt8](repeating: 0, count: 8192)
+    while true {
+      let count = read(pipes[index].fileHandleForReading.fileDescriptor, &bytes, bytes.count)
+      if count > 0 {
+        output[index].append(contentsOf: bytes.prefix(count))
+        if !cancelled, let text = String(bytes: bytes.prefix(count), encoding: .utf8) {
+          hooks[index]?.call(withArguments: [text])
+        }
+      } else if count < 0 && errno == EINTR {
+        continue
+      } else {
+        if count == 0 || (errno != EAGAIN && errno != EWOULDBLOCK) { close(index) }
+        break
+      }
+    }
+  }
+
+  private func close(_ index: Int) {
+    guard !closed[index] else { return }
+    closed[index] = true
+    sources[index].setEventHandler(handler: nil)
+    sources[index].cancel()
+  }
+
+  private func finishIfReady() {
+    guard exited, closed.allSatisfy({ $0 }), !completed else { return }
+    completed = true
+    process.terminationHandler = nil
+    let result: [String: Any] = ["status": process.terminationStatus,
+                                 "stdout": String(decoding: output[0], as: UTF8.self),
+                                 "stderr": String(decoding: output[1], as: UTF8.self)]
+    DispatchQueue.main.async { [completion] in completion(.success(result)) }
   }
 }

--- a/iina/JavascriptAPIWebSocket.swift
+++ b/iina/JavascriptAPIWebSocket.swift
@@ -27,16 +27,30 @@ class JavascriptAPIWebSocketController: JavascriptAPI, JavascriptAPIWebSocketCon
   var newConnHandler: JSManagedValue?
   var connStateHandler: JSManagedValue?
 
+  override func cleanUp(_ instance: JavascriptPluginInstance) {
+    server?.stop()
+    server = nil
+    for handler in [stateHandler, messageHandler, newConnHandler, connStateHandler] {
+      context.virtualMachine.removeManagedReference(handler, withOwner: self)
+    }
+    stateHandler = nil
+    messageHandler = nil
+    newConnHandler = nil
+    connStateHandler = nil
+  }
+
   func createServer(_ options: [String : Any]) {
+    dispatchPrecondition(condition: .onQueue(.main))
+    guard let instance = pluginInstance, instance.isActive else { return }
     if let previousServer = server {
-      previousServer.listener.cancel()
+      previousServer.stop()
       self.server = nil
     }
     guard let port = options["port"] as? UInt16 else {
       throwError(withMessage: "ws.createServer: port not specified")
       return
     }
-    server = WebSocketServer(port: port, label: "\(pluginInstance.plugin.identifier).ws")
+    server = WebSocketServer(port: port, label: "\(instance.plugin.identifier).ws")
     // The server should be created without any issue at this step,
     // but errors may occur if we add TLS support in the future.
     if server == nil {
@@ -48,6 +62,8 @@ class JavascriptAPIWebSocketController: JavascriptAPI, JavascriptAPIWebSocketCon
   }
 
   func startServer() {
+    dispatchPrecondition(condition: .onQueue(.main))
+    guard let instance = pluginInstance, instance.isActive else { return }
     guard let server else {
       throwError(withMessage: "ws.startServer: server not created")
       return
@@ -76,9 +92,11 @@ class JavascriptAPIWebSocketController: JavascriptAPI, JavascriptAPIWebSocketCon
   }
 
   private func setHandler(_ handler: JSValue, field: ReferenceWritableKeyPath<JavascriptAPIWebSocketController, JSManagedValue?>) {
+    dispatchPrecondition(condition: .onQueue(.main))
+    guard let instance = pluginInstance, instance.isActive else { return }
     func removePreviousHandler() {
-      self[keyPath: field] = nil
       JSContext.current()!.virtualMachine.removeManagedReference(self[keyPath: field], withOwner: self)
+      self[keyPath: field] = nil
     }
     if handler.isNull || handler.isUndefined || self[keyPath: field] != nil {
       removePreviousHandler()
@@ -95,28 +113,16 @@ class JavascriptAPIWebSocketController: JavascriptAPI, JavascriptAPIWebSocketCon
   func sendText(_ conn: String, _ string: String) -> JSValue {
     let data = string.data(using: .utf8)!
 
-    return createPromise { [unowned self] resolve, reject in
+    return createPromise { [unowned self] reply in
       guard let server = self.server else {
-        reject.call(withArguments: ["server does not exist"])
+        reply.reject(["server does not exist"])
         return
       }
-      guard let connEntry = server.connections[conn] else {
-        // not throwing an error hereif there's no such connection ID.
-        // because it's not the server's fault and we just want to "ignore the request"
-        resolve.call(withArguments: ["no_connection"])
-        return
+      server.send(data: data, to: conn) { error, found in
+        if let error { reply.reject([error.toDict()]) }
+        else { reply.resolve([found ? "success" : "no_connection"]) }
       }
-      do {
-        try server.send(data: data, to: connEntry, callback: { error in
-          if let error {
-            reject.call(withArguments: [error.toDict()])
-          } else {
-            resolve.call(withArguments: ["success"])
-          }
-        })
-      } catch (let error) {
-        reject.call(withArguments: [error.localizedDescription])
-      }
+
     }
   }
 }
@@ -124,61 +130,78 @@ class JavascriptAPIWebSocketController: JavascriptAPI, JavascriptAPIWebSocketCon
 
 extension JavascriptAPIWebSocketController: WebSocketServerDelegate {
   func stateUpdated(_ state: NWListener.State) {
-    guard let handler = stateHandler?.value else { return }
-
-    switch state {
-    case .setup:
-      handler.call(withArguments: ["setup"])
-    case .waiting(let nWError):
-      handler.call(withArguments: ["waiting", nWError.toDict()])
-    case .ready:
-      handler.call(withArguments: ["ready"])
-    case .failed(let nWError):
-      handler.call(withArguments: ["failed", nWError.toDict()])
-    case .cancelled:
-      handler.call(withArguments: ["cancelled"])
-    @unknown default:
-      handler.call(withArguments: ["\(state)"])
+    DispatchQueue.main.async { [weak self] in
+      guard let self, let instance = self.pluginInstance else { return }
+      instance.withActiveContext {
+        guard let handler = self.stateHandler?.value else { return }
+        switch state {
+        case .setup:
+          handler.call(withArguments: ["setup"])
+        case .waiting(let nWError):
+          handler.call(withArguments: ["waiting", nWError.toDict()])
+        case .ready:
+          handler.call(withArguments: ["ready"])
+        case .failed(let nWError):
+          handler.call(withArguments: ["failed", nWError.toDict()])
+        case .cancelled:
+          handler.call(withArguments: ["cancelled"])
+        @unknown default:
+          handler.call(withArguments: ["\(state)"])
+        }
+      }
     }
   }
 
   func newConnection(_ conn: NWConnection, connID: String) {
-    guard let handler = newConnHandler?.value else { return }
-    handler.call(withArguments: [
-      connID,
-      // may add more useful information in the future
-      [
-        "path": conn.currentPath?.remoteEndpoint?.debugDescription
-      ] as [String: Any?]
-    ])
+    DispatchQueue.main.async { [weak self] in
+      guard let self, let instance = self.pluginInstance else { return }
+      instance.withActiveContext {
+        guard let handler = self.newConnHandler?.value else { return }
+        handler.call(withArguments: [
+          connID,
+          // may add more useful information in the future
+          [
+            "path": conn.currentPath?.remoteEndpoint?.debugDescription
+          ] as [String: Any?]
+        ])
+      }
+    }
   }
 
   func connection(_ conn: String, stateUpdated state: NWConnection.State) {
-    guard let handler = connStateHandler?.value else { return }
-
-    switch state {
-    case .setup:
-      handler.call(withArguments: [conn, "setup"])
-    case .waiting(let nWError):
-      handler.call(withArguments: [conn, "waiting", nWError.toDict()])
-    case .preparing:
-      handler.call(withArguments: [conn, "preparing"])
-    case .ready:
-      handler.call(withArguments: [conn, "ready"])
-    case .failed(let nWError):
-      handler.call(withArguments: [conn, "failed", nWError.toDict()])
-    case .cancelled:
-      handler.call(withArguments: [conn, "cancelled"])
-    @unknown default:
-      handler.call(withArguments: [conn, "\(state)"])
+    DispatchQueue.main.async { [weak self] in
+      guard let self, let instance = self.pluginInstance else { return }
+      instance.withActiveContext {
+        guard let handler = self.connStateHandler?.value else { return }
+        switch state {
+        case .setup:
+          handler.call(withArguments: [conn, "setup"])
+        case .waiting(let nWError):
+          handler.call(withArguments: [conn, "waiting", nWError.toDict()])
+        case .preparing:
+          handler.call(withArguments: [conn, "preparing"])
+        case .ready:
+          handler.call(withArguments: [conn, "ready"])
+        case .failed(let nWError):
+          handler.call(withArguments: [conn, "failed", nWError.toDict()])
+        case .cancelled:
+          handler.call(withArguments: [conn, "cancelled"])
+        @unknown default:
+          handler.call(withArguments: [conn, "\(state)"])
+        }
+      }
     }
   }
 
   func connection(_ conn: String, receivedData data: Data, context: NWConnection.ContentContext) {
-    guard let handler = self.messageHandler?.value else { return }
-
-    let wsMessage = WSMessage(data: data)
-    handler.call(withArguments: [conn, wsMessage])
+    DispatchQueue.main.async { [weak self] in
+      guard let self, let instance = self.pluginInstance else { return }
+      instance.withActiveContext {
+        guard let handler = self.messageHandler?.value else { return }
+        let wsMessage = WSMessage(data: data)
+        handler.call(withArguments: [conn, wsMessage])
+      }
+    }
   }
 }
 

--- a/iina/JavascriptMessageHub.swift
+++ b/iina/JavascriptMessageHub.swift
@@ -19,7 +19,8 @@ class JavascriptMessageHub {
   }
 
   func postMessage(to webView: WKWebView, name: String, data: JSValue) {
-    DispatchQueue.main.async {
+    DispatchQueue.main.async { [weak self] in
+      guard let instance = self?.reference?.pluginInstance, instance.isActive else { return }
       var arg: String?
 
       if data.isNumber {
@@ -37,6 +38,7 @@ class JavascriptMessageHub {
         }
       }
 
+      guard instance.isActive else { return }
       if let arg {
         webView.evaluateJavaScript("window.iina._emit(`\(name)`, \(arg))")
       } else {
@@ -46,10 +48,15 @@ class JavascriptMessageHub {
   }
 
   func clearListeners() {
+    if let reference, let context = reference.context {
+      listeners.values.forEach { context.virtualMachine.removeManagedReference($0, withOwner: reference) }
+    }
     listeners.removeAll()
   }
 
   func addListener(forEvent name: String, callback: JSValue) {
+    dispatchPrecondition(condition: .onQueue(.main))
+    guard let instance = reference?.pluginInstance, instance.isActive else { return }
     if let previousCallback = listeners[name] {
       JSContext.current()!.virtualMachine.removeManagedReference(previousCallback, withOwner: reference)
     }
@@ -59,7 +66,8 @@ class JavascriptMessageHub {
   }
 
   func callListener(forEvent name: String, withDataString dataString: String?) {
-    guard let callback = listeners[name] else { return }
+    guard let instance = reference?.pluginInstance, instance.isActive,
+          let callback = listeners[name], callback.value != nil else { return }
 
     let context = callback.value.context
     var jsValue: JSValue?
@@ -82,18 +90,21 @@ class JavascriptMessageHub {
       }
     }
 
-    if let jsValue {
-      callback.value.call(withArguments: [jsValue])
-    } else {
-      callback.value.call(withArguments: [])
+    instance.withActiveContext {
+      if let jsValue {
+        callback.value.call(withArguments: [jsValue])
+      } else {
+        callback.value.call(withArguments: [])
+      }
     }
   }
 
   func callListener(forEvent name: String, withDataObject dataObject: Any?, userInfo: Any? = nil) {
-    guard let callback = listeners[name] else { return }
+    guard let instance = reference?.pluginInstance, instance.isActive,
+          let callback = listeners[name], callback.value != nil else { return }
     let data = JSValue(object: dataObject, in: callback.value.context) ?? NSNull()
     let userInfo = userInfo ?? NSNull()
-    callback.value.call(withArguments: [data, userInfo])
+    instance.withActiveContext { callback.value.call(withArguments: [data, userInfo]) }
   }
 
   func receiveMessageFromUserContentController(_ message: WKScriptMessage) {

--- a/iina/JavascriptPlugin.swift
+++ b/iina/JavascriptPlugin.swift
@@ -107,6 +107,7 @@ class JavascriptPlugin: NSObject {
   let defaultPreferences: [String: Any]
 
   static func recreateAllPlugins() {
+    plugins.forEach { $0.globalInstance?.tearDown() }
     plugins = loadPlugins()
   }
 
@@ -170,8 +171,10 @@ class JavascriptPlugin: NSObject {
       if enabled {
         // no need to reload, unless forced
         guard forced else { return }
+        globalInstance?.tearDown()
         globalInstance = .init(player: nil, plugin: self)
       } else {
+        globalInstance?.tearDown()
         globalInstance = nil
       }
     }

--- a/iina/JavascriptPluginInstance.swift
+++ b/iina/JavascriptPluginInstance.swift
@@ -14,6 +14,13 @@ class JavascriptPluginInstance {
   private var polyfill: JavascriptPolyfill!
 
   lazy var js: JSContext = createJSContext()
+  // Main-thread confinement includes JavaScriptCore, API resource registries,
+  // pending callbacks and active hooks. Background IO may only enqueue delivery.
+  private(set) var isActive = true
+  fileprivate var pendingCallbacks: [UUID: JavascriptPluginCallback] = [:]
+
+  fileprivate var activeHookContinuations: [UUID: JavascriptPluginHookContinuation] = [:]
+
   var logHandler: ((String, Logger.Level) -> Void)?
 
   weak var player: PlayerCore!
@@ -55,6 +62,7 @@ class JavascriptPluginInstance {
   private var currentFileStack: [URL] = []
 
   init(player: PlayerCore?, plugin: JavascriptPlugin) {
+    dispatchPrecondition(condition: .onQueue(.main))
     self.plugin = plugin
 
     if let player {
@@ -73,8 +81,43 @@ class JavascriptPluginInstance {
     if let plugin = self.plugin {
       Logger.log("Unload \(plugin.name)", level: .debug, subsystem: subsystem)
     }
+    tearDown()
+  }
+
+  /// Called before removing or replacing an instance, even if another owner retains it.
+  func tearDown() {
+    dispatchPrecondition(condition: .onQueue(.main))
+    guard isActive else { return }
+    isActive = false
     polyfill.removeAllTimers()
+    pendingCallbacks.values.forEach { $0.invalidate() }
+    pendingCallbacks.removeAll()
+    // Cancel delivery first, then release mpv even when the hook was awaiting IO
+    // that cleanup will cancel. Remove ownership before calling native code.
+    let continuations = Array(activeHookContinuations.values)
+    activeHookContinuations.removeAll()
+    continuations.forEach { $0.finish() }
     apis.values.forEach { $0.cleanUp(self) }
+  }
+
+  func makeCallback(_ values: [JSValue], once: Bool = true) -> JavascriptPluginCallback {
+    dispatchPrecondition(condition: .onQueue(.main))
+    let callback = JavascriptPluginCallback(instance: self, values: values, once: once)
+    if isActive {
+      pendingCallbacks[callback.id] = callback
+    } else {
+      callback.invalidate()
+    }
+    return callback
+  }
+
+  /// A callback may enter a modal AppKit loop in which the user disables/reloads
+  /// plugins. Keep both weak API owners alive until that in-flight call returns.
+  @discardableResult
+  func withActiveContext<T>(_ body: () -> T) -> T? {
+    dispatchPrecondition(condition: .onQueue(.main))
+    guard isActive, let plugin else { return nil }
+    return withExtendedLifetime((self, plugin), body)
   }
 
   func canAccess(url: URL) -> Bool {
@@ -96,6 +139,7 @@ class JavascriptPluginInstance {
   }
 
   @objc func menuItemAction(_ sender: NSMenuItem) {
+    guard isActive else { return }
     guard let item = sender.representedObject as? JavascriptPluginMenuItem else { return }
     if !item.callAction() {
       Logger.log("Action of the menu item \"\(item.title)\" is not a function", level: .error, subsystem: subsystem)
@@ -103,6 +147,7 @@ class JavascriptPluginInstance {
   }
 
   @objc func playlistMenuItemAction(_ sender: NSMenuItem) {
+    guard isActive else { return }
     guard let item = sender.representedObject as? JavascriptPluginMenuItem else { return }
     if !item.callAction() {
       Logger.log("Action of the menu item \"\(item.title)\" is not a function", level: .error, subsystem: subsystem)
@@ -111,6 +156,8 @@ class JavascriptPluginInstance {
 
   @discardableResult
   func evaluateFile(_ url: URL, asModule: Bool = false) -> JSValue! {
+    dispatchPrecondition(condition: .onQueue(.main))
+    guard isActive else { return nil }
     currentFileStack.append(url)
     guard let content = try? String(contentsOf: url) else {
       Logger.log("Cannot read script \(url.path)", level: .error, subsystem: subsystem)
@@ -140,7 +187,8 @@ class JavascriptPluginInstance {
   private func createJSContext() -> JSContext {
     let ctx = JSContext()!
     ctx.name = "\(isGlobal ? "Global" : "Main") — \(plugin.name)"
-    ctx.exceptionHandler = { [unowned self] context, exception in
+    ctx.exceptionHandler = { [weak self] context, exception in
+      guard let self, self.isActive else { return }
       let message = exception?.toString() ?? "Unknown exception"
       let stack = exception?.objectForKeyedSubscript("stack")?.toString() ?? "???"
       Logger.log(
@@ -189,5 +237,86 @@ class JavascriptPluginInstance {
     polyfill.register(inContext: ctx)
 
     return ctx
+  }
+}
+
+/// Teardown clears the JavaScript values even if native IO still retains this token.
+/// Its JavaScript values and the instance registry are accessed on the main thread.
+final class JavascriptPluginCallback {
+  fileprivate let id = UUID()
+  private weak var instance: JavascriptPluginInstance?
+  private var values: [JSValue]?
+  private let once: Bool
+
+  fileprivate init(instance: JavascriptPluginInstance, values: [JSValue], once: Bool) {
+    self.instance = instance
+    self.values = values
+    self.once = once
+  }
+
+  fileprivate func invalidate() {
+    dispatchPrecondition(condition: .onQueue(.main))
+    values = nil
+  }
+
+  func cancel() {
+    if !Thread.isMainThread {
+      DispatchQueue.main.async { [self] in cancel() }
+      return
+    }
+    instance?.pendingCallbacks.removeValue(forKey: id)
+    invalidate()
+  }
+
+  func callHook(withNextBlock next: @escaping () -> Void) {
+    DispatchQueue.main.async { [self] in
+      guard let instance, instance.isActive, let callback = values?.first else {
+        next()
+        return
+      }
+      let continuation = JavascriptPluginHookContinuation(next: next)
+      instance.activeHookContinuations[continuation.id] = continuation
+      let advance: @convention(block) () -> Void = { [weak instance] in
+        instance?.activeHookContinuations.removeValue(forKey: continuation.id)
+        continuation.finish()
+      }
+      instance.withActiveContext {
+        // Reading constructor can itself reenter JS and trigger teardown.
+        let isAsync = callback.forProperty("constructor")?.forProperty("name")?.toString() == "AsyncFunction"
+        guard instance.isActive else { return }
+        callback.call(withArguments: [JSValue(object: advance, in: callback.context)!])
+        if !isAsync { advance() }
+      }
+    }
+  }
+
+  func resolve(_ arguments: [Any]) { call(withArguments: arguments) }
+  func reject(_ arguments: [Any]) { call(withArguments: arguments, index: 1) }
+
+  func call(withArguments arguments: [Any], index: Int = 0) {
+    DispatchQueue.main.async { [self] in
+      guard let instance, instance.isActive, let values else { return }
+      // Take the values before removing the registry entry. Completion and teardown
+      // can both release their ownership without invalidating the current call.
+      if once { cancel() }
+      instance.withActiveContext {
+        values[index].call(withArguments: arguments)
+      }
+    }
+  }
+}
+
+/// Native continuation only; never owns JavaScript. All access is on main.
+fileprivate final class JavascriptPluginHookContinuation {
+  let id = UUID()
+  private var next: (() -> Void)?
+
+  init(next: @escaping () -> Void) { self.next = next }
+
+  func finish() {
+    dispatchPrecondition(condition: .onQueue(.main))
+    let action = next
+    next = nil
+    action?()
   }
 }

--- a/iina/JavascriptPolyfill.swift
+++ b/iina/JavascriptPolyfill.swift
@@ -11,6 +11,9 @@ import JavaScriptCore
 class JavascriptPolyfill {
   weak var plugin: JavascriptPluginInstance!
   var timers = [String: Timer]()
+  private var pendingTimers = Set<String>()
+  private let timerLock = NSLock()
+  private var stopped = false
 
   init(pluginInstance: JavascriptPluginInstance) {
     self.plugin = pluginInstance
@@ -23,6 +26,10 @@ class JavascriptPolyfill {
   }
 
   func removeAllTimers() {
+    timerLock.lock()
+    defer { timerLock.unlock() }
+    stopped = true
+    pendingTimers.removeAll()
     for timer in timers.values {
       timer.invalidate()
     }
@@ -30,6 +37,9 @@ class JavascriptPolyfill {
   }
 
   func removeTimer(identifier: String) {
+    timerLock.lock()
+    defer { timerLock.unlock() }
+    pendingTimers.remove(identifier)
     let timer = self.timers.removeValue(forKey: identifier)
     timer?.invalidate()
   }
@@ -38,42 +48,55 @@ class JavascriptPolyfill {
     let timeInterval  = ms/1000.0
     let uuid = NSUUID().uuidString
 
-    DispatchQueue.main.async(execute: {
-      let timer = Timer.scheduledTimer(timeInterval: timeInterval,
-                                       target: self,
-                                       selector: #selector(self.callJSCallback),
-                                       userInfo: callback,
-                                       repeats: repeats)
-      self.timers[uuid] = timer
-    })
+    timerLock.lock()
+    guard !stopped else {
+      timerLock.unlock()
+      return uuid
+    }
+    pendingTimers.insert(uuid)
+    timerLock.unlock()
+    DispatchQueue.main.async { [weak self] in
+      guard let self, let plugin = self.plugin, plugin.isActive else { return }
+      self.timerLock.lock()
+      defer { self.timerLock.unlock() }
+      guard self.pendingTimers.remove(uuid) != nil else { return }
+      withExtendedLifetime(plugin) {
+        let timer = Timer.scheduledTimer(timeInterval: timeInterval,
+                                        target: self,
+                                        selector: #selector(self.callJSCallback),
+                                        userInfo: callback,
+                                        repeats: repeats)
+        self.timers[uuid] = timer
+      }
+    }
     return uuid
   }
 
   @objc func callJSCallback(_ timer: Timer) {
-    guard timer.isValid else { return }
+    guard timer.isValid, let plugin, plugin.isActive else { return }
     let callback = (timer.userInfo as! JSValue)
-    callback.call(withArguments: nil)
+    plugin.withActiveContext { callback.call(withArguments: nil) }
   }
 
   func register(inContext context: JSContext) {
-    let setInterval: @convention(block) (JSValue, Double) -> String = { [unowned self] (callback, ms) in
-      return self.createTimer(callback: callback, ms: ms, repeats: true)
+    let setInterval: @convention(block) (JSValue, Double) -> String = { [weak self] (callback, ms) in
+      return self?.createTimer(callback: callback, ms: ms, repeats: true) ?? ""
     }
 
-    let setTimeout: @convention(block) (JSValue, Double) -> String = { [unowned self] (callback, ms) in
-      return self.createTimer(callback: callback, ms: ms, repeats: false)
+    let setTimeout: @convention(block) (JSValue, Double) -> String = { [weak self] (callback, ms) in
+      return self?.createTimer(callback: callback, ms: ms, repeats: false) ?? ""
     }
 
-    let clearInterval: @convention(block) (String) -> () = { [unowned self] identifier in
-      self.removeTimer(identifier: identifier)
+    let clearInterval: @convention(block) (String) -> () = { [weak self] identifier in
+      self?.removeTimer(identifier: identifier)
     }
 
-    let clearTimeout: @convention(block) (String) -> () = { [unowned self] identifier in
-      self.removeTimer(identifier: identifier)
+    let clearTimeout: @convention(block) (String) -> () = { [weak self] identifier in
+      self?.removeTimer(identifier: identifier)
     }
 
-    let require: @convention(block) (String) -> Any? = { [unowned self] path in
-      let instance = self.plugin!
+    let require: @convention(block) (String) -> Any? = { [weak self] path in
+      guard let instance = self?.plugin, instance.isActive else { return nil }
       let currentPath = instance.currentFile!.deletingLastPathComponent()
       let requiredURL = currentPath.appendingPathComponent(path).standardized
       guard requiredURL.absoluteString.hasPrefix(instance.plugin.root.absoluteString) else {

--- a/iina/JustXMLRPC.swift
+++ b/iina/JustXMLRPC.swift
@@ -39,10 +39,12 @@ class JustXMLRPC {
     return formatter
   }()
 
+  private let session: URLSession?
   var location: String
 
-  init(_ loc: String) {
+  init(_ loc: String, session: URLSession? = nil) {
     self.location = loc
+    self.session = session
   }
 
   /**
@@ -61,7 +63,7 @@ class JustXMLRPC {
     methodCall.addChild(params)
     let reqXML = XMLDocument(rootElement: methodCall)
     // Request
-    Just.post(location, requestBody: reqXML.xmlData, asyncCompletionHandler: { response in
+    let handleResponse: (HTTPResult) -> Void = { response in
       if response.ok, let content = response.content, let responseDoc = try? XMLDocument(data: content) {
         let rootElement = responseDoc.rootElement()
         if let _ = rootElement?.child("fault") {
@@ -78,7 +80,21 @@ class JustXMLRPC {
         callback(.error(XMLRPCError(method: method, httpCode: response.statusCode ?? 0,
                                     reason: response.reason, underlyingError: response.error)))
       }
-    })
+    }
+    if let session {
+      let builder = HTTP(session: session)
+      guard let request = builder.synthesizeRequest(.post, url: location, params: [:],
+        data: [:], json: nil, headers: .init(dictionary: [:]), files: [:], auth: nil,
+        timeout: nil, urlQuery: nil, requestBody: reqXML.xmlData) else {
+        callback(.failure)
+        return
+      }
+      session.dataTask(with: request) { data, response, error in
+        handleResponse(HTTPResult(data: data, response: response, error: error, task: nil))
+      }.resume()
+    } else {
+      Just.post(location, requestBody: reqXML.xmlData, asyncCompletionHandler: handleResponse)
+    }
   }
 
   private static func toValueElement(_ value: Any) -> XMLElement {

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -49,15 +49,13 @@ struct MPVHookValue {
   var id: String?
   var isJavascript: Bool
   var block: Block?
-  var jsBlock: JSManagedValue!
-  var context: JSContext!
-
-  init(withIdentifier id: String, jsContext context: JSContext, jsBlock block: JSValue, owner: JavascriptAPIMpv) {
+  init(withIdentifier id: String, jsContext context: JSContext, jsBlock callback: JSValue, owner: JavascriptAPIMpv) {
     self.id = id
     self.isJavascript = true
-    self.jsBlock = JSManagedValue(value: block)
-    self.context = context
-    context.virtualMachine.addManagedReference(self.jsBlock, withOwner: owner)
+    // MPV_EVENT_HOOK arrives on the mpv queue. Only the opaque token crosses
+    // that boundary; JavaScript and continuation ownership live on main.
+    let token = owner.pluginInstance.makeCallback([callback], once: false)
+    self.block = { next in token.callHook(withNextBlock: next) }
   }
 
   init(withBlock block: @escaping Block) {
@@ -66,19 +64,7 @@ struct MPVHookValue {
   }
 
   func call(withNextBlock next: @escaping () -> Void) {
-    if isJavascript {
-      let block: @convention(block) () -> Void = { next() }
-      guard let callback = jsBlock.value else {
-        next()
-        return
-      }
-      callback.call(withArguments: [JSValue(object: block, in: context)!])
-      if callback.forProperty("constructor")?.forProperty("name")?.toString() != "AsyncFunction" {
-        next()
-      }
-    } else {
-      block!(next)
-    }
+    block!(next)
   }
 }
 

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -355,12 +355,13 @@ class PlayerCore: NSObject {
   }
 
   func clearPlugins() {
+    plugins.forEach { $0.tearDown() }
     pluginMap.removeAll()
     plugins.removeAll()
   }
 
   func loadPlugins() {
-    pluginMap.removeAll()
+    clearPlugins()
     plugins = JavascriptPlugin.plugins.compactMap { plugin in
       guard plugin.enabled else { return nil }
       let instance = JavascriptPluginInstance(player: self, plugin: plugin)
@@ -375,8 +376,10 @@ class PlayerCore: NSObject {
       if plugin.enabled {
         // no need to reload, unless forced
         guard forced else { return }
+        pluginMap[id]?.tearDown()
         pluginMap[id] = JavascriptPluginInstance(player: self, plugin: plugin)
       } else {
+        pluginMap[id]?.tearDown()
         pluginMap.removeValue(forKey: id)
       }
     } else {
@@ -701,9 +704,12 @@ class PlayerCore: NSObject {
   ///     sent mpv could crash. The `stop` method takes care of instructing the background task to stop and will wait for it to stop
   ///     before sending a `stop` command to mpv. _However_ mpv will stop on its own if the end of the video is reached. When
   ///     that happens while IINA is quitting then this method may be called with the background task still running. If the background
-  ///     task is still running this method only changes the player state. When the background task ends it will notice that shutting
+  ///     task is still running this method stops plugins and changes the player state. When the background task ends it will notice that shutting
   ///     down was in progress and will call this method again to continue the process of shutting down..
   func shutdown() {
+    // Plugins must stop using player APIs before mpv starts quitting, including
+    // while shutdown is waiting for the background task to finish.
+    clearPlugins()
     info.state = .shuttingDown
     guard !backgroundTaskInUse else { return }
     log("Shutting down")
@@ -730,6 +736,9 @@ class PlayerCore: NSObject {
   ///     windows of vulnerability that can not be fully closed. IINA has no choice but to support a mpv initiated shutdown as best it
   ///     can.
   func mpvHasShutdown() {
+    // An externally initiated mpv quit bypasses shutdown(). Suppress further
+    // plugin callbacks as soon as its notification reaches the main thread.
+    clearPlugins()
     let isMPVInitiated = info.state != .shuttingDown
     let suffix = isMPVInitiated ? " (initiated by mpv)" : ""
     log("Player has shutdown\(suffix)")

--- a/iina/WebSocketServer.swift
+++ b/iina/WebSocketServer.swift
@@ -10,7 +10,7 @@ import Foundation
 import Network
 
 
-protocol WebSocketServerDelegate {
+protocol WebSocketServerDelegate: AnyObject {
   func stateUpdated(_ state: NWListener.State)
   func newConnection(_ conn: NWConnection, connID: String)
   func connection(_ conn: String, stateUpdated state: NWConnection.State)
@@ -20,11 +20,12 @@ protocol WebSocketServerDelegate {
 
 class WebSocketServer {
   let label: String
-  var delegate: WebSocketServerDelegate?
+  weak var delegate: WebSocketServerDelegate?
 
   var listener: NWListener
   var connections: [String: NWConnection] = [:]
   var timer: Timer?
+  private var stopped = false
 
   lazy var serverQueue = DispatchQueue(label: "IINAWebSocketServer.\(self.label)")
   let subsystem: Logger.Subsystem
@@ -55,17 +56,32 @@ class WebSocketServer {
   }
 
   func start() {
-    listener.newConnectionHandler = handleNewConnection(_:)
-    listener.stateUpdateHandler = handleStateUpdate(_:)
+    listener.newConnectionHandler = { [weak self] connection in
+      guard let self else { connection.cancel(); return }
+      self.handleNewConnection(connection)
+    }
+    listener.stateUpdateHandler = { [weak self] state in self?.handleStateUpdate(state) }
     // No error will be thrown here. If the port is in use, the server will fail immediately
     listener.start(queue: serverQueue)
   }
 
   func stop() {
-    listener.cancel()
+    serverQueue.async { [self] in
+      stopped = true
+      delegate = nil
+      listener.newConnectionHandler = nil
+      listener.stateUpdateHandler = nil
+      listener.cancel()
+      connections.values.forEach {
+        $0.stateUpdateHandler = nil
+        $0.cancel()
+      }
+      connections.removeAll()
+    }
   }
 
   private func handleNewConnection(_ connection: NWConnection) {
+    guard !stopped else { connection.cancel(); return }
     // Create a UUID to identify each connection
     let connID = UUID().uuidString
     Logger.log("New connection: \(connID)", level: .debug, subsystem: subsystem)
@@ -73,7 +89,8 @@ class WebSocketServer {
     connections[connID] = connection
     delegate?.newConnection(connection, connID: connID)
 
-    connection.stateUpdateHandler = { [unowned self] state in
+    connection.stateUpdateHandler = { [weak self, weak connection] state in
+      guard let self, let connection else { return }
       Logger.log("Connection \(state) (\(connID))", subsystem: subsystem)
       self.delegate?.connection(connID, stateUpdated: state)
       switch state {
@@ -89,29 +106,24 @@ class WebSocketServer {
 
     connection.start(queue: serverQueue)
 
-    func receive() {
-       connection.receiveMessage { [unowned self] (data, context, isComplete, error) in
-        if let data, let context {
-          // handle ping frames
-          if let metadata = context.protocolMetadata as? [NWProtocolWebSocket.Metadata],
-             metadata[0].opcode == .ping {
-            Logger.log("Ping (\(connID))", subsystem: subsystem)
-            let pongContext = NWConnection.ContentContext(
-              identifier: "pong",
-              metadata: [NWProtocolWebSocket.Metadata(opcode: .pong)]
-            )
-            connection.send(content: data, contentContext: pongContext, completion: .idempotent)
-          } else {
-            // normal data
-            Logger.log("Data (\(connID))", subsystem: subsystem)
-            self.delegate?.connection(connID, receivedData: data, context: context)
-          }
-          receive()
+    receive(connection, connID: connID)
+  }
+
+  private func receive(_ connection: NWConnection, connID: String) {
+    connection.receiveMessage { [weak self, weak connection] data, context, _, error in
+      guard let self, let connection, self.connections[connID] != nil else { return }
+      if let data, let context {
+        if let metadata = context.protocolMetadata as? [NWProtocolWebSocket.Metadata],
+           metadata.first?.opcode == .ping {
+          let pong = NWConnection.ContentContext(identifier: "pong",
+            metadata: [NWProtocolWebSocket.Metadata(opcode: .pong)])
+          connection.send(content: data, contentContext: pong, completion: .idempotent)
+        } else {
+          self.delegate?.connection(connID, receivedData: data, context: context)
         }
       }
+      if error == nil { self.receive(connection, connID: connID) }
     }
-
-    receive()
   }
 
   private func handleStateUpdate(_ state: NWListener.State) {
@@ -119,13 +131,16 @@ class WebSocketServer {
     delegate?.stateUpdated(state)
   }
 
-  func send(data: Data, to connection: NWConnection, callback: ((NWError?) -> Void)?) throws {
-    // do we need a separate send(text:to:) method to send text frames?
-    let metadata = NWProtocolWebSocket.Metadata(opcode: .binary)
-    let context = NWConnection.ContentContext(identifier: "message", metadata: [metadata])
-    connection.send(content: data, contentContext: context, isComplete: true, completion: .contentProcessed({ error in
-      callback?(error)
-    }))
+  func send(data: Data, to identifier: String, callback: @escaping (NWError?, Bool) -> Void) {
+    serverQueue.async { [self] in
+      guard !stopped, let connection = connections[identifier] else {
+        callback(nil, false)
+        return
+      }
+      let metadata = NWProtocolWebSocket.Metadata(opcode: .binary)
+      let context = NWConnection.ContentContext(identifier: "message", metadata: [metadata])
+      connection.send(content: data, contentContext: context, isComplete: true,
+                      completion: .contentProcessed { callback($0, true) })
+    }
   }
 }
-

--- a/other/tests/plugin-lifecycle/FileReviewTests.swift
+++ b/other/tests/plugin-lifecycle/FileReviewTests.swift
@@ -1,0 +1,162 @@
+import Cocoa
+import JavaScriptCore
+
+// Runs through the real HTTP API, session, Promise tokens and writer.
+enum LifecycleFileReviewTests {
+  static func run(plugin: JavascriptPlugin, mode: String) {
+    let env = ProcessInfo.processInfo.environment
+    let base = env["IINA_LIFECYCLE_HTTP_URL"]!
+    let folder = URL(fileURLWithPath: env["IINA_LIFECYCLE_REVIEW_RUN"]!)
+    let instance = plugin.globalInstance!
+    let js = instance.js
+    let staging = plugin.tmpURL
+    func staged() -> Set<String> {
+      Set((try! FileManager.default.contentsOfDirectory(atPath: staging.path)).filter { $0.hasPrefix(".iina-download-") })
+    }
+    let originalStaging = staged()
+    func request(_ suffix: String, to destination: URL) {
+      js.evaluateScript("var successes=0, failures=0, successType='', failure=null; iina.http.download('\(base)/\(suffix)', '\(destination.path)', {}).then(function(value){successes++; successType=typeof value},function(error){failures++; failure=error})")
+    }
+    func settled() {
+      LifecycleReviewTests.until { js.objectForKeyedSubscript("successes").toInt32() + js.objectForKeyedSubscript("failures").toInt32() > 0 }
+    }
+    func success() {
+      settled()
+      precondition(js.objectForKeyedSubscript("successes").toInt32() == 1)
+      precondition(js.objectForKeyedSubscript("failures").toInt32() == 0)
+      precondition(js.objectForKeyedSubscript("successType").toString() == "undefined")
+      precondition(staged() == originalStaging)
+    }
+    func metadata(_ url: URL) -> stat {
+      var result = stat()
+      precondition(lstat(url.path, &result) == 0)
+      return result
+    }
+    if mode == "file-exit" {
+      let destination = folder.appendingPathComponent("cancelled-target")
+      LifecycleDownloadProbe.arm()
+      request("body", to: destination)
+      LifecycleReviewTests.until { LifecycleDownloadProbe.isPaused }
+      let names = staged().subtracting(originalStaging)
+      precondition(names.count == 1, "writer must actually own a staging file before teardown")
+      let paths = names.map { staging.appendingPathComponent($0).path }
+      let record: [String: Any] = ["stagingPaths": paths, "target": destination.path, "writerPaused": true]
+      try! JSONSerialization.data(withJSONObject: record).write(to: folder.appendingPathComponent("exit-check.json"))
+      // This is the real global-plugin disable/teardown path. Do NOT release the
+      // semaphore, pump the run loop or wait for the writer before normal exit.
+      plugin.enabled = false
+      precondition(!LifecycleDownloadProbe.finished)
+      print("FILE EXIT: teardown returned while writer remains paused; normal exit(0)")
+      exit(0)
+    }
+
+    let existing = folder.appendingPathComponent("existing")
+    try! Data("old".utf8).write(to: existing)
+    precondition(chmod(existing.path, 0o755) == 0)
+    let inode = metadata(existing).st_ino
+    let hard = folder.appendingPathComponent("hard-link")
+    precondition(link(existing.path, hard.path) == 0)
+    request("held", to: existing); success()
+    precondition(metadata(existing).st_mode & 0o7777 == 0o755 && metadata(existing).st_ino == inode)
+    let body = Data(repeating: 120, count: 20)
+    precondition(try! Data(contentsOf: existing) == body)
+    precondition(try! Data(contentsOf: hard) == body)
+    print("PASS file 0755 and inode/hard-link semantics, exact body, success(undefined)=1/error=0")
+
+    let target = folder.appendingPathComponent("symlink-target")
+    try! Data("original target".utf8).write(to: target)
+    precondition(chmod(target.path, 0o754) == 0)
+    let sym = folder.appendingPathComponent("symlink")
+    precondition(symlink("symlink-target", sym.path) == 0)
+    let symlinkInode = metadata(sym).st_ino, targetInode = metadata(target).st_ino
+    request("held", to: sym); success()
+    precondition(metadata(sym).st_mode & S_IFMT == S_IFLNK && metadata(sym).st_ino == symlinkInode)
+    precondition(try! FileManager.default.destinationOfSymbolicLink(atPath: sym.path) == "symlink-target")
+    precondition(metadata(target).st_ino == targetInode && metadata(target).st_mode & 0o7777 == 0o754)
+    precondition(try! Data(contentsOf: target) == body)
+    print("PASS relative destination symlink preserved; target inode/mode/body preserved or updated correctly")
+
+    let control = folder.appendingPathComponent("data-write-control")
+    try! body.write(to: control)
+    let new = folder.appendingPathComponent("new-file")
+    request("held", to: new); success()
+    precondition(metadata(new).st_mode & 0o7777 == metadata(control).st_mode & 0o7777)
+    precondition(try! Data(contentsOf: new) == body)
+    print("PASS new-file mode matches native Data.write under the same umask; exact body and successful result")
+
+    let dangling = folder.appendingPathComponent("dangling-link")
+    precondition(symlink("new-target", dangling.path) == 0)
+    request("held", to: dangling); success()
+    precondition(metadata(dangling).st_mode & S_IFMT == S_IFLNK)
+    precondition(try! Data(contentsOf: folder.appendingPathComponent("new-target")) == body)
+    print("PASS dangling destination symlink preserved; target created")
+
+    let directory = folder.appendingPathComponent("no-directory-write")
+    try! FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    let inside = directory.appendingPathComponent("writable-file")
+    try! Data("old".utf8).write(to: inside)
+    precondition(chmod(directory.path, 0o555) == 0)
+    request("held", to: inside); success()
+    precondition(try! Data(contentsOf: inside) == body)
+    precondition(chmod(directory.path, 0o755) == 0)
+    print("PASS existing writable file in a non-writable directory (staging uses private plugin temp)")
+
+    // Filesystem failure must reject, without being mistaken for success.
+    let invalid = folder.appendingPathComponent("absent-parent/file")
+    request("held", to: invalid); settled()
+    precondition(js.objectForKeyedSubscript("successes").toInt32() == 0 && js.objectForKeyedSubscript("failures").toInt32() == 1)
+    precondition(js.objectForKeyedSubscript("failure").toString() == "Unable to write to the destination.")
+    precondition(!FileManager.default.fileExists(atPath: invalid.path))
+    precondition(staged() == originalStaging)
+    print("PASS filesystem failure: success=0/error=1, exact error, target absent, staging removed")
+
+    // HTTP failure must preserve the server result and leave the old target intact.
+    request("error", to: existing); settled()
+    precondition(js.objectForKeyedSubscript("successes").toInt32() == 0 && js.objectForKeyedSubscript("failures").toInt32() == 1)
+    precondition(js.evaluateScript("failure.statusCode === 503 && failure.text === '{\"error\":\"download-failed\"}' && failure.data.error === 'download-failed'")!.toBool())
+    precondition(try! Data(contentsOf: existing) == body)
+    precondition(metadata(existing).st_mode & 0o7777 == 0o755)
+    precondition(staged() == originalStaging)
+    print("PASS HTTP error: success=0/error=1, exact status/text/JSON, existing target untouched")
+    // Data.write is in-place, not an atomic replacement. If cancellation starts
+    // after publication, already written bytes remain but cannot change later.
+    let partial = folder.appendingPathComponent("partial-publication")
+    LifecyclePublicationProbe.armed = true
+    request("body", to: partial)
+    LifecycleReviewTests.until { LifecyclePublicationProbe.isPaused }
+    let beforeCancel = try! Data(contentsOf: partial)
+    precondition(beforeCancel.count == 256 * 1024 && beforeCancel.allSatisfy { $0 == 120 })
+    plugin.enabled = false
+    precondition(staged() == originalStaging)
+    LifecyclePublicationProbe.release.signal()
+    LifecycleReviewTests.until { LifecyclePublicationProbe.finished }
+    LifecycleReviewTests.pump(0.05)
+    precondition(try! Data(contentsOf: partial) == beforeCancel)
+    precondition(js.objectForKeyedSubscript("successes").toInt32() == 0 && js.objectForKeyedSubscript("failures").toInt32() == 0)
+    print("PASS cancel during in-place publication: pre-cancel bytes retained, zero later mutation or JS settlement, staging immediately absent")
+  }
+}
+
+// Observation seam only; production has no semaphore or test-specific branch.
+enum LifecyclePublicationProbe {
+  private static let lock = NSLock()
+  private static var enabled = false, paused = false, done = false
+  static let release = DispatchSemaphore(value: 0)
+  static var armed: Bool {
+    get { lock.lock(); defer { lock.unlock() }; return enabled }
+    set { lock.lock(); enabled = newValue; lock.unlock() }
+  }
+  static var isPaused: Bool { lock.lock(); defer { lock.unlock() }; return paused }
+  static var finished: Bool { lock.lock(); defer { lock.unlock() }; return done }
+  static func afterBlock() {
+    lock.lock()
+    let wait = enabled
+    if wait { enabled = false; paused = true }
+    lock.unlock()
+    if wait {
+      precondition(!Thread.isMainThread)
+      precondition(release.wait(timeout: .now()+3) == .success)
+      lock.lock(); done = true; lock.unlock()
+    }
+  }
+}

--- a/other/tests/plugin-lifecycle/PORTABLE.md
+++ b/other/tests/plugin-lifecycle/PORTABLE.md
@@ -1,0 +1,38 @@
+# Plugin lifecycle regression tests
+
+These tests build and run a disposable IINA application from the current checkout.
+They never launch or replace an installed IINA. The generated app uses bundle ID
+`org.iina.lifecycle-tests`, a private home directory, two local test plugins and
+loopback-only network access.
+
+From the repository root, after downloading IINA's normal build dependencies:
+
+```sh
+python3 other/tests/plugin-lifecycle/portable.py
+```
+
+For an existing dependency and Swift package cache, pass paths relative to the
+checkout or absolute paths supplied by the caller:
+
+```sh
+python3 other/tests/plugin-lifecycle/portable.py \
+  --dependencies-from path/to/deps \
+  --cloned-packages path/to/SourcePackages \
+  --package-cache path/to/PackageCache
+```
+
+The runner creates a unique ignored directory under `build/plugin-lifecycle-tests`,
+copies the tracked checkout, overlays the 16 lifecycle source files, and appends
+the Swift driver and deterministic pause probes only to that generated source.
+It runs three modes: the lifecycle suite, exact download file semantics, and a
+normal `exit(0)` while a staging writer is paused. Each child has a 45-second
+limit. The exit test does not release or join its paused writer before exiting.
+
+Coverage includes retained and idempotent teardown; timer, event, Promise and
+native IO cancellation; exactly-once mpv hook continuation; reentrant resource
+creation; isolation between two PlayerCore instances; exact download success,
+error and cancellation; inode/mode/hard-link/symlink behavior; and immediate
+staging cleanup during cancel, destination publication and process exit.
+
+Generated source, products and logs are local evidence and are not contribution
+files. The test-only source transformations must never be applied to production.

--- a/other/tests/plugin-lifecycle/PortableDriver.swift
+++ b/other/tests/plugin-lifecycle/PortableDriver.swift
@@ -1,0 +1,49 @@
+import Cocoa
+import JavaScriptCore
+
+// Entry point for the generated test build. This file is never added to IINA.
+@main
+struct PluginLifecyclePortableDriver {
+  static func main() {
+    let environment = ProcessInfo.processInfo.environment
+    guard let root = environment["IINA_LIFECYCLE_TEST_ROOT"],
+          Bundle.main.bundleIdentifier == "org.iina.lifecycle-tests",
+          NSHomeDirectory() == root + "/home",
+          Utility.pluginsURL.path.hasPrefix(root + "/home/"),
+          Utility.cacheURL.path.hasPrefix(root + "/home/"),
+          Utility.tempDirURL.path == root + "/tmp" else {
+      fatalError("Plugin lifecycle test isolation failed")
+    }
+    guard CommandLine.arguments.count == 2 else { exit(64) }
+
+    setbuf(stdout, nil)
+    _ = NSApplication.shared
+    let delegate = AppDelegate()
+    NSApp.delegate = delegate
+    for (key, value) in Preference.defaultPreference {
+      UserDefaults.standard.register(defaults: [key.rawValue: value])
+    }
+    UserDefaults.standard.set(false, forKey: "useMediaKeys")
+    UserDefaults.standard.set(false, forKey: "recordRecentFiles")
+    UserDefaults.standard.set(false, forKey: "SUEnableAutomaticChecks")
+    UserDefaults.standard.set(false, forKey: "SUAutomaticallyUpdate")
+    URLCache.shared = URLCache(memoryCapacity: 0, diskCapacity: 0, diskPath: nil)
+
+    guard let plugin = JavascriptPlugin(filename: "lifecycle.iinaplugin") else {
+      fatalError("Cannot load lifecycle test fixture")
+    }
+    plugin.enabled = true
+
+    switch CommandLine.arguments[1] {
+    case "lifecycle":
+      LifecycleReviewTests.run(plugin: plugin, root: root, red: false)
+      plugin.enabled = false
+    case "files", "file-exit":
+      LifecycleFileReviewTests.run(plugin: plugin, mode: CommandLine.arguments[1] == "files" ? "file-semantics" : "file-exit")
+      plugin.enabled = false
+    default:
+      exit(64)
+    }
+    withExtendedLifetime(delegate) {}
+  }
+}

--- a/other/tests/plugin-lifecycle/ReviewTests.swift
+++ b/other/tests/plugin-lifecycle/ReviewTests.swift
@@ -1,0 +1,332 @@
+import Cocoa
+import JavaScriptCore
+
+// Compiled into the disposable laboratory executable only.
+enum LifecycleReviewTests {
+  static func run(plugin: JavascriptPlugin, root: String, red: Bool) {
+    let env = ProcessInfo.processInfo.environment
+    let url = env["IINA_LIFECYCLE_HTTP_URL"]!
+    let folder = env["IINA_LIFECYCLE_REVIEW_RUN"]!
+    func pump(_ seconds: Double) { RunLoop.main.run(until: Date(timeIntervalSinceNow: seconds)) }
+    func fresh() -> JavascriptPluginInstance { JavascriptPluginInstance(player: nil, plugin: plugin) }
+    var findings = 0
+    for kind in ["timer", "http", "exec"] {
+      for cancel in [false, true] {
+        let instance = fresh(), js = instance.js
+        let api = JavascriptAPIMpv(context: js, pluginInstance: instance)
+        var nextCount = 0
+        let stem = folder + "/hook-\(kind)-\(cancel)"
+        let awaited: String
+        switch kind {
+        case "timer": awaited = "new Promise(r => setTimeout(r, 150))"
+        case "http": awaited = "iina.http.get('\(url)/held', {})"
+        default: awaited = "iina.utils.exec('\(root)/exec-probe', ['\(stem)-gate', '\(stem)-pid', 'normal'])"
+        }
+        js.evaluateScript("var entered = 0, delivered = 0; var mainThread = false; var savedNext;")
+        let threadCheck: @convention(block) () -> Bool = { Thread.isMainThread }
+        js.setObject(threadCheck, forKeyedSubscript: "isMainThread" as NSString)
+        let callback = js.evaluateScript("(async function(next) { entered++; savedNext=next; mainThread = isMainThread(); await \(awaited); delivered++; next(); next(); })")!
+        let hook = MPVHookValue(withIdentifier: "review", jsContext: js, jsBlock: callback, owner: api)
+        // Same ingress as MPV_EVENT_HOOK; no other queue touches this JSContext.
+        DispatchQueue.global().async { hook.call { nextCount += 1 } }
+        pump(0.08)
+        let entered = js.objectForKeyedSubscript("entered").toInt32()
+        precondition(entered == 1)
+        let onMain = js.objectForKeyedSubscript("mainThread").toBool()
+        if cancel { instance.tearDown(); instance.tearDown() }
+        try! Data([1]).write(to: URL(fileURLWithPath: stem + "-gate"))
+        until { nextCount == 1 }
+        pump(cancel ? 0.35 : 0.05)
+        let delivered = js.objectForKeyedSubscript("delivered").toInt32()
+        let good = nextCount == 1 && delivered == (cancel ? 0 : 1) && onMain
+        print("REVIEW hook \(kind) cancel=\(cancel) main=\(onMain) next=\(nextCount) JS=\(delivered) \(good ? "PASS" : "FINDING")")
+        if !good { findings += 1 }
+        instance.tearDown()
+        if !red {
+          precondition(good)
+          js.evaluateScript("savedNext()")
+          precondition(nextCount == 1, "retained late next advanced twice")
+        }
+        withExtendedLifetime(api) {}
+      }
+    }
+    let instance = fresh(), js = instance.js
+    let ws = instance.apis["ws"] as! JavascriptAPIWebSocketController
+    let disable: @convention(block) () -> Void = { instance.tearDown() }
+    js.setObject(disable, forKeyedSubscript: "disableNow" as NSString)
+    let port = Int(env["IINA_LIFECYCLE_WS_PORT"]!)!
+    js.evaluateScript("(function(){ disableNow(); iina.ws.createServer({port:\(port)}); iina.ws.startServer(); })()")
+    pump(0.08)
+    let noListener = ws.server == nil
+    print("REVIEW reentrant WebSocket absent=\(noListener) \(noListener ? "PASS" : "FINDING")")
+    if !noListener { findings += 1 }
+    // Explicit laboratory cleanup of the confirmed pre-fix leaked server.
+    ws.cleanUp(instance); ws.cleanUp(instance)
+    pump(0.08)
+    if !red { precondition(noListener) }
+    let download = fresh()
+    download.js.evaluateScript("iina.http.download('\(url)/body', '\(folder)/download-control', {})")
+    pump(0.4)
+    download.tearDown()
+    print("REVIEW \(red ? "RED" : "GREEN") findings=\(findings)")
+    if red { precondition(findings == 7) }
+    else {
+      concurrentCallbacks(plugin: plugin)
+      slowDownloads(plugin: plugin, url: url, folder: folder)
+      realMpvHooks(plugin: plugin, root: root, url: url, folder: folder)
+      twoPlayers(plugin: plugin)
+    }
+  }
+  static func pump(_ seconds: Double) { RunLoop.main.run(until: Date(timeIntervalSinceNow: seconds)) }
+  static func until(_ check: () -> Bool) {
+    let deadline = Date(timeIntervalSinceNow: 3)
+    while !check() && Date() < deadline { pump(0.01) }
+    precondition(check(), "bounded condition did not complete")
+  }
+
+  static func concurrentCallbacks(plugin: JavascriptPlugin) {
+    for cancel in [false, true] {
+      let instance = JavascriptPluginInstance(player: nil, plugin: plugin)
+      let js = instance.js, api = instance.apis["utils"]!
+      js.evaluateScript("var deliveries = 0")
+      var registrations = 0
+      let release = DispatchSemaphore(value: 0)
+      let jobs = DispatchGroup()
+      for _ in 0..<64 {
+        jobs.enter()
+        DispatchQueue.global().async {
+          // Producers never enter JSC from a worker, just like mpv hook ingress.
+          DispatchQueue.main.async {
+            let promise = api.createPromise { token in
+              DispatchQueue.global().async {
+                release.wait()
+                token.resolve([]); token.reject([]); token.resolve([])
+                jobs.leave()
+              }
+            }
+            let delivered = js.evaluateScript("(function(){deliveries++})")!
+            promise.invokeMethod("then", withArguments: [delivered, delivered])
+            registrations += 1
+          }
+        }
+      }
+      until { registrations == 64 }
+      // Completions race with teardown but can only consume values on main.
+      for _ in 0..<64 { release.signal() }
+      if cancel { instance.tearDown() }
+      until { jobs.wait(timeout: .now()) == .success }
+      pump(0.05)
+      let count = js.objectForKeyedSubscript("deliveries").toInt32()
+      precondition(count == (cancel ? 0 : 64))
+      instance.tearDown()
+      var resurrected = false
+      _ = api.createPromise { _ in resurrected = true }
+      precondition(!resurrected)
+      print("PASS concurrent createPromise/completion/teardown: 64 producers, duplicate completions, cancel=\(cancel), delivered=\(count)")
+    }
+    let instance = JavascriptPluginInstance(player: nil, plugin: plugin)
+    let api = JavascriptAPIMpv(context: instance.js, pluginInstance: instance)
+    let callback = instance.js.evaluateScript("(async function(next){await new Promise(r => setTimeout(r,100)); next()})")!
+    let hook = MPVHookValue(withIdentifier: "race", jsContext: instance.js, jsBlock: callback, owner: api)
+    var advances = 0
+    for _ in 0..<128 {
+      DispatchQueue.global().async { hook.call { advances += 1 } }
+    }
+    instance.tearDown()
+    until { advances == 128 }
+    pump(0.15)
+    precondition(advances == 128)
+    print("PASS 128 concurrent mpv hook ingress/teardown: every continuation released once, no JS entry")
+  }
+
+  static func slowDownloads(plugin: JavascriptPlugin, url: String, folder: String) {
+    for shutdown in [false, true] {
+      let player: PlayerCore? = shutdown ? PlayerCore() : nil
+      if let player {
+        player.label = "download-shutdown"
+        HardwareDecodeCapabilities.shared.checkCapabilities()
+        player.startMPV()
+      }
+      let instance = JavascriptPluginInstance(player: player, plugin: plugin)
+      if let player { player.plugins = [instance] }
+      let destination = URL(fileURLWithPath: folder + "/slow-\(shutdown)")
+      if shutdown { try! Data("old-file".utf8).write(to: destination) }
+      LifecycleDownloadProbe.arm()
+      instance.js.evaluateScript("var downloadReplies=0; iina.http.download('\(url)/body', '\(destination.path)', {}).then(()=>downloadReplies++, ()=>downloadReplies++)")
+      until { LifecycleDownloadProbe.isPaused }
+      let start = Date()
+      if let player { player.shutdown() } else { instance.tearDown() }
+      precondition(Date().timeIntervalSince(start) < 0.2, "teardown waited for blocked body IO")
+      var mainResponsive = false
+      DispatchQueue.main.async { mainResponsive = true }
+      pump(0.03)
+      precondition(mainResponsive)
+      let stagingBeforeResume = try! FileManager.default.contentsOfDirectory(atPath: plugin.tmpURL.path).filter { $0.hasPrefix(".iina-download-") }
+      precondition(stagingBeforeResume.isEmpty, "teardown must unlink without waiting for writer")
+      LifecycleDownloadProbe.release.signal()
+      until { LifecycleDownloadProbe.finished }
+      pump(0.15)
+      if shutdown { precondition(try! Data(contentsOf: destination) == Data("old-file".utf8)) }
+      else { precondition(!FileManager.default.fileExists(atPath: destination.path)) }
+      precondition(instance.js.objectForKeyedSubscript("downloadReplies").toInt32() == 0)
+      let temporary = try! FileManager.default.contentsOfDirectory(atPath: plugin.tmpURL.path).filter { $0.hasPrefix(".iina-download-") }
+      precondition(temporary.isEmpty)
+      print("PASS 8 MiB HTTP body paused after first 256 KiB, main responsive, \(shutdown ? "shutdown preserved existing file" : "disable left destination absent"), late replies=0, staging files=0")
+    }
+  }
+
+  static func realMpvHooks(plugin: JavascriptPlugin, root: String, url: String, folder: String) {
+    for kind in ["timer", "http", "exec"] {
+    for cancel in [false, true] {
+      let handle = mpv_create()!
+      for (name, value) in [("config","no"),("vo","null"),("ao","null"),("pause","yes")] {
+        precondition(mpv_set_option_string(handle, name, value) >= 0)
+      }
+      precondition(mpv_initialize(handle) >= 0)
+      precondition(mpv_hook_add(handle, 1, "on_load", 0) >= 0)
+      let instance = JavascriptPluginInstance(player: nil, plugin: plugin)
+      let api = JavascriptAPIMpv(context: instance.js, pluginInstance: instance)
+      let stem = folder + "/real-\(kind)-\(cancel)"
+      let awaited: String
+      if kind == "timer" { awaited = "new Promise(r => setTimeout(r,100))" }
+      else if kind == "http" { awaited = "iina.http.get('\(url)/held', {})" }
+      else { awaited = "iina.utils.exec('\(root)/exec-probe', ['\(stem)-gate', '\(stem)-pid', 'normal'])" }
+      let callback = instance.js.evaluateScript("(async function(next){await \(awaited); next(); next()})")!
+      let hook = MPVHookValue(withIdentifier: "native-mpv", jsContext: instance.js, jsBlock: callback, owner: api)
+      precondition(mpv_command_string(handle, "loadfile \"\(root)/lifecycle-test.mp4\"") >= 0)
+      var received = false, loaded = false, nextCount = 0
+      let deadline = Date(timeIntervalSinceNow: 2)
+      while !loaded && Date() < deadline {
+        let event = mpv_wait_event(handle, 0)!.pointee
+        if event.event_id == MPV_EVENT_HOOK {
+          received = true
+          let id = event.data.assumingMemoryBound(to: mpv_event_hook.self).pointee.id
+          DispatchQueue.global().async { hook.call { nextCount += 1; precondition(mpv_hook_continue(handle, id) >= 0) } }
+          pump(0.02)
+          if cancel { instance.tearDown() }
+          try! Data([1]).write(to: URL(fileURLWithPath: stem + "-gate"))
+        } else if event.event_id == MPV_EVENT_FILE_LOADED { loaded = true }
+        pump(0.01)
+      }
+      precondition(received && loaded && nextCount == 1)
+      instance.tearDown()
+      mpv_terminate_destroy(handle)
+      print("PASS actual libmpv \(kind) on_load unblocked to FILE_LOADED, cancel=\(cancel), next=1, null audio/video output")
+    }
+  }
+
+  }
+
+  static func twoPlayers(plugin: JavascriptPlugin) {
+    let witness = JavascriptPlugin(filename: "witness.iinaplugin")!
+    JavascriptPlugin.plugins = [plugin, witness]
+    witness.enabled = true
+    let players = [PlayerCore(), PlayerCore()]
+    PlayerCore.playerCores = players
+    for (index, player) in players.enumerated() {
+      player.label = "review-\(index)"
+      player.startMPV(); player.loadPlugins()
+    }
+    let retained = players.flatMap { $0.plugins }
+    let disabledOwners = players.map { player in
+      player.plugins.first { $0.plugin.identifier == plugin.identifier }!
+    }
+    let cleanupProbes = disabledOwners.map { owner in
+      let probe = LifecycleReviewCleanupProbe(context: owner.js, pluginInstance: owner)
+      owner.apis["lifecycleReviewCleanup"] = probe
+      owner.js.evaluateScript("var eventDeliveries=0; iina.event.on('iina.window-will-close', function(){eventDeliveries++})")
+      return probe
+    }
+    players.forEach { $0.events.emit(.windowWillClose) }
+    precondition(disabledOwners.allSatisfy {
+      $0.js.objectForKeyedSubscript("eventDeliveries").toInt32() == 1
+    })
+    plugin.enabled = false
+    precondition(players.allSatisfy { $0.plugins.count == 1 && $0.plugins[0].plugin === witness })
+    precondition(retained.filter { $0.plugin === plugin }.allSatisfy { !$0.isActive })
+    precondition(cleanupProbes.allSatisfy { $0.count == 1 })
+    disabledOwners.forEach { $0.tearDown(); $0.tearDown() }
+    players.forEach { $0.events.emit(.windowWillClose) }
+    precondition(cleanupProbes.allSatisfy { $0.count == 1 })
+    precondition(disabledOwners.allSatisfy {
+      $0.js.objectForKeyedSubscript("eventDeliveries").toInt32() == 1
+    })
+    print("PASS retained instances: event delivery stopped after disable and repeated teardown cleaned exactly once")
+    pump(0.2)
+    precondition(players.allSatisfy { $0.plugins[0].js.objectForKeyedSubscript("lifecycleTicks").toInt32() > 0 })
+    plugin.enabled = true
+    precondition(players.allSatisfy { $0.plugins.count == 2 })
+    let beforeReload = players.flatMap { $0.plugins }
+    // Execute the same host reload operations without constructing the menu nib.
+    // The actual menu action is covered separately by the bounded GUI check.
+    players.forEach { $0.clearPlugins() }
+    JavascriptPlugin.recreateAllPlugins()
+    JavascriptPlugin.loadGlobalInstances()
+    players.forEach { player in
+      JavascriptPlugin.plugins.forEach { player.reloadPlugin($0, forced: true) }
+    }
+    precondition(beforeReload.allSatisfy { !$0.isActive })
+    precondition(players.allSatisfy { $0.plugins.count == 2 && $0.plugins.allSatisfy { $0.isActive } })
+    let beforeShutdown = players.flatMap { $0.plugins }
+    let owners = players.map { player in player.plugins.first { $0.plugin.identifier == plugin.identifier }! }
+    let identifier = plugin.identifier
+    for owner in owners {
+      owner.js.evaluateScript("var hookEntries=0, hookCompletions=0; iina.mpv.addHook('on_load',0,async function(next){hookEntries++; await new Promise(r=>setTimeout(r,200)); hookCompletions++; next()})")
+    }
+    var firstNext = 0, secondNext = 0
+    DispatchQueue.global().async { players[0].mpv.lifecycleInvokeHook(identifier) { firstNext += 1 } }
+    DispatchQueue.global().async { players[1].mpv.lifecycleInvokeHook(identifier) { secondNext += 1 } }
+    until { owners.allSatisfy { $0.js.objectForKeyedSubscript("hookEntries").toInt32() == 1 } }
+    let survivorTicks = owners[1].js.objectForKeyedSubscript("lifecycleTicks").toInt32()
+    players[0].shutdown(); players[0].shutdown()
+    precondition(!owners[0].isActive && owners[1].isActive)
+    precondition(firstNext == 1 && secondNext == 0)
+    precondition(players[0].mpv.lifecycleHookCount(identifier) == 0)
+    precondition(players[1].mpv.lifecycleHookCount(identifier) == 1)
+    until { secondNext == 1 }
+    precondition(owners[0].js.objectForKeyedSubscript("hookCompletions").toInt32() == 0)
+    precondition(owners[1].js.objectForKeyedSubscript("hookCompletions").toInt32() == 1)
+    precondition(owners[1].js.objectForKeyedSubscript("lifecycleTicks").toInt32() > survivorTicks)
+    precondition(players[1].plugins.allSatisfy { $0.isActive })
+    print("PASS isolated PlayerCore shutdown: first hook released without JS, second registered hook completed normally, survivor instance and timers remained active")
+    players[1].shutdown(); players[1].shutdown()
+    precondition(firstNext == 1 && secondNext == 1)
+    precondition(beforeShutdown.allSatisfy { !$0.isActive })
+    pump(0.25)
+    precondition(players.allSatisfy { $0.plugins.isEmpty })
+    PlayerCore.playerCores = []
+    JavascriptPlugin.plugins.forEach { $0.enabled = false }
+    plugin.enabled = false; witness.enabled = false
+    print("PASS two real PlayerCore instances: disable/survivor/re-enable/Reload All Plugins/repeated shutdown")
+  }
+}
+
+private final class LifecycleReviewCleanupProbe: JavascriptAPI {
+  var count = 0
+
+  override func cleanUp(_ instance: JavascriptPluginInstance) {
+    count += 1
+  }
+}
+
+// Deterministic observation seam injected only into the laboratory HTTP writer.
+// The semaphore deliberately blocks body IO while main performs teardown.
+enum LifecycleDownloadProbe {
+  private static let lock = NSLock()
+  private static var armed = false, paused = false, done = false
+  static let release = DispatchSemaphore(value: 0)
+  static var isPaused: Bool { lock.lock(); defer { lock.unlock() }; return paused }
+  static var finished: Bool { lock.lock(); defer { lock.unlock() }; return done }
+  static func arm() { lock.lock(); armed = true; paused = false; done = false; lock.unlock() }
+  static func afterChunk() {
+    lock.lock()
+    let wait = armed
+    if wait { armed = false; paused = true }
+    lock.unlock()
+    if wait {
+      precondition(!Thread.isMainThread)
+      precondition(release.wait(timeout: .now() + 3) == .success)
+      lock.lock(); done = true; lock.unlock()
+    }
+  }
+}

--- a/other/tests/plugin-lifecycle/exec-probe.c
+++ b/other/tests/plugin-lifecycle/exec-probe.c
@@ -1,0 +1,20 @@
+// Bounded direct child used only inside the lifecycle sandbox; no subprocesses.
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+int main(int argc, char **argv) {
+  if (argc != 4) return 64;
+  if (!strcmp(argv[3], "ignore-term")) signal(SIGTERM, SIG_IGN);
+  FILE *pid = fopen(argv[2], "w");
+  if (!pid) return 65;
+  fprintf(pid, "%d", getpid()); fclose(pid);
+  setbuf(stdout, NULL); setbuf(stderr, NULL);
+  puts("stdout-ready"); fputs("stderr-ready\n", stderr);
+  for (int i = 0; i < 1200; i++) {
+    if (access(argv[1], F_OK) == 0) { puts("stdout-done"); return 0; }
+    usleep(50000);
+  }
+  return 70;
+}

--- a/other/tests/plugin-lifecycle/portable-fixture/Info.json
+++ b/other/tests/plugin-lifecycle/portable-fixture/Info.json
@@ -1,0 +1,20 @@
+{
+  "name": "Plugin Lifecycle Test",
+  "identifier": "org.iina.lifecycle-test",
+  "version": "1.0.0",
+  "author": {
+    "name": "IINA contributors"
+  },
+  "entry": "main.js",
+  "globalEntry": "main.js",
+  "permissions": [
+    "file-system",
+    "network-request"
+  ],
+  "allowedDomains": [
+    "127.0.0.1"
+  ],
+  "preferenceDefaults": {
+    "probe": "alive"
+  }
+}

--- a/other/tests/plugin-lifecycle/portable-fixture/main.js
+++ b/other/tests/plugin-lifecycle/portable-fixture/main.js
@@ -1,0 +1,5 @@
+var lifecycleTicks = 0;
+var lifecycleTimer = setInterval(function () {
+  lifecycleTicks += 1;
+  iina.preferences.get("probe");
+}, 25);

--- a/other/tests/plugin-lifecycle/portable.py
+++ b/other/tests/plugin-lifecycle/portable.py
@@ -1,0 +1,307 @@
+#!/usr/bin/env python3
+"""Build and run the portable plugin lifecycle regression suite."""
+
+import argparse
+import base64
+import http.server
+import io
+import json
+import os
+from pathlib import Path
+import platform
+import plistlib
+import shutil
+import signal
+import socket
+import subprocess
+import tarfile
+import threading
+import time
+import uuid
+
+
+ROOT = Path(__file__).resolve().parents[3]
+HERE = Path(__file__).resolve().parent
+PRODUCTION_FILES = [
+    "iina/AppDelegate.swift",
+    "iina/JavascriptAPI.swift",
+    "iina/JavascriptAPIEvent.swift",
+    "iina/JavascriptAPIHttp.swift",
+    "iina/JavascriptAPIMpv.swift",
+    "iina/JavascriptAPIOverlay.swift",
+    "iina/JavascriptAPIUtils.swift",
+    "iina/JavascriptAPIWebSocket.swift",
+    "iina/JavascriptMessageHub.swift",
+    "iina/JavascriptPlugin.swift",
+    "iina/JavascriptPluginInstance.swift",
+    "iina/JavascriptPolyfill.swift",
+    "iina/JustXMLRPC.swift",
+    "iina/MPVController.swift",
+    "iina/PlayerCore.swift",
+    "iina/WebSocketServer.swift",
+]
+TEST_VIDEO = """AAAAIGZ0eXBpc29tAAACAGlzb21pc28yYXZjMW1wNDEAAAAIZnJlZQAAAyttZGF0AAACrQYF//+p3EXpvebZSLeWLNgg2SPu73gyNjQgLSBjb3JlIDE2NSByMzIyMiBiMzU2MDVhIC0gSC4yNjQvTVBFRy00IEFWQyBjb2RlYyAtIENvcHlsZWZ0IDIwMDMtMjAyNSAtIGh0dHA6Ly93d3cudmlkZW9sYW4ub3JnL3gyNjQuaHRtbCAtIG9wdGlvbnM6IGNhYmFjPTEgcmVmPTMgZGVibG9jaz0xOjA6MCBhbmFseXNlPTB4MzoweDExMyBtZT1oZXggc3VibWU9NyBwc3k9MSBwc3lfcmQ9MS4wMDowLjAwIG1peGVkX3JlZj0xIG1lX3JhbmdlPTE2IGNocm9tYV9tZT0xIHRyZWxsaXM9MSA4eDhkY3Q9MSBjcW09MCBkZWFkem9uZT0yMSwxMSBmYXN0X3Bza2lwPTEgY2hyb21hX3FwX29mZnNldD0tMiB0aHJlYWRzPTYgbG9va2FoZWFkX3RocmVhZHM9MSBzbGljZWRfdGhyZWFkcz0wIG5yPTAgZGVjaW1hdGU9MSBpbnRlcmxhY2VkPTAgYmx1cmF5X2NvbXBhdD0wIGNvbnN0cmFpbmVkX2ludHJhPTAgYmZyYW1lcz0zIGJfcHlyYW1pZD0yIGJfYWRhcHQ9MSBiX2JpYXM9MCBkaXJlY3Q9MSB3ZWlnaHRiPTEgb3Blbl9nb3A9MCB3ZWlnaHRwPTIga2V5aW50PTI1MCBrZXlpbnRfbWluPTIgc2NlbmVjdXQ9NDAgaW50cmFfcmVmcmVzaD0wIHJjX2xvb2thaGVhZD00MCByYz1jcmYgbWJ0cmVlPTEgY3JmPTIzLjAgcWNvbXA9MC42MCBxcG1pbj0wIHFwbWF4PTY5IHFwc3RlcD00IGlwX3JhdGlvPTEuNDAgYXE9MToxLjAwAIAAAABBZYiEABX//uzPfgU3IDyL9ZQIdLVudeOY06aGeK6v9N6hcRjDjyW4ADcS20LxOJaF3F/wElAAAHgEJji2UyWbxpcAAAANQZojbEEv/rUqgABCwAAAAApBnkF4gn8AABZxAAAACgGeYmpBLwAAIOAAAANjbW9vdgAAAGxtdmhkAAAAAAAAAAAAAAAAAAAD6AAAB9AAAQAAAQAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAgAAAo50cmFrAAAAXHRraGQAAAADAAAAAAAAAAAAAAABAAAAAAAAB9AAAAAAAAAAAAAAAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAABAAAAAAAAAAAAAAAAAABAAAAAAUAAAAC0AAAAAAAkZWR0cwAAABxlbHN0AAAAAAAAAAEAAAfQAABAAAABAAAAAAIGbWRpYQAAACBtZGhkAAAAAAAAAAAAAAAAAABAAAAAgABVxAAAAAAALWhkbHIAAAAAAAAAAHZpZGUAAAAAAAAAAAAAAABWaWRlb0hhbmRsZXIAAAABsW1pbmYAAAAUdm1oZAAAAAEAAAAAAAAAAAAAACRkaW5mAAAAHGRyZWYAAAAAAAAAAQAAAAx1cmwgAAAAAQAAAXFzdGJsAAAAwXN0c2QAAAAAAAAAAQAAALFhdmMxAAAAAAAAAAEAAAAAAAAAAAAAAAAAAAAAAUAAtABIAAAASAAAAAAAAAABFExhdmM2My4xLjEwMSBsaWJ4MjY0AAAAAAAAAAAAAAAAGP//AAAAN2F2Y0MBZAAM/+EAGmdkAAys2UFBn58BEAAAAwAQAAADAEDxQplgAQAGaOvjyyLA/fj4AAAAABBwYXNwAAAAAQAAAAEAAAAUYnRydAAAAAAAAAyMAAAAAAAAABhzdHRzAAAAAAAAAAEAAAAEAAAgAAAAABRzdHNzAAAAAAAAAAEAAAABAAAAKGN0dHMAAAAAAAAAAwAAAAEAAEAAAAAAAQAAgAAAAAACAAAgAAAAABxzdHNjAAAAAAAAAAEAAAABAAAABAAAAAEAAAAkc3RzegAAAAAAAAAAAAAABAAAAvYAAAARAAAADgAAAA4AAAAUc3RjbwAAAAAAAAABAAAAMAAAAGF1ZHRhAAAAWW1ldGEAAAAAAAAAIWhkbHIAAAAAAAAAAG1kaXJhcHBsAAAAAAAAAAAAAAAALGlsc3QAAAAkqXRvbwAAABxkYXRhAAAAAQAAAABMYXZmNjMuMS4xMDE="""
+
+
+class Handler(http.server.BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/held":
+            time.sleep(0.18)
+        if self.path == "/error":
+            status, body, content_type = 503, b'{"error":"download-failed"}', "application/json"
+        else:
+            size = 8 * 1024 * 1024 if self.path == "/body" else 20
+            status, body, content_type = 200, b"x" * size, "application/octet-stream"
+        try:
+            self.send_response(status)
+            self.send_header("Content-Type", content_type)
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        except (BrokenPipeError, ConnectionResetError):
+            pass
+
+    def log_message(self, *args):
+        pass
+
+
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--dependencies-from", type=Path)
+    parser.add_argument("--cloned-packages", type=Path)
+    parser.add_argument("--package-cache", type=Path)
+    return parser.parse_args()
+
+
+def copy_checkout(source):
+    archive = subprocess.check_output(["git", "archive", "HEAD"], cwd=ROOT)
+    with tarfile.open(fileobj=io.BytesIO(archive)) as tar:
+        tar.extractall(source, filter="data")
+    for name in PRODUCTION_FILES:
+        destination = source / name
+        destination.write_bytes((ROOT / name).read_bytes())
+
+
+def prepare_source(source, run):
+    app_delegate = source / "iina/AppDelegate.swift"
+    text = app_delegate.read_text()
+    assert "@NSApplicationMain\n" in text
+    app_delegate.write_text(
+        text.replace("@NSApplicationMain\n", "", 1)
+        + "\n"
+        + (HERE / "PortableDriver.swift").read_text()
+        + "\n"
+        + (HERE / "ReviewTests.swift").read_text()
+        + "\n"
+        + (HERE / "FileReviewTests.swift").read_text()
+    )
+
+    utility = source / "iina/Utility.swift"
+    old = "static let tempDirURL: URL = URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)"
+    text = utility.read_text()
+    assert old in text
+    utility.write_text(text.replace(
+        old,
+        'static let tempDirURL: URL = URL(fileURLWithPath: ProcessInfo.processInfo.environment["IINA_LIFECYCLE_TEST_ROOT"]! + "/tmp", isDirectory: true)',
+        1,
+    ))
+
+    http = source / "iina/JavascriptAPIHttp.swift"
+    text = http.read_text()
+    assert text.count("        offset += count") == 1
+    assert text.count("          offset += written") == 1
+    text = text.replace("        offset += count", "        offset += count\n        LifecycleDownloadProbe.afterChunk()", 1)
+    text = text.replace("          offset += written", "          offset += written\n          LifecyclePublicationProbe.afterBlock()", 1)
+    http.write_text(text)
+
+    mpv = source / "iina/MPVController.swift"
+    mpv.write_text(mpv.read_text() + """
+
+extension MPVController {
+  func lifecycleInvokeHook(_ identifier: String, next: @escaping () -> Void) {
+    let hook = $hooks.withLock { $0.values.first { $0.id == identifier } }
+    precondition(hook != nil)
+    hook!.call(withNextBlock: next)
+  }
+
+  func lifecycleHookCount(_ identifier: String) -> Int {
+    $hooks.withLock { $0.values.filter { $0.id == identifier }.count }
+  }
+}
+""")
+
+    info = source / "iina/Info.plist"
+    data = plistlib.loads(info.read_bytes())
+    for key in ("CFBundleDocumentTypes", "CFBundleURLTypes", "NSServices", "UTExportedTypeDeclarations", "UTImportedTypeDeclarations"):
+        data.pop(key, None)
+    data.update(SUEnableAutomaticChecks=False, SUAutomaticallyUpdate=False)
+    info.write_bytes(plistlib.dumps(data))
+
+    plugins = run / "home/Library/Application Support/org.iina.lifecycle-tests/plugins"
+    plugins.mkdir(parents=True)
+    for folder, identifier, name in (
+        ("lifecycle.iinaplugin", "org.iina.lifecycle-test", "Plugin Lifecycle Test"),
+        ("witness.iinaplugin", "org.iina.lifecycle-witness", "Plugin Lifecycle Witness"),
+    ):
+        destination = plugins / folder
+        shutil.copytree(HERE / "portable-fixture", destination)
+        manifest = json.loads((destination / "Info.json").read_text())
+        manifest.update(identifier=identifier, name=name)
+        (destination / "Info.json").write_text(json.dumps(manifest, indent=2) + "\n")
+
+
+def prepare_dependencies(source, supplied):
+    if supplied is None and (ROOT / "deps/lib").is_dir():
+        supplied = ROOT / "deps"
+    if supplied is not None:
+        supplied = supplied.resolve()
+        if not (supplied / "lib/libmpv.2.dylib").exists():
+            raise SystemExit(f"Missing libmpv in dependency directory: {supplied}")
+        generated = source / "deps"
+        shutil.rmtree(generated)
+        generated.symlink_to(supplied, target_is_directory=True)
+        return
+    subprocess.run([
+        str(source / "other/download_libs.sh"), "--arch", platform.machine(),
+        "--parallel", "3", "--skip-plugins",
+    ], cwd=source, check=True)
+
+
+def build(source, run, args):
+    derived = run / "DerivedData"
+    cloned = args.cloned_packages.resolve() if args.cloned_packages else run / "SourcePackages"
+    cache = args.package_cache.resolve() if args.package_cache else run / "PackageCache"
+    command = [
+        "xcodebuild", "-project", str(source / "iina.xcodeproj"), "-scheme", "iina",
+        "-configuration", "Debug", "-derivedDataPath", str(derived),
+        "-clonedSourcePackagesDirPath", str(cloned), "-packageCachePath", str(cache),
+        "-jobs", "3", "CODE_SIGNING_ALLOWED=NO",
+        "PRODUCT_BUNDLE_IDENTIFIER=org.iina.lifecycle-tests", "build",
+    ]
+    with (run / "build.log").open("w") as log:
+        result = subprocess.run(command, cwd=source, stdout=log, stderr=subprocess.STDOUT)
+    if result.returncode != 0:
+        raise SystemExit(f"Build failed; see {run / 'build.log'}")
+    app = derived / "Build/Products/Debug/IINA.app"
+    shutil.rmtree(app / "Contents/PlugIns/OpenInIINA.appex", ignore_errors=True)
+    for plugin in (app / "Contents/Resources/plugins").glob("*.iinaplgz"):
+        plugin.unlink()
+    sparkle = app / "Contents/Frameworks/Sparkle.framework"
+    subprocess.run(["codesign", "--force", "--deep", "--sign", "-", str(sparkle)], check=True)
+    subprocess.run(["codesign", "--force", "--sign", "-", "--identifier", "org.iina.lifecycle-tests", str(app)], check=True)
+    subprocess.run(["codesign", "--verify", "--deep", "--strict", str(app)], check=True)
+    return app
+
+
+def sandbox_profile(run, executable, helper, http_port, ws_port):
+    profile = """(version 1)
+(allow default)
+(deny network*)
+(deny signal)
+(deny file-write*)
+"""
+    profile += f'(allow file-write* (subpath "{run}") (literal "/dev/null"))\n'
+    profile += f'(allow network-outbound (remote ip "localhost:{http_port}"))\n'
+    profile += f'(allow network-bind network-inbound (local ip "*:{ws_port}"))\n'
+    profile += '(allow signal (target children))\n(deny process-exec)\n'
+    profile += f'(allow process-exec (literal "{executable}") (literal "{helper}") (literal "/usr/bin/true"))\n'
+    path = run / "isolation.sb"
+    path.write_text(profile)
+    return path
+
+
+def process_group_exists(pgid):
+    try:
+        os.killpg(pgid, 0)
+        return True
+    except ProcessLookupError:
+        return False
+
+
+def run_mode(mode, app, run, profile, server_port, ws_port):
+    case = run / mode
+    case.mkdir()
+    executable = app / "Contents/MacOS/IINA"
+    environment = os.environ.copy()
+    environment.update(
+        CFFIXED_USER_HOME=str(run / "home"),
+        TMPDIR=str(run / "tmp") + "/",
+        IINA_LIFECYCLE_TEST_ROOT=str(run),
+        IINA_LIFECYCLE_LAB=str(run),
+        IINA_LIFECYCLE_REVIEW_RUN=str(case),
+        IINA_LIFECYCLE_HTTP_URL=f"http://127.0.0.1:{server_port}",
+        IINA_LIFECYCLE_WS_PORT=str(ws_port),
+    )
+    with (case / "test.log").open("w") as log:
+        process = subprocess.Popen(
+            ["/usr/bin/sandbox-exec", "-f", str(profile), str(executable), mode],
+            cwd=run, env=environment, stdout=log, stderr=subprocess.STDOUT,
+            start_new_session=True,
+        )
+        try:
+            result = process.wait(timeout=45)
+        except subprocess.TimeoutExpired:
+            os.killpg(process.pid, signal.SIGTERM)
+            try:
+                process.wait(timeout=3)
+            except subprocess.TimeoutExpired:
+                os.killpg(process.pid, signal.SIGKILL)
+                process.wait(timeout=3)
+            raise AssertionError(f"{mode} timed out")
+    remaining_group = process_group_exists(process.pid)
+    if remaining_group:
+        os.killpg(process.pid, signal.SIGKILL)
+    assert result == 0, (case / "test.log").read_text()[-5000:]
+    assert not remaining_group, f"{mode} left a test process behind"
+    if mode == "file-exit":
+        record = json.loads((case / "exit-check.json").read_text())
+        assert record["writerPaused"] and record["stagingPaths"]
+        assert not Path(record["target"]).exists()
+        assert all(not Path(path).exists() for path in record["stagingPaths"])
+    print(f"PASS {mode}")
+
+
+def main():
+    args = parse_args()
+    run = ROOT / "build/plugin-lifecycle-tests" / (time.strftime("%Y%m%d-%H%M%S-") + uuid.uuid4().hex[:8])
+    source = run / "source"
+    source.mkdir(parents=True)
+    (run / "home").mkdir()
+    (run / "tmp").mkdir()
+    print(f"Plugin lifecycle test run: {run}", flush=True)
+    copy_checkout(source)
+    prepare_source(source, run)
+    prepare_dependencies(source, args.dependencies_from)
+    helper = run / "exec-probe"
+    subprocess.run(["clang", str(HERE / "exec-probe.c"), "-o", str(helper)], check=True)
+    (run / "lifecycle-test.mp4").write_bytes(base64.b64decode(TEST_VIDEO))
+    app = build(source, run, args)
+
+    server = http.server.ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    with socket.socket() as temporary:
+        temporary.bind(("127.0.0.1", 0))
+        ws_port = temporary.getsockname()[1]
+    profile = sandbox_profile(run, app / "Contents/MacOS/IINA", helper, server.server_port, ws_port)
+    try:
+        for mode in ("lifecycle", "files", "file-exit"):
+            run_mode(mode, app, run, profile, server.server_port, ws_port)
+    finally:
+        server.shutdown()
+        server.server_close()
+    with socket.socket() as check:
+        check.bind(("127.0.0.1", ws_port))
+    result = {
+        "modes": ["lifecycle", "files", "file-exit"],
+        "productionFiles": PRODUCTION_FILES,
+        "installedApplicationUsed": False,
+        "testProcessesRemaining": False,
+        "webSocketPortReleased": True,
+    }
+    (run / "result.json").write_text(json.dumps(result, indent=2) + "\n")
+    print(f"PASS portable plugin lifecycle suite: {run}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] Related issue: #
- [x] Related Design Proposal: #6336
---
- [x] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**

Disabled, reloaded, and shutting-down JavaScript plugin instances could remain
alive long enough to receive asynchronous callbacks or retain native resources.
An awaited mpv hook could also be cancelled without advancing mpv.

This change adds explicit, idempotent instance teardown and invokes it before
instance replacement and at player/application shutdown boundaries. JavaScriptCore
and callback/resource registries are confined to the main queue; pending delivery
is invalidated, active hook continuations call `next()` exactly once, and inactive
instances cannot register new events, hooks, message handlers, HTTP/XMLRPC work,
processes, overlays, or WebSocket listeners. Direct child process IO and WebSocket
state are serialized with cleanup.

Downloads stage response bodies off the main queue, then preserve the previous
in-place destination semantics: existing inode/mode and hard links survive,
symlinks update their targets, and new files use normal mode/umask behavior.
Cancellation immediately unlinks its staging name and suppresses late completion.

The JavaScript API surface is unchanged, and teardown of one instance leaves
other plugins and players active. Related reports include #6094 and #6204;
#6162 was an earlier, narrower reload proposal and is closed without merge.
These links provide context, not a claim that every reported crash was reproduced.

**Testing:**

- Portable disposable-app lifecycle suite: retained and repeated teardown;
  timer/event/Promise/HTTP/exec cancellation; inactive WebSocket registration;
  real mpv hooks with exactly one continuation; shutdown isolation between two
  PlayerCore instances; disable/re-enable/reload.
- Download suite: exact success/error/cancel results; inode, mode, hard-link and
  symlink behavior; new-file permissions; no late writes or delivery; no staging
  after cancel, destination publication, or normal `exit(0)` with a paused writer.
- Earlier isolated GUI smoke on the same production diff: ordinary window close/reopen kept the test plugin
  active, normal quit produced no TypeError, late callback, listener, or process.
- Fresh Debug build, Swift parse, test syntax, and diff checks pass. Earlier focused
  lifecycle TSan passed; it was not whole-app TSan.

Cancellation after destination writing begins can leave a truncated or partial
file, as the previous non-atomic write could. Filesystem syscalls have no guaranteed
short latency. Whole-app TSan was not run. External mpv IPC quit, arbitrary child
process trees, special files, and external filesystem changes are not exhaustively
covered.

OpenAI Codex was used during investigation, implementation, testing, and review. The author also contributed to and reviewed the implementation and remains responsible for the submitted changes and GPLv3 compliance.
