### PR TITLE
Reduce default-app UTI prompts and await consent

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7FA364E0D900440FDDFB3848 /* DefaultApplicationSetter.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA6261B6B7303FCE1E585D69 /* DefaultApplicationSetter.swift */; };
+		A67EFAA8AC5541F4CAC9739E /* DefaultAppUTITargets.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2E0D3C71DB1354DBBC4E0FB /* DefaultAppUTITargets.swift */; };
 		1326717E20852D0D000FA7E2 /* SubChooseViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1326718020852D0D000FA7E2 /* SubChooseViewController.xib */; };
 		3412DB8E2C2FC64C00BBC142 /* Equalizations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3412DB8D2C2FC64800BBC142 /* Equalizations.swift */; };
 		3415BC8A2FC82FD9003B3FBD /* TimePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3415BC892FC82FD5003B3FBD /* TimePreviewView.swift */; };
@@ -531,6 +533,8 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		EA6261B6B7303FCE1E585D69 /* DefaultApplicationSetter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultApplicationSetter.swift; sourceTree = "<group>"; };
+		A2E0D3C71DB1354DBBC4E0FB /* DefaultAppUTITargets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAppUTITargets.swift; sourceTree = "<group>"; };
 		0507C25E2B5617650043AD05 /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/MainMenu.strings; sourceTree = "<group>"; };
 		0507C25F2B5617660043AD05 /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/MainWindowController.strings; sourceTree = "<group>"; };
 		0507C2622B5617660043AD05 /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/InspectorWindowController.strings; sourceTree = "<group>"; };
@@ -2158,6 +2162,8 @@
 				51854CD92A1C489300C40B78 /* FFmpegLogger.swift */,
 				E3EC8C422F9432FD00FBB51E /* Dialog.swift */,
 				84EB1F061D2F5E76004FA5A1 /* Utility.swift */,
+				EA6261B6B7303FCE1E585D69 /* DefaultApplicationSetter.swift */,
+				A2E0D3C71DB1354DBBC4E0FB /* DefaultAppUTITargets.swift */,
 				8461C52F1D462488006E91FF /* VideoTime.swift */,
 				8434BAA61D5DF2DA003BECF2 /* Extensions.swift */,
 				84C8D5901D796F9700D98A0E /* Aspect.swift */,
@@ -2930,6 +2936,8 @@
 				E3EC8C412F92E6BA00FBB51E /* PluginManager.swift in Sources */,
 				E3C12F6B201F281F00297964 /* FirstRunManager.swift in Sources */,
 				84EB1F071D2F5E76004FA5A1 /* Utility.swift in Sources */,
+				7FA364E0D900440FDDFB3848 /* DefaultApplicationSetter.swift in Sources */,
+				A67EFAA8AC5541F4CAC9739E /* DefaultAppUTITargets.swift in Sources */,
 				E34BC28D2C27733200A94680 /* SettingsPage.swift in Sources */,
 				E3530702214935DE008FE492 /* JavascriptAPIConsole.swift in Sources */,
 				E3C2280D2FDFBE30009A1A89 /* SidebarSliderView.swift in Sources */,

--- a/iina/DefaultAppUTITargets.swift
+++ b/iina/DefaultAppUTITargets.swift
@@ -1,0 +1,62 @@
+//
+//  DefaultAppUTITargets.swift
+//  iina
+//
+//  Pure UTI selection for “Set as default application”.
+//
+
+import Foundation
+
+enum DefaultAppUTITargets {
+  struct ImportedType: Equatable {
+    let identifier: String
+    let conformsTo: [String]
+    let extensions: [String]
+  }
+
+  /// Prefer each imported identifier plus one preferred UTI per extension —
+  /// do not expand every UTI that claims the extension (prompt flood on Tahoe+).
+  static func identifiers(
+    importedTypes: [ImportedType],
+    checkedCategories: [String: Bool],
+    preferredIdentifierForExtension: (String) -> String?
+  ) -> Set<String> {
+    var result = Set<String>()
+    for type in importedTypes {
+      let matchesChecked = checkedCategories.contains { category, checked in
+        checked && type.conformsTo.contains(category)
+      }
+      guard matchesChecked else { continue }
+      result.insert(type.identifier)
+      for ext in type.extensions {
+        if let preferred = preferredIdentifierForExtension(ext) {
+          result.insert(preferred)
+        }
+      }
+    }
+    return result
+  }
+
+  static func parseImportedTypes(_ raw: [[String: Any]]) -> [ImportedType]? {
+    var parsed: [ImportedType] = []
+    for utiImportedType in raw {
+      guard
+        let identifier = utiImportedType["UTTypeIdentifier"] as? String,
+        let conformsTo = utiImportedType["UTTypeConformsTo"] as? [String],
+        let tagSpec = utiImportedType["UTTypeTagSpecification"] as? [String: Any]
+      else {
+        return nil
+      }
+      let exts: [String]
+      if let list = tagSpec["public.filename-extension"] as? [String] {
+        exts = list
+      } else if let single = tagSpec["public.filename-extension"] as? String {
+        exts = [single]
+      } else {
+        return nil
+      }
+      parsed.append(ImportedType(identifier: identifier, conformsTo: conformsTo, extensions: exts))
+    }
+    return parsed
+  }
+}

--- a/iina/DefaultApplicationSetter.swift
+++ b/iina/DefaultApplicationSetter.swift
@@ -1,0 +1,95 @@
+//
+//  DefaultApplicationSetter.swift
+//  iina
+//
+//  Sets IINA as the default handler for selected media UTIs.
+//
+
+import AppKit
+import UniformTypeIdentifiers
+
+enum DefaultApplicationSetter {
+
+  /// Collect UTI identifiers for the checked media categories using preferred types only.
+  static func targetIdentifiers(
+    utiImportedTypes: [[String: Any]],
+    checkedCategories: [String: Bool]
+  ) -> Set<String>? {
+    guard let imported = DefaultAppUTITargets.parseImportedTypes(utiImportedTypes) else {
+      return nil
+    }
+    return DefaultAppUTITargets.identifiers(
+      importedTypes: imported,
+      checkedCategories: checkedCategories,
+      preferredIdentifierForExtension: { ext in
+        UTType(filenameExtension: ext)?.identifier
+      }
+    )
+  }
+
+  /// Apply default-app registration. Uses `NSWorkspace` on macOS 12+ so consent
+  /// completions finish before reporting success; falls back to Launch Services otherwise.
+  static func setAsDefault(
+    identifiers: Set<String>,
+    completion: @escaping (_ successCount: Int, _ failedCount: Int) -> Void
+  ) {
+    let sorted = identifiers.sorted()
+    guard !sorted.isEmpty else {
+      completion(0, 0)
+      return
+    }
+
+    if #available(macOS 12.0, *) {
+      let appURL = Bundle.main.bundleURL
+      let group = DispatchGroup()
+      let lock = NSLock()
+      var successCount = 0
+      var failedCount = 0
+
+      for identifier in sorted {
+        guard let contentType = UTType(identifier) else {
+          Logger.log("Unknown UTI: \(identifier.quoted)", level: .error)
+          lock.lock()
+          failedCount += 1
+          lock.unlock()
+          continue
+        }
+        Logger.log("Setting default for UTI: \(identifier.quoted)", level: .verbose)
+        group.enter()
+        NSWorkspace.shared.setDefaultApplication(at: appURL, toOpen: contentType) { error in
+          lock.lock()
+          if let error {
+            Logger.log("Failed for \(identifier.quoted): \(error.localizedDescription)", level: .error)
+            failedCount += 1
+          } else {
+            successCount += 1
+          }
+          lock.unlock()
+          group.leave()
+        }
+      }
+
+      group.notify(queue: .main) {
+        completion(successCount, failedCount)
+      }
+    } else {
+      guard let cfBundleID = Bundle.main.bundleIdentifier as CFString? else {
+        completion(0, sorted.count)
+        return
+      }
+      var successCount = 0
+      var failedCount = 0
+      for identifier in sorted {
+        Logger.log("Setting default for UTI: \(identifier.quoted)", level: .verbose)
+        let status = LSSetDefaultRoleHandlerForContentType(identifier as CFString, .all, cfBundleID)
+        if status == kOSReturnSuccess {
+          successCount += 1
+        } else {
+          Logger.log("Failed for \(identifier.quoted): return value \(status)", level: .error)
+          failedCount += 1
+        }
+      }
+      completion(successCount, failedCount)
+    }
+  }
+}

--- a/iina/PrefUtilsViewController.swift
+++ b/iina/PrefUtilsViewController.swift
@@ -7,7 +7,6 @@
 //
 
 import Cocoa
-import UniformTypeIdentifiers
 
 class PrefUtilsViewController: PreferenceViewController, PreferenceWindowEmbeddable {
 
@@ -59,14 +58,10 @@ class PrefUtilsViewController: PreferenceViewController, PreferenceWindowEmbedda
   @IBAction func setAsDefaultOKBtnAction(_ sender: Any) {
 
     guard
-      let utiImportedTypes = Bundle.main.infoDictionary?["UTImportedTypeDeclarations"] as? [[String: Any]],
-      let cfBundleID = Bundle.main.bundleIdentifier as CFString?
+      let utiImportedTypes = Bundle.main.infoDictionary?["UTImportedTypeDeclarations"] as? [[String: Any]]
       else { return }
 
     Logger.log("Setting this app as default")
-
-    var successCount = 0
-    var failedCount = 0
 
     let utiChecked = [
       "public.movie": setAsDefaultVideoCheckBox.state == .on,
@@ -74,45 +69,17 @@ class PrefUtilsViewController: PreferenceViewController, PreferenceWindowEmbedda
       "public.text": setAsDefaultPlaylistCheckBox.state == .on
     ]
 
-    var utiTargetSet: Set<String> = []
-    for utiImportedType in utiImportedTypes {
-      guard
-        let identifier = utiImportedType["UTTypeIdentifier"] as? String,
-        let conformsTo = utiImportedType["UTTypeConformsTo"] as? [String],
-        let tagSpec = utiImportedType["UTTypeTagSpecification"] as? [String: Any],
-        let exts = tagSpec["public.filename-extension"] as? [String]
-      else {
-        return
-      }
+    guard let utiTargetSet = DefaultApplicationSetter.targetIdentifiers(
+      utiImportedTypes: utiImportedTypes,
+      checkedCategories: utiChecked
+    ) else { return }
 
-      // make sure that `conformsTo` contains a checked UTI type
-      guard utiChecked.map({ (uti, checked) in checked && conformsTo.contains(uti) }).contains(true) else {
-        continue
-      }
-
-      Logger.log("UTImportedType: \(identifier.quoted) ➤ \(exts)", level: .verbose)
-      for ext in exts {
-        let uttypesForExt = UTType.types(tag: ext, tagClass: .filenameExtension, conformingTo: nil)
-        for uttype in uttypesForExt {
-          utiTargetSet.insert(uttype.identifier)
-        }
-      }
+    DefaultApplicationSetter.setAsDefault(identifiers: utiTargetSet) { [weak self] successCount, failedCount in
+      guard let self else { return }
+      Utility.showAlert("set_default.success", arguments: [successCount, failedCount], style: .informational,
+                        sheetWindow: self.view.window)
+      self.view.window!.endSheet(self.setAsDefaultSheet)
     }
-
-    for identifier in utiTargetSet {
-      Logger.log("Setting default for UTI: \(identifier.quoted)", level: .verbose)
-      let status = LSSetDefaultRoleHandlerForContentType(identifier as CFString, .all, cfBundleID)
-      if status == kOSReturnSuccess {
-        successCount += 1
-      } else {
-        Logger.log("Failed for \(identifier.quoted): return value \(status)", level: .error)
-        failedCount += 1
-      }
-    }
-
-    Utility.showAlert("set_default.success", arguments: [successCount, failedCount], style: .informational,
-                      sheetWindow: view.window)
-    view.window!.endSheet(setAsDefaultSheet)
   }
 
   @IBAction func setAsDefaultCancelBtnAction(_ sender: Any) {

--- a/iina/SettingsPageUtilities.swift
+++ b/iina/SettingsPageUtilities.swift
@@ -208,14 +208,10 @@ fileprivate class SetAsDefaultSheetWindow: NSWindow {
   @objc func okBtnAction(_ sender: Any) {
     guard let window = contextWindow else { return }
     guard
-      let utiImportedTypes = Bundle.main.infoDictionary?["UTImportedTypeDeclarations"] as? [[String: Any]],
-      let cfBundleID = Bundle.main.bundleIdentifier as CFString?
+      let utiImportedTypes = Bundle.main.infoDictionary?["UTImportedTypeDeclarations"] as? [[String: Any]]
       else { return }
 
     Logger.log("Setting this app as default")
-
-    var successCount = 0
-    var failedCount = 0
 
     let utiChecked = [
       "public.movie": videoCheckBox.state == .on,
@@ -223,45 +219,17 @@ fileprivate class SetAsDefaultSheetWindow: NSWindow {
       "public.text": playListCheckBox.state == .on
     ]
 
-    var utiTargetSet: Set<String> = []
-    for utiImportedType in utiImportedTypes {
-      guard
-        let identifier = utiImportedType["UTTypeIdentifier"] as? String,
-        let conformsTo = utiImportedType["UTTypeConformsTo"] as? [String],
-        let tagSpec = utiImportedType["UTTypeTagSpecification"] as? [String: Any],
-        let exts = tagSpec["public.filename-extension"] as? [String]
-      else {
-        return
-      }
+    guard let utiTargetSet = DefaultApplicationSetter.targetIdentifiers(
+      utiImportedTypes: utiImportedTypes,
+      checkedCategories: utiChecked
+    ) else { return }
 
-      // make sure that `conformsTo` contains a checked UTI type
-      guard utiChecked.map({ (uti, checked) in checked && conformsTo.contains(uti) }).contains(true) else {
-        continue
-      }
-
-      Logger.log("UTImportedType: \(identifier.quoted) ➤ \(exts)", level: .verbose)
-      for ext in exts {
-        let uttypesForExt = UTType.types(tag: ext, tagClass: .filenameExtension, conformingTo: nil)
-        for uttype in uttypesForExt {
-          utiTargetSet.insert(uttype.identifier)
-        }
-      }
+    DefaultApplicationSetter.setAsDefault(identifiers: utiTargetSet) { [weak self] successCount, failedCount in
+      guard let self else { return }
+      Utility.showAlert("set_default.success", arguments: [successCount, failedCount], style: .informational,
+                        sheetWindow: window)
+      window.endSheet(self)
     }
-
-    for identifier in utiTargetSet {
-      Logger.log("Setting default for UTI: \(identifier.quoted)", level: .verbose)
-      let status = LSSetDefaultRoleHandlerForContentType(identifier as CFString, .all, cfBundleID)
-      if status == kOSReturnSuccess {
-        successCount += 1
-      } else {
-        Logger.log("Failed for \(identifier.quoted): return value \(status)", level: .error)
-        failedCount += 1
-      }
-    }
-
-    Utility.showAlert("set_default.success", arguments: [successCount, failedCount], style: .informational,
-                      sheetWindow: window)
-    window.endSheet(self)
   }
 
   @objc func cancelBtnAction(_ sender: Any) {


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] Related issue: #6300
- [x] Related Design Proposal: # / Not applicable
---
- [x] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**

“Set as default application” expanded every UTI that claimed each file extension via `UTType.types(...)`, then called deprecated `LSSetDefaultRoleHandlerForContentType` and reported success before macOS finished asking for consent (prompt flood on Tahoe+).

This selects each IINA-imported UTI plus the preferred UTI per extension, uses `NSWorkspace.setDefaultApplication(at:toOpen:)` on modern macOS, and shows the result alert after completions. Shared helper covers both the new Settings utilities sheet and legacy prefs. Also splits a `MainWindowController` expression that fails type-checking on Xcode 26.2 (CI uses 26.5).

**Test plan:**
- [x] `cd other/LogicTests && swift test` (3 tests)
- [x] Nightly `xcodebuild` build succeeded locally
- [ ] Settings → Utilities → Set as Default → confirm fewer prompts than before when IINA is not already default
- [ ] Success alert appears only after consent dialogs finish