### PR TITLE
Add support for tone-mapping-param

### DIFF
--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -666,6 +666,9 @@
 "settings.loadIccProfile.desc" = "Load the ICC profile for current display and use it to transform video RGB to screen output. (Only for SDR mode)";
 "settings.loadIccProfile.label" = "Load ICC profile";
 "settings.toneMappingAlgorithm.label" = "Algorithm";
+"settings.toneMappingAlgorithm.desc" = "Algorithm to use for tone-mapping images onto the target display.";
+"settings.toneMappingParamOverride.desc" = "Parameter for tuning the tone mapping algorithm. By default this is set to an algorithm-specific default value. Enable this setting to override that default.";
+"settings.toneMappingParamOverride.label" = "Tuning parameter";
 "settings.toneMappingTargetPeak.desc" = "Measured peak brightness of the display. By default IINA detects this value. If detection fails, target peak will be set to an appropriate value based on the transfer characteristics of the display. Enable this setting to manually specify the display's brightness.";
 "settings.toneMappingTargetPeak.label" = "Target peak";
 "settings.videoThreads.desc" = "Default: 0 (Auto)";

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -50,10 +50,12 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
   
   internal var observedPrefKeys: [Preference.Key] = [
     .enableToneMapping,
+    .enableToneMappingParamOverride,
     .enableToneMappingTargetPeakOverride,
     .toneMappingTargetPeak,
     .loadIccProfile,
     .toneMappingAlgorithm,
+    .toneMappingParamOverride,
     .toneMappingTargetPeakOverride,
     .themeMaterial,
     .showRemainingTime,
@@ -77,10 +79,12 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
     
     switch keyPath {
     case PK.enableToneMapping.rawValue,
+      PK.enableToneMappingParamOverride.rawValue,
       PK.enableToneMappingTargetPeakOverride.rawValue,
       PK.toneMappingTargetPeak.rawValue,
       PK.loadIccProfile.rawValue,
       PK.toneMappingAlgorithm.rawValue,
+      PK.toneMappingParamOverride.rawValue,
       PK.toneMappingTargetPeakOverride.rawValue:
       videoView.refreshEdrMode()
     case PK.themeMaterial.rawValue:

--- a/iina/Preference.swift
+++ b/iina/Preference.swift
@@ -192,6 +192,8 @@ struct Preference {
     static let enableToneMappingTargetPeakOverride = Key("enableToneMappingTargetPeakOverride")
     static let toneMappingTargetPeakOverride = Key("toneMappingTargetPeakOverride")
     static let toneMappingAlgorithm = Key("toneMappingAlgorithm")
+    static let enableToneMappingParamOverride = Key("enableToneMappingParamOverride")
+    static let toneMappingParamOverride = Key("toneMappingParamOverride")
 
     static let audioDriverEnableAVFoundation = Key("audioDriverEnableAVFoundation")
     static let audioThreads = Key("audioThreads")
@@ -1154,6 +1156,8 @@ struct Preference {
     .enableToneMappingTargetPeakOverride: false,
     .toneMappingTargetPeakOverride: 400,
     .toneMappingAlgorithm: ToneMappingAlgorithmOption.defaultValue.rawValue,
+    .enableToneMappingParamOverride: false,
+    .toneMappingParamOverride: Float(1), // Most common default for tone mapping algorithms.
     .audioDriverEnableAVFoundation: false,
     .audioThreads: 0,
     .audioLanguage: "",
@@ -1441,6 +1445,7 @@ struct Preference {
            .disableOSDSeekMsg,
            .disableOSDSpeedMsg,
            .disablePlaySliderScrolling,
+           .enableToneMappingParamOverride,
            .enableToneMappingTargetPeakOverride,
            .disableVolumeSliderScrolling,
            .displayInLetterBox,
@@ -1549,7 +1554,8 @@ struct Preference {
            .subPos,
            .subShadowSize,
            .subSpacing,
-           .subTextSize:
+           .subTextSize,
+           .toneMappingParamOverride:
         guard let defaultAsFloat = defaultValue as? Float else {
           // Should not occur. Internal error.
           log("Default for \(key) is of type \(type(of: value)) and cannot be cast to Float",

--- a/iina/SettingsPageVideo.swift
+++ b/iina/SettingsPageVideo.swift
@@ -101,7 +101,17 @@ class SettingsPageVideo: SettingsPage {
               .withHelpLink(AppData.mpvManualLink.appending("/#options-target-peak"))
             SettingsItem.PopupButton()
               .bindTo(.toneMappingAlgorithm, ofType: Preference.ToneMappingAlgorithmOption.self)
+              .hasDescription()
               .withHelpLink(AppData.mpvManualLink.appending("/#options-tone-mapping"))
+              .withDetailView {
+                SettingsItem.SwitchWithInput()
+                  .labelKey(.toneMappingParamOverride)
+                  .bindInputTo(.toneMappingParamOverride)
+                  .bindSwitchTo(.enableToneMappingParamOverride)
+                  .range(-Double.infinity...Double.infinity, allowsFloats: true)
+                  .hasDescription()
+                  .withHelpLink(AppData.mpvManualLink.appending("/#options-tone-mapping-param"))
+              }
           }
       }
     }

--- a/iina/VideoView.swift
+++ b/iina/VideoView.swift
@@ -512,6 +512,7 @@ extension VideoView {
       // Reset options to their defaults.
       mpv.setStringToDefault(MPVOption.GPURendererOptions.targetPeak)
       mpv.setStringToDefault(MPVOption.GPURendererOptions.toneMapping)
+      mpv.setStringToDefault(MPVOption.GPURendererOptions.toneMappingParam)
       return
     }
     var targetPeak = "auto"
@@ -544,9 +545,14 @@ extension VideoView {
     }
     let algorithm = String(describing: Preference.enum(for: .toneMappingAlgorithm) as
                            Preference.ToneMappingAlgorithmOption)
-    logHDR("Will enable tone mapping: target-peak=\(targetPeak) algorithm=\(algorithm)")
+    let param = {
+      guard Preference.bool(for: .enableToneMappingParamOverride) else { return "default" }
+      return String(Preference.double(for: .toneMappingParamOverride))
+    }()
+    logHDR("Will enable tone mapping: target-peak=\(targetPeak) algorithm=\(algorithm) param=\(param)")
     mpv.setString(MPVOption.GPURendererOptions.targetPeak, targetPeak)
     mpv.setString(MPVOption.GPURendererOptions.toneMapping, algorithm)
+    mpv.setString(MPVOption.GPURendererOptions.toneMappingParam, param)
   }
 
   /// Set the mpv tone mapping options appropriately for a SDR video.
@@ -562,11 +568,13 @@ extension VideoView {
       // Reset options to their defaults.
       mpv.setStringToDefault(MPVOption.GPURendererOptions.targetPeak)
       mpv.setStringToDefault(MPVOption.GPURendererOptions.toneMapping)
+      mpv.setStringToDefault(MPVOption.GPURendererOptions.toneMappingParam)
       return
     }
-    logHDR("Will enable tone mapping: target-peak=auto algorithm=auto")
+    logHDR("Will enable tone mapping: target-peak=auto algorithm=auto param=default")
     mpv.setString(MPVOption.GPURendererOptions.targetPeak, "auto")
     mpv.setString(MPVOption.GPURendererOptions.toneMapping, "auto")
+    mpv.setString(MPVOption.GPURendererOptions.toneMappingParam, "default")
   }
 
   // MARK: - Utils

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -666,6 +666,9 @@
 "settings.loadIccProfile.desc" = "Load the ICC profile for current display and use it to transform video RGB to screen output. (Only for SDR mode)";
 "settings.loadIccProfile.label" = "Load ICC profile";
 "settings.toneMappingAlgorithm.label" = "Algorithm";
+"settings.toneMappingAlgorithm.desc" = "Algorithm to use for tone-mapping images onto the target display.";
+"settings.toneMappingParamOverride.desc" = "Parameter for tuning the tone mapping algorithm. By default this is set to an algorithm-specific default value. Enable this setting to override that default.";
+"settings.toneMappingParamOverride.label" = "Tuning parameter";
 "settings.toneMappingTargetPeak.desc" = "Measured peak brightness of the display. By default IINA detects this value. If detection fails, target peak will be set to an appropriate value based on the transfer characteristics of the display. Enable this setting to manually specify the display's brightness.";
 "settings.toneMappingTargetPeak.label" = "Target peak";
 "settings.videoThreads.desc" = "Default: 0 (Auto)";


### PR DESCRIPTION
This commit will:
- Add `enableToneMappingParamOverride` and `toneMappingParamOverride` settings
- Change `SettingsPageVideo.sectionColor` to support the new settings
- Change `VideoView` to support setting `tone-mapping-param`
- Add a description for the tone mapping algorithm setting

The mpv tone-mapping-param option is a companion to the tone-mapping option. This commit allows users to customize the behavior of the tone mapping algorithm they select.

- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] Related issue: #
- [ ] Related Design Proposal: # / Not applicable
---
- [ ] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**
