### PR TITLE
Add AirPlay to the community plugins list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,7 @@ IINA is always looking for contributions, whether it's through bug reports, code
 - **[User Scripts](https://github.com/iina/plugin-userscript)** (`iina/plugin-userscript`) - Run custom JavaScript snippets.
 
 ### Community Plugins
+- **[AirPlay](https://github.com/ozykhan/iina-airplay)** (`ozykhan/iina-airplay`) - Cast the current file to an Apple TV over AirPlay; IINA stays the remote.
 - **[Anime4K](https://github.com/yorkyang2333/iina-anime4k)** (`yorkyang2333/iina-anime4k`) - Apply Anime4K shaders for real-time anime upscaling.
 - **[Auto Skip](https://github.com/pangziqiang/iina-auto-skip)** (`pangziqiang/iina-auto-skip`) - Automatically skip intro and outro sections with visual drag-to-set overlay.
 - **[Bilingual Audio](https://github.com/glechic/iina-bilingual-audio)** (`glechic/iina-bilingual-audio`) - Play two audio tracks with left/right channel separation for bilingual viewing.

--- a/plugins.json
+++ b/plugins.json
@@ -1,5 +1,11 @@
 [
   {
+    "name": "AirPlay",
+    "url": "https://github.com/ozykhan/iina-airplay",
+    "desc": "Cast the current file to an Apple TV over AirPlay; IINA stays the remote.",
+    "id": "dev.faruk.iina-airplay"
+  },
+  {
     "name": "Anime4K",
     "url": "https://github.com/yorkyang2333/iina-anime4k",
     "desc": "Apply Anime4K shaders for real-time anime upscaling.",


### PR DESCRIPTION
- [x] I have read [CONTRIBUTING.md](https://github.com/iina/iina/blob/develop/CONTRIBUTING.md)
- [ ] Related issue: #
- [x] Related Design Proposal: # / Not applicable
---
- [x] AI was used to write the code in this pull request.
  - [ ] The code is fully written by AI / I am an AI agent.
---

**Description:**

Add [AirPlay](https://github.com/ozykhan/iina-airplay) to the community plugins list.

Cast the current file to an Apple TV over AirPlay; IINA stays the remote.

Install from IINA: `ozykhan/iina-airplay`

v0.3.1 includes an `.iinaplgz` asset. `Info.json` has `ghRepo` and `ghVersion`. The list `id` matches `dev.faruk.iina-airplay`. Both entries are inserted at the top of their lists, which keeps them in alphabetical order.

Disclosure: an AI assistant was used while building the plugin and drafting this description. The `plugins.json` / README entry was checked by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
