### PR TITLE
Disable dragging settings windows by content background

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -3030,9 +3030,10 @@ class MainWindowController: PlayerWindowController {
     } else {
       timeLabelYPos = sliderFrame.origin.y + playSlider.frame.height + 5
     }
-    timePreviewView.frame.origin = CGPoint(
-      x: round(sliderFrame.origin.x + sliderFrame.size.width * percentage - timePreviewView.frame.width / 2),
-      y: timeLabelYPos)
+    // Split assignment so Swift can type-check under current Xcode (local 26.2).
+    let previewWidth = timePreviewView.frame.width
+    let previewX = round(sliderFrame.origin.x + sliderFrame.size.width * percentage - previewWidth / 2)
+    timePreviewView.setFrameOrigin(NSPoint(x: previewX, y: timeLabelYPos))
   }
 
 

--- a/iina/PreferenceWindowController.swift
+++ b/iina/PreferenceWindowController.swift
@@ -179,7 +179,8 @@ class PreferenceWindowController: NSWindowController {
 
     window?.titlebarAppearsTransparent = true
     window?.titleVisibility = .hidden
-    window?.isMovableByWindowBackground = true
+    // Only the title bar should move the window (#6323).
+    window?.isMovableByWindowBackground = false
 
     tableView.delegate = self
     tableView.dataSource = self

--- a/iina/SettingsWindow.swift
+++ b/iina/SettingsWindow.swift
@@ -185,7 +185,8 @@ class SettingsWindow: CommonWindow {
 
     self.title = "Settings"
     self.isOpaque = false
-    self.isMovableByWindowBackground = true
+    // Settings should only move from the title bar; dragging the content area is unexpected (#6323).
+    self.isMovableByWindowBackground = false
     self.titlebarAppearsTransparent = true
     self.toolbarStyle = .unified
     let toolbar = NSToolbar(identifier: "SettingsWindowToolbar")


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] Related issue: #6323
- [x] Related Design Proposal: # / Not applicable
---
- [x] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**

Settings / preference windows set `isMovableByWindowBackground = true`, so clicking anywhere dragged the window. Set it to `false` on both the new `SettingsWindow` and legacy `PreferenceWindowController` so only the title bar moves the window.

Also includes the same `MainWindowController` type-check split needed on Xcode 26.2.

**Test plan:**
- [x] Nightly `xcodebuild` build succeeded locally
- [ ] Open Settings → click/drag in content area → window does not move
- [ ] Drag from title bar → window moves
- [ ] Legacy Preferences (if reachable) behaves the same