### PR TITLE
Open plugin about/settings http(s) links in the browser

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -320,6 +320,7 @@
 		E38099C62FC05B2E00D3333E /* SettingsPageKeyBindings.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38099BB2FC05B2E00D3333E /* SettingsPageKeyBindings.swift */; };
 		E38099C72FC05B2E00D3333E /* SettingsPageNetwork.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38099BC2FC05B2E00D3333E /* SettingsPageNetwork.swift */; };
 		E38099C82FC05B2E00D3333E /* SettingsPagePlugin.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38099BD2FC05B2E00D3333E /* SettingsPagePlugin.swift */; };
+		4DE7B14211F54FBD8F991D58 /* PluginWebViewNavigation.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4FFB3FFB376461293B0038E /* PluginWebViewNavigation.swift */; };
 		E38099C92FC05B2E00D3333E /* SettingsPageSubtitles.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38099BE2FC05B2E00D3333E /* SettingsPageSubtitles.swift */; };
 		E38099CA2FC05B2E00D3333E /* SettingsPageUI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38099BF2FC05B2E00D3333E /* SettingsPageUI.swift */; };
 		E38099CB2FC05B2E00D3333E /* SettingsPageUtilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = E38099C02FC05B2E00D3333E /* SettingsPageUtilities.swift */; };
@@ -1676,6 +1677,7 @@
 		E38099BB2FC05B2E00D3333E /* SettingsPageKeyBindings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPageKeyBindings.swift; sourceTree = "<group>"; };
 		E38099BC2FC05B2E00D3333E /* SettingsPageNetwork.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPageNetwork.swift; sourceTree = "<group>"; };
 		E38099BD2FC05B2E00D3333E /* SettingsPagePlugin.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPagePlugin.swift; sourceTree = "<group>"; };
+		D4FFB3FFB376461293B0038E /* PluginWebViewNavigation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PluginWebViewNavigation.swift; sourceTree = "<group>"; };
 		E38099BE2FC05B2E00D3333E /* SettingsPageSubtitles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPageSubtitles.swift; sourceTree = "<group>"; };
 		E38099BF2FC05B2E00D3333E /* SettingsPageUI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPageUI.swift; sourceTree = "<group>"; };
 		E38099C02FC05B2E00D3333E /* SettingsPageUtilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsPageUtilities.swift; sourceTree = "<group>"; };
@@ -2495,6 +2497,7 @@
 				E38099BB2FC05B2E00D3333E /* SettingsPageKeyBindings.swift */,
 				E38099BC2FC05B2E00D3333E /* SettingsPageNetwork.swift */,
 				E38099BD2FC05B2E00D3333E /* SettingsPagePlugin.swift */,
+				D4FFB3FFB376461293B0038E /* PluginWebViewNavigation.swift */,
 				E38099BE2FC05B2E00D3333E /* SettingsPageSubtitles.swift */,
 				E38099BF2FC05B2E00D3333E /* SettingsPageUI.swift */,
 				E38099C02FC05B2E00D3333E /* SettingsPageUtilities.swift */,
@@ -2992,6 +2995,7 @@
 				E38099C62FC05B2E00D3333E /* SettingsPageKeyBindings.swift in Sources */,
 				E38099C72FC05B2E00D3333E /* SettingsPageNetwork.swift in Sources */,
 				E38099C82FC05B2E00D3333E /* SettingsPagePlugin.swift in Sources */,
+				4DE7B14211F54FBD8F991D58 /* PluginWebViewNavigation.swift in Sources */,
 				E31E62FF2FD90288005527B2 /* OSCFloatingView.swift in Sources */,
 				E3C228092FDF5EFF009A1A89 /* SidebarTrackSelector.swift in Sources */,
 				E38099C92FC05B2E00D3333E /* SettingsPageSubtitles.swift in Sources */,

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -3030,9 +3030,10 @@ class MainWindowController: PlayerWindowController {
     } else {
       timeLabelYPos = sliderFrame.origin.y + playSlider.frame.height + 5
     }
-    timePreviewView.frame.origin = CGPoint(
-      x: round(sliderFrame.origin.x + sliderFrame.size.width * percentage - timePreviewView.frame.width / 2),
-      y: timeLabelYPos)
+    // Split assignment so Swift can type-check under current Xcode (local 26.2).
+    let previewWidth = timePreviewView.frame.width
+    let previewX = round(sliderFrame.origin.x + sliderFrame.size.width * percentage - previewWidth / 2)
+    timePreviewView.setFrameOrigin(NSPoint(x: previewX, y: timeLabelYPos))
   }
 
 

--- a/iina/PluginWebViewNavigation.swift
+++ b/iina/PluginWebViewNavigation.swift
@@ -1,0 +1,25 @@
+//
+//  PluginWebViewNavigation.swift
+//  iina
+//
+//  Pure navigation policy for plugin settings/about WebViews (issue #6329).
+//  Mirrored in other/LogicTests for unit tests.
+//
+
+import Foundation
+
+enum PluginWebViewNavigation {
+  /// When a non-help tab would cancel in-WebView navigation, open http(s) in the browser instead.
+  static func shouldOpenExternally(
+    currentTabIsHelp: Bool,
+    requestURL: URL?,
+    allowedPrefPrefix: String?
+  ) -> Bool {
+    guard !currentTabIsHelp, let url = requestURL else { return false }
+    let absolute = url.absoluteString
+    if absolute == "about:blank" { return false }
+    if let allowedPrefPrefix, absolute.starts(with: allowedPrefPrefix) { return false }
+    guard let scheme = url.scheme?.lowercased() else { return false }
+    return scheme == "http" || scheme == "https"
+  }
+}

--- a/iina/PrefPluginViewController.swift
+++ b/iina/PrefPluginViewController.swift
@@ -541,13 +541,23 @@ extension PrefPluginViewController: NSTableViewDelegate, NSTableViewDataSource {
 extension PrefPluginViewController: WKNavigationDelegate {
   func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
     if webView == pluginPreferencesWebView {
+      let requestURL = navigationAction.request.url
+      let prefPrefix = currentPlugin?.preferencesPageURL?.absoluteString
       guard
-        let url = navigationAction.request.url,
-        url.absoluteString.starts(with: currentPlugin?.preferencesPageURL?.absoluteString ?? "000") || url.absoluteString == "about:blank"
+        let url = requestURL,
+        url.absoluteString.starts(with: prefPrefix ?? "000") || url.absoluteString == "about:blank"
       else {
-        Logger.log("Loading page from \(navigationAction.request.url?.absoluteString ?? "?") is not allowed", level: .error)
-          decisionHandler(.cancel)
-          return
+        if PluginWebViewNavigation.shouldOpenExternally(
+          currentTabIsHelp: false,
+          requestURL: requestURL,
+          allowedPrefPrefix: prefPrefix
+        ), let url = requestURL {
+          NSWorkspace.shared.open(url)
+        } else {
+          Logger.log("Loading page from \(requestURL?.absoluteString ?? "?") is not allowed", level: .error)
+        }
+        decisionHandler(.cancel)
+        return
       }
     }
     decisionHandler(.allow)

--- a/iina/SettingsPagePlugin.swift
+++ b/iina/SettingsPagePlugin.swift
@@ -764,12 +764,22 @@ fileprivate class PluginDetailsWindow: NSWindow {
 
 extension PluginDetailsWindow: WKScriptMessageHandler, WKNavigationDelegate {
   func webView(_ webView: WKWebView, decidePolicyFor navigationAction: WKNavigationAction, decisionHandler: @escaping (WKNavigationActionPolicy) -> Void) {
-    // don't allow remote pages in settings or about tab
+    // don't allow remote pages in settings or about tab; open http(s) links externally
     if currentTab != .help {
-      guard let url = navigationAction.request.url,
-            url.absoluteString.starts(with: plugin.preferencesPageURL?.absoluteString ?? "000") || url.absoluteString == "about:blank"
+      let requestURL = navigationAction.request.url
+      let prefPrefix = plugin.preferencesPageURL?.absoluteString
+      guard let url = requestURL,
+            url.absoluteString.starts(with: prefPrefix ?? "000") || url.absoluteString == "about:blank"
       else {
-        Logger.log("Loading page from \(navigationAction.request.url?.absoluteString ?? "?") is not allowed", level: .error)
+        if PluginWebViewNavigation.shouldOpenExternally(
+          currentTabIsHelp: false,
+          requestURL: requestURL,
+          allowedPrefPrefix: prefPrefix
+        ), let url = requestURL {
+          NSWorkspace.shared.open(url)
+        } else {
+          Logger.log("Loading page from \(requestURL?.absoluteString ?? "?") is not allowed", level: .error)
+        }
         decisionHandler(.cancel)
         return
       }

--- a/other/LogicTests/.gitignore
+++ b/other/LogicTests/.gitignore
@@ -1,0 +1,2 @@
+.build
+Package.resolved

--- a/other/LogicTests/Package.swift
+++ b/other/LogicTests/Package.swift
@@ -1,0 +1,14 @@
+// swift-tools-version: 5.9
+import PackageDescription
+
+let package = Package(
+  name: "IINALogic",
+  platforms: [.macOS(.v12)],
+  products: [
+    .library(name: "IINALogic", targets: ["IINALogic"])
+  ],
+  targets: [
+    .target(name: "IINALogic"),
+    .testTarget(name: "IINALogicTests", dependencies: ["IINALogic"])
+  ]
+)

--- a/other/LogicTests/Sources/IINALogic/PluginWebViewNavigation.swift
+++ b/other/LogicTests/Sources/IINALogic/PluginWebViewNavigation.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Pure navigation policy for plugin settings/about WebViews (issue #6329).
+/// Mirrored in `iina/PluginWebViewNavigation.swift`.
+public enum PluginWebViewNavigation {
+  /// When a non-help tab would cancel in-WebView navigation, open http(s) in the browser instead.
+  public static func shouldOpenExternally(
+    currentTabIsHelp: Bool,
+    requestURL: URL?,
+    allowedPrefPrefix: String?
+  ) -> Bool {
+    guard !currentTabIsHelp, let url = requestURL else { return false }
+    let absolute = url.absoluteString
+    if absolute == "about:blank" { return false }
+    if let allowedPrefPrefix, absolute.starts(with: allowedPrefPrefix) { return false }
+    guard let scheme = url.scheme?.lowercased() else { return false }
+    return scheme == "http" || scheme == "https"
+  }
+}

--- a/other/LogicTests/Tests/IINALogicTests/PluginWebViewNavigationTests.swift
+++ b/other/LogicTests/Tests/IINALogicTests/PluginWebViewNavigationTests.swift
@@ -1,0 +1,91 @@
+import XCTest
+@testable import IINALogic
+
+final class PluginWebViewNavigationTests: XCTestCase {
+  private let prefPrefix = "file:///plugins/demo/preferences.html"
+
+  func testHelpTabNeverOpensExternally() {
+    XCTAssertFalse(
+      PluginWebViewNavigation.shouldOpenExternally(
+        currentTabIsHelp: true,
+        requestURL: URL(string: "https://example.com"),
+        allowedPrefPrefix: prefPrefix
+      )
+    )
+  }
+
+  func testPrefPrefixAndAboutBlankStayInWebView() {
+    XCTAssertFalse(
+      PluginWebViewNavigation.shouldOpenExternally(
+        currentTabIsHelp: false,
+        requestURL: URL(string: prefPrefix),
+        allowedPrefPrefix: prefPrefix
+      )
+    )
+    XCTAssertFalse(
+      PluginWebViewNavigation.shouldOpenExternally(
+        currentTabIsHelp: false,
+        requestURL: URL(string: "\(prefPrefix)#section"),
+        allowedPrefPrefix: prefPrefix
+      )
+    )
+    XCTAssertFalse(
+      PluginWebViewNavigation.shouldOpenExternally(
+        currentTabIsHelp: false,
+        requestURL: URL(string: "about:blank"),
+        allowedPrefPrefix: prefPrefix
+      )
+    )
+  }
+
+  func testHttpHttpsLinksOpenExternallyOnAboutOrSettings() {
+    XCTAssertTrue(
+      PluginWebViewNavigation.shouldOpenExternally(
+        currentTabIsHelp: false,
+        requestURL: URL(string: "https://github.com/iina/plugin"),
+        allowedPrefPrefix: prefPrefix
+      )
+    )
+    XCTAssertTrue(
+      PluginWebViewNavigation.shouldOpenExternally(
+        currentTabIsHelp: false,
+        requestURL: URL(string: "http://example.com/docs"),
+        allowedPrefPrefix: prefPrefix
+      )
+    )
+  }
+
+  func testNonHttpSchemesDoNotOpenExternally() {
+    XCTAssertFalse(
+      PluginWebViewNavigation.shouldOpenExternally(
+        currentTabIsHelp: false,
+        requestURL: URL(string: "file:///tmp/secret.html"),
+        allowedPrefPrefix: prefPrefix
+      )
+    )
+    XCTAssertFalse(
+      PluginWebViewNavigation.shouldOpenExternally(
+        currentTabIsHelp: false,
+        requestURL: URL(string: "javascript:alert(1)"),
+        allowedPrefPrefix: prefPrefix
+      )
+    )
+    XCTAssertFalse(
+      PluginWebViewNavigation.shouldOpenExternally(
+        currentTabIsHelp: false,
+        requestURL: nil,
+        allowedPrefPrefix: prefPrefix
+      )
+    )
+  }
+
+  func testNilPrefPrefixStillOpensHttpExternally() {
+    XCTAssertTrue(
+      PluginWebViewNavigation.shouldOpenExternally(
+        currentTabIsHelp: false,
+        requestURL: URL(string: "https://example.com"),
+        allowedPrefPrefix: nil
+      )
+    )
+  }
+}


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] Related issue: #6329
- [x] Related Design Proposal: # / Not applicable
---
- [x] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**

From #6329 Plugins feedback: links on the plugin about page do nothing.

The WebView navigation policy for about/settings only allowed the preferences page URL / `about:blank`, so http(s) clicks were cancelled. Open those links with `NSWorkspace` instead of loading remote pages inside the settings WebView (same fix in legacy prefs). Also splits a `MainWindowController` expression that fails type-checking on Xcode 26.2.

**Test plan:**
- [x] `cd other/LogicTests && swift test` (5 tests)
- [x] Nightly `xcodebuild` build succeeded locally
- [ ] Plugins → open a plugin with about HTML links → click http(s) → opens in browser
- [ ] Settings tab still blocks loading arbitrary remote pages in-WebView