### PR TITLE
Respect natural scrolling for volume and seek

### DIFF
--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -531,9 +531,8 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
     var deltaX = isPrecise ? Double(event.scrollingDeltaX) : event.scrollingDeltaX.unifiedDouble
     var deltaY = isPrecise ? Double(event.scrollingDeltaY) : event.scrollingDeltaY.unifiedDouble * 2
 
-    if isNatural {
-      deltaY = -deltaY
-    } else {
+    // Keep system natural-scrolling for vertical (volume/seek); only flip X when not natural.
+    if !isNatural {
       deltaX = -deltaX
     }
 


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] Related issue: #6255
- [x] Related Design Proposal: # / Not applicable
---
- [x] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**

When system Mouse natural scrolling is on, `scrollingDeltaY` is already inverted. IINA then negated `deltaY` again, so volume/seek direction did not follow the system setting (unlike AppKit scroll views in Settings).

Stop re-inverting vertical deltas; keep the existing horizontal flip when natural scrolling is off.

**Test plan:**
- [ ] Toggle System Settings → Mouse → Natural scrolling
- [ ] Vertical scroll over video for volume (or seek) reverses with the system setting
- [ ] Settings window scroll still matches