### PR TITLE
Reserve space for interactive crop controls

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -257,6 +257,7 @@
 		84FBF23E1EF06A90003EA491 /* ThumbnailCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FBF23D1EF06A90003EA491 /* ThumbnailCache.swift */; };
 		8F49C36E213EFB7E0076C4F9 /* MiniPlayerWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8F49C370213EFB7E0076C4F9 /* MiniPlayerWindowController.xib */; };
 		9E47DAC01E3CFA6D00457420 /* DurationDisplayTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E47DABF1E3CFA6D00457420 /* DurationDisplayTextField.swift */; };
+		A450E0A1009F0C67AFE09A99 /* InteractiveModeLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C7CBDDDBC78271535F26B6E /* InteractiveModeLayout.swift */; };
 		B4E446E825CB53920069F06E /* PromiseKit in Frameworks */ = {isa = PBXBuildFile; productRef = B4E446E725CB53920069F06E /* PromiseKit */; };
 		B4E446F725CB54EF0069F06E /* Mustache in Frameworks */ = {isa = PBXBuildFile; productRef = B4E446F625CB54EF0069F06E /* Mustache */; };
 		B4E4470125CE3F930069F06E /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = B4E4470025CE3F930069F06E /* Sparkle */; };
@@ -1159,6 +1160,7 @@
 		6DC77D441F1439A800E96176 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/Localizable.strings; sourceTree = "<group>"; };
 		6DC77D461F1439A800E96176 /* uk */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = uk; path = uk.lproj/KeyBinding.strings; sourceTree = "<group>"; };
 		72CAEE6D1E229EAE00B8C894 /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/PrefGeneralViewController.strings"; sourceTree = "<group>"; };
+		7C7CBDDDBC78271535F26B6E /* InteractiveModeLayout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = InteractiveModeLayout.swift; sourceTree = "<group>"; };
 		8400D5C21E17C6D2006785F5 /* AboutWindowController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AboutWindowController.swift; sourceTree = "<group>"; };
 		8400D5C71E1AB2F1006785F5 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainWindowController.xib; sourceTree = "<group>"; };
 		8400D5D31E1AB312006785F5 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/InspectorWindowController.xib; sourceTree = "<group>"; };
@@ -2408,6 +2410,7 @@
 				E3CAD4AD2146DB23000B373A /* Javascript */,
 				84A0BAA61D2FAF8400BC8DA1 /* Utils */,
 				518DB7002FA6A1480024F0B0 /* Scripts */,
+				7C7CBDDDBC78271535F26B6E /* InteractiveModeLayout.swift */,
 			);
 			indentWidth = 2;
 			path = iina;
@@ -3116,6 +3119,7 @@
 				842F55A51EA17E7E0081D475 /* IINACommand.swift in Sources */,
 				840D47981DFEEE6A000D9A64 /* KeyMapping.swift in Sources */,
 				84BEEC3F1DFEDE2F00F945CA /* PrefKeyBindingViewController.swift in Sources */,
+				A450E0A1009F0C67AFE09A99 /* InteractiveModeLayout.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/iina/InteractiveMode.swift
+++ b/iina/InteractiveMode.swift
@@ -87,13 +87,24 @@ class InteractiveModeController: NSObject {
     mainWindow.hideUI(force: true)
     mainWindow.liveText.clearAnalysis()
 
-    // horizontal padding 20, top padding 20
+    // Measure control bar before sizing video so controls are not clipped.
+    mainWindow.videoViewContainer.addSubview(controlBar)
+    controlBar.translatesAutoresizingMaskIntoConstraints = false
+    controlBar.layoutSubtreeIfNeeded()
+    let controlBarHeight = max(controlBar.fittingSize.height, controlBar.frame.height)
+    let bottomMargin = InteractiveModeLayout.defaultBottomMargin
+    let topPadding = InteractiveModeLayout.defaultTopPadding
+    let reservedBottom = InteractiveModeLayout.reservedBottomHeight(controlBarHeight: controlBarHeight, bottomMargin: bottomMargin)
+
     let aspect = NSSize(width: player.videoSizeForDisplay.0, height: player.videoSizeForDisplay.1)
     let containerSize = mainWindow.videoViewContainer.frame.size
-    let maxSize = NSSize(width: containerSize.width - 40, height: containerSize.height - 108)
+    let maxSize = InteractiveModeLayout.maxVideoSize(
+      container: containerSize,
+      topPadding: topPadding,
+      reservedBottom: reservedBottom
+    )
     let newSize = aspect.shrink(toSize: maxSize)
     let horizontalPadding = (containerSize.width - newSize.width) / 2
-    let topPadding = CGFloat(20)
     let bottomPadding = containerSize.height - topPadding - newSize.height
 
     mainWindow.updateVideoViewConstraints([
@@ -109,8 +120,7 @@ class InteractiveModeController: NSObject {
     mainWindow.videoView.layoutSubtreeIfNeeded()
     mainWindow.forceDraw("interactive cropping")
 
-    mainWindow.videoViewContainer.addSubview(controlBar)
-    controlBar.padding(.bottom(20)).center(.x)
+    controlBar.padding(.bottom(bottomMargin)).center(.x)
 
     let origVideoSize = NSSize(width: ow, height: oh)
     let selectedRect: NSRect = selectWholeVideoByDefault ? NSRect(origin: .zero, size: origVideoSize) : .zero

--- a/iina/InteractiveModeLayout.swift
+++ b/iina/InteractiveModeLayout.swift
@@ -1,0 +1,21 @@
+import Foundation
+
+enum InteractiveModeLayout {
+  static let defaultTopPadding: CGFloat = 20
+  static let defaultSidePadding: CGFloat = 20
+  static let defaultBottomMargin: CGFloat = 20
+
+  static func reservedBottomHeight(controlBarHeight: CGFloat, bottomMargin: CGFloat = defaultBottomMargin) -> CGFloat {
+    controlBarHeight + bottomMargin * 2
+  }
+
+  static func maxVideoSize(container: CGSize,
+                           topPadding: CGFloat = defaultTopPadding,
+                           reservedBottom: CGFloat,
+                           sidePadding: CGFloat = defaultSidePadding) -> CGSize {
+    CGSize(
+      width: max(1, container.width - sidePadding * 2),
+      height: max(1, container.height - topPadding - reservedBottom)
+    )
+  }
+}


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] Related issue: #6286
- [x] Related Design Proposal: # / Not applicable
---
- [x] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**

Custom crop mode used a fixed 108pt bottom reserve. On short/narrow windows the control bar (aspect segments + Done/Cancel) could be clipped. The control bar is measured first and `InteractiveModeLayout` reserves enough space under the video.

**Test plan:**
- [x] `cd other/LogicTests && swift test` (3 layout tests)
- [x] Nightly `xcodebuild` build succeeded locally
- [ ] Open a small vertical video → Video → Crop → Custom…
- [ ] Confirm Done/Cancel and aspect segments are fully visible
- [ ] Apply/cancel crop still works