### PR TITLE
Apply iina:// mpv_* options as file-local loadfile args

### DIFF
--- a/iina/AppDelegate.swift
+++ b/iina/AppDelegate.swift
@@ -898,6 +898,20 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         player = PlayerCore.activeOrNewForMenuAction(isAlternative: false)
       }
 
+      var fileLocalOptions: [String: String] = [:]
+      for query in queries {
+        if query.name.hasPrefix("mpv_") {
+          let mpvOptionName = String(query.name.dropFirst(4))
+          guard safeMPVOptions.contains(mpvOptionName) else {
+            Logger.log("mpv option \(mpvOptionName) rejected when parsing URL", level: .warning)
+            continue
+          }
+          guard let mpvOptionValue = query.value else { continue }
+          Logger.log("Using file-local mpv option \(mpvOptionName)=\(mpvOptionValue)")
+          fileLocalOptions[mpvOptionName] = mpvOptionValue
+        }
+      }
+
       // enqueue
       let playlistEmpty = PlayerCore.lastActive.info.$playlist.withLock { $0.isEmpty }
       if let enqueueValue = queryDict["enqueue"], enqueueValue == "1", !playlistEmpty {
@@ -905,6 +919,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
         PlayerCore.lastActive.postNotification(.iinaPlaylistChanged)
         PlayerCore.lastActive.sendOSD(.addToPlaylist(1))
       } else {
+        player.pendingFileLocalOptions = fileLocalOptions
         player.openURLString(urlValue)
       }
 
@@ -915,20 +930,6 @@ class AppDelegate: NSObject, NSApplicationDelegate, SPUUpdaterDelegate {
       } else if let pipValue = queryDict["pip"], pipValue == "1" {
         // pip
         player.mainWindow.enterPIP()
-      }
-
-      // mpv options
-      for query in queries {
-        if query.name.hasPrefix("mpv_") {
-          let mpvOptionName = String(query.name.dropFirst(4))
-          guard safeMPVOptions.contains(mpvOptionName) else {
-            Logger.log("mpv option \(mpvOptionName) rejected when parsing URL", level: .warning)
-            continue
-          }
-          guard let mpvOptionValue = query.value else { continue }
-          Logger.log("Setting \(mpvOptionName) to \(mpvOptionValue)")
-          player.mpv.setString(mpvOptionName, mpvOptionValue)
-        }
       }
 
       Logger.log("Finished URL scheme handling")

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -212,6 +212,9 @@ class PlayerCore: NSObject {
 
   var mpv: MPVController!
 
+  /// File-local mpv options from `iina://` `mpv_*` query items (applied via `loadfile`).
+  var pendingFileLocalOptions: [String: String] = [:]
+
   var receivedEndFileWhileLoading: Bool = false
 
   var plugins: [JavascriptPluginInstance] = []
@@ -574,7 +577,17 @@ class PlayerCore: NSObject {
     // Send load file command
     info.justOpenedFile = true
     info.state = .loading
-    mpv.command(.loadfile, args: [path], level: .verbose)
+    let fileLocalOptions = pendingFileLocalOptions
+    pendingFileLocalOptions.removeAll()
+    if fileLocalOptions.isEmpty {
+      mpv.command(.loadfile, args: [path], level: .verbose)
+    } else {
+      let optionsArg = fileLocalOptions
+        .sorted { $0.key < $1.key }
+        .map { "\($0.key)=\($0.value)" }
+        .joined(separator: ",")
+      mpv.command(.loadfile, args: [path, "replace", "0", optionsArg], level: .verbose)
+    }
 
     if Preference.bool(for: .autoRepeat) {
        let loopMode = Preference.DefaultRepeatMode(rawValue: Preference.integer(for: .defaultRepeatMode))


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] Related issue: #6246
- [x] Related Design Proposal: # / Not applicable
---
- [x] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**

`parsePendingURL` applied `mpv_*` query options with `setString` on the player core after `loadfile`. On a reused idle core those options (notably `start`) stuck into the next open.

Collect whitelisted options first and pass them as `loadfile`’s per-file options argument so they apply only to that media.

**Test plan:**
- [ ] Enable multiple windows; disable resume last playback
- [ ] `iina://open?url=file://…/long.mp4&new_window=1&mpv_start=50` → starts ~50s
- [ ] Close window (don’t quit); open short file via `iina://` without `mpv_start` → starts at 0 (does not jump to end)
- [ ] Other whitelisted `mpv_*` options still apply for that URL only