### PR TITLE
Show loading indicator when opening media takes longer than usual

### DIFF
--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		3412DB8E2C2FC64C00BBC142 /* Equalizations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3412DB8D2C2FC64800BBC142 /* Equalizations.swift */; };
 		3415BC8A2FC82FD9003B3FBD /* TimePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3415BC892FC82FD5003B3FBD /* TimePreviewView.swift */; };
 		3465CC8F2FC72181008DBFB6 /* BufferIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3465CC8E2FC7217C008DBFB6 /* BufferIndicatorView.swift */; };
+		A100CC8F2FC72181008DBFB6 /* MediaLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100CC8E2FC7217C008DBFB6 /* MediaLoadingView.swift */; };
 		348F71962DE2A819006C587D /* MPVCommandWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348F71952DE2A814006C587D /* MPVCommandWrappers.swift */; };
 		34AAF7CE302EAF6500E9835C /* libjxl.0.11.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34AAF7B6302EAF6500E9835C /* libjxl.0.11.dylib */; };
 		34AAF7CF302EAF6500E9835C /* libunibreak.7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34AAF7C7302EAF6500E9835C /* libunibreak.7.dylib */; };
@@ -603,6 +604,7 @@
 		3412DB8D2C2FC64800BBC142 /* Equalizations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Equalizations.swift; sourceTree = "<group>"; };
 		3415BC892FC82FD5003B3FBD /* TimePreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimePreviewView.swift; sourceTree = "<group>"; };
 		3465CC8E2FC7217C008DBFB6 /* BufferIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BufferIndicatorView.swift; sourceTree = "<group>"; };
+		A100CC8E2FC7217C008DBFB6 /* MediaLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaLoadingView.swift; sourceTree = "<group>"; };
 		348B000028DC688D0045F683 /* sr-Latn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "sr-Latn"; path = "sr-Latn.lproj/MiniPlayerWindowController.strings"; sourceTree = "<group>"; };
 		348B000128DC688D0045F683 /* sr-Latn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "sr-Latn"; path = "sr-Latn.lproj/GuideWindowController.strings"; sourceTree = "<group>"; };
 		348B000428DC688E0045F683 /* sr-Latn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "sr-Latn"; path = "sr-Latn.lproj/FontPickerWindowController.strings"; sourceTree = "<group>"; };
@@ -2524,6 +2526,7 @@
 				E3A239AB2FC70EC200CE6ACC /* AdditionalInfoView.swift */,
 				E3A239A92FC6D88C00CE6ACC /* OSDView.swift */,
 				3465CC8E2FC7217C008DBFB6 /* BufferIndicatorView.swift */,
+				A100CC8E2FC7217C008DBFB6 /* MediaLoadingView.swift */,
 				E3A239A72FC6D44D00CE6ACC /* TranslucentView.swift */,
 				E3B93C862FE9F77000803513 /* InteractiveMode.swift */,
 				34C4D19B2FC58482006B829F /* LiveTextSupport.swift */,
@@ -3093,6 +3096,7 @@
 				D17504A82918F13E005C3DD0 /* OSCToolbarButton.swift in Sources */,
 				84F7258F1D486185000DEF1B /* MPVProperty.swift in Sources */,
 				3465CC8F2FC72181008DBFB6 /* BufferIndicatorView.swift in Sources */,
+				A100CC8F2FC72181008DBFB6 /* MediaLoadingView.swift in Sources */,
 				E35306FC214813B7008FE492 /* JavascriptPluginInstance.swift in Sources */,
 				E3C228072FDF4E0C009A1A89 /* SidebarVideoPane.swift in Sources */,
 				84A0BA971D2FA1CE00BC8DA1 /* PlayerCore.swift in Sources */,

--- a/iina.xcodeproj/project.pbxproj
+++ b/iina.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		3412DB8E2C2FC64C00BBC142 /* Equalizations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3412DB8D2C2FC64800BBC142 /* Equalizations.swift */; };
 		3415BC8A2FC82FD9003B3FBD /* TimePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3415BC892FC82FD5003B3FBD /* TimePreviewView.swift */; };
 		3465CC8F2FC72181008DBFB6 /* BufferIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3465CC8E2FC7217C008DBFB6 /* BufferIndicatorView.swift */; };
-		A100CC8F2FC72181008DBFB6 /* MediaLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100CC8E2FC7217C008DBFB6 /* MediaLoadingView.swift */; };
 		348F71962DE2A819006C587D /* MPVCommandWrappers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 348F71952DE2A814006C587D /* MPVCommandWrappers.swift */; };
 		34AAF7CE302EAF6500E9835C /* libjxl.0.11.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34AAF7B6302EAF6500E9835C /* libjxl.0.11.dylib */; };
 		34AAF7CF302EAF6500E9835C /* libunibreak.7.dylib in Frameworks */ = {isa = PBXBuildFile; fileRef = 34AAF7C7302EAF6500E9835C /* libunibreak.7.dylib */; };
@@ -258,6 +257,7 @@
 		84FBF23E1EF06A90003EA491 /* ThumbnailCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 84FBF23D1EF06A90003EA491 /* ThumbnailCache.swift */; };
 		8F49C36E213EFB7E0076C4F9 /* MiniPlayerWindowController.xib in Resources */ = {isa = PBXBuildFile; fileRef = 8F49C370213EFB7E0076C4F9 /* MiniPlayerWindowController.xib */; };
 		9E47DAC01E3CFA6D00457420 /* DurationDisplayTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E47DABF1E3CFA6D00457420 /* DurationDisplayTextField.swift */; };
+		A100CC8F2FC72181008DBFB6 /* MediaLoadingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A100CC8E2FC7217C008DBFB6 /* MediaLoadingView.swift */; };
 		B4E446E825CB53920069F06E /* PromiseKit in Frameworks */ = {isa = PBXBuildFile; productRef = B4E446E725CB53920069F06E /* PromiseKit */; };
 		B4E446F725CB54EF0069F06E /* Mustache in Frameworks */ = {isa = PBXBuildFile; productRef = B4E446F625CB54EF0069F06E /* Mustache */; };
 		B4E4470125CE3F930069F06E /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = B4E4470025CE3F930069F06E /* Sparkle */; };
@@ -604,7 +604,6 @@
 		3412DB8D2C2FC64800BBC142 /* Equalizations.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Equalizations.swift; sourceTree = "<group>"; };
 		3415BC892FC82FD5003B3FBD /* TimePreviewView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimePreviewView.swift; sourceTree = "<group>"; };
 		3465CC8E2FC7217C008DBFB6 /* BufferIndicatorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BufferIndicatorView.swift; sourceTree = "<group>"; };
-		A100CC8E2FC7217C008DBFB6 /* MediaLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaLoadingView.swift; sourceTree = "<group>"; };
 		348B000028DC688D0045F683 /* sr-Latn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "sr-Latn"; path = "sr-Latn.lproj/MiniPlayerWindowController.strings"; sourceTree = "<group>"; };
 		348B000128DC688D0045F683 /* sr-Latn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "sr-Latn"; path = "sr-Latn.lproj/GuideWindowController.strings"; sourceTree = "<group>"; };
 		348B000428DC688E0045F683 /* sr-Latn */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = "sr-Latn"; path = "sr-Latn.lproj/FontPickerWindowController.strings"; sourceTree = "<group>"; };
@@ -1499,6 +1498,7 @@
 		9DB9ED5C20889D66006B1492 /* nl */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = nl; path = nl.lproj/SubChooseViewController.strings; sourceTree = "<group>"; };
 		9E47DABF1E3CFA6D00457420 /* DurationDisplayTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DurationDisplayTextField.swift; sourceTree = "<group>"; };
 		9E63CAB61E3F7D0E00EA66C9 /* fr */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = fr; path = fr.lproj/MainMenu.strings; sourceTree = "<group>"; };
+		A100CC8E2FC7217C008DBFB6 /* MediaLoadingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MediaLoadingView.swift; sourceTree = "<group>"; };
 		B305513A2190B0C600D3F70E /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/MiniPlayerWindowController.strings; sourceTree = "<group>"; };
 		B3066F5F1F161538004D7559 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/InitialWindowController.strings; sourceTree = "<group>"; };
 		B35E0A072107C0E500453AA7 /* it */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = it; path = it.lproj/PrefUtilsViewController.strings; sourceTree = "<group>"; };
@@ -4318,6 +4318,7 @@
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = 67CQ77V27R;
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 			};
@@ -4365,6 +4366,7 @@
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = 67CQ77V27R;
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 			};
@@ -4412,6 +4414,7 @@
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = 67CQ77V27R;
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 			};
@@ -4424,6 +4427,7 @@
 				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
 				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				DEAD_CODE_STRIPPING = YES;
+				DEVELOPMENT_TEAM = 67CQ77V27R;
 				SKIP_INSTALL = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
 			};

--- a/iina/MainWindowController.swift
+++ b/iina/MainWindowController.swift
@@ -96,6 +96,7 @@ class MainWindowController: PlayerWindowController {
   var osdView: OSDView!
   var additionalInfoView: AdditionalInfoView!
   var bufferIndicatorView: BufferIndicatorView!
+  var mediaLoadingView: MediaLoadingView!
   var timePreviewView: TimePreviewView!
   var titlebarOnTopButton: NSButton!
   var thumbnailPeekView: ThumbnailPeekView!
@@ -484,6 +485,14 @@ class MainWindowController: PlayerWindowController {
     cv.addSubview(additionalInfoView)
     bufferIndicatorView = BufferIndicatorView(mainWindow: self)
     cv.addSubview(bufferIndicatorView)
+    mediaLoadingView = MediaLoadingView(style: .regular)
+    cv.addSubview(mediaLoadingView)
+    NSLayoutConstraint.activate([
+      mediaLoadingView.leadingAnchor.constraint(equalTo: cv.leadingAnchor),
+      mediaLoadingView.trailingAnchor.constraint(equalTo: cv.trailingAnchor),
+      mediaLoadingView.topAnchor.constraint(equalTo: cv.topAnchor),
+      mediaLoadingView.bottomAnchor.constraint(equalTo: cv.bottomAnchor)
+    ])
     titleBarView = Titlebar(mainWindow: self)
     cv.addSubview(titleBarView)
     sidebars.installSubviews(in: cv)
@@ -1433,6 +1442,7 @@ class MainWindowController: PlayerWindowController {
     // Reset default visibilities
     thumbnailPeekView.isHidden = true
     timePreviewView.isHidden = true
+    mediaLoadingView?.hide()
 
     player.events.emit(.windowWillClose)
   }
@@ -2168,6 +2178,43 @@ class MainWindowController: PlayerWindowController {
         fsState == .windowed ? .auto : .alwaysShown
       }
     }
+  }
+
+  override func showLoadingScreen(for url: URL?) {
+    guard let window else { return }
+
+    updateTitle()
+
+    titleBarView?.isHidden = false
+    titleBarView?.alphaValue = 1.0
+
+    oscBottomView?.isHidden = true
+    oscFloatingView?.isHidden = true
+
+    mediaLoadingView?.show()
+
+    if !window.isVisible {
+      let screen = determineScreenToUse(window)
+      let screenRect = screen.visibleFrame
+      var initialFrame: NSRect
+
+      if let rectString = UserDefaults.standard.value(forKey: "MainWindowLastPosition") as? String,
+         let _ = NSScreen.screens.first(where: { NSPointInRect(NSRectFromString(rectString).origin, $0.frame) }) {
+        initialFrame = NSRectFromString(rectString)
+      } else {
+        initialFrame = AppData.sizeWhenNoVideo.centeredRect(in: screenRect)
+      }
+      initialFrame = initialFrame.constrain(in: screenRect)
+      window.setFrame(initialFrame, display: false)
+
+      showWindow(self)
+    } else {
+      window.makeKeyAndOrderFront(self)
+    }
+  }
+
+  override func hideLoadingScreen() {
+    mediaLoadingView?.hide()
   }
 
   // MARK: - UI: OSD

--- a/iina/MediaLoadingView.swift
+++ b/iina/MediaLoadingView.swift
@@ -1,0 +1,95 @@
+//
+//  MediaLoadingView.swift
+//  iina
+//
+//  Created by Antigravity on 2026/09/12.
+//  Copyright © 2026 lhc. All rights reserved.
+//
+
+import Cocoa
+
+class MediaLoadingView: NSView {
+
+  enum Style {
+    case regular
+    case compact
+  }
+
+  private let style: Style
+  private let stackView: NSStackView
+  let progressIndicator: NSProgressIndicator
+  let loadingLabel: NSTextField
+
+  init(style: Style = .regular) {
+    self.style = style
+    self.progressIndicator = NSProgressIndicator()
+    self.loadingLabel = NSTextField(labelWithString: NSLocalizedString("main.loading", comment: "Loading…"))
+    self.stackView = NSStackView()
+
+    super.init(frame: .zero)
+
+    setupView()
+  }
+
+  @MainActor required init?(coder: NSCoder) {
+    fatalError("init(coder:) has not been implemented")
+  }
+
+  private func setupView() {
+    wantsLayer = true
+    translatesAutoresizingMaskIntoConstraints = false
+    isHidden = true
+
+    // Background is dark to match video canvas
+    layer?.backgroundColor = NSColor.black.cgColor
+
+    progressIndicator.style = .spinning
+    progressIndicator.isDisplayedWhenStopped = false
+    progressIndicator.translatesAutoresizingMaskIntoConstraints = false
+
+    loadingLabel.alignment = .center
+    loadingLabel.lineBreakMode = .byTruncatingTail
+    loadingLabel.translatesAutoresizingMaskIntoConstraints = false
+
+    switch style {
+    case .regular:
+      progressIndicator.controlSize = .regular
+      loadingLabel.font = .systemFont(ofSize: 14, weight: .medium)
+      loadingLabel.textColor = .secondaryLabelColor
+      stackView.spacing = 12
+    case .compact:
+      progressIndicator.controlSize = .small
+      loadingLabel.font = .systemFont(ofSize: 11, weight: .regular)
+      loadingLabel.textColor = .secondaryLabelColor
+      stackView.spacing = 6
+    }
+
+    stackView.orientation = .vertical
+    stackView.alignment = .centerX
+    stackView.distribution = .fill
+    stackView.translatesAutoresizingMaskIntoConstraints = false
+
+    stackView.addArrangedSubview(progressIndicator)
+    stackView.addArrangedSubview(loadingLabel)
+
+    addSubview(stackView)
+
+    NSLayoutConstraint.activate([
+      stackView.centerXAnchor.constraint(equalTo: centerXAnchor),
+      stackView.centerYAnchor.constraint(equalTo: centerYAnchor),
+      stackView.leadingAnchor.constraint(greaterThanOrEqualTo: leadingAnchor, constant: 16),
+      stackView.trailingAnchor.constraint(lessThanOrEqualTo: trailingAnchor, constant: -16),
+    ])
+  }
+
+  func show(message: String? = nil) {
+    loadingLabel.stringValue = message ?? NSLocalizedString("main.loading", comment: "Loading…")
+    progressIndicator.startAnimation(nil)
+    isHidden = false
+  }
+
+  func hide() {
+    progressIndicator.stopAnimation(nil)
+    isHidden = true
+  }
+}

--- a/iina/MediaLoadingView.swift
+++ b/iina/MediaLoadingView.swift
@@ -40,8 +40,8 @@ class MediaLoadingView: NSView {
     translatesAutoresizingMaskIntoConstraints = false
     isHidden = true
 
-    // Background is dark to match video canvas
-    layer?.backgroundColor = NSColor.black.cgColor
+    // Dark gray background matching QuickTime Player (#222222)
+    layer?.backgroundColor = NSColor(srgbRed: 34.0 / 255.0, green: 34.0 / 255.0, blue: 34.0 / 255.0, alpha: 1.0).cgColor
 
     progressIndicator.style = .spinning
     progressIndicator.isDisplayedWhenStopped = false
@@ -54,13 +54,13 @@ class MediaLoadingView: NSView {
     switch style {
     case .regular:
       progressIndicator.controlSize = .regular
-      loadingLabel.font = .systemFont(ofSize: 14, weight: .medium)
-      loadingLabel.textColor = .secondaryLabelColor
-      stackView.spacing = 12
+      loadingLabel.font = .systemFont(ofSize: 15, weight: .semibold)
+      loadingLabel.textColor = NSColor(white: 0.92, alpha: 1.0)
+      stackView.spacing = 10
     case .compact:
       progressIndicator.controlSize = .small
-      loadingLabel.font = .systemFont(ofSize: 11, weight: .regular)
-      loadingLabel.textColor = .secondaryLabelColor
+      loadingLabel.font = .systemFont(ofSize: 12, weight: .medium)
+      loadingLabel.textColor = NSColor(white: 0.92, alpha: 1.0)
       stackView.spacing = 6
     }
 

--- a/iina/MiniPlayerWindowController.swift
+++ b/iina/MiniPlayerWindowController.swift
@@ -51,6 +51,7 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
   var volumeControlBackground: NSVisualEffectView!
   var volumeContainerTrailingConstraint: NSLayoutConstraint!
   var defaultAlbumArt: NSView!
+  var mediaLoadingView: MediaLoadingView!
   var togglePlaylistButton: NSButton!
   var toggleAlbumArtButton: NSButton!
 
@@ -123,6 +124,15 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     videoWrapperShrinkConstraint.priority = NSLayoutConstraint.Priority(250)
     videoWrapperShrinkConstraint.isActive = true
     defaultAlbumArt.widthAnchor.constraint(equalTo: defaultAlbumArt.heightAnchor).isActive = true
+
+    self.mediaLoadingView = MediaLoadingView(style: .compact)
+    videoWrapperView.addSubview(mediaLoadingView)
+    NSLayoutConstraint.activate([
+      mediaLoadingView.leadingAnchor.constraint(equalTo: videoWrapperView.leadingAnchor),
+      mediaLoadingView.trailingAnchor.constraint(equalTo: videoWrapperView.trailingAnchor),
+      mediaLoadingView.topAnchor.constraint(equalTo: videoWrapperView.topAnchor),
+      mediaLoadingView.bottomAnchor.constraint(equalTo: videoWrapperView.bottomAnchor)
+    ])
 
     // background view
 
@@ -496,6 +506,21 @@ class MiniPlayerWindowController: PlayerWindowController, NSPopoverDelegate {
     }
     titleLabel.scroll()
     artistAlbumLabel.scroll()
+  }
+
+  override func showLoadingScreen(for url: URL?) {
+    guard let window else { return }
+    updateTitle()
+    mediaLoadingView?.show()
+    if !window.isVisible {
+      showWindow(self)
+    } else {
+      window.makeKeyAndOrderFront(self)
+    }
+  }
+
+  override func hideLoadingScreen() {
+    mediaLoadingView?.hide()
   }
 
   override func updateVolume() {

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -227,6 +227,22 @@ class PlayerCore: NSObject {
   lazy var info: PlaybackInfo = PlaybackInfo(self)
 
   var syncUITimer: Timer?
+  private var loadingTimer: Timer?
+
+  func scheduleLoadingTimer(for url: URL?) {
+    cancelLoadingTimer()
+    loadingTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: false) { [weak self] _ in
+      guard let self else { return }
+      if self.info.state == .loading || self.info.state == .starting {
+        self.currentController.showLoadingScreen(for: url)
+      }
+    }
+  }
+
+  func cancelLoadingTimer() {
+    loadingTimer?.invalidate()
+    loadingTimer = nil
+  }
 
   var displayOSD: Bool = true
 
@@ -546,9 +562,7 @@ class PlayerCore: NSObject {
     info.videoPosition = nil
     info.videoTracks = []
     info.videoWidth = nil
-    if isNetwork {
-      AppDelegate.shared.openURLWindow.showLoadingScreen(playerCore: self)
-    }
+    scheduleLoadingTimer(for: url)
 
     let _ = mainWindow.window
     mainWindow.pendingShow = true
@@ -943,6 +957,8 @@ class PlayerCore: NSObject {
   ///     and call this method again to continue the process of stopping. It is important to stop the background task as if it is still
   ///     running when the mpv core is shutdown it may call into mpv triggering a crash.
   func stop() {
+    cancelLoadingTimer()
+    currentController.hideLoadingScreen()
     guard info.state != .shutDown else { return }
     savePlaybackPosition()
 
@@ -2084,6 +2100,10 @@ class PlayerCore: NSObject {
     }
     info.isNetworkResource = !info.currentURL!.isFileURL
 
+    if loadingTimer == nil {
+      scheduleLoadingTimer(for: info.currentURL)
+    }
+
     // set "date last opened" attribute
     if let url = info.currentURL, url.isFileURL {
       let time = Date().timeIntervalSince1970
@@ -2333,6 +2353,8 @@ class PlayerCore: NSObject {
   }
 
   func idleActiveChanged() {
+    cancelLoadingTimer()
+    currentController.hideLoadingScreen()
     if receivedEndFileWhileLoading && info.state == .starting {
       DispatchQueue.main.async { [unowned self] in
         currentController.close()
@@ -2733,6 +2755,8 @@ class PlayerCore: NSObject {
   }
 
   func notifyWindowVideoSizeChanged() {
+    cancelLoadingTimer()
+    currentController.hideLoadingScreen()
     currentController.handleVideoSizeChange()
     if currentController.pendingShow {
       currentController.pendingShow = false

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -563,12 +563,20 @@ class PlayerCore: NSObject {
     info.videoPosition = nil
     info.videoTracks = []
     info.videoWidth = nil
-    scheduleLoadingTimer(for: url)
-
     let _ = mainWindow.window
     mainWindow.pendingShow = true
     miniPlayer.pendingShow = true
     initialWindow.close()
+
+    // If autoSwitchToMusicMode is enabled and opening an audio file, pre-switch to miniPlayer
+    // so loading screen and playback are hosted directly in miniPlayer without window jumping.
+    let isAudioFile = Utility.mediaType(forExtension: url.pathExtension) == .audio
+    if Preference.bool(for: .autoSwitchToMusicMode), !overrideAutoSwitchToMusicMode, isAudioFile, !isInMiniPlayer {
+      log("Pre-switching to mini player for audio file: \(url.pathExtension)")
+      switchToMiniPlayer(automatically: true, showMiniPlayer: false)
+    }
+
+    scheduleLoadingTimer(for: url)
 
     if !mpv.getFlag(MPVOption.PlaybackControl.pause) {
       log("Pausing playback before running load command")

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -228,10 +228,11 @@ class PlayerCore: NSObject {
 
   var syncUITimer: Timer?
   private var loadingTimer: Timer?
+  private static let loadingScreenThreshold: TimeInterval = 1.0
 
   func scheduleLoadingTimer(for url: URL?) {
     cancelLoadingTimer()
-    loadingTimer = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: false) { [weak self] _ in
+    loadingTimer = Timer.scheduledTimer(withTimeInterval: Self.loadingScreenThreshold, repeats: false) { [weak self] _ in
       guard let self else { return }
       if self.info.state == .loading || self.info.state == .starting {
         self.currentController.showLoadingScreen(for: url)

--- a/iina/PlayerCore.swift
+++ b/iina/PlayerCore.swift
@@ -571,7 +571,7 @@ class PlayerCore: NSObject {
     // If autoSwitchToMusicMode is enabled and opening an audio file, pre-switch to miniPlayer
     // so loading screen and playback are hosted directly in miniPlayer without window jumping.
     let isAudioFile = Utility.mediaType(forExtension: url.pathExtension) == .audio
-    if Preference.bool(for: .autoSwitchToMusicMode), !overrideAutoSwitchToMusicMode, isAudioFile, !isInMiniPlayer {
+    if Preference.bool(for: .autoSwitchToMusicMode), !overrideAutoSwitchToMusicMode, isAudioFile, !isInMiniPlayer, !mainWindow.fsState.isFullscreen {
       log("Pre-switching to mini player for audio file: \(url.pathExtension)")
       switchToMiniPlayer(automatically: true, showMiniPlayer: false)
     }

--- a/iina/PlayerWindowController.swift
+++ b/iina/PlayerWindowController.swift
@@ -617,6 +617,12 @@ class PlayerWindowController: NSWindowController, NSWindowDelegate {
   func updateTitle() {
     fatalError("Must implement in the subclass")
   }
+
+  @objc
+  func showLoadingScreen(for url: URL?) {}
+
+  @objc
+  func hideLoadingScreen() {}
   
   func updateVolume() {
     volumeSlider.doubleValue = player.info.volume

--- a/iina/en.lproj/Localizable.strings
+++ b/iina/en.lproj/Localizable.strings
@@ -43,6 +43,7 @@
 "main.buffering_indicator" = "Buffering… %d%%";
 "main.opening_stream" = "Opening stream…";
 "main.seeking_indicator" = "Seeking…";
+"main.loading" = "Loading…";
 "osc.precision" = "Precision";
 "osc.1s" = "1 second";
 "osc.100ms" = "100 milliseconds";

--- a/iina/zh-Hans.lproj/Localizable.strings
+++ b/iina/zh-Hans.lproj/Localizable.strings
@@ -43,6 +43,7 @@
 "main.buffering_indicator" = "缓冲中… %d%%";
 "main.opening_stream" = "正在打开流媒体……";
 "main.seeking_indicator" = "检索中…";
+"main.loading" = "加载中…";
 "osc.precision" = "精确度";
 "osc.1s" = "1秒";
 "osc.100ms" = "100毫秒";

--- a/iina/zh-Hans.lproj/Localizable.strings
+++ b/iina/zh-Hans.lproj/Localizable.strings
@@ -43,7 +43,6 @@
 "main.buffering_indicator" = "缓冲中… %d%%";
 "main.opening_stream" = "正在打开流媒体……";
 "main.seeking_indicator" = "检索中…";
-"main.loading" = "加载中…";
 "osc.precision" = "精确度";
 "osc.1s" = "1秒";
 "osc.100ms" = "100毫秒";


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] Related issue: N/A
- [ ] Related Design Proposal: N/A
---
- [x] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**

Sometimes opening a file (e.g. an extra large one or one from a network share) can take a couple of seconds before playback starts. Right now nothing shows up during that time, which can feel like the app hung or the click didn't register.

This PR adds a simple QuickTime-like spinner and "Loading…" text on the window when a file takes longer than 1 second to load. Fast/local files won't show it at all. It also supports mini player, and if music mode auto-switch is on, audio files will stay in mini player while loading instead of jumping between windows.

<img width="1072" height="652" alt="Screenshot 2026-09-12 at 14 15 23" src="https://github.com/user-attachments/assets/a1ebee01-0115-4cee-a979-032f91a86e71" />
