### PR TITLE
Fix crash when bundled keybinding .conf is missing

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		B5561001A1B2C3D4E5F60718 /* KeyBindingDefaultConfigs.swift in Sources */ = {isa = PBXBuildFile; fileRef = F5561001A1B2C3D4E5F60718 /* KeyBindingDefaultConfigs.swift */; };
 		1326717E20852D0D000FA7E2 /* SubChooseViewController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 1326718020852D0D000FA7E2 /* SubChooseViewController.xib */; };
 		3412DB8E2C2FC64C00BBC142 /* Equalizations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3412DB8D2C2FC64800BBC142 /* Equalizations.swift */; };
 		3415BC8A2FC82FD9003B3FBD /* TimePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3415BC892FC82FD5003B3FBD /* TimePreviewView.swift */; };
@@ -531,6 +532,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		F5561001A1B2C3D4E5F60718 /* KeyBindingDefaultConfigs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyBindingDefaultConfigs.swift; sourceTree = "<group>"; };
 		0507C25E2B5617650043AD05 /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/MainMenu.strings; sourceTree = "<group>"; };
 		0507C25F2B5617660043AD05 /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/MainWindowController.strings; sourceTree = "<group>"; };
 		0507C2622B5617660043AD05 /* he */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = he; path = he.lproj/InspectorWindowController.strings; sourceTree = "<group>"; };
@@ -2158,6 +2160,7 @@
 				51854CD92A1C489300C40B78 /* FFmpegLogger.swift */,
 				E3EC8C422F9432FD00FBB51E /* Dialog.swift */,
 				84EB1F061D2F5E76004FA5A1 /* Utility.swift */,
+				F5561001A1B2C3D4E5F60718 /* KeyBindingDefaultConfigs.swift */,
 				8461C52F1D462488006E91FF /* VideoTime.swift */,
 				8434BAA61D5DF2DA003BECF2 /* Extensions.swift */,
 				84C8D5901D796F9700D98A0E /* Aspect.swift */,
@@ -2930,6 +2933,7 @@
 				E3EC8C412F92E6BA00FBB51E /* PluginManager.swift in Sources */,
 				E3C12F6B201F281F00297964 /* FirstRunManager.swift in Sources */,
 				84EB1F071D2F5E76004FA5A1 /* Utility.swift in Sources */,
+				B5561001A1B2C3D4E5F60718 /* KeyBindingDefaultConfigs.swift in Sources */,
 				E34BC28D2C27733200A94680 /* SettingsPage.swift in Sources */,
 				E3530702214935DE008FE492 /* JavascriptAPIConsole.swift in Sources */,
 				E3C2280D2FDFBE30009A1A89 /* SidebarSliderView.swift in Sources */,

--- a/iina/KeyBindingDefaultConfigs.swift
+++ b/iina/KeyBindingDefaultConfigs.swift
@@ -1,0 +1,26 @@
+//
+//  KeyBindingDefaultConfigs.swift
+//  iina
+//
+
+import Foundation
+
+enum KeyBindingDefaultConfigs {
+  /// Builds `[displayName: absolutePath]` from a config map and path resolver.
+  /// Skips missing resources instead of force-unwrapping bundle paths.
+  static func resolve(
+    configMap: KeyValuePairs<String, String>,
+    pathForResource: (String) -> String?,
+    onMissing: ((String, String) -> Void)? = nil
+  ) -> [String: String] {
+    var configs: [String: String] = [:]
+    for (name, resource) in configMap {
+      if let path = pathForResource(resource) {
+        configs[name] = path
+      } else {
+        onMissing?(name, resource)
+      }
+    }
+    return configs
+  }
+}

--- a/iina/MPVController.swift
+++ b/iina/MPVController.swift
@@ -614,11 +614,17 @@ class MPVController: NSObject {
 
     // Load keybindings. This is still required for mpv to handle media keys or apple remote.
     let userConfigs = PrefKeyBindingViewController.userConfigs
-    var inputConfPath =  PrefKeyBindingViewController.defaultConfigs["IINA Default"]
+    var inputConfPath = PrefKeyBindingViewController.defaultConfigs["IINA Default"]
+    if inputConfPath == nil {
+      log("Missing bundled keybinding config \"IINA Default\"", level: .error)
+    }
     if let confFromUd = Preference.string(for: .currentInputConfigName) {
       if let currentConfigFilePath = Utility.getFilePath(Configs: userConfigs, forConfig: confFromUd, showAlert: false) {
         inputConfPath = currentConfigFilePath
       }
+    }
+    if inputConfPath == nil {
+      log("Unable to resolve a key binding config path for mpv input-conf", level: .error)
     }
     chkErr(setOptionalOptionString(MPVOption.Input.inputConf, inputConfPath, level: .verbose))
 

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -585,14 +585,32 @@ class PlayerCore: NSObject {
   static func loadKeyBindings() {
     Logger.log("Loading key bindings")
     let userConfigs = PrefKeyBindingViewController.userConfigs
-    let iinaDefaultConfPath = PrefKeyBindingViewController.defaultConfigs["IINA Default"]!
+    let iinaDefaultConfPath = PrefKeyBindingViewController.defaultConfigs["IINA Default"]
+    if iinaDefaultConfPath == nil {
+      Logger.log("Missing bundled keybinding config \"IINA Default\"", level: .error)
+    }
     var inputConfPath = iinaDefaultConfPath
     if let confFromUd = Preference.string(for: .currentInputConfigName) {
       if let currentConfigFilePath = Utility.getFilePath(Configs: userConfigs, forConfig: confFromUd, showAlert: false) {
         inputConfPath = currentConfigFilePath
       }
     }
-    setKeyBindings(KeyMapping.parseInputConf(at: inputConfPath) ?? KeyMapping.parseInputConf(at: iinaDefaultConfPath)!)
+    guard let path = inputConfPath else {
+      Logger.log("Unable to resolve a key binding config path; using empty bindings", level: .error)
+      setKeyBindings([])
+      return
+    }
+    if let mappings = KeyMapping.parseInputConf(at: path) {
+      setKeyBindings(mappings)
+      return
+    }
+    if let fallback = iinaDefaultConfPath, fallback != path,
+       let mappings = KeyMapping.parseInputConf(at: fallback) {
+      setKeyBindings(mappings)
+      return
+    }
+    Logger.log("Unable to parse key binding config at \(path); using empty bindings", level: .error)
+    setKeyBindings([])
   }
 
   static func setKeyBindings(_ keyMappings: [KeyMapping]) {

--- a/iina/PrefKeyBindingViewController.swift
+++ b/iina/PrefKeyBindingViewController.swift
@@ -41,11 +41,13 @@ class PrefKeyBindingViewController: PreferenceViewController, PreferenceWindowEm
   let fallbackDefault = "IINA Default"
 
   static var defaultConfigs: [String: String] = {
-    var configs: [String: String] = [:]
-    for (key, value) in defaultConfigMap {
-      configs[key] = Bundle.main.path(forResource: value, ofType: "conf", inDirectory: "config")!
-    }
-    return configs
+    KeyBindingDefaultConfigs.resolve(
+      configMap: defaultConfigMap,
+      pathForResource: { Bundle.main.path(forResource: $0, ofType: "conf", inDirectory: "config") },
+      onMissing: { name, resource in
+        Logger.log("Missing bundled keybinding config \"\(name)\" (\(resource).conf in config/)", level: .error)
+      }
+    )
   }()
 
   static var userConfigs: [String: String] {
@@ -285,7 +287,12 @@ class PrefKeyBindingViewController: PreferenceViewController, PreferenceWindowEm
       DispatchQueue.main.async {
         Utility.showAlert("keybinding_config.error", arguments: [configName ?? "Unknown"], sheetWindow: self.view.window)
       }
-      loadConfigFile(fallbackDefault)
+      // Avoid infinite recursion if the bundled fallback default is also missing.
+      if configName != fallbackDefault, KC.defaultConfigs[fallbackDefault] != nil {
+        loadConfigFile(fallbackDefault)
+      } else {
+        Logger.log("Unable to load keybinding config \(configName ?? "Unknown"); bundled fallback unavailable", level: .error)
+      }
     }
 
     guard let configName = configName,

--- a/iina/SettingsPageKeyBindings.swift
+++ b/iina/SettingsPageKeyBindings.swift
@@ -97,11 +97,13 @@ fileprivate class ConfigEditor: SettingsAccessory.Base {
   let fallbackDefault = "IINA Default"
 
   static var defaultConfigs: [String: String] = {
-    var configs: [String: String] = [:]
-    for (key, value) in defaultConfigMap {
-      configs[key] = Bundle.main.path(forResource: value, ofType: "conf", inDirectory: "config")!
-    }
-    return configs
+    KeyBindingDefaultConfigs.resolve(
+      configMap: defaultConfigMap,
+      pathForResource: { Bundle.main.path(forResource: $0, ofType: "conf", inDirectory: "config") },
+      onMissing: { name, resource in
+        Logger.log("Missing bundled keybinding config \"\(name)\" (\(resource).conf in config/)", level: .error)
+      }
+    )
   }()
 
   static var userConfigs: [String: String] {
@@ -229,7 +231,12 @@ fileprivate class ConfigEditor: SettingsAccessory.Base {
       DispatchQueue.main.async {
         Utility.showAlert("keybinding_config.error", arguments: [configName ?? "Unknown"], sheetWindow: self.view.window)
       }
-      loadConfigFile(fallbackDefault)
+      // Avoid infinite recursion if the bundled fallback default is also missing.
+      if configName != fallbackDefault, KC.defaultConfigs[fallbackDefault] != nil {
+        loadConfigFile(fallbackDefault)
+      } else {
+        Logger.log("Unable to load keybinding config \(configName ?? "Unknown"); bundled fallback unavailable", level: .error)
+      }
     }
 
     guard let configName, let confFilePath = getFilePath(forConfig: configName, showAlert: false) else {


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] Related issue: #5561
- [x] Related Design Proposal: # / Not applicable
---
- [x] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**

`PrefKeyBindingViewController.defaultConfigs` (and the new Settings key-bindings page) force-unwrapped `Bundle.main.path(forResource:…)` for each bundled `.conf`. A missing resource crashed at launch while loading key bindings.

Resolve paths via a helper that skips/logs missing files, and stop force-unwrapping `"IINA Default"` in `PlayerCore.loadKeyBindings`. Also splits a `MainWindowController` expression that fails type-checking on Xcode 26.2 (CI uses 26.5).

**Test plan:**
- [x] `cd other/LogicTests && swift test` (3 tests)
- [x] Nightly `xcodebuild` build succeeded locally
- [ ] Launch with normal bundle → key bindings load as before
- [ ] Settings → Key Bindings still lists default configs when resources are present