### PR TITLE
Hide Fit Window to Video in full screen

### DIFF
--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -886,6 +886,7 @@ class MainWindowController: PlayerWindowController {
 
   @objc func removeVideoViewBlackBars() {
     guard let window, Preference.unlockWindowAspectRatio else { return }
+    guard !fsState.isFullscreen else { return }
 
     let currentSize = videoViewContainer.frame.size
     let videoSize = player.videoSizeForDisplay
@@ -1537,6 +1538,7 @@ class MainWindowController: PlayerWindowController {
       blackOutOtherMonitors()
     }
     fadeableViews.update()
+    titleBarView.updateRemoveBlackBarButton()
 
     if player.info.state == .paused {
       if Preference.bool(for: .playWhenEnteringFullScreen) {
@@ -1674,6 +1676,7 @@ class MainWindowController: PlayerWindowController {
     fsState.finishAnimating()
     setWindowToolbar()
     fadeableViews.update()
+    titleBarView.updateRemoveBlackBarButton()
 
     if Preference.bool(for: .blackOutMonitor) {
       removeBlackWindow()

--- a/iina/SidebarLayoutPane.swift
+++ b/iina/SidebarLayoutPane.swift
@@ -159,8 +159,8 @@ class SidebarLayoutPane: SidebarScrollView {
       videoSettingsStack.setVisibilityPriority(.notVisible, for: lockWindowAspectStack)
       videoSettingsStack.setVisibilityPriority(.mustHold, for: dockedUIStack)
     }
-    // remove black bar button
-    if Preference.unlockWindowAspectRatio {
+    // remove black bar button (not applicable in full screen)
+    if Preference.unlockWindowAspectRatio && !player.mainWindow.fsState.isFullscreen {
       videoSettingsStack.setVisibilityPriority(.mustHold, for: removeBlackBarBtn)
     } else {
       videoSettingsStack.setVisibilityPriority(.notVisible, for: removeBlackBarBtn)

--- a/iina/Titlebar.swift
+++ b/iina/Titlebar.swift
@@ -257,7 +257,7 @@ class Titlebar: NSView {
   }
 
   func updateRemoveBlackBarButton() {
-    let shouldShow = Preference.unlockWindowAspectRatio
+    let shouldShow = Preference.unlockWindowAspectRatio && !mainWindow.fsState.isFullscreen
     removeBlackBarButton.isHidden = !shouldShow
   }
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] Related issue: #6280
- [x] Related Design Proposal: # / Not applicable
---
- [x] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**

In full screen, “Fit Window to Video” resizes the window around the video and breaks the FS layout (sidebar/OSC constrained to the video area).

No-op the action while fullscreen and hide the title bar / sidebar controls.

**Test plan:**
- [ ] Enter full screen with unlocked aspect → Fit Window to Video controls hidden
- [ ] If somehow invoked, layout unchanged
- [ ] Exit full screen → controls return; Fit Window to Video still works windowed