### PR TITLE
Make slider scroll respect Control→Mouse None

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -244,6 +244,7 @@
 		84EB1EDC1D2F51D3004FA5A1 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 84EB1EDB1D2F51D3004FA5A1 /* Assets.xcassets */; };
 		84EB1F051D2F5C5B004FA5A1 /* AppData.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84EB1F041D2F5C5B004FA5A1 /* AppData.swift */; };
 		84EB1F071D2F5E76004FA5A1 /* Utility.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84EB1F061D2F5E76004FA5A1 /* Utility.swift */; };
+		57FEA4F1D4F4D5819C8D981B /* SliderScrollPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0DEDDF8F7AAD09B6F4892D7 /* SliderScrollPolicy.swift */; };
 		84EC12831F4F939000137C1E /* FilterPresets.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84EC12821F4F939000137C1E /* FilterPresets.swift */; };
 		84EC12861F504D2500137C1E /* FilterPresets.strings in Resources */ = {isa = PBXBuildFile; fileRef = 84EC12881F504D2500137C1E /* FilterPresets.strings */; };
 		84ED99FF1E009C8100A5159B /* PrefAdvancedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84ED99FD1E009C8100A5159B /* PrefAdvancedViewController.swift */; };
@@ -1461,6 +1462,7 @@
 		84EB1EE01D2F51D3004FA5A1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		84EB1F041D2F5C5B004FA5A1 /* AppData.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppData.swift; sourceTree = "<group>"; };
 		84EB1F061D2F5E76004FA5A1 /* Utility.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Utility.swift; sourceTree = "<group>"; };
+		B0DEDDF8F7AAD09B6F4892D7 /* SliderScrollPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SliderScrollPolicy.swift; sourceTree = "<group>"; };
 		84EC12821F4F939000137C1E /* FilterPresets.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FilterPresets.swift; sourceTree = "<group>"; };
 		84EC12871F504D2500137C1E /* Base */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = Base; path = Base.lproj/FilterPresets.strings; sourceTree = "<group>"; };
 		84EC12891F504D3B00137C1E /* zh-Hans */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "zh-Hans"; path = "zh-Hans.lproj/FilterPresets.strings"; sourceTree = "<group>"; };
@@ -2158,6 +2160,7 @@
 				51854CD92A1C489300C40B78 /* FFmpegLogger.swift */,
 				E3EC8C422F9432FD00FBB51E /* Dialog.swift */,
 				84EB1F061D2F5E76004FA5A1 /* Utility.swift */,
+				B0DEDDF8F7AAD09B6F4892D7 /* SliderScrollPolicy.swift */,
 				8461C52F1D462488006E91FF /* VideoTime.swift */,
 				8434BAA61D5DF2DA003BECF2 /* Extensions.swift */,
 				84C8D5901D796F9700D98A0E /* Aspect.swift */,
@@ -2930,6 +2933,7 @@
 				E3EC8C412F92E6BA00FBB51E /* PluginManager.swift in Sources */,
 				E3C12F6B201F281F00297964 /* FirstRunManager.swift in Sources */,
 				84EB1F071D2F5E76004FA5A1 /* Utility.swift in Sources */,
+				57FEA4F1D4F4D5819C8D981B /* SliderScrollPolicy.swift in Sources */,
 				E34BC28D2C27733200A94680 /* SettingsPage.swift in Sources */,
 				E3530702214935DE008FE492 /* JavascriptAPIConsole.swift in Sources */,
 				E3C2280D2FDFBE30009A1A89 /* SidebarSliderView.swift in Sources */,

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -3030,9 +3030,10 @@ class MainWindowController: PlayerWindowController {
     } else {
       timeLabelYPos = sliderFrame.origin.y + playSlider.frame.height + 5
     }
-    timePreviewView.frame.origin = CGPoint(
-      x: round(sliderFrame.origin.x + sliderFrame.size.width * percentage - timePreviewView.frame.width / 2),
-      y: timeLabelYPos)
+    // Split assignment so Swift can type-check under current Xcode (local 26.2).
+    let previewWidth = timePreviewView.frame.width
+    let previewX = round(sliderFrame.origin.x + sliderFrame.size.width * percentage - previewWidth / 2)
+    timePreviewView.setFrameOrigin(NSPoint(x: previewX, y: timeLabelYPos))
   }
 
 

--- a/iina/MiniPlaySlider.swift
+++ b/iina/MiniPlaySlider.swift
@@ -20,7 +20,15 @@ class MiniPlaySlider: NSSlider {
   /// position or click on a position within the slider.
   /// - Parameter event: Event indicating the scroll wheel position changed.
   override func scrollWheel(with event: NSEvent) {
-    guard !Preference.bool(for: .disablePlaySliderScrolling) else { return }
+    let verticalNone = (Preference.enum(for: .verticalScrollAction) as Preference.ScrollAction) == .none
+    let horizontalNone = (Preference.enum(for: .horizontalScrollAction) as Preference.ScrollAction) == .none
+    guard SliderScrollPolicy.shouldAllowScroll(
+      disableSliderScrolling: Preference.bool(for: .disablePlaySliderScrolling),
+      verticalActionNone: verticalNone,
+      horizontalActionNone: horizontalNone,
+      deltaX: event.scrollingDeltaX,
+      deltaY: event.scrollingDeltaY
+    ) else { return }
     super.scrollWheel(with: event)
   }
 }

--- a/iina/PlaySlider.swift
+++ b/iina/PlaySlider.swift
@@ -123,7 +123,15 @@ final class PlaySlider: NSSlider {
   /// position or click on a position within the slider.
   /// - Parameter event: Event indicating the scroll wheel position changed.
   override func scrollWheel(with event: NSEvent) {
-    guard !Preference.bool(for: .disablePlaySliderScrolling) else { return }
+    let verticalNone = (Preference.enum(for: .verticalScrollAction) as Preference.ScrollAction) == .none
+    let horizontalNone = (Preference.enum(for: .horizontalScrollAction) as Preference.ScrollAction) == .none
+    guard SliderScrollPolicy.shouldAllowScroll(
+      disableSliderScrolling: Preference.bool(for: .disablePlaySliderScrolling),
+      verticalActionNone: verticalNone,
+      horizontalActionNone: horizontalNone,
+      deltaX: event.scrollingDeltaX,
+      deltaY: event.scrollingDeltaY
+    ) else { return }
     super.scrollWheel(with: event)
   }
 }

--- a/iina/SliderScrollPolicy.swift
+++ b/iina/SliderScrollPolicy.swift
@@ -1,0 +1,25 @@
+//
+//  SliderScrollPolicy.swift
+//  iina
+//
+//  Pure rules for whether NSSlider should handle scrollWheel (issue #6324).
+//  Mirrored in other/LogicTests for unit tests.
+//
+
+import CoreGraphics
+
+enum SliderScrollPolicy {
+  /// Returns false when slider scrolling is disabled, or the dominant scroll axis
+  /// maps to ScrollAction.none (equal deltas count as vertical).
+  static func shouldAllowScroll(
+    disableSliderScrolling: Bool,
+    verticalActionNone: Bool,
+    horizontalActionNone: Bool,
+    deltaX: CGFloat,
+    deltaY: CGFloat
+  ) -> Bool {
+    if disableSliderScrolling { return false }
+    let verticalDominant = abs(deltaY) >= abs(deltaX)
+    return verticalDominant ? !verticalActionNone : !horizontalActionNone
+  }
+}

--- a/iina/VolumeSlider.swift
+++ b/iina/VolumeSlider.swift
@@ -30,7 +30,15 @@ class VolumeSlider: NSSlider {
   /// position within the slider.
   /// - Parameter event: Event indicating the scroll wheel position changed.
   override func scrollWheel(with event: NSEvent) {
-    guard !Preference.bool(for: .disableVolumeSliderScrolling) else { return }
+    let verticalNone = (Preference.enum(for: .verticalScrollAction) as Preference.ScrollAction) == .none
+    let horizontalNone = (Preference.enum(for: .horizontalScrollAction) as Preference.ScrollAction) == .none
+    guard SliderScrollPolicy.shouldAllowScroll(
+      disableSliderScrolling: Preference.bool(for: .disableVolumeSliderScrolling),
+      verticalActionNone: verticalNone,
+      horizontalActionNone: horizontalNone,
+      deltaX: event.scrollingDeltaX,
+      deltaY: event.scrollingDeltaY
+    ) else { return }
     super.scrollWheel(with: event)
   }
 }

--- a/other/LogicTests/Package.swift
+++ b/other/LogicTests/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+  name: "IINALogic",
+  platforms: [.macOS(.v12)],
+  products: [
+    .library(name: "IINALogic", targets: ["IINALogic"])
+  ],
+  targets: [
+    .target(name: "IINALogic"),
+    .testTarget(name: "IINALogicTests", dependencies: ["IINALogic"])
+  ]
+)

--- a/other/LogicTests/Sources/IINALogic/SliderScrollPolicy.swift
+++ b/other/LogicTests/Sources/IINALogic/SliderScrollPolicy.swift
@@ -1,0 +1,20 @@
+import CoreGraphics
+
+/// Pure rules for whether NSSlider should handle scrollWheel (issue #6324).
+/// Mirrored in `iina/SliderScrollPolicy.swift`.
+public enum SliderScrollPolicy {
+  /// Returns false when slider scrolling is disabled, or the dominant scroll axis
+  /// maps to ScrollAction.none (equal deltas count as vertical).
+  public static func shouldAllowScroll(
+    disableSliderScrolling: Bool,
+    verticalActionNone: Bool,
+    horizontalActionNone: Bool,
+    deltaX: CGFloat,
+    deltaY: CGFloat
+  ) -> Bool {
+    if disableSliderScrolling { return false }
+    let verticalDominant = abs(deltaY) >= abs(deltaX)
+    return verticalDominant ? !verticalActionNone : !horizontalActionNone
+  }
+}
+

--- a/other/LogicTests/Tests/IINALogicTests/SliderScrollPolicyTests.swift
+++ b/other/LogicTests/Tests/IINALogicTests/SliderScrollPolicyTests.swift
@@ -1,0 +1,113 @@
+import XCTest
+import CoreGraphics
+@testable import IINALogic
+
+final class SliderScrollPolicyTests: XCTestCase {
+  func testDisableSliderScrollingBlocksAllAxes() {
+    XCTAssertFalse(
+      SliderScrollPolicy.shouldAllowScroll(
+        disableSliderScrolling: true,
+        verticalActionNone: false,
+        horizontalActionNone: false,
+        deltaX: 0,
+        deltaY: 3
+      )
+    )
+    XCTAssertFalse(
+      SliderScrollPolicy.shouldAllowScroll(
+        disableSliderScrolling: true,
+        verticalActionNone: false,
+        horizontalActionNone: false,
+        deltaX: 3,
+        deltaY: 0
+      )
+    )
+  }
+
+  func testVerticalNoneBlocksVerticalDominantScroll() {
+    XCTAssertFalse(
+      SliderScrollPolicy.shouldAllowScroll(
+        disableSliderScrolling: false,
+        verticalActionNone: true,
+        horizontalActionNone: false,
+        deltaX: 0,
+        deltaY: 2
+      )
+    )
+  }
+
+  func testHorizontalNoneBlocksHorizontalDominantScroll() {
+    XCTAssertFalse(
+      SliderScrollPolicy.shouldAllowScroll(
+        disableSliderScrolling: false,
+        verticalActionNone: false,
+        horizontalActionNone: true,
+        deltaX: 2,
+        deltaY: 0
+      )
+    )
+  }
+
+  func testEqualDeltasTreatedAsVertical() {
+    XCTAssertFalse(
+      SliderScrollPolicy.shouldAllowScroll(
+        disableSliderScrolling: false,
+        verticalActionNone: true,
+        horizontalActionNone: false,
+        deltaX: 2,
+        deltaY: 2
+      )
+    )
+    XCTAssertTrue(
+      SliderScrollPolicy.shouldAllowScroll(
+        disableSliderScrolling: false,
+        verticalActionNone: false,
+        horizontalActionNone: true,
+        deltaX: 2,
+        deltaY: 2
+      )
+    )
+  }
+
+  func testAllowsScrollWhenAxisActionIsNotNone() {
+    XCTAssertTrue(
+      SliderScrollPolicy.shouldAllowScroll(
+        disableSliderScrolling: false,
+        verticalActionNone: false,
+        horizontalActionNone: true,
+        deltaX: 0,
+        deltaY: 3
+      )
+    )
+    XCTAssertTrue(
+      SliderScrollPolicy.shouldAllowScroll(
+        disableSliderScrolling: false,
+        verticalActionNone: true,
+        horizontalActionNone: false,
+        deltaX: 3,
+        deltaY: 0
+      )
+    )
+  }
+
+  func testBothAxesNoneBlocksEverything() {
+    XCTAssertFalse(
+      SliderScrollPolicy.shouldAllowScroll(
+        disableSliderScrolling: false,
+        verticalActionNone: true,
+        horizontalActionNone: true,
+        deltaX: 0,
+        deltaY: 1
+      )
+    )
+    XCTAssertFalse(
+      SliderScrollPolicy.shouldAllowScroll(
+        disableSliderScrolling: false,
+        verticalActionNone: true,
+        horizontalActionNone: true,
+        deltaX: 1,
+        deltaY: 0
+      )
+    )
+  }
+}


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] Related issue: #6324
- [x] Related Design Proposal: # / Not applicable
---
- [x] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**

With “Scroll vertically/horizontally to” set to None, scrolling over the play/volume bars still changed position/volume because `NSSlider.scrollWheel` bypasses IINA’s Control→Mouse handlers.

Gate play/volume slider scrolling with `SliderScrollPolicy` so None on the dominant axis (and the existing disable-slider-scroll prefs) blocks accidental seeks/volume changes. Also splits a `MainWindowController` expression that fails type-checking on Xcode 26.2 (CI uses 26.5).

**Test plan:**
- [x] `cd other/LogicTests && swift test` (6 tests)
- [x] Nightly `xcodebuild` build succeeded locally
- [ ] Set both scroll actions to None → scroll over seekbar/volume → no change
- [ ] Set vertical scroll to Seek → scroll over video still seeks; seekbar still usable by drag