### PR TITLE
Fix Key Bindings edit/delete buttons disappearing after scroll

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -318,6 +318,7 @@
 		E38099C42FC05B2E00D3333E /* SettingsPageControl.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38099B92FC05B2E00D3333E /* SettingsPageControl.swift */; };
 		E38099C52FC05B2E00D3333E /* SettingsPageGeneral.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38099BA2FC05B2E00D3333E /* SettingsPageGeneral.swift */; };
 		E38099C62FC05B2E00D3333E /* SettingsPageKeyBindings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38099BB2FC05B2E00D3333E /* SettingsPageKeyBindings.swift */; };
+		D27748F34C084C1EAA427F67 /* KeyMappingActionButtons.swift in Sources */ = {isa = PBXBuildFile; fileRef = E887D3272B1F4C07983A1E17 /* KeyMappingActionButtons.swift */; };
 		E38099C72FC05B2E00D3333E /* SettingsPageNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38099BC2FC05B2E00D3333E /* SettingsPageNetwork.swift */; };
 		E38099C82FC05B2E00D3333E /* SettingsPagePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38099BD2FC05B2E00D3333E /* SettingsPagePlugin.swift */; };
 		E38099C92FC05B2E00D3333E /* SettingsPageSubtitles.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38099BE2FC05B2E00D3333E /* SettingsPageSubtitles.swift */; };
@@ -1674,6 +1675,7 @@
 		E38099B92FC05B2E00D3333E /* SettingsPageControl.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPageControl.swift; sourceTree = "<group>"; };
 		E38099BA2FC05B2E00D3333E /* SettingsPageGeneral.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPageGeneral.swift; sourceTree = "<group>"; };
 		E38099BB2FC05B2E00D3333E /* SettingsPageKeyBindings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPageKeyBindings.swift; sourceTree = "<group>"; };
+		E887D3272B1F4C07983A1E17 /* KeyMappingActionButtons.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyMappingActionButtons.swift; sourceTree = "<group>"; };
 		E38099BC2FC05B2E00D3333E /* SettingsPageNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPageNetwork.swift; sourceTree = "<group>"; };
 		E38099BD2FC05B2E00D3333E /* SettingsPagePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPagePlugin.swift; sourceTree = "<group>"; };
 		E38099BE2FC05B2E00D3333E /* SettingsPageSubtitles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPageSubtitles.swift; sourceTree = "<group>"; };
@@ -2493,6 +2495,7 @@
 				E38099B92FC05B2E00D3333E /* SettingsPageControl.swift */,
 				E38099BA2FC05B2E00D3333E /* SettingsPageGeneral.swift */,
 				E38099BB2FC05B2E00D3333E /* SettingsPageKeyBindings.swift */,
+				E887D3272B1F4C07983A1E17 /* KeyMappingActionButtons.swift */,
 				E38099BC2FC05B2E00D3333E /* SettingsPageNetwork.swift */,
 				E38099BD2FC05B2E00D3333E /* SettingsPagePlugin.swift */,
 				E38099BE2FC05B2E00D3333E /* SettingsPageSubtitles.swift */,
@@ -2990,6 +2993,7 @@
 				E38099C42FC05B2E00D3333E /* SettingsPageControl.swift in Sources */,
 				E38099C52FC05B2E00D3333E /* SettingsPageGeneral.swift in Sources */,
 				E38099C62FC05B2E00D3333E /* SettingsPageKeyBindings.swift in Sources */,
+				D27748F34C084C1EAA427F67 /* KeyMappingActionButtons.swift in Sources */,
 				E38099C72FC05B2E00D3333E /* SettingsPageNetwork.swift in Sources */,
 				E38099C82FC05B2E00D3333E /* SettingsPagePlugin.swift in Sources */,
 				E31E62FF2FD90288005527B2 /* OSCFloatingView.swift in Sources */,

--- a/iina/KeyMappingActionButtons.swift
+++ b/iina/KeyMappingActionButtons.swift
@@ -1,0 +1,19 @@
+//
+//  KeyMappingActionButtons.swift
+//  iina
+//
+//  Pure visibility rules for Key Bindings row action buttons (issue #6329).
+//  Mirrored in other/LogicTests for unit tests.
+//
+
+enum KeyMappingActionButtons {
+  /// Edit/delete appear only for a selected row in an editable config.
+  static func shouldShowEditButtons(isSelected: Bool, isEditable: Bool) -> Bool {
+    isSelected && isEditable
+  }
+
+  /// Lock help appears only for a selected row in a locked/built-in config.
+  static func shouldShowLockButton(isSelected: Bool, isEditable: Bool) -> Bool {
+    isSelected && !isEditable
+  }
+}

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -3030,9 +3030,10 @@ class MainWindowController: PlayerWindowController {
     } else {
       timeLabelYPos = sliderFrame.origin.y + playSlider.frame.height + 5
     }
-    timePreviewView.frame.origin = CGPoint(
-      x: round(sliderFrame.origin.x + sliderFrame.size.width * percentage - timePreviewView.frame.width / 2),
-      y: timeLabelYPos)
+    // Split assignment so Swift can type-check under current Xcode (local 26.2).
+    let previewWidth = timePreviewView.frame.width
+    let previewX = round(sliderFrame.origin.x + sliderFrame.size.width * percentage - previewWidth / 2)
+    timePreviewView.setFrameOrigin(NSPoint(x: previewX, y: timeLabelYPos))
   }
 
 

--- a/iina/SettingsPageKeyBindings.swift
+++ b/iina/SettingsPageKeyBindings.swift
@@ -66,6 +66,7 @@ class SettingsPageKeyBindings: SettingsPage {
 
 private extension NSUserInterfaceItemIdentifier {
   static let columnID = NSUserInterfaceItemIdentifier("MainColumn")
+  static let rowViewID = NSUserInterfaceItemIdentifier("KeyMappingRowView")
 }
 
 
@@ -496,11 +497,18 @@ extension ConfigEditor: NSTableViewDelegate, NSMenuDelegate {
     let cell = (tableView.makeView(withIdentifier: .columnID, owner: self) as? KeyMappingCell) ?? KeyMappingCell()
 
     cell.setup(keyMapping: km, self)
+    // Cell reuse may keep isSelected true without firing RowView.isSelected didSet.
+    cell.selectionChanged(tableView.selectedRowIndexes.contains(row))
     return cell
   }
 
   func tableView(_ tableView: NSTableView, rowViewForRow row: Int) -> NSTableRowView? {
-    return RowView()
+    if let rowView = tableView.makeView(withIdentifier: .rowViewID, owner: self) as? RowView {
+      return rowView
+    }
+    let rowView = RowView()
+    rowView.identifier = .rowViewID
+    return rowView
   }
 
   func tableView(_ tableView: NSTableView, heightOfRow row: Int) -> CGFloat {
@@ -593,13 +601,12 @@ fileprivate class KeyMappingCell: NSTableCellView {
   }
 
   func selectionChanged(_ selected: Bool) {
-    if editor.isCurrentConfigEditable() {
-      editButton.isHidden = !selected
-      removeButton.isHidden = !selected
-      lockHelpButton.isHidden = true
-    } else {
-      lockHelpButton.isHidden = !selected
-    }
+    let editable = editor.isCurrentConfigEditable()
+    let showEdit = KeyMappingActionButtons.shouldShowEditButtons(isSelected: selected, isEditable: editable)
+    let showLock = KeyMappingActionButtons.shouldShowLockButton(isSelected: selected, isEditable: editable)
+    editButton.isHidden = !showEdit
+    removeButton.isHidden = !showEdit
+    lockHelpButton.isHidden = !showLock
   }
 }
 

--- a/other/LogicTests/Package.swift
+++ b/other/LogicTests/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+  name: "IINALogic",
+  platforms: [.macOS(.v12)],
+  products: [
+    .library(name: "IINALogic", targets: ["IINALogic"])
+  ],
+  targets: [
+    .target(name: "IINALogic"),
+    .testTarget(name: "IINALogicTests", dependencies: ["IINALogic"])
+  ]
+)

--- a/other/LogicTests/Sources/IINALogic/KeyMappingActionButtons.swift
+++ b/other/LogicTests/Sources/IINALogic/KeyMappingActionButtons.swift
@@ -1,0 +1,13 @@
+/// Pure visibility rules for Key Bindings row action buttons (issue #6329).
+/// Mirrored in `iina/KeyMappingActionButtons.swift`.
+public enum KeyMappingActionButtons {
+  /// Edit/delete appear only for a selected row in an editable config.
+  public static func shouldShowEditButtons(isSelected: Bool, isEditable: Bool) -> Bool {
+    isSelected && isEditable
+  }
+
+  /// Lock help appears only for a selected row in a locked/built-in config.
+  public static func shouldShowLockButton(isSelected: Bool, isEditable: Bool) -> Bool {
+    isSelected && !isEditable
+  }
+}

--- a/other/LogicTests/Tests/IINALogicTests/KeyMappingActionButtonsTests.swift
+++ b/other/LogicTests/Tests/IINALogicTests/KeyMappingActionButtonsTests.swift
@@ -1,0 +1,34 @@
+import XCTest
+@testable import IINALogic
+
+final class KeyMappingActionButtonsTests: XCTestCase {
+  func testEditButtonsShownOnlyWhenSelectedAndEditable() {
+    XCTAssertTrue(
+      KeyMappingActionButtons.shouldShowEditButtons(isSelected: true, isEditable: true)
+    )
+    XCTAssertFalse(
+      KeyMappingActionButtons.shouldShowEditButtons(isSelected: true, isEditable: false)
+    )
+    XCTAssertFalse(
+      KeyMappingActionButtons.shouldShowEditButtons(isSelected: false, isEditable: true)
+    )
+    XCTAssertFalse(
+      KeyMappingActionButtons.shouldShowEditButtons(isSelected: false, isEditable: false)
+    )
+  }
+
+  func testLockButtonShownOnlyWhenSelectedAndNotEditable() {
+    XCTAssertTrue(
+      KeyMappingActionButtons.shouldShowLockButton(isSelected: true, isEditable: false)
+    )
+    XCTAssertFalse(
+      KeyMappingActionButtons.shouldShowLockButton(isSelected: true, isEditable: true)
+    )
+    XCTAssertFalse(
+      KeyMappingActionButtons.shouldShowLockButton(isSelected: false, isEditable: false)
+    )
+    XCTAssertFalse(
+      KeyMappingActionButtons.shouldShowLockButton(isSelected: false, isEditable: true)
+    )
+  }
+}


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] Related issue: #6329
- [x] Related Design Proposal: # / Not applicable
---
- [x] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**

From #6329 Key Bindings feedback: select a shortcut, scroll it out of view and back — edit/delete buttons disappear.

`KeyMappingCell.setup` always hides the buttons; visibility was only restored via `RowView.isSelected` didSet, which does not fire again on cell reuse when the row is already selected. Re-sync selection after setup, and reuse `RowView` via `makeView`. Also splits a `MainWindowController` expression that fails type-checking on Xcode 26.2.

**Test plan:**
- [x] `cd other/LogicTests && swift test` (2 tests)
- [x] Nightly `xcodebuild` build succeeded locally
- [ ] Settings → Key Bindings → select row → scroll away/back → edit/delete still visible