### PR TITLE
Delete file when volume has no Trash

### DIFF
--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -331,6 +331,7 @@
 
 "alert.permanent_delete_no_trash.title" = "Trash Unavailable";
 "alert.permanent_delete_no_trash.message" = "This volume does not have a Trash. Permanently delete the file? This cannot be undone.";
+"alert.permanent_delete_no_trash.button" = "Delete Permanently";
 
 "alert.filter_hwdec.message" = "You are about to apply a video filter. However, your current hardware decoder may not support video filters well. You can either disable hardware decoding or switch to Auto(Copy), which will consume twice the memory.\nYou may need to repeat previous operation (like setting the crop) to make it work.";
 "alert.filter_hwdec.abort" = "Abort";

--- a/iina/Base.lproj/Localizable.strings
+++ b/iina/Base.lproj/Localizable.strings
@@ -329,6 +329,9 @@
 "alert.delete_file.title" = "Delete File";
 "alert.delete_file.message" = "Are you sure to trash the selected files?";
 
+"alert.permanent_delete_no_trash.title" = "Trash Unavailable";
+"alert.permanent_delete_no_trash.message" = "This volume does not have a Trash. Permanently delete the file? This cannot be undone.";
+
 "alert.filter_hwdec.message" = "You are about to apply a video filter. However, your current hardware decoder may not support video filters well. You can either disable hardware decoding or switch to Auto(Copy), which will consume twice the memory.\nYou may need to repeat previous operation (like setting the crop) to make it work.";
 "alert.filter_hwdec.abort" = "Abort";
 "alert.filter_hwdec.turn_off" = "Turn off hardware decoding";

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -56,7 +56,7 @@ class MainMenuActionHandler: NSResponder, NSMenuItemValidation {
     do {
       let index = player.mpv.getInt(MPVProperty.playlistPos)
       player.playlistRemove(index)
-      try FileManager.default.trashItem(at: url, resultingItemURL: nil)
+      try Utility.trashOrRemoveItem(at: url)
     } catch let error {
       Utility.showAlert("playlist.error_deleting", arguments: [error.localizedDescription])
     }

--- a/iina/MainMenuActions.swift
+++ b/iina/MainMenuActions.swift
@@ -55,8 +55,8 @@ class MainMenuActionHandler: NSResponder, NSMenuItemValidation {
     guard let url = player.info.currentURL, !player.info.isNetworkResource else { return }
     do {
       let index = player.mpv.getInt(MPVProperty.playlistPos)
+      guard try Utility.trashOrRemoveItem(at: url) else { return }
       player.playlistRemove(index)
-      try Utility.trashOrRemoveItem(at: url)
     } catch let error {
       Utility.showAlert("playlist.error_deleting", arguments: [error.localizedDescription])
     }

--- a/iina/SidebarPlaylistPane.swift
+++ b/iina/SidebarPlaylistPane.swift
@@ -557,7 +557,7 @@ extension SidebarPlaylistPane: NSMenuDelegate, NSMenuItemValidation {
       let url = URL(fileURLWithPath: playlistItem.filename)
       do {
         Logger.log("Trashing row \(index): \(url.standardizedFileURL)", subsystem: player.subsystem)
-        try Utility.trashOrRemoveItem(at: url)
+        guard try Utility.trashOrRemoveItem(at: url) else { continue }
         successes.insert(index)
       } catch let error {
         Utility.showAlert("playlist.error_deleting", arguments: [error.localizedDescription])

--- a/iina/SidebarPlaylistPane.swift
+++ b/iina/SidebarPlaylistPane.swift
@@ -557,7 +557,7 @@ extension SidebarPlaylistPane: NSMenuDelegate, NSMenuItemValidation {
       let url = URL(fileURLWithPath: playlistItem.filename)
       do {
         Logger.log("Trashing row \(index): \(url.standardizedFileURL)", subsystem: player.subsystem)
-        try FileManager.default.trashItem(at: url, resultingItemURL: nil)
+        try Utility.trashOrRemoveItem(at: url)
         successes.insert(index)
       } catch let error {
         Utility.showAlert("playlist.error_deleting", arguments: [error.localizedDescription])

--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -421,7 +421,14 @@ class Utility {
       return true
     } catch let error as NSError
       where error.domain == NSCocoaErrorDomain && error.code == NSFeatureUnsupportedError {
-      guard quickAskPanel("permanent_delete_no_trash") else { return false }
+      let panel = NSAlert()
+      panel.messageText = NSLocalizedString("alert.permanent_delete_no_trash.title", comment: "Trash Unavailable")
+      panel.informativeText = NSLocalizedString("alert.permanent_delete_no_trash.message", comment: "This volume does not have a Trash…")
+      panel.alertStyle = .warning
+      // Label the destructive action on the button — users often skip the message text.
+      panel.addButton(withTitle: NSLocalizedString("alert.permanent_delete_no_trash.button", comment: "Delete Permanently"))
+      panel.addButton(withTitle: NSLocalizedString("general.cancel", comment: "Cancel"))
+      guard panel.runModal() == .alertFirstButtonReturn else { return false }
       try FileManager.default.removeItem(at: url)
       return true
     }

--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -412,13 +412,18 @@ class Utility {
     }
   }
 
-  /// Move `url` to Trash, or permanently delete it when the volume has no Trash (e.g. some network shares).
-  static func trashOrRemoveItem(at url: URL) throws {
+  /// Move `url` to Trash. If the volume has no Trash, ask before permanently deleting.
+  /// - Returns: `false` if the user canceled permanent delete; otherwise `true` after the file is gone.
+  @discardableResult
+  static func trashOrRemoveItem(at url: URL) throws -> Bool {
     do {
       try FileManager.default.trashItem(at: url, resultingItemURL: nil)
+      return true
     } catch let error as NSError
       where error.domain == NSCocoaErrorDomain && error.code == NSFeatureUnsupportedError {
+      guard quickAskPanel("permanent_delete_no_trash") else { return false }
       try FileManager.default.removeItem(at: url)
+      return true
     }
   }
 

--- a/iina/Utility.swift
+++ b/iina/Utility.swift
@@ -412,6 +412,16 @@ class Utility {
     }
   }
 
+  /// Move `url` to Trash, or permanently delete it when the volume has no Trash (e.g. some network shares).
+  static func trashOrRemoveItem(at url: URL) throws {
+    do {
+      try FileManager.default.trashItem(at: url, resultingItemURL: nil)
+    } catch let error as NSError
+      where error.domain == NSCocoaErrorDomain && error.code == NSFeatureUnsupportedError {
+      try FileManager.default.removeItem(at: url)
+    }
+  }
+
   static private let allTypes: [MPVTrack.TrackType] = [.video, .audio, .sub]
 
   static func mediaType(forExtension ext: String) -> MPVTrack.TrackType? {

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -331,6 +331,7 @@
 
 "alert.permanent_delete_no_trash.title" = "Trash Unavailable";
 "alert.permanent_delete_no_trash.message" = "This volume does not have a Trash. Permanently delete the file? This cannot be undone.";
+"alert.permanent_delete_no_trash.button" = "Delete Permanently";
 
 "alert.filter_hwdec.message" = "You are about to apply a video filter. However, your current hardware decoder may not support video filters well. You can either disable hardware decoding or switch to Auto(Copy), which will consume twice the memory.\nYou may need to repeat previous operation (like setting the crop) to make it work.";
 "alert.filter_hwdec.abort" = "Abort";

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -329,6 +329,9 @@
 "alert.delete_file.title" = "Delete File";
 "alert.delete_file.message" = "Are you sure to trash the selected files?";
 
+"alert.permanent_delete_no_trash.title" = "Trash Unavailable";
+"alert.permanent_delete_no_trash.message" = "This volume does not have a Trash. Permanently delete the file? This cannot be undone.";
+
 "alert.filter_hwdec.message" = "You are about to apply a video filter. However, your current hardware decoder may not support video filters well. You can either disable hardware decoding or switch to Auto(Copy), which will consume twice the memory.\nYou may need to repeat previous operation (like setting the crop) to make it work.";
 "alert.filter_hwdec.abort" = "Abort";
 "alert.filter_hwdec.turn_off" = "Turn off hardware decoding";


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [x] Related issue: #5870
- [x] Related Design Proposal: # / Not applicable
---
- [x] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**

`trashItem` fails with `NSFeatureUnsupportedError` on volumes without a Trash (e.g. some network shares / forced `.Trashes`). Delete Current File and playlist “delete file” then showed an alert and left the file.

Fall back to `removeItem` only for that error code.

**Test plan:**
- [ ] Local volume with Trash → Delete still moves to Bin
- [ ] Volume without Trash (SMB / no `.Trashes`) → Delete removes the file, no alert
- [ ] Other trash failures (permissions) still show the error alert